### PR TITLE
AMDGPU: Select vector reg class for divergent build_vector

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -726,10 +726,14 @@ void AMDGPUDAGToDAGISel::Select(SDNode *N) {
       break;
     }
 
+    const SIRegisterInfo *TRI = Subtarget->getRegisterInfo();
     assert(VT.getVectorElementType().bitsEq(MVT::i32));
-    unsigned RegClassID =
-        SIRegisterInfo::getSGPRClassForBitWidth(NumVectorElts * 32)->getID();
-    SelectBuildVector(N, RegClassID);
+    const TargetRegisterClass *RegClass =
+        N->isDivergent()
+            ? TRI->getDefaultVectorSuperClassForBitWidth(NumVectorElts * 32)
+            : SIRegisterInfo::getSGPRClassForBitWidth(NumVectorElts * 32);
+
+    SelectBuildVector(N, RegClass->getID());
     return;
   }
   case ISD::VECTOR_SHUFFLE:

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -470,6 +470,24 @@ MachineSDNode *AMDGPUDAGToDAGISel::buildSMovImm64(SDLoc &DL, uint64_t Imm,
   return CurDAG->getMachineNode(TargetOpcode::REG_SEQUENCE, DL, VT, Ops);
 }
 
+SDNode *AMDGPUDAGToDAGISel::packConstantV2I16(const SDNode *N,
+                                              SelectionDAG &DAG) const {
+  // TODO: Handle undef as zero
+
+  assert(N->getOpcode() == ISD::BUILD_VECTOR && N->getNumOperands() == 2);
+  uint32_t LHSVal, RHSVal;
+  if (getConstantValue(N->getOperand(0), LHSVal) &&
+      getConstantValue(N->getOperand(1), RHSVal)) {
+    SDLoc SL(N);
+    uint32_t K = (LHSVal & 0xffff) | (RHSVal << 16);
+    return DAG.getMachineNode(
+        isVGPRImm(N) ? AMDGPU::V_MOV_B32_e32 : AMDGPU::S_MOV_B32, SL,
+        N->getValueType(0), DAG.getTargetConstant(K, SL, MVT::i32));
+  }
+
+  return nullptr;
+}
+
 void AMDGPUDAGToDAGISel::SelectBuildVector(SDNode *N, unsigned RegClassID) {
   EVT VT = N->getValueType(0);
   unsigned NumVectorElts = VT.getVectorNumElements();

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
@@ -45,21 +45,6 @@ static inline bool getConstantValue(SDValue N, uint32_t &Out) {
   return false;
 }
 
-// TODO: Handle undef as zero
-static inline SDNode *packConstantV2I16(const SDNode *N, SelectionDAG &DAG) {
-  assert(N->getOpcode() == ISD::BUILD_VECTOR && N->getNumOperands() == 2);
-  uint32_t LHSVal, RHSVal;
-  if (getConstantValue(N->getOperand(0), LHSVal) &&
-      getConstantValue(N->getOperand(1), RHSVal)) {
-    SDLoc SL(N);
-    uint32_t K = (LHSVal & 0xffff) | (RHSVal << 16);
-    return DAG.getMachineNode(AMDGPU::S_MOV_B32, SL, N->getValueType(0),
-                              DAG.getTargetConstant(K, SL, MVT::i32));
-  }
-
-  return nullptr;
-}
-
 /// AMDGPU specific code to select AMDGPU machine instructions for
 /// SelectionDAG operations.
 class AMDGPUDAGToDAGISel : public SelectionDAGISel {
@@ -114,6 +99,8 @@ private:
                                   SDValue &RHS) const;
 
   MachineSDNode *buildSMovImm64(SDLoc &DL, uint64_t Val, EVT VT) const;
+
+  SDNode *packConstantV2I16(const SDNode *N, SelectionDAG &DAG) const;
 
   SDNode *glueCopyToOp(SDNode *N, SDValue NewChain, SDValue Glue) const;
   SDNode *glueCopyToM0(SDNode *N, SDValue Val) const;

--- a/llvm/test/CodeGen/AMDGPU/a-v-flat-atomic-cmpxchg.ll
+++ b/llvm/test/CodeGen/AMDGPU/a-v-flat-atomic-cmpxchg.ll
@@ -95,13 +95,13 @@ define void @flat_atomic_cmpxchg_i32_ret_a_a__a(ptr %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def a0
-; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a1
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a0
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    flat_atomic_cmpswap v0, v[0:1], v[2:3] offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -126,13 +126,13 @@ define void @flat_atomic_cmpxchg_i32_ret_a_a__v(ptr %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def a0
-; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a1
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a0
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    flat_atomic_cmpswap v0, v[0:1], v[2:3] offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -156,12 +156,14 @@ define void @flat_atomic_cmpxchg_i32_ret_v_a__v(ptr %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def v2
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_write_b32 a1, v2
+; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a0
 ; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
-; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def v3
-; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    flat_atomic_cmpswap v0, v[0:1], v[2:3] offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -299,12 +301,13 @@ define void @flat_atomic_cmpxchg_i32_ret_av_a__av(ptr %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a1
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a0
 ; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
-; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def v3
-; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    flat_atomic_cmpswap v0, v[0:1], v[2:3] offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -328,12 +331,13 @@ define void @flat_atomic_cmpxchg_i32_ret_a_av__av(ptr %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a1
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a0
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a0
-; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def v2
-; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    flat_atomic_cmpswap v0, v[0:1], v[2:3] offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -533,50 +537,55 @@ define void @flat_atomic_cmpxchg_i64_ret_a_a__a(ptr %ptr) #0 {
 ; CHECK-LABEL: flat_atomic_cmpxchg_i64_ret_a_a__a:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CHECK-NEXT:    v_add_co_u32_e32 v4, vcc, 0x50, v0
-; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def a[0:1]
-; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
+; CHECK-NEXT:    v_add_co_u32_e32 v0, vcc, 0x50, v0
 ; CHECK-NEXT:    s_mov_b64 s[4:5], src_private_base
-; CHECK-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v1, vcc
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
+; CHECK-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def a[0:1]
+; CHECK-NEXT:    ; def a[2:3]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v0, a0
-; CHECK-NEXT:    v_accvgpr_read_b32 v1, a1
-; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v5
+; CHECK-NEXT:    v_accvgpr_read_b32 v5, a3
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a[4:5]
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a4
+; CHECK-NEXT:    v_accvgpr_read_b32 v4, a2
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a5
+; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v1
 ; CHECK-NEXT:    ; implicit-def: $agpr0_agpr1
 ; CHECK-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; CHECK-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB15_2
 ; CHECK-NEXT:  ; %bb.1: ; %atomicrmw.global
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a4
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a5
+; CHECK-NEXT:    v_accvgpr_read_b32 v4, a2
+; CHECK-NEXT:    v_accvgpr_read_b32 v5, a3
 ; CHECK-NEXT:    buffer_wbl2
-; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[4:5], v[0:3] glc
+; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[0:1], v[2:5] glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_invl2
 ; CHECK-NEXT:    buffer_wbinvl1_vol
 ; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
+; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
 ; CHECK-NEXT:    v_accvgpr_write_b32 a0, v0
 ; CHECK-NEXT:    v_accvgpr_write_b32 a1, v1
-; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
+; CHECK-NEXT:    ; implicit-def: $vgpr0_vgpr1
 ; CHECK-NEXT:  .LBB15_2: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB15_4
 ; CHECK-NEXT:  ; %bb.3: ; %atomicrmw.private
-; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[4:5]
-; CHECK-NEXT:    v_cndmask_b32_e32 v6, -1, v4, vcc
-; CHECK-NEXT:    buffer_load_dword v4, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_load_dword v5, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
+; CHECK-NEXT:    v_cndmask_b32_e32 v6, -1, v0, vcc
+; CHECK-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:    s_waitcnt vmcnt(1)
-; CHECK-NEXT:    v_accvgpr_write_b32 a0, v4
+; CHECK-NEXT:    v_accvgpr_write_b32 a0, v0
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
-; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[4:5], v[2:3]
-; CHECK-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; CHECK-NEXT:    v_accvgpr_write_b32 a1, v5
-; CHECK-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; CHECK-NEXT:    buffer_store_dword v1, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[4:5]
+; CHECK-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc
+; CHECK-NEXT:    v_accvgpr_write_b32 a1, v1
+; CHECK-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
+; CHECK-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen
 ; CHECK-NEXT:  .LBB15_4: ; %atomicrmw.phi
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -598,50 +607,55 @@ define void @flat_atomic_cmpxchg_i64_ret_a_a__v(ptr %ptr) #0 {
 ; CHECK-LABEL: flat_atomic_cmpxchg_i64_ret_a_a__v:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CHECK-NEXT:    v_add_co_u32_e32 v6, vcc, 0x50, v0
-; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def a[0:1]
-; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
+; CHECK-NEXT:    v_add_co_u32_e32 v0, vcc, 0x50, v0
 ; CHECK-NEXT:    s_mov_b64 s[4:5], src_private_base
-; CHECK-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v1, vcc
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
+; CHECK-NEXT:    v_addc_co_u32_e32 v1, vcc, 0, v1, vcc
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v0, a0
-; CHECK-NEXT:    v_accvgpr_read_b32 v1, a1
-; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v7
-; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
+; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a[2:3]
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v7, a3
+; CHECK-NEXT:    v_accvgpr_read_b32 v4, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v6, a2
+; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v1
+; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
 ; CHECK-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; CHECK-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB16_2
 ; CHECK-NEXT:  ; %bb.1: ; %atomicrmw.global
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a2
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a3
+; CHECK-NEXT:    v_accvgpr_read_b32 v4, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
 ; CHECK-NEXT:    buffer_wbl2
-; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[4:5], v[6:7], v[0:3] glc
+; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[2:3], v[0:1], v[2:5] glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_invl2
 ; CHECK-NEXT:    buffer_wbinvl1_vol
+; CHECK-NEXT:    ; implicit-def: $vgpr0_vgpr1
+; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
 ; CHECK-NEXT:    ; implicit-def: $vgpr6_vgpr7
-; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
 ; CHECK-NEXT:  .LBB16_2: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB16_4
 ; CHECK-NEXT:  ; %bb.3: ; %atomicrmw.private
-; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[6:7]
-; CHECK-NEXT:    v_cndmask_b32_e32 v6, -1, v6, vcc
-; CHECK-NEXT:    buffer_load_dword v4, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_load_dword v5, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
+; CHECK-NEXT:    v_cndmask_b32_e32 v0, -1, v0, vcc
+; CHECK-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_load_dword v3, v0, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
-; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[4:5], v[2:3]
-; CHECK-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; CHECK-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; CHECK-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_store_dword v1, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
+; CHECK-NEXT:    v_cndmask_b32_e32 v4, v2, v6, vcc
+; CHECK-NEXT:    v_cndmask_b32_e32 v1, v3, v7, vcc
+; CHECK-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:  .LBB16_4: ; %atomicrmw.phi
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; use v[4:5]
+; CHECK-NEXT:    ; use v[2:3]
 ; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
@@ -658,48 +672,51 @@ define void @flat_atomic_cmpxchg_i64_ret_v_a__v(ptr %ptr) #0 {
 ; CHECK-LABEL: flat_atomic_cmpxchg_i64_ret_v_a__v:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CHECK-NEXT:    v_add_co_u32_e32 v6, vcc, 0x50, v0
+; CHECK-NEXT:    v_add_co_u32_e32 v4, vcc, 0x50, v0
 ; CHECK-NEXT:    s_mov_b64 s[4:5], src_private_base
-; CHECK-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v1, vcc
+; CHECK-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v1, vcc
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v0, a0
-; CHECK-NEXT:    v_accvgpr_read_b32 v1, a1
-; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v7
+; CHECK-NEXT:    v_accvgpr_read_b32 v7, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v6, a0
+; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v5
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def v[2:3]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
+; CHECK-NEXT:    ; implicit-def: $vgpr0_vgpr1
 ; CHECK-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; CHECK-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB17_2
 ; CHECK-NEXT:  ; %bb.1: ; %atomicrmw.global
+; CHECK-NEXT:    v_accvgpr_read_b32 v0, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v1, a1
 ; CHECK-NEXT:    buffer_wbl2
-; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[4:5], v[6:7], v[0:3] glc
+; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[4:5], v[0:3] glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_invl2
 ; CHECK-NEXT:    buffer_wbinvl1_vol
-; CHECK-NEXT:    ; implicit-def: $vgpr6_vgpr7
+; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
 ; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
+; CHECK-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; CHECK-NEXT:  .LBB17_2: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB17_4
 ; CHECK-NEXT:  ; %bb.3: ; %atomicrmw.private
-; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[6:7]
-; CHECK-NEXT:    v_cndmask_b32_e32 v6, -1, v6, vcc
-; CHECK-NEXT:    buffer_load_dword v4, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_load_dword v5, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[4:5]
+; CHECK-NEXT:    v_cndmask_b32_e32 v4, -1, v4, vcc
+; CHECK-NEXT:    buffer_load_dword v0, v4, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_load_dword v1, v4, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
-; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[4:5], v[2:3]
-; CHECK-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; CHECK-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; CHECK-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_store_dword v1, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
+; CHECK-NEXT:    v_cndmask_b32_e32 v3, v0, v6, vcc
+; CHECK-NEXT:    v_cndmask_b32_e32 v2, v1, v7, vcc
+; CHECK-NEXT:    buffer_store_dword v3, v4, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:  .LBB17_4: ; %atomicrmw.phi
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; use v[4:5]
+; CHECK-NEXT:    ; use v[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
@@ -716,48 +733,51 @@ define void @flat_atomic_cmpxchg_i64_ret_a_v__v(ptr %ptr) #0 {
 ; CHECK-LABEL: flat_atomic_cmpxchg_i64_ret_a_v__v:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CHECK-NEXT:    v_add_co_u32_e32 v6, vcc, 0x50, v0
+; CHECK-NEXT:    v_add_co_u32_e32 v4, vcc, 0x50, v0
 ; CHECK-NEXT:    s_mov_b64 s[4:5], src_private_base
-; CHECK-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v1, vcc
+; CHECK-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v1, vcc
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
-; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v7
+; CHECK-NEXT:    v_accvgpr_read_b32 v7, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v6, a0
+; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v5
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def v[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
+; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
 ; CHECK-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; CHECK-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB18_2
 ; CHECK-NEXT:  ; %bb.1: ; %atomicrmw.global
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    buffer_wbl2
-; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[4:5], v[6:7], v[0:3] glc
+; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[2:3], v[4:5], v[0:3] glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_invl2
 ; CHECK-NEXT:    buffer_wbinvl1_vol
+; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
 ; CHECK-NEXT:    ; implicit-def: $vgpr6_vgpr7
-; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
+; CHECK-NEXT:    ; implicit-def: $vgpr0_vgpr1
 ; CHECK-NEXT:  .LBB18_2: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB18_4
 ; CHECK-NEXT:  ; %bb.3: ; %atomicrmw.private
-; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[6:7]
-; CHECK-NEXT:    v_cndmask_b32_e32 v6, -1, v6, vcc
-; CHECK-NEXT:    buffer_load_dword v4, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_load_dword v5, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[4:5]
+; CHECK-NEXT:    v_cndmask_b32_e32 v4, -1, v4, vcc
+; CHECK-NEXT:    buffer_load_dword v2, v4, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_load_dword v3, v4, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
-; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[4:5], v[2:3]
-; CHECK-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; CHECK-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; CHECK-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_store_dword v1, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[6:7]
+; CHECK-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; CHECK-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; CHECK-NEXT:    buffer_store_dword v0, v4, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_store_dword v1, v4, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:  .LBB18_4: ; %atomicrmw.phi
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; use v[4:5]
+; CHECK-NEXT:    ; use v[2:3]
 ; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
@@ -947,48 +967,51 @@ define void @flat_atomic_cmpxchg_i64_ret_av_a__av(ptr %ptr) #0 {
 ; CHECK-LABEL: flat_atomic_cmpxchg_i64_ret_av_a__av:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CHECK-NEXT:    v_add_co_u32_e32 v6, vcc, 0x50, v0
+; CHECK-NEXT:    v_add_co_u32_e32 v4, vcc, 0x50, v0
 ; CHECK-NEXT:    s_mov_b64 s[4:5], src_private_base
-; CHECK-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v1, vcc
+; CHECK-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v1, vcc
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v0, a0
-; CHECK-NEXT:    v_accvgpr_read_b32 v1, a1
-; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v7
+; CHECK-NEXT:    v_accvgpr_read_b32 v7, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v6, a0
+; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v5
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def v[2:3]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
+; CHECK-NEXT:    ; implicit-def: $vgpr0_vgpr1
 ; CHECK-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; CHECK-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB22_2
 ; CHECK-NEXT:  ; %bb.1: ; %atomicrmw.global
+; CHECK-NEXT:    v_accvgpr_read_b32 v0, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v1, a1
 ; CHECK-NEXT:    buffer_wbl2
-; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[4:5], v[6:7], v[0:3] glc
+; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[4:5], v[0:3] glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_invl2
 ; CHECK-NEXT:    buffer_wbinvl1_vol
-; CHECK-NEXT:    ; implicit-def: $vgpr6_vgpr7
+; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
 ; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
+; CHECK-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; CHECK-NEXT:  .LBB22_2: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB22_4
 ; CHECK-NEXT:  ; %bb.3: ; %atomicrmw.private
-; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[6:7]
-; CHECK-NEXT:    v_cndmask_b32_e32 v6, -1, v6, vcc
-; CHECK-NEXT:    buffer_load_dword v4, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_load_dword v5, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[4:5]
+; CHECK-NEXT:    v_cndmask_b32_e32 v4, -1, v4, vcc
+; CHECK-NEXT:    buffer_load_dword v0, v4, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_load_dword v1, v4, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
-; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[4:5], v[2:3]
-; CHECK-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; CHECK-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; CHECK-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_store_dword v1, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
+; CHECK-NEXT:    v_cndmask_b32_e32 v3, v0, v6, vcc
+; CHECK-NEXT:    v_cndmask_b32_e32 v2, v1, v7, vcc
+; CHECK-NEXT:    buffer_store_dword v3, v4, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:  .LBB22_4: ; %atomicrmw.phi
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; use v[4:5]
+; CHECK-NEXT:    ; use v[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
@@ -1005,48 +1028,51 @@ define void @flat_atomic_cmpxchg_i64_ret_a_av__av(ptr %ptr) #0 {
 ; CHECK-LABEL: flat_atomic_cmpxchg_i64_ret_a_av__av:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; CHECK-NEXT:    v_add_co_u32_e32 v6, vcc, 0x50, v0
+; CHECK-NEXT:    v_add_co_u32_e32 v4, vcc, 0x50, v0
 ; CHECK-NEXT:    s_mov_b64 s[4:5], src_private_base
-; CHECK-NEXT:    v_addc_co_u32_e32 v7, vcc, 0, v1, vcc
+; CHECK-NEXT:    v_addc_co_u32_e32 v5, vcc, 0, v1, vcc
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
-; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v7
+; CHECK-NEXT:    v_accvgpr_read_b32 v7, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v6, a0
+; CHECK-NEXT:    v_cmp_ne_u32_e32 vcc, s5, v5
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def v[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
+; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
 ; CHECK-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; CHECK-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB23_2
 ; CHECK-NEXT:  ; %bb.1: ; %atomicrmw.global
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    buffer_wbl2
-; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[4:5], v[6:7], v[0:3] glc
+; CHECK-NEXT:    flat_atomic_cmpswap_x2 v[2:3], v[4:5], v[0:3] glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    buffer_invl2
 ; CHECK-NEXT:    buffer_wbinvl1_vol
+; CHECK-NEXT:    ; implicit-def: $vgpr4_vgpr5
 ; CHECK-NEXT:    ; implicit-def: $vgpr6_vgpr7
-; CHECK-NEXT:    ; implicit-def: $vgpr2_vgpr3
+; CHECK-NEXT:    ; implicit-def: $vgpr0_vgpr1
 ; CHECK-NEXT:  .LBB23_2: ; %Flow
 ; CHECK-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
 ; CHECK-NEXT:    s_cbranch_execz .LBB23_4
 ; CHECK-NEXT:  ; %bb.3: ; %atomicrmw.private
-; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[6:7]
-; CHECK-NEXT:    v_cndmask_b32_e32 v6, -1, v6, vcc
-; CHECK-NEXT:    buffer_load_dword v4, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_load_dword v5, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[4:5]
+; CHECK-NEXT:    v_cndmask_b32_e32 v4, -1, v4, vcc
+; CHECK-NEXT:    buffer_load_dword v2, v4, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_load_dword v3, v4, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
-; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[4:5], v[2:3]
-; CHECK-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; CHECK-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; CHECK-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen
-; CHECK-NEXT:    buffer_store_dword v1, v6, s[0:3], 0 offen offset:4
+; CHECK-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[6:7]
+; CHECK-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; CHECK-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; CHECK-NEXT:    buffer_store_dword v0, v4, s[0:3], 0 offen
+; CHECK-NEXT:    buffer_store_dword v1, v4, s[0:3], 0 offen offset:4
 ; CHECK-NEXT:  .LBB23_4: ; %atomicrmw.phi
 ; CHECK-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; use v[4:5]
+; CHECK-NEXT:    ; use v[2:3]
 ; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/a-v-flat-atomicrmw.ll
+++ b/llvm/test/CodeGen/AMDGPU/a-v-flat-atomicrmw.ll
@@ -2531,16 +2531,16 @@ define void @flat_atomic_xor_expansion_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:  ; %bb.5: ; %atomicrmw.private
 ; GFX90A-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, -1, v0, vcc
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_xor_b32_e32 v4, v2, v6
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_xor_b32_e32 v3, v1, v7
-; GFX90A-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen
-; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:4
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX90A-NEXT:    v_xor_b32_e32 v1, v1, v6
+; GFX90A-NEXT:    v_xor_b32_e32 v2, v2, v7
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB32_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
@@ -2779,16 +2779,16 @@ define void @flat_atomic_xor_expansion_i64_ret_v_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:  ; %bb.5: ; %atomicrmw.private
 ; GFX90A-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, -1, v0, vcc
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_xor_b32_e32 v4, v2, v6
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_xor_b32_e32 v3, v1, v7
-; GFX90A-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen
-; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:4
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX90A-NEXT:    v_xor_b32_e32 v1, v1, v6
+; GFX90A-NEXT:    v_xor_b32_e32 v2, v2, v7
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB34_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
@@ -3138,16 +3138,16 @@ define void @flat_atomic_xor_expansion_i64_ret_av_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:  ; %bb.5: ; %atomicrmw.private
 ; GFX90A-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, -1, v0, vcc
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_xor_b32_e32 v4, v2, v6
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_xor_b32_e32 v3, v1, v7
-; GFX90A-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen
-; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:4
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX90A-NEXT:    v_xor_b32_e32 v1, v1, v6
+; GFX90A-NEXT:    v_xor_b32_e32 v2, v2, v7
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB37_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
@@ -4332,15 +4332,15 @@ define void @flat_atomic_xor_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:  ; %bb.3: ; %atomicrmw.private
 ; GFX90A-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, -1, v0, vcc
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_xor_b32_e32 v2, v4, v2
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v4
-; GFX90A-NEXT:    v_xor_b32_e32 v3, v1, v3
-; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v4
+; GFX90A-NEXT:    v_xor_b32_e32 v1, v1, v2
+; GFX90A-NEXT:    v_xor_b32_e32 v3, v4, v3
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB53_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -4520,15 +4520,15 @@ define void @flat_atomic_xor_i64_ret_v_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:  ; %bb.3: ; %atomicrmw.private
 ; GFX90A-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, -1, v0, vcc
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_xor_b32_e32 v2, v4, v2
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v4
-; GFX90A-NEXT:    v_xor_b32_e32 v3, v1, v3
-; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v4
+; GFX90A-NEXT:    v_xor_b32_e32 v1, v1, v2
+; GFX90A-NEXT:    v_xor_b32_e32 v3, v4, v3
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB55_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -4789,15 +4789,15 @@ define void @flat_atomic_xor_i64_ret_av_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:  ; %bb.3: ; %atomicrmw.private
 ; GFX90A-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, -1, v0, vcc
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_xor_b32_e32 v2, v4, v2
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v4
-; GFX90A-NEXT:    v_xor_b32_e32 v3, v1, v3
-; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v4
+; GFX90A-NEXT:    v_xor_b32_e32 v1, v1, v2
+; GFX90A-NEXT:    v_xor_b32_e32 v3, v4, v3
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB58_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -6704,15 +6704,15 @@ define void @flat_atomic_and_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:  ; %bb.3: ; %atomicrmw.private
 ; GFX90A-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, -1, v0, vcc
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_and_b32_e32 v2, v4, v2
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v4
-; GFX90A-NEXT:    v_and_b32_e32 v3, v1, v3
-; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v4
+; GFX90A-NEXT:    v_and_b32_e32 v1, v1, v2
+; GFX90A-NEXT:    v_and_b32_e32 v3, v4, v3
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB93_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -6905,17 +6905,17 @@ define void @flat_atomic_nand_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:  ; %bb.5: ; %atomicrmw.private
 ; GFX90A-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, -1, v4, vcc
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_and_b32_e32 v3, v1, v7
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
+; GFX90A-NEXT:    v_and_b32_e32 v1, v1, v6
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_and_b32_e32 v4, v2, v6
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_not_b32_e32 v2, v3
-; GFX90A-NEXT:    v_not_b32_e32 v3, v4
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX90A-NEXT:    v_and_b32_e32 v2, v2, v7
+; GFX90A-NEXT:    v_not_b32_e32 v1, v1
+; GFX90A-NEXT:    v_not_b32_e32 v2, v2
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB95_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -7147,15 +7147,15 @@ define void @flat_atomic_or_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:  ; %bb.3: ; %atomicrmw.private
 ; GFX90A-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, -1, v0, vcc
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v4, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_or_b32_e32 v2, v4, v2
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v4
-; GFX90A-NEXT:    v_or_b32_e32 v3, v1, v3
-; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v4
+; GFX90A-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX90A-NEXT:    v_or_b32_e32 v3, v4, v3
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB97_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -8787,15 +8787,15 @@ define void @flat_atomic_usub_sat_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_sub_co_u32_e32 v3, vcc, v1, v6
-; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_subb_co_u32_e32 v4, vcc, v2, v7, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
-; GFX90A-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
+; GFX90A-NEXT:    v_sub_co_u32_e32 v1, vcc, v1, v6
+; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
-; GFX90A-NEXT:    v_cndmask_b32_e64 v1, v4, 0, vcc
-; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen
-; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen offset:4
+; GFX90A-NEXT:    v_subb_co_u32_e32 v2, vcc, v2, v7, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB113_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
@@ -9848,9 +9848,8 @@ define void @flat_atomic_fadd_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v4, -1, v0, vcc
 ; GFX90A-NEXT:    buffer_load_dword v0, v4, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v4, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_add_f64 v[2:3], v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
@@ -10117,9 +10116,8 @@ define void @flat_atomic_fsub_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v4, -1, v4, vcc
 ; GFX90A-NEXT:    buffer_load_dword v0, v4, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v4, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_add_f64 v[2:3], v[0:1], -v[6:7]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
@@ -10338,10 +10336,9 @@ define void @flat_atomic_fmax_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[2:3], v[2:3]
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[4:5], v[0:1], v[0:1]
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[4:5], v[2:3]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
@@ -10527,10 +10524,9 @@ define void @flat_atomic_fmin_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[2:3], v[2:3]
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[4:5], v[0:1], v[0:1]
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[4:5], v[2:3]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
@@ -10733,16 +10729,15 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
 ; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v3, v7, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
-; GFX90A-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen offset:4
+; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB135_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
@@ -11001,16 +10996,15 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
 ; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v3, v7, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
-; GFX90A-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen offset:4
+; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB137_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
@@ -13378,27 +13372,28 @@ define void @flat_atomic_nand_i32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_pk_mov_b32 v[0:1], s[16:17], s[16:17] op_sel:[0,1]
-; GFX90A-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX90A-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX90A-NEXT:    s_mov_b64 s[4:5], 0
+; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], s[16:17], s[16:17] op_sel:[0,1]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v4
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:  .LBB172_1: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_and_b32_e32 v2, v3, v4
-; GFX90A-NEXT:    v_not_b32_e32 v2, v2
-; GFX90A-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 glc
+; GFX90A-NEXT:    v_and_b32_e32 v0, v1, v4
+; GFX90A-NEXT:    v_not_b32_e32 v0, v0
+; GFX90A-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX90A-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX90A-NEXT:    s_andn2_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB172_1
 ; GFX90A-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; use v2
+; GFX90A-NEXT:    ; use v0
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -13406,26 +13401,27 @@ define void @flat_atomic_nand_i32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
-; GFX950-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX950-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v4
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:  .LBB172_1: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_bitop3_b32 v2, v3, v4, v3 bitop3:0x3f
-; GFX950-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-NEXT:    v_bitop3_b32 v0, v1, v4, v1 bitop3:0x3f
+; GFX950-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    s_cbranch_execnz .LBB172_1
 ; GFX950-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    ;;#ASMSTART
-; GFX950-NEXT:    ; use v2
+; GFX950-NEXT:    ; use v0
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %gep.0 = getelementptr inbounds [512 x i32], ptr %ptr, i64 0, i64 10
@@ -14144,28 +14140,29 @@ define void @flat_atomic_usub_cond_i32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_pk_mov_b32 v[0:1], s[16:17], s[16:17] op_sel:[0,1]
-; GFX90A-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX90A-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX90A-NEXT:    s_mov_b64 s[4:5], 0
+; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], s[16:17], s[16:17] op_sel:[0,1]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v4
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:  .LBB190_1: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_sub_u32_e32 v2, v3, v4
-; GFX90A-NEXT:    v_cmp_ge_u32_e32 vcc, v3, v4
-; GFX90A-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX90A-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 glc
+; GFX90A-NEXT:    v_sub_u32_e32 v0, v1, v4
+; GFX90A-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v4
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX90A-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX90A-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX90A-NEXT:    s_andn2_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB190_1
 ; GFX90A-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; use v2
+; GFX90A-NEXT:    ; use v0
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -14173,29 +14170,30 @@ define void @flat_atomic_usub_cond_i32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
-; GFX950-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX950-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v4
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:  .LBB190_1: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_sub_u32_e32 v2, v3, v4
-; GFX950-NEXT:    v_cmp_ge_u32_e32 vcc, v3, v4
+; GFX950-NEXT:    v_sub_u32_e32 v0, v1, v4
+; GFX950-NEXT:    v_cmp_ge_u32_e32 vcc, v1, v4
 ; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX950-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX950-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    s_cbranch_execnz .LBB190_1
 ; GFX950-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    ;;#ASMSTART
-; GFX950-NEXT:    ; use v2
+; GFX950-NEXT:    ; use v0
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %gep.0 = getelementptr inbounds [512 x i32], ptr %ptr, i64 0, i64 10
@@ -14277,26 +14275,27 @@ define void @flat_atomic_usub_sat_i32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_pk_mov_b32 v[0:1], s[16:17], s[16:17] op_sel:[0,1]
-; GFX90A-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX90A-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX90A-NEXT:    s_mov_b64 s[4:5], 0
+; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], s[16:17], s[16:17] op_sel:[0,1]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v4
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:  .LBB192_1: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_sub_u32_e64 v2, v3, v4 clamp
-; GFX90A-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 glc
+; GFX90A-NEXT:    v_sub_u32_e64 v0, v1, v4 clamp
+; GFX90A-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX90A-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX90A-NEXT:    s_andn2_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB192_1
 ; GFX90A-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; use v2
+; GFX90A-NEXT:    ; use v0
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -14304,26 +14303,27 @@ define void @flat_atomic_usub_sat_i32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
-; GFX950-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX950-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v4
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:  .LBB192_1: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_sub_u32_e64 v2, v3, v4 clamp
-; GFX950-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-NEXT:    v_sub_u32_e64 v0, v1, v4 clamp
+; GFX950-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    s_cbranch_execnz .LBB192_1
 ; GFX950-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    ;;#ASMSTART
-; GFX950-NEXT:    ; use v2
+; GFX950-NEXT:    ; use v0
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %gep.0 = getelementptr inbounds [512 x i32], ptr %ptr, i64 0, i64 10
@@ -14894,14 +14894,14 @@ define void @flat_atomic_and_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX90A-NEXT:    s_cselect_b32 s4, s4, -1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, s4
-; GFX90A-NEXT:    buffer_load_dword v3, v2, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v4, v2, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v3, v2, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v4, v2, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v3
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_and_b32_e32 v0, v4, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v4
-; GFX90A-NEXT:    v_and_b32_e32 v1, v3, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v4
+; GFX90A-NEXT:    v_and_b32_e32 v0, v3, v0
+; GFX90A-NEXT:    v_and_b32_e32 v1, v4, v1
 ; GFX90A-NEXT:    buffer_store_dword v0, v2, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v1, v2, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB199_4: ; %atomicrmw.end
@@ -15088,17 +15088,17 @@ define void @flat_atomic_nand_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX90A-NEXT:    s_cselect_b32 s4, s4, -1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, s4
-; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_and_b32_e32 v3, v1, v5
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
+; GFX90A-NEXT:    v_and_b32_e32 v1, v1, v4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_and_b32_e32 v4, v2, v4
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_not_b32_e32 v2, v3
-; GFX90A-NEXT:    v_not_b32_e32 v3, v4
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX90A-NEXT:    v_and_b32_e32 v2, v2, v5
+; GFX90A-NEXT:    v_not_b32_e32 v1, v1
+; GFX90A-NEXT:    v_not_b32_e32 v2, v2
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB201_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    ;;#ASMSTART
@@ -15323,14 +15323,14 @@ define void @flat_atomic_or_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX90A-NEXT:    s_cselect_b32 s4, s4, -1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, s4
-; GFX90A-NEXT:    buffer_load_dword v3, v2, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v4, v2, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v3, v2, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v4, v2, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v3
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_or_b32_e32 v0, v4, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v4
-; GFX90A-NEXT:    v_or_b32_e32 v1, v3, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v4
+; GFX90A-NEXT:    v_or_b32_e32 v0, v3, v0
+; GFX90A-NEXT:    v_or_b32_e32 v1, v4, v1
 ; GFX90A-NEXT:    buffer_store_dword v0, v2, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v1, v2, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB203_4: ; %atomicrmw.end
@@ -15502,14 +15502,14 @@ define void @flat_atomic_xor_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX90A-NEXT:    s_cselect_b32 s4, s4, -1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, s4
-; GFX90A-NEXT:    buffer_load_dword v3, v2, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    buffer_load_dword v4, v2, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v3, v2, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_load_dword v4, v2, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v3
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_xor_b32_e32 v0, v4, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v4
-; GFX90A-NEXT:    v_xor_b32_e32 v1, v3, v1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v4
+; GFX90A-NEXT:    v_xor_b32_e32 v0, v3, v0
+; GFX90A-NEXT:    v_xor_b32_e32 v1, v4, v1
 ; GFX90A-NEXT:    buffer_store_dword v0, v2, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v1, v2, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB205_4: ; %atomicrmw.end
@@ -17091,15 +17091,15 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_sub_co_u32_e32 v3, vcc, v1, v4
-; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    v_subb_co_u32_e32 v4, vcc, v2, v5, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v1
-; GFX90A-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
+; GFX90A-NEXT:    v_sub_co_u32_e32 v1, vcc, v1, v4
+; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
-; GFX90A-NEXT:    v_cndmask_b32_e64 v1, v4, 0, vcc
-; GFX90A-NEXT:    buffer_store_dword v3, v0, s[0:3], 0 offen
-; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen offset:4
+; GFX90A-NEXT:    v_subb_co_u32_e32 v2, vcc, v2, v5, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB221_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -17533,26 +17533,27 @@ define void @flat_atomic_fsub_f32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_pk_mov_b32 v[0:1], s[16:17], s[16:17] op_sel:[0,1]
-; GFX90A-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX90A-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX90A-NEXT:    s_mov_b64 s[4:5], 0
+; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], s[16:17], s[16:17] op_sel:[0,1]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v4
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:  .LBB226_1: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_sub_f32_e32 v2, v3, v4
-; GFX90A-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 glc
+; GFX90A-NEXT:    v_sub_f32_e32 v0, v1, v4
+; GFX90A-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX90A-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX90A-NEXT:    s_andn2_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB226_1
 ; GFX90A-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; use v2
+; GFX90A-NEXT:    ; use v0
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -17560,26 +17561,27 @@ define void @flat_atomic_fsub_f32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
-; GFX950-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX950-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v4
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:  .LBB226_1: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_sub_f32_e32 v2, v3, v4
-; GFX950-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-NEXT:    v_sub_f32_e32 v0, v1, v4
+; GFX950-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    s_cbranch_execnz .LBB226_1
 ; GFX950-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    ;;#ASMSTART
-; GFX950-NEXT:    ; use v2
+; GFX950-NEXT:    ; use v0
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %gep.0 = getelementptr inbounds [512 x float], ptr %ptr, i64 0, i64 10
@@ -17971,26 +17973,27 @@ define void @flat_atomic_fmaximum_f32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
-; GFX950-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX950-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v4
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:  .LBB232_1: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_maximum3_f32 v2, v3, v4, v4
-; GFX950-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-NEXT:    v_maximum3_f32 v0, v1, v4, v4
+; GFX950-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    s_cbranch_execnz .LBB232_1
 ; GFX950-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    ;;#ASMSTART
-; GFX950-NEXT:    ; use v2
+; GFX950-NEXT:    ; use v0
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %gep.0 = getelementptr inbounds [512 x float], ptr %ptr, i64 0, i64 10
@@ -18106,26 +18109,27 @@ define void @flat_atomic_fminimum_f32_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
-; GFX950-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX950-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v4
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:  .LBB234_1: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_minimum3_f32 v2, v3, v4, v4
-; GFX950-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-NEXT:    v_minimum3_f32 v0, v1, v4, v4
+; GFX950-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    s_cbranch_execnz .LBB234_1
 ; GFX950-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    ;;#ASMSTART
-; GFX950-NEXT:    ; use v2
+; GFX950-NEXT:    ; use v0
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %gep.0 = getelementptr inbounds [512 x float], ptr %ptr, i64 0, i64 10
@@ -18180,9 +18184,8 @@ define void @flat_atomic_fadd_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX90A-NEXT:    buffer_load_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v3, v6, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
 ; GFX90A-NEXT:    v_add_f64 v[4:5], v[2:3], v[0:1]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX90A-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
@@ -18429,9 +18432,8 @@ define void @flat_atomic_fsub_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_add_f64 v[2:3], v[0:1], -v[4:5]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
@@ -18643,10 +18645,9 @@ define void @flat_atomic_fmax_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_max_f64 v[0:1], v[0:1], v[0:1]
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[4:5], v[2:3], v[2:3]
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
 ; GFX90A-NEXT:    v_max_f64 v[0:1], v[4:5], v[0:1]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX90A-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen
@@ -18826,10 +18827,9 @@ define void @flat_atomic_fmin_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_max_f64 v[0:1], v[0:1], v[0:1]
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[4:5], v[2:3], v[2:3]
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
 ; GFX90A-NEXT:    v_min_f64 v[0:1], v[4:5], v[0:1]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX90A-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen
@@ -19025,16 +19025,15 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
 ; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v3, v7, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
-; GFX90A-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen offset:4
+; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB243_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -19285,16 +19284,15 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
-; GFX90A-NEXT:    s_waitcnt vmcnt(1)
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
 ; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v3, v7, vcc
+; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
-; GFX90A-NEXT:    buffer_store_dword v0, v6, s[0:3], 0 offen offset:4
+; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB245_6: ; %atomicrmw.phi
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -19559,26 +19557,27 @@ define void @flat_atomic_fadd_v2f16_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_pk_mov_b32 v[0:1], s[16:17], s[16:17] op_sel:[0,1]
-; GFX90A-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX90A-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX90A-NEXT:    s_mov_b64 s[4:5], 0
+; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], s[16:17], s[16:17] op_sel:[0,1]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v4
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:  .LBB248_1: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_pk_add_f16 v2, v3, v4
-; GFX90A-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 glc
+; GFX90A-NEXT:    v_pk_add_f16 v0, v1, v4
+; GFX90A-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX90A-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX90A-NEXT:    s_andn2_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB248_1
 ; GFX90A-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; use v2
+; GFX90A-NEXT:    ; use v0
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -19675,26 +19674,27 @@ define void @flat_atomic_fsub_v2f16_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    v_pk_mov_b32 v[0:1], s[16:17], s[16:17] op_sel:[0,1]
-; GFX90A-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX90A-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX90A-NEXT:    s_mov_b64 s[4:5], 0
+; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], s[16:17], s[16:17] op_sel:[0,1]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v4
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:  .LBB250_1: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_pk_add_f16 v2, v3, v4 neg_lo:[0,1] neg_hi:[0,1]
-; GFX90A-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 glc
+; GFX90A-NEXT:    v_pk_add_f16 v0, v1, v4 neg_lo:[0,1] neg_hi:[0,1]
+; GFX90A-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 glc
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX90A-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX90A-NEXT:    s_andn2_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB250_1
 ; GFX90A-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; use v2
+; GFX90A-NEXT:    ; use v0
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -19702,26 +19702,27 @@ define void @flat_atomic_fsub_v2f16_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
-; GFX950-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX950-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v4
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:  .LBB250_1: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_pk_add_f16 v2, v3, v4 neg_lo:[0,1] neg_hi:[0,1]
-; GFX950-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-NEXT:    v_pk_add_f16 v0, v1, v4 neg_lo:[0,1] neg_hi:[0,1]
+; GFX950-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    s_cbranch_execnz .LBB250_1
 ; GFX950-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    ;;#ASMSTART
-; GFX950-NEXT:    ; use v2
+; GFX950-NEXT:    ; use v0
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %gep.0 = getelementptr inbounds [512 x <2 x half>], ptr %ptr, i64 0, i64 10
@@ -20125,26 +20126,27 @@ define void @flat_atomic_fmaximum_v2f16_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
-; GFX950-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX950-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v4
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:  .LBB256_1: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_pk_maximum3_f16 v2, v3, v4, v4
-; GFX950-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-NEXT:    v_pk_maximum3_f16 v0, v1, v4, v4
+; GFX950-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    s_cbranch_execnz .LBB256_1
 ; GFX950-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    ;;#ASMSTART
-; GFX950-NEXT:    ; use v2
+; GFX950-NEXT:    ; use v0
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %gep.0 = getelementptr inbounds [512 x <2 x half>], ptr %ptr, i64 0, i64 10
@@ -20268,26 +20270,27 @@ define void @flat_atomic_fminimum_v2f16_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
-; GFX950-NEXT:    flat_load_dword v3, v[0:1] offset:40
+; GFX950-NEXT:    flat_load_dword v1, v[0:1] offset:40
 ; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v4
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:  .LBB258_1: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_pk_minimum3_f16 v2, v3, v4, v4
-; GFX950-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-NEXT:    v_pk_minimum3_f16 v0, v1, v4, v4
+; GFX950-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    s_cbranch_execnz .LBB258_1
 ; GFX950-NEXT:  ; %bb.2: ; %atomicrmw.end
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX950-NEXT:    ;;#ASMSTART
-; GFX950-NEXT:    ; use v2
+; GFX950-NEXT:    ; use v0
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    s_setpc_b64 s[30:31]
   %gep.0 = getelementptr inbounds [512 x <2 x half>], ptr %ptr, i64 0, i64 10

--- a/llvm/test/CodeGen/AMDGPU/a-v-global-atomic-cmpxchg.ll
+++ b/llvm/test/CodeGen/AMDGPU/a-v-global-atomic-cmpxchg.ll
@@ -95,13 +95,13 @@ define void @global_atomic_cmpxchg_i32_ret_a_a__a(ptr addrspace(1) %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def a0
-; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a1
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a0
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    global_atomic_cmpswap v0, v[0:1], v[2:3], off offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
@@ -126,13 +126,13 @@ define void @global_atomic_cmpxchg_i32_ret_a_a__v(ptr addrspace(1) %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def a0
-; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a1
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a0
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    global_atomic_cmpswap v0, v[0:1], v[2:3], off offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
@@ -156,12 +156,14 @@ define void @global_atomic_cmpxchg_i32_ret_v_a__v(ptr addrspace(1) %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def v2
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_write_b32 a1, v2
+; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a0
 ; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
-; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def v3
-; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    global_atomic_cmpswap v0, v[0:1], v[2:3], off offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
@@ -299,12 +301,13 @@ define void @global_atomic_cmpxchg_i32_ret_av_a__av(ptr addrspace(1) %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a1
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a0
 ; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
-; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def v3
-; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    global_atomic_cmpswap v0, v[0:1], v[2:3], off offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
@@ -328,12 +331,13 @@ define void @global_atomic_cmpxchg_i32_ret_a_av__av(ptr addrspace(1) %ptr) #0 {
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a1
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a0
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a0
-; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def v2
-; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    global_atomic_cmpswap v0, v[0:1], v[2:3], off offset:40 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
@@ -449,13 +453,13 @@ define void @global_atomic_cmpxchg_i64_ret_a_a__a(ptr addrspace(1) %ptr) #0 {
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v4, a0
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def a[0:1]
+; CHECK-NEXT:    ; def a[2:3]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a2
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a3
+; CHECK-NEXT:    v_accvgpr_read_b32 v4, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    global_atomic_cmpswap_x2 v[0:1], v[0:1], v[2:5], off offset:80 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
@@ -483,13 +487,13 @@ define void @global_atomic_cmpxchg_i64_ret_a_a__v(ptr addrspace(1) %ptr) #0 {
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v4, a0
 ; CHECK-NEXT:    ;;#ASMSTART
-; CHECK-NEXT:    ; def a[0:1]
+; CHECK-NEXT:    ; def a[2:3]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
-; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v2, a2
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a3
+; CHECK-NEXT:    v_accvgpr_read_b32 v4, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
 ; CHECK-NEXT:    buffer_wbl2
 ; CHECK-NEXT:    global_atomic_cmpswap_x2 v[0:1], v[0:1], v[2:5], off offset:80 glc
 ; CHECK-NEXT:    s_waitcnt vmcnt(0)
@@ -515,8 +519,8 @@ define void @global_atomic_cmpxchg_i64_ret_v_a__v(ptr addrspace(1) %ptr) #0 {
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def v[4:5]
 ; CHECK-NEXT:    ;;#ASMEND
@@ -545,8 +549,8 @@ define void @global_atomic_cmpxchg_i64_ret_a_v__v(ptr addrspace(1) %ptr) #0 {
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
 ; CHECK-NEXT:    v_accvgpr_read_b32 v4, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def v[2:3]
 ; CHECK-NEXT:    ;;#ASMEND
@@ -661,8 +665,8 @@ define void @global_atomic_cmpxchg_i64_ret_av_a__av(ptr addrspace(1) %ptr) #0 {
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    v_accvgpr_read_b32 v2, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v3, a1
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def v[4:5]
 ; CHECK-NEXT:    ;;#ASMEND
@@ -691,8 +695,8 @@ define void @global_atomic_cmpxchg_i64_ret_a_av__av(ptr addrspace(1) %ptr) #0 {
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def a[0:1]
 ; CHECK-NEXT:    ;;#ASMEND
-; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
 ; CHECK-NEXT:    v_accvgpr_read_b32 v4, a0
+; CHECK-NEXT:    v_accvgpr_read_b32 v5, a1
 ; CHECK-NEXT:    ;;#ASMSTART
 ; CHECK-NEXT:    ; def v[2:3]
 ; CHECK-NEXT:    ;;#ASMEND

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.128bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.128bit.ll
@@ -24269,13 +24269,13 @@ define <16 x i8> @bitcast_v8bf16_to_v16i8(<8 x bfloat> %a, i32 %b) {
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr6_hi16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr10_lo16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr16_hi16
-; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr19_lo16
+; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr22_lo16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr4_hi16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr5_lo16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr7_lo16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr8_hi16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr9_lo16
-; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr21_hi16
+; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr20_hi16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr18_lo16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr12_hi16
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr13_lo16
@@ -24285,22 +24285,22 @@ define <16 x i8> @bitcast_v8bf16_to_v16i8(<8 x bfloat> %a, i32 %b) {
 ; GFX11-TRUE16-NEXT:    s_xor_b32 s0, exec_lo, s0
 ; GFX11-TRUE16-NEXT:    s_cbranch_execz .LBB108_2
 ; GFX11-TRUE16-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[18:19], 24, v[2:3]
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v15, 24, v3
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v13, 8, v3
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v9, 8, v2
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v1
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v1
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v10, 8, v0
-; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[19:20], 24, v[0:1]
+; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[18:19], 24, v[2:3]
+; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[22:23], 24, v[0:1]
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v6.h, v0.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v16.h, v0.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v4.h, v1.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v17.h, v1.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v8.h, v2.l
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v21.h, v2.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v20.h, v2.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v12.h, v3.l
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v22.h, v3.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v21.h, v3.h
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr1
 ; GFX11-TRUE16-NEXT:    ; implicit-def: $vgpr3
 ; GFX11-TRUE16-NEXT:  .LBB108_2: ; %Flow
@@ -24372,32 +24372,32 @@ define <16 x i8> @bitcast_v8bf16_to_v16i8(<8 x bfloat> %a, i32 %b) {
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v8, v8, v13, vcc_lo
 ; GFX11-TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v0, v0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[22:23], 24, v[16:17]
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v10, 8, v16
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v22, v7, v9, vcc_lo
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v21, v7, v9, vcc_lo
 ; GFX11-TRUE16-NEXT:    v_cmp_u_f32_e32 vcc_lo, v2, v2
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v22.l, v12.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v21.l, v12.h
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v7, 24, v17
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v21, v1, v3, vcc_lo
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v21.l, v8.h
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v20, v1, v3, vcc_lo
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v20.l, v8.h
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v15, 24, v22
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v13, 8, v22
-; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[18:19], 24, v[21:22]
-; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[19:20], 24, v[16:17]
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v9, 8, v21
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v15, 24, v21
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v13, 8, v21
+; GFX11-TRUE16-NEXT:    v_lshrrev_b64 v[18:19], 24, v[20:21]
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v9, 8, v20
 ; GFX11-TRUE16-NEXT:  .LBB108_4: ; %end
 ; GFX11-TRUE16-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v6.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v10.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v16.h
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v19.l
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v22.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v4.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v17.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v8.h
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v21.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v20.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v11.l, v18.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v12.l, v12.h
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v14.l, v22.h
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v14.l, v21.h
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: bitcast_v8bf16_to_v16i8:

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.160bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.160bit.ll
@@ -424,7 +424,7 @@ define <10 x i16> @bitcast_v5i32_to_v10i16(<5 x i32> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB4_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v9, s4, v8, 16
+; SI-NEXT:    v_alignbit_b32 v9, v0, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
@@ -439,7 +439,7 @@ define <10 x i16> @bitcast_v5i32_to_v10i16(<5 x i32> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v4, vcc, 3, v4
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v9, s4, v8, 16
+; SI-NEXT:    v_alignbit_b32 v9, v0, v8, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
 ; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -1634,7 +1634,7 @@ define <10 x i16> @bitcast_v5f32_to_v10i16(<5 x float> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB12_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v9, s4, v8, 16
+; SI-NEXT:    v_alignbit_b32 v9, v0, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
@@ -1649,7 +1649,7 @@ define <10 x i16> @bitcast_v5f32_to_v10i16(<5 x float> %a, i32 %b) {
 ; SI-NEXT:    v_add_f32_e32 v4, 1.0, v4
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v9, s4, v8, 16
+; SI-NEXT:    v_alignbit_b32 v9, v0, v8, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
 ; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.224bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.224bit.ll
@@ -476,7 +476,7 @@ define <14 x i16> @bitcast_v7i32_to_v14i16(<7 x i32> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB4_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v13, s4, v12, 16
+; SI-NEXT:    v_alignbit_b32 v13, v0, v12, 16
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
@@ -496,7 +496,7 @@ define <14 x i16> @bitcast_v7i32_to_v14i16(<7 x i32> %a, i32 %b) {
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v13, s4, v12, 16
+; SI-NEXT:    v_alignbit_b32 v13, v0, v12, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
 ; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
@@ -1939,7 +1939,7 @@ define <14 x i16> @bitcast_v7f32_to_v14i16(<7 x float> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB12_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v13, s4, v12, 16
+; SI-NEXT:    v_alignbit_b32 v13, v0, v12, 16
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
@@ -1959,7 +1959,7 @@ define <14 x i16> @bitcast_v7f32_to_v14i16(<7 x float> %a, i32 %b) {
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v13, s4, v12, 16
+; SI-NEXT:    v_alignbit_b32 v13, v0, v12, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
 ; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.288bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.288bit.ll
@@ -526,7 +526,7 @@ define <18 x i16> @bitcast_v9i32_to_v18i16(<9 x i32> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB4_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v17, s4, v16, 16
+; SI-NEXT:    v_alignbit_b32 v17, v0, v16, 16
 ; SI-NEXT:    v_alignbit_b32 v13, v14, v12, 16
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
@@ -551,7 +551,7 @@ define <18 x i16> @bitcast_v9i32_to_v18i16(<9 x i32> %a, i32 %b) {
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v17, s4, v16, 16
+; SI-NEXT:    v_alignbit_b32 v17, v0, v16, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
 ; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
@@ -2240,7 +2240,7 @@ define <18 x i16> @bitcast_v9f32_to_v18i16(<9 x float> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB12_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v17, s4, v16, 16
+; SI-NEXT:    v_alignbit_b32 v17, v0, v16, 16
 ; SI-NEXT:    v_alignbit_b32 v13, v14, v12, 16
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
@@ -2265,7 +2265,7 @@ define <18 x i16> @bitcast_v9f32_to_v18i16(<9 x float> %a, i32 %b) {
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v17, s4, v16, 16
+; SI-NEXT:    v_alignbit_b32 v17, v0, v16, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
 ; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.320bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.320bit.ll
@@ -20108,7 +20108,7 @@ define <5 x double> @bitcast_v20i16_to_v5f64(<20 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v5, vcc, s6, v5
 ; SI-NEXT:    v_add_i32_e32 v6, vcc, s6, v6
 ; SI-NEXT:    v_add_i32_e32 v7, vcc, s6, v7
-; SI-NEXT:    v_add_i32_e32 v8, vcc, s6, v8
+; SI-NEXT:    v_add_i32_e32 v8, vcc, 0x30000, v8
 ; SI-NEXT:    v_add_i32_e32 v9, vcc, 0x30000, v9
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -20954,7 +20954,7 @@ define <5 x i64> @bitcast_v20i16_to_v5i64(<20 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v5, vcc, s6, v5
 ; SI-NEXT:    v_add_i32_e32 v6, vcc, s6, v6
 ; SI-NEXT:    v_add_i32_e32 v7, vcc, s6, v7
-; SI-NEXT:    v_add_i32_e32 v8, vcc, s6, v8
+; SI-NEXT:    v_add_i32_e32 v8, vcc, 0x30000, v8
 ; SI-NEXT:    v_add_i32_e32 v9, vcc, 0x30000, v9
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.352bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.352bit.ll
@@ -581,7 +581,7 @@ define <22 x i16> @bitcast_v11i32_to_v22i16(<11 x i32> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB4_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v21, s4, v20, 16
+; SI-NEXT:    v_alignbit_b32 v21, v0, v20, 16
 ; SI-NEXT:    v_alignbit_b32 v17, v18, v16, 16
 ; SI-NEXT:    v_alignbit_b32 v13, v14, v12, 16
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
@@ -611,7 +611,7 @@ define <22 x i16> @bitcast_v11i32_to_v22i16(<11 x i32> %a, i32 %b) {
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v21, s4, v20, 16
+; SI-NEXT:    v_alignbit_b32 v21, v0, v20, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v18
 ; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
 ; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
@@ -2541,7 +2541,7 @@ define <22 x i16> @bitcast_v11f32_to_v22i16(<11 x float> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB12_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v21, s4, v20, 16
+; SI-NEXT:    v_alignbit_b32 v21, v0, v20, 16
 ; SI-NEXT:    v_alignbit_b32 v17, v18, v16, 16
 ; SI-NEXT:    v_alignbit_b32 v13, v14, v12, 16
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
@@ -2571,7 +2571,7 @@ define <22 x i16> @bitcast_v11f32_to_v22i16(<11 x float> %a, i32 %b) {
 ; SI-NEXT:    v_alignbit_b32 v9, v10, v8, 16
 ; SI-NEXT:    v_alignbit_b32 v5, v6, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v21, s4, v20, 16
+; SI-NEXT:    v_alignbit_b32 v21, v0, v20, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v18
 ; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
 ; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v10

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.384bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.384bit.ll
@@ -7980,7 +7980,7 @@ define <6 x double> @bitcast_v24i16_to_v6f64(<24 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v7, vcc, s6, v7
 ; SI-NEXT:    v_add_i32_e32 v8, vcc, s6, v8
 ; SI-NEXT:    v_add_i32_e32 v9, vcc, s6, v9
-; SI-NEXT:    v_add_i32_e32 v10, vcc, s6, v10
+; SI-NEXT:    v_add_i32_e32 v10, vcc, 0x30000, v10
 ; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x30000, v11
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -10034,7 +10034,7 @@ define <6 x i64> @bitcast_v24i16_to_v6i64(<24 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v7, vcc, s6, v7
 ; SI-NEXT:    v_add_i32_e32 v8, vcc, s6, v8
 ; SI-NEXT:    v_add_i32_e32 v9, vcc, s6, v9
-; SI-NEXT:    v_add_i32_e32 v10, vcc, s6, v10
+; SI-NEXT:    v_add_i32_e32 v10, vcc, 0x30000, v10
 ; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x30000, v11
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.448bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.448bit.ll
@@ -2383,7 +2383,7 @@ define <14 x i32> @bitcast_v28i16_to_v14i32(<28 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v8, vcc, s6, v8
 ; SI-NEXT:    v_add_i32_e32 v9, vcc, s6, v9
 ; SI-NEXT:    v_add_i32_e32 v10, vcc, s6, v10
-; SI-NEXT:    v_add_i32_e32 v11, vcc, s6, v11
+; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x30000, v11
 ; SI-NEXT:    v_add_i32_e32 v12, vcc, 0x30000, v12
 ; SI-NEXT:    v_add_i32_e32 v13, vcc, 0x30000, v13
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -5942,7 +5942,7 @@ define <14 x float> @bitcast_v28i16_to_v14f32(<28 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v8, vcc, s6, v8
 ; SI-NEXT:    v_add_i32_e32 v9, vcc, s6, v9
 ; SI-NEXT:    v_add_i32_e32 v10, vcc, s6, v10
-; SI-NEXT:    v_add_i32_e32 v11, vcc, s6, v11
+; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x30000, v11
 ; SI-NEXT:    v_add_i32_e32 v12, vcc, 0x30000, v12
 ; SI-NEXT:    v_add_i32_e32 v13, vcc, 0x30000, v13
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -8862,7 +8862,7 @@ define <7 x i64> @bitcast_v28i16_to_v7i64(<28 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v8, vcc, s6, v8
 ; SI-NEXT:    v_add_i32_e32 v9, vcc, s6, v9
 ; SI-NEXT:    v_add_i32_e32 v10, vcc, s6, v10
-; SI-NEXT:    v_add_i32_e32 v11, vcc, s6, v11
+; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x30000, v11
 ; SI-NEXT:    v_add_i32_e32 v12, vcc, 0x30000, v12
 ; SI-NEXT:    v_add_i32_e32 v13, vcc, 0x30000, v13
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -11188,7 +11188,7 @@ define <7 x double> @bitcast_v28i16_to_v7f64(<28 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v8, vcc, s6, v8
 ; SI-NEXT:    v_add_i32_e32 v9, vcc, s6, v9
 ; SI-NEXT:    v_add_i32_e32 v10, vcc, s6, v10
-; SI-NEXT:    v_add_i32_e32 v11, vcc, s6, v11
+; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x30000, v11
 ; SI-NEXT:    v_add_i32_e32 v12, vcc, 0x30000, v12
 ; SI-NEXT:    v_add_i32_e32 v13, vcc, 0x30000, v13
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.576bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.576bit.ll
@@ -2759,169 +2759,197 @@ define inreg <36 x i16> @bitcast_v18i32_to_v36i16_scalar(<18 x i32> inreg %a, i3
 ; SI-LABEL: bitcast_v18i32_to_v36i16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v6, s16
+; SI-NEXT:    v_mov_b32_e32 v7, s17
+; SI-NEXT:    v_mov_b32_e32 v8, s18
+; SI-NEXT:    v_mov_b32_e32 v9, s19
+; SI-NEXT:    v_mov_b32_e32 v10, s20
+; SI-NEXT:    v_mov_b32_e32 v11, s21
+; SI-NEXT:    v_mov_b32_e32 v12, s22
+; SI-NEXT:    v_mov_b32_e32 v13, s23
+; SI-NEXT:    v_mov_b32_e32 v14, s24
+; SI-NEXT:    v_mov_b32_e32 v15, s25
+; SI-NEXT:    v_mov_b32_e32 v16, s26
+; SI-NEXT:    v_mov_b32_e32 v17, s27
+; SI-NEXT:    v_mov_b32_e32 v18, s28
+; SI-NEXT:    v_mov_b32_e32 v19, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; SI-NEXT:    v_readfirstlane_b32 s20, v6
+; SI-NEXT:    v_readfirstlane_b32 s21, v7
+; SI-NEXT:    v_readfirstlane_b32 s18, v8
+; SI-NEXT:    v_readfirstlane_b32 s19, v9
+; SI-NEXT:    v_readfirstlane_b32 s16, v10
+; SI-NEXT:    v_readfirstlane_b32 s17, v11
+; SI-NEXT:    v_readfirstlane_b32 s14, v12
+; SI-NEXT:    v_readfirstlane_b32 s15, v13
+; SI-NEXT:    v_readfirstlane_b32 s12, v14
+; SI-NEXT:    v_readfirstlane_b32 s13, v15
+; SI-NEXT:    v_readfirstlane_b32 s10, v16
+; SI-NEXT:    v_readfirstlane_b32 s11, v17
+; SI-NEXT:    v_readfirstlane_b32 s8, v18
+; SI-NEXT:    v_readfirstlane_b32 s9, v19
 ; SI-NEXT:    v_readfirstlane_b32 s6, v1
 ; SI-NEXT:    v_readfirstlane_b32 s7, v2
 ; SI-NEXT:    v_readfirstlane_b32 s4, v3
-; SI-NEXT:    s_and_b64 s[8:9], vcc, exec
+; SI-NEXT:    s_and_b64 s[22:23], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v4
 ; SI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s60, s5, 16
 ; SI-NEXT:    s_lshr_b32 s61, s7, 16
-; SI-NEXT:    s_lshr_b32 s62, s29, 16
-; SI-NEXT:    s_lshr_b32 s63, s27, 16
-; SI-NEXT:    s_lshr_b32 s72, s25, 16
-; SI-NEXT:    s_lshr_b32 s73, s23, 16
-; SI-NEXT:    s_lshr_b32 s74, s21, 16
+; SI-NEXT:    s_lshr_b32 s62, s9, 16
+; SI-NEXT:    s_lshr_b32 s63, s11, 16
+; SI-NEXT:    s_lshr_b32 s72, s13, 16
+; SI-NEXT:    s_lshr_b32 s73, s15, 16
+; SI-NEXT:    s_lshr_b32 s74, s17, 16
 ; SI-NEXT:    s_lshr_b32 s75, s19, 16
-; SI-NEXT:    s_lshr_b32 s76, s17, 16
-; SI-NEXT:    s_lshr_b64 s[8:9], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[10:11], s[6:7], 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[20:21], 16
+; SI-NEXT:    s_lshr_b32 s76, s21, 16
+; SI-NEXT:    s_lshr_b64 s[22:23], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[24:25], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[8:9], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[10:11], 16
+; SI-NEXT:    s_lshr_b64 s[40:41], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[42:43], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[16:17], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[20:21], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB13_3
 ; SI-NEXT:  .LBB13_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
 ; SI-NEXT:    s_add_i32 s21, s21, 3
 ; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s23, s23, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
-; SI-NEXT:    s_add_i32 s25, s25, 3
-; SI-NEXT:    s_add_i32 s24, s24, 3
-; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s26, s26, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
+; SI-NEXT:    s_add_i32 s15, s15, 3
+; SI-NEXT:    s_add_i32 s14, s14, 3
+; SI-NEXT:    s_add_i32 s13, s13, 3
+; SI-NEXT:    s_add_i32 s12, s12, 3
+; SI-NEXT:    s_add_i32 s11, s11, 3
+; SI-NEXT:    s_add_i32 s10, s10, 3
+; SI-NEXT:    s_add_i32 s9, s9, 3
+; SI-NEXT:    s_add_i32 s8, s8, 3
 ; SI-NEXT:    s_add_i32 s7, s7, 3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s5, s5, 3
 ; SI-NEXT:    s_add_i32 s4, s4, 3
-; SI-NEXT:    s_lshr_b64 s[8:9], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[10:11], s[6:7], 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[22:23], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[24:25], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[8:9], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[10:11], 16
+; SI-NEXT:    s_lshr_b64 s[40:41], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[42:43], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[16:17], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[20:21], 16
 ; SI-NEXT:    s_lshr_b32 s60, s5, 16
 ; SI-NEXT:    s_lshr_b32 s61, s7, 16
-; SI-NEXT:    s_lshr_b32 s62, s29, 16
-; SI-NEXT:    s_lshr_b32 s63, s27, 16
-; SI-NEXT:    s_lshr_b32 s72, s25, 16
-; SI-NEXT:    s_lshr_b32 s73, s23, 16
-; SI-NEXT:    s_lshr_b32 s74, s21, 16
+; SI-NEXT:    s_lshr_b32 s62, s9, 16
+; SI-NEXT:    s_lshr_b32 s63, s11, 16
+; SI-NEXT:    s_lshr_b32 s72, s13, 16
+; SI-NEXT:    s_lshr_b32 s73, s15, 16
+; SI-NEXT:    s_lshr_b32 s74, s17, 16
 ; SI-NEXT:    s_lshr_b32 s75, s19, 16
-; SI-NEXT:    s_lshr_b32 s76, s17, 16
+; SI-NEXT:    s_lshr_b32 s76, s21, 16
 ; SI-NEXT:  .LBB13_3: ; %end
-; SI-NEXT:    s_lshl_b32 s9, s56, 16
-; SI-NEXT:    s_and_b32 s11, s16, 0xffff
-; SI-NEXT:    s_or_b32 s9, s11, s9
-; SI-NEXT:    v_mov_b32_e32 v1, s9
-; SI-NEXT:    s_and_b32 s9, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s76, 16
-; SI-NEXT:    s_or_b32 s9, s9, s11
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s18, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s46, 16
+; SI-NEXT:    s_lshl_b32 s23, s56, 16
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_or_b32 s20, s20, s23
+; SI-NEXT:    v_mov_b32_e32 v1, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s76, 16
+; SI-NEXT:    s_or_b32 s20, s20, s21
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s46, 16
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s75, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s75, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s20, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s44, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s44, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s74, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
+; SI-NEXT:    s_lshl_b32 s17, s74, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s16, s16, s17
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s42, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s14, s14, 0xffff
+; SI-NEXT:    s_lshl_b32 s16, s42, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s14, s14, s16
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s73, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s14, s15, 0xffff
+; SI-NEXT:    s_lshl_b32 s15, s73, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s14, s14, s15
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s40, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s12, s12, 0xffff
+; SI-NEXT:    s_lshl_b32 s14, s40, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s12, s12, s14
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s12, s13, 0xffff
+; SI-NEXT:    s_lshl_b32 s13, s72, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s12, s12, s13
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s14, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s10, s10, 0xffff
+; SI-NEXT:    s_lshl_b32 s12, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s10, s10, s12
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s27, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v2, s10
+; SI-NEXT:    s_and_b32 s10, s11, 0xffff
 ; SI-NEXT:    s_lshl_b32 s11, s63, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s10, s10, s11
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s12, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s10
+; SI-NEXT:    s_and_b32 s8, s8, 0xffff
+; SI-NEXT:    s_lshl_b32 s10, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s8, s8, s10
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s62, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s8
+; SI-NEXT:    s_and_b32 s8, s9, 0xffff
+; SI-NEXT:    s_lshl_b32 s9, s62, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s8, s8, s9
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
+; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s9, s10, 16
+; SI-NEXT:    s_lshl_b32 s8, s24, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s6, s6, s9
+; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
@@ -2933,7 +2961,7 @@ define inreg <36 x i16> @bitcast_v18i32_to_v36i16_scalar(<18 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s8, 16
+; SI-NEXT:    s_lshl_b32 s6, s22, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 60, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -2960,20 +2988,48 @@ define inreg <36 x i16> @bitcast_v18i32_to_v36i16_scalar(<18 x i32> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr73
 ; SI-NEXT:    ; implicit-def: $sgpr40
 ; SI-NEXT:    ; implicit-def: $sgpr72
-; SI-NEXT:    ; implicit-def: $sgpr14
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr63
-; SI-NEXT:    ; implicit-def: $sgpr12
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr62
-; SI-NEXT:    ; implicit-def: $sgpr10
+; SI-NEXT:    ; implicit-def: $sgpr24
 ; SI-NEXT:    ; implicit-def: $sgpr61
-; SI-NEXT:    ; implicit-def: $sgpr8
+; SI-NEXT:    ; implicit-def: $sgpr22
 ; SI-NEXT:    ; implicit-def: $sgpr60
 ; SI-NEXT:    s_branch .LBB13_2
 ;
 ; VI-LABEL: bitcast_v18i32_to_v36i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v5, s16
+; VI-NEXT:    v_mov_b32_e32 v6, s17
+; VI-NEXT:    v_mov_b32_e32 v7, s18
+; VI-NEXT:    v_mov_b32_e32 v8, s19
+; VI-NEXT:    v_mov_b32_e32 v9, s20
+; VI-NEXT:    v_mov_b32_e32 v10, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s23
+; VI-NEXT:    v_mov_b32_e32 v13, s24
+; VI-NEXT:    v_mov_b32_e32 v14, s25
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_mov_b32_e32 v16, s27
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; VI-NEXT:    v_readfirstlane_b32 s23, v5
+; VI-NEXT:    v_readfirstlane_b32 s22, v6
+; VI-NEXT:    v_readfirstlane_b32 s21, v7
+; VI-NEXT:    v_readfirstlane_b32 s20, v8
+; VI-NEXT:    v_readfirstlane_b32 s19, v9
+; VI-NEXT:    v_readfirstlane_b32 s18, v10
+; VI-NEXT:    v_readfirstlane_b32 s17, v11
+; VI-NEXT:    v_readfirstlane_b32 s16, v12
+; VI-NEXT:    v_readfirstlane_b32 s15, v13
+; VI-NEXT:    v_readfirstlane_b32 s14, v14
+; VI-NEXT:    v_readfirstlane_b32 s13, v15
+; VI-NEXT:    v_readfirstlane_b32 s12, v16
+; VI-NEXT:    v_readfirstlane_b32 s11, v17
+; VI-NEXT:    v_readfirstlane_b32 s10, v18
 ; VI-NEXT:    v_readfirstlane_b32 s9, v0
 ; VI-NEXT:    v_readfirstlane_b32 s8, v1
 ; VI-NEXT:    v_readfirstlane_b32 s6, v2
@@ -2981,131 +3037,131 @@ define inreg <36 x i16> @bitcast_v18i32_to_v36i16_scalar(<18 x i32> inreg %a, i3
 ; VI-NEXT:    v_readfirstlane_b32 s7, v3
 ; VI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s10, s7, 16
-; VI-NEXT:    s_lshr_b32 s11, s6, 16
-; VI-NEXT:    s_lshr_b32 s12, s8, 16
-; VI-NEXT:    s_lshr_b32 s13, s9, 16
-; VI-NEXT:    s_lshr_b32 s14, s29, 16
-; VI-NEXT:    s_lshr_b32 s15, s28, 16
-; VI-NEXT:    s_lshr_b32 s40, s27, 16
-; VI-NEXT:    s_lshr_b32 s41, s26, 16
-; VI-NEXT:    s_lshr_b32 s42, s25, 16
-; VI-NEXT:    s_lshr_b32 s43, s24, 16
-; VI-NEXT:    s_lshr_b32 s44, s23, 16
-; VI-NEXT:    s_lshr_b32 s45, s22, 16
-; VI-NEXT:    s_lshr_b32 s46, s21, 16
-; VI-NEXT:    s_lshr_b32 s47, s20, 16
-; VI-NEXT:    s_lshr_b32 s56, s19, 16
-; VI-NEXT:    s_lshr_b32 s57, s18, 16
-; VI-NEXT:    s_lshr_b32 s58, s17, 16
-; VI-NEXT:    s_lshr_b32 s59, s16, 16
+; VI-NEXT:    s_lshr_b32 s24, s7, 16
+; VI-NEXT:    s_lshr_b32 s25, s6, 16
+; VI-NEXT:    s_lshr_b32 s26, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s9, 16
+; VI-NEXT:    s_lshr_b32 s28, s10, 16
+; VI-NEXT:    s_lshr_b32 s29, s11, 16
+; VI-NEXT:    s_lshr_b32 s40, s12, 16
+; VI-NEXT:    s_lshr_b32 s41, s13, 16
+; VI-NEXT:    s_lshr_b32 s42, s14, 16
+; VI-NEXT:    s_lshr_b32 s43, s15, 16
+; VI-NEXT:    s_lshr_b32 s44, s16, 16
+; VI-NEXT:    s_lshr_b32 s45, s17, 16
+; VI-NEXT:    s_lshr_b32 s46, s18, 16
+; VI-NEXT:    s_lshr_b32 s47, s19, 16
+; VI-NEXT:    s_lshr_b32 s56, s20, 16
+; VI-NEXT:    s_lshr_b32 s57, s21, 16
+; VI-NEXT:    s_lshr_b32 s58, s22, 16
+; VI-NEXT:    s_lshr_b32 s59, s23, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB13_3
 ; VI-NEXT:  .LBB13_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
 ; VI-NEXT:    s_add_i32 s6, s6, 3
 ; VI-NEXT:    s_add_i32 s8, s8, 3
 ; VI-NEXT:    s_add_i32 s9, s9, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s10, s10, 3
+; VI-NEXT:    s_add_i32 s11, s11, 3
+; VI-NEXT:    s_add_i32 s12, s12, 3
+; VI-NEXT:    s_add_i32 s13, s13, 3
+; VI-NEXT:    s_add_i32 s14, s14, 3
+; VI-NEXT:    s_add_i32 s15, s15, 3
 ; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s10, s7, 16
-; VI-NEXT:    s_lshr_b32 s11, s6, 16
-; VI-NEXT:    s_lshr_b32 s12, s8, 16
-; VI-NEXT:    s_lshr_b32 s13, s9, 16
-; VI-NEXT:    s_lshr_b32 s14, s29, 16
-; VI-NEXT:    s_lshr_b32 s15, s28, 16
-; VI-NEXT:    s_lshr_b32 s40, s27, 16
-; VI-NEXT:    s_lshr_b32 s41, s26, 16
-; VI-NEXT:    s_lshr_b32 s42, s25, 16
-; VI-NEXT:    s_lshr_b32 s43, s24, 16
-; VI-NEXT:    s_lshr_b32 s44, s23, 16
-; VI-NEXT:    s_lshr_b32 s45, s22, 16
-; VI-NEXT:    s_lshr_b32 s46, s21, 16
-; VI-NEXT:    s_lshr_b32 s47, s20, 16
-; VI-NEXT:    s_lshr_b32 s56, s19, 16
-; VI-NEXT:    s_lshr_b32 s57, s18, 16
-; VI-NEXT:    s_lshr_b32 s58, s17, 16
-; VI-NEXT:    s_lshr_b32 s59, s16, 16
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_lshr_b32 s24, s7, 16
+; VI-NEXT:    s_lshr_b32 s25, s6, 16
+; VI-NEXT:    s_lshr_b32 s26, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s9, 16
+; VI-NEXT:    s_lshr_b32 s28, s10, 16
+; VI-NEXT:    s_lshr_b32 s29, s11, 16
+; VI-NEXT:    s_lshr_b32 s40, s12, 16
+; VI-NEXT:    s_lshr_b32 s41, s13, 16
+; VI-NEXT:    s_lshr_b32 s42, s14, 16
+; VI-NEXT:    s_lshr_b32 s43, s15, 16
+; VI-NEXT:    s_lshr_b32 s44, s16, 16
+; VI-NEXT:    s_lshr_b32 s45, s17, 16
+; VI-NEXT:    s_lshr_b32 s46, s18, 16
+; VI-NEXT:    s_lshr_b32 s47, s19, 16
+; VI-NEXT:    s_lshr_b32 s56, s20, 16
+; VI-NEXT:    s_lshr_b32 s57, s21, 16
+; VI-NEXT:    s_lshr_b32 s58, s22, 16
+; VI-NEXT:    s_lshr_b32 s59, s23, 16
 ; VI-NEXT:  .LBB13_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s23
 ; VI-NEXT:    s_lshl_b32 s5, s59, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s58, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s57, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s56, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s47, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s46, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s45, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s44, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s22, s58, 16
+; VI-NEXT:    s_or_b32 s5, s5, s22
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s22, s57, 16
 ; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s43, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s42, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s41, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s40, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
-; VI-NEXT:    s_or_b32 s15, s26, s15
-; VI-NEXT:    s_and_b32 s26, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s22, s56, 16
+; VI-NEXT:    s_or_b32 s20, s20, s22
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s22, s47, 16
+; VI-NEXT:    s_or_b32 s19, s19, s22
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s22, s46, 16
+; VI-NEXT:    s_or_b32 s18, s18, s22
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s22, s45, 16
+; VI-NEXT:    s_or_b32 s17, s17, s22
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s22, s44, 16
+; VI-NEXT:    s_or_b32 s16, s16, s22
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s22, s43, 16
+; VI-NEXT:    s_or_b32 s15, s15, s22
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s22, s42, 16
+; VI-NEXT:    s_or_b32 s14, s14, s22
+; VI-NEXT:    s_and_b32 s13, 0xffff, s13
+; VI-NEXT:    s_lshl_b32 s22, s41, 16
+; VI-NEXT:    s_or_b32 s13, s13, s22
+; VI-NEXT:    s_and_b32 s12, 0xffff, s12
+; VI-NEXT:    s_lshl_b32 s22, s40, 16
+; VI-NEXT:    s_or_b32 s12, s12, s22
+; VI-NEXT:    s_and_b32 s11, 0xffff, s11
+; VI-NEXT:    s_lshl_b32 s22, s29, 16
+; VI-NEXT:    s_or_b32 s11, s11, s22
+; VI-NEXT:    s_and_b32 s10, 0xffff, s10
+; VI-NEXT:    s_lshl_b32 s22, s28, 16
+; VI-NEXT:    s_or_b32 s10, s10, s22
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s13, s13, 16
+; VI-NEXT:    s_lshl_b32 s22, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s22
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s12, s12, 16
+; VI-NEXT:    s_lshl_b32 s22, s26, 16
+; VI-NEXT:    s_or_b32 s8, s8, s22
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s11, s11, 16
+; VI-NEXT:    s_lshl_b32 s22, s25, 16
+; VI-NEXT:    s_or_b32 s6, s6, s22
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s10, s10, 16
-; VI-NEXT:    s_or_b32 s14, s26, s14
-; VI-NEXT:    s_or_b32 s9, s9, s13
-; VI-NEXT:    s_or_b32 s8, s8, s12
-; VI-NEXT:    s_or_b32 s6, s6, s11
-; VI-NEXT:    s_or_b32 s7, s7, s10
+; VI-NEXT:    s_lshl_b32 s22, s24, 16
+; VI-NEXT:    s_or_b32 s7, s7, s22
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s15
-; VI-NEXT:    v_mov_b32_e32 v13, s14
+; VI-NEXT:    v_mov_b32_e32 v2, s21
+; VI-NEXT:    v_mov_b32_e32 v3, s20
+; VI-NEXT:    v_mov_b32_e32 v4, s19
+; VI-NEXT:    v_mov_b32_e32 v5, s18
+; VI-NEXT:    v_mov_b32_e32 v6, s17
+; VI-NEXT:    v_mov_b32_e32 v7, s16
+; VI-NEXT:    v_mov_b32_e32 v8, s15
+; VI-NEXT:    v_mov_b32_e32 v9, s14
+; VI-NEXT:    v_mov_b32_e32 v10, s13
+; VI-NEXT:    v_mov_b32_e32 v11, s12
+; VI-NEXT:    v_mov_b32_e32 v12, s11
+; VI-NEXT:    v_mov_b32_e32 v13, s10
 ; VI-NEXT:    v_mov_b32_e32 v14, s9
 ; VI-NEXT:    v_mov_b32_e32 v15, s8
 ; VI-NEXT:    v_mov_b32_e32 v16, s6
@@ -3124,55 +3180,73 @@ define inreg <36 x i16> @bitcast_v18i32_to_v36i16_scalar(<18 x i32> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
 ; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
-; VI-NEXT:    ; implicit-def: $sgpr13
-; VI-NEXT:    ; implicit-def: $sgpr12
-; VI-NEXT:    ; implicit-def: $sgpr11
-; VI-NEXT:    ; implicit-def: $sgpr10
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
+; VI-NEXT:    ; implicit-def: $sgpr26
+; VI-NEXT:    ; implicit-def: $sgpr25
+; VI-NEXT:    ; implicit-def: $sgpr24
 ; VI-NEXT:    s_branch .LBB13_2
 ;
 ; GFX9-LABEL: bitcast_v18i32_to_v36i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v5, s16
+; GFX9-NEXT:    v_mov_b32_e32 v6, s17
+; GFX9-NEXT:    v_mov_b32_e32 v7, s18
+; GFX9-NEXT:    v_mov_b32_e32 v8, s19
+; GFX9-NEXT:    v_mov_b32_e32 v9, s20
+; GFX9-NEXT:    v_mov_b32_e32 v10, s21
+; GFX9-NEXT:    v_mov_b32_e32 v11, s22
+; GFX9-NEXT:    v_mov_b32_e32 v12, s23
+; GFX9-NEXT:    v_mov_b32_e32 v13, s24
+; GFX9-NEXT:    v_mov_b32_e32 v14, s25
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s10, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s11, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s24, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s25, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB13_3
 ; GFX9-NEXT:  .LBB13_2: ; %cmp.true
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
-; GFX9-NEXT:    s_add_i32 s29, s29, 3
-; GFX9-NEXT:    s_add_i32 s28, s28, 3
-; GFX9-NEXT:    s_add_i32 s27, s27, 3
-; GFX9-NEXT:    s_add_i32 s26, s26, 3
-; GFX9-NEXT:    s_add_i32 s25, s25, 3
-; GFX9-NEXT:    s_add_i32 s24, s24, 3
 ; GFX9-NEXT:    s_add_i32 s23, s23, 3
 ; GFX9-NEXT:    s_add_i32 s22, s22, 3
 ; GFX9-NEXT:    s_add_i32 s21, s21, 3
@@ -3181,61 +3255,71 @@ define inreg <36 x i16> @bitcast_v18i32_to_v36i16_scalar(<18 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
-; GFX9-NEXT:    s_lshr_b32 s10, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s11, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s16, 16
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
+; GFX9-NEXT:    s_lshr_b32 s24, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s25, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s6, 16
 ; GFX9-NEXT:  .LBB13_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s28, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s29, s14
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s13
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s12
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s11
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s10
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s28
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s27
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s26
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s25
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s24
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s15
-; GFX9-NEXT:    v_mov_b32_e32 v13, s14
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB13_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr59
@@ -3250,12 +3334,12 @@ define inreg <36 x i16> @bitcast_v18i32_to_v36i16_scalar(<18 x i32> inreg %a, i3
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
-; GFX9-NEXT:    ; implicit-def: $sgpr13
-; GFX9-NEXT:    ; implicit-def: $sgpr12
-; GFX9-NEXT:    ; implicit-def: $sgpr11
-; GFX9-NEXT:    ; implicit-def: $sgpr10
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
+; GFX9-NEXT:    ; implicit-def: $sgpr27
+; GFX9-NEXT:    ; implicit-def: $sgpr26
+; GFX9-NEXT:    ; implicit-def: $sgpr25
+; GFX9-NEXT:    ; implicit-def: $sgpr24
 ; GFX9-NEXT:    s_branch .LBB13_2
 ;
 ; GFX11-LABEL: bitcast_v18i32_to_v36i16_scalar:
@@ -5438,7 +5522,35 @@ define inreg <36 x half> @bitcast_v18i32_to_v36f16_scalar(<18 x i32> inreg %a, i
 ; SI-LABEL: bitcast_v18i32_to_v36f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v6, s16
+; SI-NEXT:    v_mov_b32_e32 v7, s17
+; SI-NEXT:    v_mov_b32_e32 v8, s18
+; SI-NEXT:    v_mov_b32_e32 v9, s19
+; SI-NEXT:    v_mov_b32_e32 v10, s20
+; SI-NEXT:    v_mov_b32_e32 v11, s21
+; SI-NEXT:    v_mov_b32_e32 v12, s22
+; SI-NEXT:    v_mov_b32_e32 v13, s23
+; SI-NEXT:    v_mov_b32_e32 v14, s24
+; SI-NEXT:    v_mov_b32_e32 v15, s25
+; SI-NEXT:    v_mov_b32_e32 v16, s26
+; SI-NEXT:    v_mov_b32_e32 v17, s27
+; SI-NEXT:    v_mov_b32_e32 v18, s28
+; SI-NEXT:    v_mov_b32_e32 v19, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; SI-NEXT:    v_readfirstlane_b32 s23, v6
+; SI-NEXT:    v_readfirstlane_b32 s22, v7
+; SI-NEXT:    v_readfirstlane_b32 s21, v8
+; SI-NEXT:    v_readfirstlane_b32 s20, v9
+; SI-NEXT:    v_readfirstlane_b32 s19, v10
+; SI-NEXT:    v_readfirstlane_b32 s18, v11
+; SI-NEXT:    v_readfirstlane_b32 s17, v12
+; SI-NEXT:    v_readfirstlane_b32 s16, v13
+; SI-NEXT:    v_readfirstlane_b32 s15, v14
+; SI-NEXT:    v_readfirstlane_b32 s14, v15
+; SI-NEXT:    v_readfirstlane_b32 s13, v16
+; SI-NEXT:    v_readfirstlane_b32 s12, v17
+; SI-NEXT:    v_readfirstlane_b32 s11, v18
+; SI-NEXT:    v_readfirstlane_b32 s10, v19
 ; SI-NEXT:    v_readfirstlane_b32 s8, v1
 ; SI-NEXT:    v_readfirstlane_b32 s7, v2
 ; SI-NEXT:    v_readfirstlane_b32 s6, v3
@@ -5454,86 +5566,86 @@ define inreg <36 x half> @bitcast_v18i32_to_v36f16_scalar(<18 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s4
 ; SI-NEXT:    s_lshr_b32 s4, s8, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v6, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s10, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v8, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    s_lshr_b32 s4, s11, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v10, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    s_lshr_b32 s4, s12, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    s_lshr_b32 s4, s13, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
 ; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, s4
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s9
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
 ; SI-NEXT:    v_cvt_f32_f16_e32 v7, s7
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, s10
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, s11
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, s13
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s23
 ; SI-NEXT:    s_cbranch_execnz .LBB17_3
 ; SI-NEXT:  .LBB17_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
 ; SI-NEXT:    s_add_i32 s23, s23, 3
-; SI-NEXT:    s_add_i32 s24, s24, 3
-; SI-NEXT:    s_add_i32 s25, s25, 3
-; SI-NEXT:    s_add_i32 s26, s26, 3
-; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
+; SI-NEXT:    s_add_i32 s15, s15, 3
+; SI-NEXT:    s_add_i32 s14, s14, 3
+; SI-NEXT:    s_add_i32 s13, s13, 3
+; SI-NEXT:    s_add_i32 s12, s12, 3
+; SI-NEXT:    s_add_i32 s11, s11, 3
+; SI-NEXT:    s_add_i32 s10, s10, 3
 ; SI-NEXT:    s_add_i32 s8, s8, 3
 ; SI-NEXT:    s_add_i32 s7, s7, 3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s9, s9, 3
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    s_lshr_b32 s5, s17, 16
-; SI-NEXT:    s_lshr_b32 s10, s18, 16
-; SI-NEXT:    s_lshr_b32 s11, s19, 16
-; SI-NEXT:    s_lshr_b32 s12, s20, 16
-; SI-NEXT:    s_lshr_b32 s13, s21, 16
-; SI-NEXT:    s_lshr_b32 s14, s22, 16
-; SI-NEXT:    s_lshr_b32 s15, s23, 16
-; SI-NEXT:    s_lshr_b32 s40, s24, 16
-; SI-NEXT:    s_lshr_b32 s41, s25, 16
-; SI-NEXT:    s_lshr_b32 s42, s26, 16
-; SI-NEXT:    s_lshr_b32 s43, s27, 16
-; SI-NEXT:    s_lshr_b32 s44, s28, 16
-; SI-NEXT:    s_lshr_b32 s45, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    s_lshr_b32 s5, s22, 16
+; SI-NEXT:    s_lshr_b32 s24, s21, 16
+; SI-NEXT:    s_lshr_b32 s25, s20, 16
+; SI-NEXT:    s_lshr_b32 s26, s19, 16
+; SI-NEXT:    s_lshr_b32 s27, s18, 16
+; SI-NEXT:    s_lshr_b32 s28, s17, 16
+; SI-NEXT:    s_lshr_b32 s29, s16, 16
+; SI-NEXT:    s_lshr_b32 s40, s15, 16
+; SI-NEXT:    s_lshr_b32 s41, s14, 16
+; SI-NEXT:    s_lshr_b32 s42, s13, 16
+; SI-NEXT:    s_lshr_b32 s43, s12, 16
+; SI-NEXT:    s_lshr_b32 s44, s11, 16
+; SI-NEXT:    s_lshr_b32 s45, s10, 16
 ; SI-NEXT:    s_lshr_b32 s46, s8, 16
 ; SI-NEXT:    s_lshr_b32 s47, s7, 16
 ; SI-NEXT:    s_lshr_b32 s56, s6, 16
@@ -5542,20 +5654,20 @@ define inreg <36 x half> @bitcast_v18i32_to_v36f16_scalar(<18 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
 ; SI-NEXT:    v_cvt_f32_f16_e32 v7, s7
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, s10
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, s11
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, s13
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s23
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s57
 ; SI-NEXT:    v_cvt_f32_f16_e32 v2, s56
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s47
@@ -5566,12 +5678,12 @@ define inreg <36 x half> @bitcast_v18i32_to_v36f16_scalar(<18 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s42
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s41
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s10
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s24
 ; SI-NEXT:    v_cvt_f32_f16_e32 v34, s5
 ; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
 ; SI-NEXT:  .LBB17_3: ; %end
@@ -5743,7 +5855,35 @@ define inreg <36 x half> @bitcast_v18i32_to_v36f16_scalar(<18 x i32> inreg %a, i
 ; VI-LABEL: bitcast_v18i32_to_v36f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v5, s16
+; VI-NEXT:    v_mov_b32_e32 v6, s17
+; VI-NEXT:    v_mov_b32_e32 v7, s18
+; VI-NEXT:    v_mov_b32_e32 v8, s19
+; VI-NEXT:    v_mov_b32_e32 v9, s20
+; VI-NEXT:    v_mov_b32_e32 v10, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s23
+; VI-NEXT:    v_mov_b32_e32 v13, s24
+; VI-NEXT:    v_mov_b32_e32 v14, s25
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_mov_b32_e32 v16, s27
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; VI-NEXT:    v_readfirstlane_b32 s23, v5
+; VI-NEXT:    v_readfirstlane_b32 s22, v6
+; VI-NEXT:    v_readfirstlane_b32 s21, v7
+; VI-NEXT:    v_readfirstlane_b32 s20, v8
+; VI-NEXT:    v_readfirstlane_b32 s19, v9
+; VI-NEXT:    v_readfirstlane_b32 s18, v10
+; VI-NEXT:    v_readfirstlane_b32 s17, v11
+; VI-NEXT:    v_readfirstlane_b32 s16, v12
+; VI-NEXT:    v_readfirstlane_b32 s15, v13
+; VI-NEXT:    v_readfirstlane_b32 s14, v14
+; VI-NEXT:    v_readfirstlane_b32 s13, v15
+; VI-NEXT:    v_readfirstlane_b32 s12, v16
+; VI-NEXT:    v_readfirstlane_b32 s11, v17
+; VI-NEXT:    v_readfirstlane_b32 s10, v18
 ; VI-NEXT:    v_readfirstlane_b32 s9, v0
 ; VI-NEXT:    v_readfirstlane_b32 s8, v1
 ; VI-NEXT:    v_readfirstlane_b32 s6, v2
@@ -5751,131 +5891,131 @@ define inreg <36 x half> @bitcast_v18i32_to_v36f16_scalar(<18 x i32> inreg %a, i
 ; VI-NEXT:    v_readfirstlane_b32 s7, v3
 ; VI-NEXT:    s_cbranch_scc0 .LBB17_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s10, s7, 16
-; VI-NEXT:    s_lshr_b32 s11, s6, 16
-; VI-NEXT:    s_lshr_b32 s12, s8, 16
-; VI-NEXT:    s_lshr_b32 s13, s9, 16
-; VI-NEXT:    s_lshr_b32 s14, s29, 16
-; VI-NEXT:    s_lshr_b32 s15, s28, 16
-; VI-NEXT:    s_lshr_b32 s40, s27, 16
-; VI-NEXT:    s_lshr_b32 s41, s26, 16
-; VI-NEXT:    s_lshr_b32 s42, s25, 16
-; VI-NEXT:    s_lshr_b32 s43, s24, 16
-; VI-NEXT:    s_lshr_b32 s44, s23, 16
-; VI-NEXT:    s_lshr_b32 s45, s22, 16
-; VI-NEXT:    s_lshr_b32 s46, s21, 16
-; VI-NEXT:    s_lshr_b32 s47, s20, 16
-; VI-NEXT:    s_lshr_b32 s56, s19, 16
-; VI-NEXT:    s_lshr_b32 s57, s18, 16
-; VI-NEXT:    s_lshr_b32 s58, s17, 16
-; VI-NEXT:    s_lshr_b32 s59, s16, 16
+; VI-NEXT:    s_lshr_b32 s24, s7, 16
+; VI-NEXT:    s_lshr_b32 s25, s6, 16
+; VI-NEXT:    s_lshr_b32 s26, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s9, 16
+; VI-NEXT:    s_lshr_b32 s28, s10, 16
+; VI-NEXT:    s_lshr_b32 s29, s11, 16
+; VI-NEXT:    s_lshr_b32 s40, s12, 16
+; VI-NEXT:    s_lshr_b32 s41, s13, 16
+; VI-NEXT:    s_lshr_b32 s42, s14, 16
+; VI-NEXT:    s_lshr_b32 s43, s15, 16
+; VI-NEXT:    s_lshr_b32 s44, s16, 16
+; VI-NEXT:    s_lshr_b32 s45, s17, 16
+; VI-NEXT:    s_lshr_b32 s46, s18, 16
+; VI-NEXT:    s_lshr_b32 s47, s19, 16
+; VI-NEXT:    s_lshr_b32 s56, s20, 16
+; VI-NEXT:    s_lshr_b32 s57, s21, 16
+; VI-NEXT:    s_lshr_b32 s58, s22, 16
+; VI-NEXT:    s_lshr_b32 s59, s23, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB17_3
 ; VI-NEXT:  .LBB17_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
 ; VI-NEXT:    s_add_i32 s6, s6, 3
 ; VI-NEXT:    s_add_i32 s8, s8, 3
 ; VI-NEXT:    s_add_i32 s9, s9, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s10, s10, 3
+; VI-NEXT:    s_add_i32 s11, s11, 3
+; VI-NEXT:    s_add_i32 s12, s12, 3
+; VI-NEXT:    s_add_i32 s13, s13, 3
+; VI-NEXT:    s_add_i32 s14, s14, 3
+; VI-NEXT:    s_add_i32 s15, s15, 3
 ; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s10, s7, 16
-; VI-NEXT:    s_lshr_b32 s11, s6, 16
-; VI-NEXT:    s_lshr_b32 s12, s8, 16
-; VI-NEXT:    s_lshr_b32 s13, s9, 16
-; VI-NEXT:    s_lshr_b32 s14, s29, 16
-; VI-NEXT:    s_lshr_b32 s15, s28, 16
-; VI-NEXT:    s_lshr_b32 s40, s27, 16
-; VI-NEXT:    s_lshr_b32 s41, s26, 16
-; VI-NEXT:    s_lshr_b32 s42, s25, 16
-; VI-NEXT:    s_lshr_b32 s43, s24, 16
-; VI-NEXT:    s_lshr_b32 s44, s23, 16
-; VI-NEXT:    s_lshr_b32 s45, s22, 16
-; VI-NEXT:    s_lshr_b32 s46, s21, 16
-; VI-NEXT:    s_lshr_b32 s47, s20, 16
-; VI-NEXT:    s_lshr_b32 s56, s19, 16
-; VI-NEXT:    s_lshr_b32 s57, s18, 16
-; VI-NEXT:    s_lshr_b32 s58, s17, 16
-; VI-NEXT:    s_lshr_b32 s59, s16, 16
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_lshr_b32 s24, s7, 16
+; VI-NEXT:    s_lshr_b32 s25, s6, 16
+; VI-NEXT:    s_lshr_b32 s26, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s9, 16
+; VI-NEXT:    s_lshr_b32 s28, s10, 16
+; VI-NEXT:    s_lshr_b32 s29, s11, 16
+; VI-NEXT:    s_lshr_b32 s40, s12, 16
+; VI-NEXT:    s_lshr_b32 s41, s13, 16
+; VI-NEXT:    s_lshr_b32 s42, s14, 16
+; VI-NEXT:    s_lshr_b32 s43, s15, 16
+; VI-NEXT:    s_lshr_b32 s44, s16, 16
+; VI-NEXT:    s_lshr_b32 s45, s17, 16
+; VI-NEXT:    s_lshr_b32 s46, s18, 16
+; VI-NEXT:    s_lshr_b32 s47, s19, 16
+; VI-NEXT:    s_lshr_b32 s56, s20, 16
+; VI-NEXT:    s_lshr_b32 s57, s21, 16
+; VI-NEXT:    s_lshr_b32 s58, s22, 16
+; VI-NEXT:    s_lshr_b32 s59, s23, 16
 ; VI-NEXT:  .LBB17_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s23
 ; VI-NEXT:    s_lshl_b32 s5, s59, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s58, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s57, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s56, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s47, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s46, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s45, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s44, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s22, s58, 16
+; VI-NEXT:    s_or_b32 s5, s5, s22
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s22, s57, 16
 ; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s43, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s42, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s41, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s40, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
-; VI-NEXT:    s_or_b32 s15, s26, s15
-; VI-NEXT:    s_and_b32 s26, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s22, s56, 16
+; VI-NEXT:    s_or_b32 s20, s20, s22
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s22, s47, 16
+; VI-NEXT:    s_or_b32 s19, s19, s22
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s22, s46, 16
+; VI-NEXT:    s_or_b32 s18, s18, s22
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s22, s45, 16
+; VI-NEXT:    s_or_b32 s17, s17, s22
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s22, s44, 16
+; VI-NEXT:    s_or_b32 s16, s16, s22
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s22, s43, 16
+; VI-NEXT:    s_or_b32 s15, s15, s22
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s22, s42, 16
+; VI-NEXT:    s_or_b32 s14, s14, s22
+; VI-NEXT:    s_and_b32 s13, 0xffff, s13
+; VI-NEXT:    s_lshl_b32 s22, s41, 16
+; VI-NEXT:    s_or_b32 s13, s13, s22
+; VI-NEXT:    s_and_b32 s12, 0xffff, s12
+; VI-NEXT:    s_lshl_b32 s22, s40, 16
+; VI-NEXT:    s_or_b32 s12, s12, s22
+; VI-NEXT:    s_and_b32 s11, 0xffff, s11
+; VI-NEXT:    s_lshl_b32 s22, s29, 16
+; VI-NEXT:    s_or_b32 s11, s11, s22
+; VI-NEXT:    s_and_b32 s10, 0xffff, s10
+; VI-NEXT:    s_lshl_b32 s22, s28, 16
+; VI-NEXT:    s_or_b32 s10, s10, s22
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s13, s13, 16
+; VI-NEXT:    s_lshl_b32 s22, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s22
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s12, s12, 16
+; VI-NEXT:    s_lshl_b32 s22, s26, 16
+; VI-NEXT:    s_or_b32 s8, s8, s22
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s11, s11, 16
+; VI-NEXT:    s_lshl_b32 s22, s25, 16
+; VI-NEXT:    s_or_b32 s6, s6, s22
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s10, s10, 16
-; VI-NEXT:    s_or_b32 s14, s26, s14
-; VI-NEXT:    s_or_b32 s9, s9, s13
-; VI-NEXT:    s_or_b32 s8, s8, s12
-; VI-NEXT:    s_or_b32 s6, s6, s11
-; VI-NEXT:    s_or_b32 s7, s7, s10
+; VI-NEXT:    s_lshl_b32 s22, s24, 16
+; VI-NEXT:    s_or_b32 s7, s7, s22
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s15
-; VI-NEXT:    v_mov_b32_e32 v13, s14
+; VI-NEXT:    v_mov_b32_e32 v2, s21
+; VI-NEXT:    v_mov_b32_e32 v3, s20
+; VI-NEXT:    v_mov_b32_e32 v4, s19
+; VI-NEXT:    v_mov_b32_e32 v5, s18
+; VI-NEXT:    v_mov_b32_e32 v6, s17
+; VI-NEXT:    v_mov_b32_e32 v7, s16
+; VI-NEXT:    v_mov_b32_e32 v8, s15
+; VI-NEXT:    v_mov_b32_e32 v9, s14
+; VI-NEXT:    v_mov_b32_e32 v10, s13
+; VI-NEXT:    v_mov_b32_e32 v11, s12
+; VI-NEXT:    v_mov_b32_e32 v12, s11
+; VI-NEXT:    v_mov_b32_e32 v13, s10
 ; VI-NEXT:    v_mov_b32_e32 v14, s9
 ; VI-NEXT:    v_mov_b32_e32 v15, s8
 ; VI-NEXT:    v_mov_b32_e32 v16, s6
@@ -5894,55 +6034,73 @@ define inreg <36 x half> @bitcast_v18i32_to_v36f16_scalar(<18 x i32> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
 ; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
-; VI-NEXT:    ; implicit-def: $sgpr13
-; VI-NEXT:    ; implicit-def: $sgpr12
-; VI-NEXT:    ; implicit-def: $sgpr11
-; VI-NEXT:    ; implicit-def: $sgpr10
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
+; VI-NEXT:    ; implicit-def: $sgpr26
+; VI-NEXT:    ; implicit-def: $sgpr25
+; VI-NEXT:    ; implicit-def: $sgpr24
 ; VI-NEXT:    s_branch .LBB17_2
 ;
 ; GFX9-LABEL: bitcast_v18i32_to_v36f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v5, s16
+; GFX9-NEXT:    v_mov_b32_e32 v6, s17
+; GFX9-NEXT:    v_mov_b32_e32 v7, s18
+; GFX9-NEXT:    v_mov_b32_e32 v8, s19
+; GFX9-NEXT:    v_mov_b32_e32 v9, s20
+; GFX9-NEXT:    v_mov_b32_e32 v10, s21
+; GFX9-NEXT:    v_mov_b32_e32 v11, s22
+; GFX9-NEXT:    v_mov_b32_e32 v12, s23
+; GFX9-NEXT:    v_mov_b32_e32 v13, s24
+; GFX9-NEXT:    v_mov_b32_e32 v14, s25
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s10, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s11, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s24, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s25, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB17_3
 ; GFX9-NEXT:  .LBB17_2: ; %cmp.true
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
-; GFX9-NEXT:    s_add_i32 s29, s29, 3
-; GFX9-NEXT:    s_add_i32 s28, s28, 3
-; GFX9-NEXT:    s_add_i32 s27, s27, 3
-; GFX9-NEXT:    s_add_i32 s26, s26, 3
-; GFX9-NEXT:    s_add_i32 s25, s25, 3
-; GFX9-NEXT:    s_add_i32 s24, s24, 3
 ; GFX9-NEXT:    s_add_i32 s23, s23, 3
 ; GFX9-NEXT:    s_add_i32 s22, s22, 3
 ; GFX9-NEXT:    s_add_i32 s21, s21, 3
@@ -5951,61 +6109,71 @@ define inreg <36 x half> @bitcast_v18i32_to_v36f16_scalar(<18 x i32> inreg %a, i
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
-; GFX9-NEXT:    s_lshr_b32 s10, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s11, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s16, 16
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
+; GFX9-NEXT:    s_lshr_b32 s24, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s25, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s6, 16
 ; GFX9-NEXT:  .LBB17_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s28, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s29, s14
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s13
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s12
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s11
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s10
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s28
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s27
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s26
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s25
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s24
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s15
-; GFX9-NEXT:    v_mov_b32_e32 v13, s14
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB17_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr59
@@ -6020,12 +6188,12 @@ define inreg <36 x half> @bitcast_v18i32_to_v36f16_scalar(<18 x i32> inreg %a, i
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
-; GFX9-NEXT:    ; implicit-def: $sgpr13
-; GFX9-NEXT:    ; implicit-def: $sgpr12
-; GFX9-NEXT:    ; implicit-def: $sgpr11
-; GFX9-NEXT:    ; implicit-def: $sgpr10
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
+; GFX9-NEXT:    ; implicit-def: $sgpr27
+; GFX9-NEXT:    ; implicit-def: $sgpr26
+; GFX9-NEXT:    ; implicit-def: $sgpr25
+; GFX9-NEXT:    ; implicit-def: $sgpr24
 ; GFX9-NEXT:    s_branch .LBB17_2
 ;
 ; GFX11-LABEL: bitcast_v18i32_to_v36f16_scalar:
@@ -12552,277 +12720,306 @@ define inreg <36 x half> @bitcast_v18f32_to_v36f16_scalar(<18 x float> inreg %a,
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
-; SI-NEXT:    v_readfirstlane_b32 s8, v1
-; SI-NEXT:    v_readfirstlane_b32 s7, v2
-; SI-NEXT:    v_readfirstlane_b32 s6, v3
+; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v46, s16
+; SI-NEXT:    v_mov_b32_e32 v45, s17
+; SI-NEXT:    v_mov_b32_e32 v44, s18
+; SI-NEXT:    v_mov_b32_e32 v43, s19
+; SI-NEXT:    v_mov_b32_e32 v42, s20
+; SI-NEXT:    v_mov_b32_e32 v41, s21
+; SI-NEXT:    v_mov_b32_e32 v40, s22
+; SI-NEXT:    v_mov_b32_e32 v55, s23
+; SI-NEXT:    v_mov_b32_e32 v54, s24
+; SI-NEXT:    v_mov_b32_e32 v53, s25
+; SI-NEXT:    v_mov_b32_e32 v51, s26
+; SI-NEXT:    v_mov_b32_e32 v50, s27
+; SI-NEXT:    v_mov_b32_e32 v49, s28
 ; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s9, v4
+; SI-NEXT:    v_mov_b32_e32 v52, s29
 ; SI-NEXT:    s_cbranch_scc0 .LBB33_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s4, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s4
-; SI-NEXT:    s_lshr_b32 s4, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s4
-; SI-NEXT:    s_lshr_b32 s4, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s4
-; SI-NEXT:    s_lshr_b32 s4, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v54
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v45
+; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v54
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v46
 ; SI-NEXT:    s_cbranch_execnz .LBB33_3
 ; SI-NEXT:  .LBB33_2: ; %cmp.true
-; SI-NEXT:    v_add_f32_e64 v1, s16, 1.0
-; SI-NEXT:    v_add_f32_e64 v2, s17, 1.0
-; SI-NEXT:    v_add_f32_e64 v4, s18, 1.0
-; SI-NEXT:    v_add_f32_e64 v6, s19, 1.0
-; SI-NEXT:    v_add_f32_e64 v8, s20, 1.0
-; SI-NEXT:    v_add_f32_e64 v10, s21, 1.0
-; SI-NEXT:    v_add_f32_e64 v12, s22, 1.0
-; SI-NEXT:    v_add_f32_e64 v15, s23, 1.0
-; SI-NEXT:    v_add_f32_e64 v17, s24, 1.0
-; SI-NEXT:    v_add_f32_e64 v18, s25, 1.0
-; SI-NEXT:    v_add_f32_e64 v16, s26, 1.0
-; SI-NEXT:    v_add_f32_e64 v14, s27, 1.0
-; SI-NEXT:    v_add_f32_e64 v13, s28, 1.0
-; SI-NEXT:    v_add_f32_e64 v11, s29, 1.0
-; SI-NEXT:    v_add_f32_e64 v9, s8, 1.0
-; SI-NEXT:    v_add_f32_e64 v7, s7, 1.0
-; SI-NEXT:    v_add_f32_e64 v5, s6, 1.0
-; SI-NEXT:    v_add_f32_e64 v3, s9, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v4
-; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v6
-; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v8
-; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v10
-; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v15
-; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v17
-; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v13
-; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v11
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v9
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v7
-; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v5
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v13
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; SI-NEXT:    v_add_f32_e32 v5, 1.0, v46
+; SI-NEXT:    v_add_f32_e32 v6, 1.0, v45
+; SI-NEXT:    v_add_f32_e32 v8, 1.0, v44
+; SI-NEXT:    v_add_f32_e32 v10, 1.0, v43
+; SI-NEXT:    v_add_f32_e32 v12, 1.0, v42
+; SI-NEXT:    v_add_f32_e32 v14, 1.0, v41
+; SI-NEXT:    v_add_f32_e32 v16, 1.0, v40
+; SI-NEXT:    v_add_f32_e32 v19, 1.0, v55
+; SI-NEXT:    v_add_f32_e32 v21, 1.0, v54
+; SI-NEXT:    v_add_f32_e32 v22, 1.0, v53
+; SI-NEXT:    v_add_f32_e32 v20, 1.0, v51
+; SI-NEXT:    v_add_f32_e32 v18, 1.0, v50
+; SI-NEXT:    v_add_f32_e32 v17, 1.0, v49
+; SI-NEXT:    v_add_f32_e32 v15, 1.0, v52
+; SI-NEXT:    v_add_f32_e32 v1, 1.0, v1
+; SI-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; SI-NEXT:    v_add_f32_e32 v3, 1.0, v3
+; SI-NEXT:    v_add_f32_e32 v4, 1.0, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v17
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v52
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v49
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v39
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v38
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v5, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v54
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v53
 ; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
 ; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
 ; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
 ; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
 ; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
 ; SI-NEXT:  .LBB33_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v36, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v35, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v34, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v33, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v32, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v31, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v30
-; SI-NEXT:    v_lshlrev_b32_e32 v36, 16, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v29, v29
-; SI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; SI-NEXT:    v_or_b32_e32 v35, v35, v36
-; SI-NEXT:    v_lshlrev_b32_e32 v34, 16, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v28, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v25, v25
-; SI-NEXT:    buffer_store_dword v35, v0, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v39
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v38
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v37
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v33, v33, v34
-; SI-NEXT:    v_lshlrev_b32_e32 v32, 16, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v23, v23
-; SI-NEXT:    buffer_store_dword v33, v35, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 8, v0
-; SI-NEXT:    v_or_b32_e32 v31, v31, v32
-; SI-NEXT:    v_lshlrev_b32_e32 v30, 16, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v21, v21
-; SI-NEXT:    buffer_store_dword v31, v33, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 12, v0
-; SI-NEXT:    v_or_b32_e32 v29, v29, v30
-; SI-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v19, v19
-; SI-NEXT:    buffer_store_dword v29, v31, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v29, vcc, 16, v0
-; SI-NEXT:    v_or_b32_e32 v27, v28, v27
-; SI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v17, v17
-; SI-NEXT:    buffer_store_dword v27, v29, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v27, vcc, 20, v0
-; SI-NEXT:    v_or_b32_e32 v25, v26, v25
-; SI-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v15, v15
-; SI-NEXT:    buffer_store_dword v25, v27, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v25, vcc, 24, v0
-; SI-NEXT:    v_or_b32_e32 v23, v24, v23
-; SI-NEXT:    v_lshlrev_b32_e32 v21, 16, v21
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; SI-NEXT:    buffer_store_dword v23, v25, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v23, vcc, 28, v0
-; SI-NEXT:    v_or_b32_e32 v21, v22, v21
-; SI-NEXT:    v_lshlrev_b32_e32 v19, 16, v19
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; SI-NEXT:    buffer_store_dword v21, v23, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v21, vcc, 32, v0
-; SI-NEXT:    v_or_b32_e32 v19, v20, v19
-; SI-NEXT:    v_lshlrev_b32_e32 v17, 16, v17
-; SI-NEXT:    buffer_store_dword v19, v21, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v19, vcc, 36, v0
-; SI-NEXT:    v_or_b32_e32 v17, v18, v17
-; SI-NEXT:    v_lshlrev_b32_e32 v15, 16, v15
-; SI-NEXT:    buffer_store_dword v17, v19, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v17, vcc, 40, v0
-; SI-NEXT:    v_or_b32_e32 v15, v16, v15
-; SI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
-; SI-NEXT:    buffer_store_dword v15, v17, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v15, vcc, 44, v0
-; SI-NEXT:    v_or_b32_e32 v12, v14, v12
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v10
-; SI-NEXT:    buffer_store_dword v12, v15, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v13
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v12, v10
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v8
-; SI-NEXT:    buffer_store_dword v10, v13, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v11
-; SI-NEXT:    v_add_i32_e32 v11, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
-; SI-NEXT:    v_or_b32_e32 v8, v10, v8
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v6
-; SI-NEXT:    buffer_store_dword v8, v11, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v9
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; SI-NEXT:    buffer_store_dword v6, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v7
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v4, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v5
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
 ; SI-NEXT:    v_or_b32_e32 v2, v4, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v5, s[0:3], 0 offen
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v36
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v3
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v35
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v34
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v33
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v31
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v32
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v29
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v30
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v27
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v28
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v25
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v26
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v23
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v24
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v21
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v22
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v19
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v20
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v16
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v18
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v14
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v17
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v12
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v15
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v10
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v13
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v8
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v11
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v6
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v9
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v5
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v7
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x44, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB33_4:
+; SI-NEXT:    ; implicit-def: $vgpr39
+; SI-NEXT:    ; implicit-def: $vgpr48
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr38
 ; SI-NEXT:    ; implicit-def: $vgpr35
 ; SI-NEXT:    ; implicit-def: $vgpr36
 ; SI-NEXT:    ; implicit-def: $vgpr33
 ; SI-NEXT:    ; implicit-def: $vgpr34
-; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    ; implicit-def: $vgpr30
+; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr28
 ; SI-NEXT:    ; implicit-def: $vgpr27
 ; SI-NEXT:    ; implicit-def: $vgpr26
@@ -12834,10 +13031,10 @@ define inreg <36 x half> @bitcast_v18f32_to_v36f16_scalar(<18 x float> inreg %a,
 ; SI-NEXT:    ; implicit-def: $vgpr20
 ; SI-NEXT:    ; implicit-def: $vgpr19
 ; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr17
 ; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr15
+; SI-NEXT:    ; implicit-def: $vgpr17
 ; SI-NEXT:    ; implicit-def: $vgpr14
+; SI-NEXT:    ; implicit-def: $vgpr15
 ; SI-NEXT:    ; implicit-def: $vgpr12
 ; SI-NEXT:    ; implicit-def: $vgpr13
 ; SI-NEXT:    ; implicit-def: $vgpr10
@@ -12846,11 +13043,7 @@ define inreg <36 x half> @bitcast_v18f32_to_v36f16_scalar(<18 x float> inreg %a,
 ; SI-NEXT:    ; implicit-def: $vgpr9
 ; SI-NEXT:    ; implicit-def: $vgpr6
 ; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr4
 ; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr1
 ; SI-NEXT:    s_branch .LBB33_2
 ;
 ; VI-LABEL: bitcast_v18f32_to_v36f16_scalar:
@@ -16237,169 +16430,197 @@ define inreg <36 x i16> @bitcast_v9i64_to_v36i16_scalar(<9 x i64> inreg %a, i32 
 ; SI-LABEL: bitcast_v9i64_to_v36i16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v6, s16
+; SI-NEXT:    v_mov_b32_e32 v7, s17
+; SI-NEXT:    v_mov_b32_e32 v8, s18
+; SI-NEXT:    v_mov_b32_e32 v9, s19
+; SI-NEXT:    v_mov_b32_e32 v10, s20
+; SI-NEXT:    v_mov_b32_e32 v11, s21
+; SI-NEXT:    v_mov_b32_e32 v12, s22
+; SI-NEXT:    v_mov_b32_e32 v13, s23
+; SI-NEXT:    v_mov_b32_e32 v14, s24
+; SI-NEXT:    v_mov_b32_e32 v15, s25
+; SI-NEXT:    v_mov_b32_e32 v16, s26
+; SI-NEXT:    v_mov_b32_e32 v17, s27
+; SI-NEXT:    v_mov_b32_e32 v18, s28
+; SI-NEXT:    v_mov_b32_e32 v19, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; SI-NEXT:    v_readfirstlane_b32 s20, v6
+; SI-NEXT:    v_readfirstlane_b32 s21, v7
+; SI-NEXT:    v_readfirstlane_b32 s18, v8
+; SI-NEXT:    v_readfirstlane_b32 s19, v9
+; SI-NEXT:    v_readfirstlane_b32 s16, v10
+; SI-NEXT:    v_readfirstlane_b32 s17, v11
+; SI-NEXT:    v_readfirstlane_b32 s14, v12
+; SI-NEXT:    v_readfirstlane_b32 s15, v13
+; SI-NEXT:    v_readfirstlane_b32 s12, v14
+; SI-NEXT:    v_readfirstlane_b32 s13, v15
+; SI-NEXT:    v_readfirstlane_b32 s10, v16
+; SI-NEXT:    v_readfirstlane_b32 s11, v17
+; SI-NEXT:    v_readfirstlane_b32 s8, v18
+; SI-NEXT:    v_readfirstlane_b32 s9, v19
 ; SI-NEXT:    v_readfirstlane_b32 s6, v1
 ; SI-NEXT:    v_readfirstlane_b32 s7, v2
 ; SI-NEXT:    v_readfirstlane_b32 s4, v3
-; SI-NEXT:    s_and_b64 s[8:9], vcc, exec
+; SI-NEXT:    s_and_b64 s[22:23], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v4
 ; SI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s60, s5, 16
 ; SI-NEXT:    s_lshr_b32 s61, s7, 16
-; SI-NEXT:    s_lshr_b32 s62, s29, 16
-; SI-NEXT:    s_lshr_b32 s63, s27, 16
-; SI-NEXT:    s_lshr_b32 s72, s25, 16
-; SI-NEXT:    s_lshr_b32 s73, s23, 16
-; SI-NEXT:    s_lshr_b32 s74, s21, 16
+; SI-NEXT:    s_lshr_b32 s62, s9, 16
+; SI-NEXT:    s_lshr_b32 s63, s11, 16
+; SI-NEXT:    s_lshr_b32 s72, s13, 16
+; SI-NEXT:    s_lshr_b32 s73, s15, 16
+; SI-NEXT:    s_lshr_b32 s74, s17, 16
 ; SI-NEXT:    s_lshr_b32 s75, s19, 16
-; SI-NEXT:    s_lshr_b32 s76, s17, 16
-; SI-NEXT:    s_lshr_b64 s[8:9], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[10:11], s[6:7], 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[20:21], 16
+; SI-NEXT:    s_lshr_b32 s76, s21, 16
+; SI-NEXT:    s_lshr_b64 s[22:23], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[24:25], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[8:9], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[10:11], 16
+; SI-NEXT:    s_lshr_b64 s[40:41], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[42:43], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[16:17], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[20:21], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB41_3
 ; SI-NEXT:  .LBB41_2: ; %cmp.true
 ; SI-NEXT:    s_add_u32 s4, s4, 3
 ; SI-NEXT:    s_addc_u32 s5, s5, 0
 ; SI-NEXT:    s_add_u32 s6, s6, 3
 ; SI-NEXT:    s_addc_u32 s7, s7, 0
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_add_u32 s20, s20, 3
-; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s8, s8, 3
+; SI-NEXT:    s_addc_u32 s9, s9, 0
+; SI-NEXT:    s_add_u32 s10, s10, 3
+; SI-NEXT:    s_addc_u32 s11, s11, 0
+; SI-NEXT:    s_add_u32 s12, s12, 3
+; SI-NEXT:    s_addc_u32 s13, s13, 0
+; SI-NEXT:    s_add_u32 s14, s14, 3
+; SI-NEXT:    s_addc_u32 s15, s15, 0
 ; SI-NEXT:    s_add_u32 s16, s16, 3
 ; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
 ; SI-NEXT:    s_lshr_b32 s60, s5, 16
 ; SI-NEXT:    s_lshr_b32 s61, s7, 16
-; SI-NEXT:    s_lshr_b32 s62, s29, 16
-; SI-NEXT:    s_lshr_b32 s63, s27, 16
-; SI-NEXT:    s_lshr_b32 s72, s25, 16
-; SI-NEXT:    s_lshr_b32 s73, s23, 16
-; SI-NEXT:    s_lshr_b32 s74, s21, 16
+; SI-NEXT:    s_lshr_b32 s62, s9, 16
+; SI-NEXT:    s_lshr_b32 s63, s11, 16
+; SI-NEXT:    s_lshr_b32 s72, s13, 16
+; SI-NEXT:    s_lshr_b32 s73, s15, 16
+; SI-NEXT:    s_lshr_b32 s74, s17, 16
 ; SI-NEXT:    s_lshr_b32 s75, s19, 16
-; SI-NEXT:    s_lshr_b32 s76, s17, 16
-; SI-NEXT:    s_lshr_b64 s[8:9], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[10:11], s[6:7], 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[20:21], 16
+; SI-NEXT:    s_lshr_b32 s76, s21, 16
+; SI-NEXT:    s_lshr_b64 s[22:23], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[24:25], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[8:9], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[10:11], 16
+; SI-NEXT:    s_lshr_b64 s[40:41], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[42:43], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[16:17], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[20:21], 16
 ; SI-NEXT:  .LBB41_3: ; %end
-; SI-NEXT:    s_lshl_b32 s9, s56, 16
-; SI-NEXT:    s_and_b32 s11, s16, 0xffff
-; SI-NEXT:    s_or_b32 s9, s11, s9
-; SI-NEXT:    v_mov_b32_e32 v1, s9
-; SI-NEXT:    s_and_b32 s9, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s76, 16
-; SI-NEXT:    s_or_b32 s9, s9, s11
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s18, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s46, 16
+; SI-NEXT:    s_lshl_b32 s23, s56, 16
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_or_b32 s20, s20, s23
+; SI-NEXT:    v_mov_b32_e32 v1, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s76, 16
+; SI-NEXT:    s_or_b32 s20, s20, s21
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s46, 16
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s75, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s75, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s20, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s44, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s44, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s74, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
+; SI-NEXT:    s_lshl_b32 s17, s74, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s16, s16, s17
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s42, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s14, s14, 0xffff
+; SI-NEXT:    s_lshl_b32 s16, s42, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s14, s14, s16
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s73, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s14, s15, 0xffff
+; SI-NEXT:    s_lshl_b32 s15, s73, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s14, s14, s15
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s40, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s12, s12, 0xffff
+; SI-NEXT:    s_lshl_b32 s14, s40, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s12, s12, s14
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s12, s13, 0xffff
+; SI-NEXT:    s_lshl_b32 s13, s72, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s12, s12, s13
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s14, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s10, s10, 0xffff
+; SI-NEXT:    s_lshl_b32 s12, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s10, s10, s12
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s27, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v2, s10
+; SI-NEXT:    s_and_b32 s10, s11, 0xffff
 ; SI-NEXT:    s_lshl_b32 s11, s63, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s10, s10, s11
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s12, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s10
+; SI-NEXT:    s_and_b32 s8, s8, 0xffff
+; SI-NEXT:    s_lshl_b32 s10, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s8, s8, s10
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
-; SI-NEXT:    s_and_b32 s9, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s62, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s8
+; SI-NEXT:    s_and_b32 s8, s9, 0xffff
+; SI-NEXT:    s_lshl_b32 s9, s62, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s9, s9, s11
+; SI-NEXT:    s_or_b32 s8, s8, s9
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s9
+; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s9, s10, 16
+; SI-NEXT:    s_lshl_b32 s8, s24, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s6, s6, s9
+; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
@@ -16411,7 +16632,7 @@ define inreg <36 x i16> @bitcast_v9i64_to_v36i16_scalar(<9 x i64> inreg %a, i32 
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s8, 16
+; SI-NEXT:    s_lshl_b32 s6, s22, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 60, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -16438,20 +16659,48 @@ define inreg <36 x i16> @bitcast_v9i64_to_v36i16_scalar(<9 x i64> inreg %a, i32 
 ; SI-NEXT:    ; implicit-def: $sgpr73
 ; SI-NEXT:    ; implicit-def: $sgpr40
 ; SI-NEXT:    ; implicit-def: $sgpr72
-; SI-NEXT:    ; implicit-def: $sgpr14
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr63
-; SI-NEXT:    ; implicit-def: $sgpr12
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr62
-; SI-NEXT:    ; implicit-def: $sgpr10
+; SI-NEXT:    ; implicit-def: $sgpr24
 ; SI-NEXT:    ; implicit-def: $sgpr61
-; SI-NEXT:    ; implicit-def: $sgpr8
+; SI-NEXT:    ; implicit-def: $sgpr22
 ; SI-NEXT:    ; implicit-def: $sgpr60
 ; SI-NEXT:    s_branch .LBB41_2
 ;
 ; VI-LABEL: bitcast_v9i64_to_v36i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v5, s16
+; VI-NEXT:    v_mov_b32_e32 v6, s17
+; VI-NEXT:    v_mov_b32_e32 v7, s18
+; VI-NEXT:    v_mov_b32_e32 v8, s19
+; VI-NEXT:    v_mov_b32_e32 v9, s20
+; VI-NEXT:    v_mov_b32_e32 v10, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s23
+; VI-NEXT:    v_mov_b32_e32 v13, s24
+; VI-NEXT:    v_mov_b32_e32 v14, s25
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_mov_b32_e32 v16, s27
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; VI-NEXT:    v_readfirstlane_b32 s23, v5
+; VI-NEXT:    v_readfirstlane_b32 s22, v6
+; VI-NEXT:    v_readfirstlane_b32 s21, v7
+; VI-NEXT:    v_readfirstlane_b32 s20, v8
+; VI-NEXT:    v_readfirstlane_b32 s19, v9
+; VI-NEXT:    v_readfirstlane_b32 s18, v10
+; VI-NEXT:    v_readfirstlane_b32 s17, v11
+; VI-NEXT:    v_readfirstlane_b32 s16, v12
+; VI-NEXT:    v_readfirstlane_b32 s15, v13
+; VI-NEXT:    v_readfirstlane_b32 s14, v14
+; VI-NEXT:    v_readfirstlane_b32 s13, v15
+; VI-NEXT:    v_readfirstlane_b32 s12, v16
+; VI-NEXT:    v_readfirstlane_b32 s11, v17
+; VI-NEXT:    v_readfirstlane_b32 s10, v18
 ; VI-NEXT:    v_readfirstlane_b32 s9, v0
 ; VI-NEXT:    v_readfirstlane_b32 s8, v1
 ; VI-NEXT:    v_readfirstlane_b32 s6, v2
@@ -16459,131 +16708,131 @@ define inreg <36 x i16> @bitcast_v9i64_to_v36i16_scalar(<9 x i64> inreg %a, i32 
 ; VI-NEXT:    v_readfirstlane_b32 s7, v3
 ; VI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s10, s7, 16
-; VI-NEXT:    s_lshr_b32 s11, s6, 16
-; VI-NEXT:    s_lshr_b32 s12, s8, 16
-; VI-NEXT:    s_lshr_b32 s13, s9, 16
-; VI-NEXT:    s_lshr_b32 s14, s29, 16
-; VI-NEXT:    s_lshr_b32 s15, s28, 16
-; VI-NEXT:    s_lshr_b32 s40, s27, 16
-; VI-NEXT:    s_lshr_b32 s41, s26, 16
-; VI-NEXT:    s_lshr_b32 s42, s25, 16
-; VI-NEXT:    s_lshr_b32 s43, s24, 16
-; VI-NEXT:    s_lshr_b32 s44, s23, 16
-; VI-NEXT:    s_lshr_b32 s45, s22, 16
-; VI-NEXT:    s_lshr_b32 s46, s21, 16
-; VI-NEXT:    s_lshr_b32 s47, s20, 16
-; VI-NEXT:    s_lshr_b32 s56, s19, 16
-; VI-NEXT:    s_lshr_b32 s57, s18, 16
-; VI-NEXT:    s_lshr_b32 s58, s17, 16
-; VI-NEXT:    s_lshr_b32 s59, s16, 16
+; VI-NEXT:    s_lshr_b32 s24, s7, 16
+; VI-NEXT:    s_lshr_b32 s25, s6, 16
+; VI-NEXT:    s_lshr_b32 s26, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s9, 16
+; VI-NEXT:    s_lshr_b32 s28, s10, 16
+; VI-NEXT:    s_lshr_b32 s29, s11, 16
+; VI-NEXT:    s_lshr_b32 s40, s12, 16
+; VI-NEXT:    s_lshr_b32 s41, s13, 16
+; VI-NEXT:    s_lshr_b32 s42, s14, 16
+; VI-NEXT:    s_lshr_b32 s43, s15, 16
+; VI-NEXT:    s_lshr_b32 s44, s16, 16
+; VI-NEXT:    s_lshr_b32 s45, s17, 16
+; VI-NEXT:    s_lshr_b32 s46, s18, 16
+; VI-NEXT:    s_lshr_b32 s47, s19, 16
+; VI-NEXT:    s_lshr_b32 s56, s20, 16
+; VI-NEXT:    s_lshr_b32 s57, s21, 16
+; VI-NEXT:    s_lshr_b32 s58, s22, 16
+; VI-NEXT:    s_lshr_b32 s59, s23, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB41_3
 ; VI-NEXT:  .LBB41_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
 ; VI-NEXT:    s_addc_u32 s7, s7, 0
 ; VI-NEXT:    s_add_u32 s9, s9, 3
 ; VI-NEXT:    s_addc_u32 s8, s8, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s10, s7, 16
-; VI-NEXT:    s_lshr_b32 s11, s6, 16
-; VI-NEXT:    s_lshr_b32 s12, s8, 16
-; VI-NEXT:    s_lshr_b32 s13, s9, 16
-; VI-NEXT:    s_lshr_b32 s14, s29, 16
-; VI-NEXT:    s_lshr_b32 s15, s28, 16
-; VI-NEXT:    s_lshr_b32 s40, s27, 16
-; VI-NEXT:    s_lshr_b32 s41, s26, 16
-; VI-NEXT:    s_lshr_b32 s42, s25, 16
-; VI-NEXT:    s_lshr_b32 s43, s24, 16
-; VI-NEXT:    s_lshr_b32 s44, s23, 16
-; VI-NEXT:    s_lshr_b32 s45, s22, 16
-; VI-NEXT:    s_lshr_b32 s46, s21, 16
-; VI-NEXT:    s_lshr_b32 s47, s20, 16
-; VI-NEXT:    s_lshr_b32 s56, s19, 16
-; VI-NEXT:    s_lshr_b32 s57, s18, 16
-; VI-NEXT:    s_lshr_b32 s58, s17, 16
-; VI-NEXT:    s_lshr_b32 s59, s16, 16
+; VI-NEXT:    s_add_u32 s11, s11, 3
+; VI-NEXT:    s_addc_u32 s10, s10, 0
+; VI-NEXT:    s_add_u32 s13, s13, 3
+; VI-NEXT:    s_addc_u32 s12, s12, 0
+; VI-NEXT:    s_add_u32 s15, s15, 3
+; VI-NEXT:    s_addc_u32 s14, s14, 0
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_lshr_b32 s24, s7, 16
+; VI-NEXT:    s_lshr_b32 s25, s6, 16
+; VI-NEXT:    s_lshr_b32 s26, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s9, 16
+; VI-NEXT:    s_lshr_b32 s28, s10, 16
+; VI-NEXT:    s_lshr_b32 s29, s11, 16
+; VI-NEXT:    s_lshr_b32 s40, s12, 16
+; VI-NEXT:    s_lshr_b32 s41, s13, 16
+; VI-NEXT:    s_lshr_b32 s42, s14, 16
+; VI-NEXT:    s_lshr_b32 s43, s15, 16
+; VI-NEXT:    s_lshr_b32 s44, s16, 16
+; VI-NEXT:    s_lshr_b32 s45, s17, 16
+; VI-NEXT:    s_lshr_b32 s46, s18, 16
+; VI-NEXT:    s_lshr_b32 s47, s19, 16
+; VI-NEXT:    s_lshr_b32 s56, s20, 16
+; VI-NEXT:    s_lshr_b32 s57, s21, 16
+; VI-NEXT:    s_lshr_b32 s58, s22, 16
+; VI-NEXT:    s_lshr_b32 s59, s23, 16
 ; VI-NEXT:  .LBB41_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s23
 ; VI-NEXT:    s_lshl_b32 s5, s59, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s58, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s57, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s56, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s47, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s46, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s45, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s44, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s22, s58, 16
+; VI-NEXT:    s_or_b32 s5, s5, s22
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s22, s57, 16
 ; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s43, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s42, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s41, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s40, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
-; VI-NEXT:    s_or_b32 s15, s26, s15
-; VI-NEXT:    s_and_b32 s26, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s22, s56, 16
+; VI-NEXT:    s_or_b32 s20, s20, s22
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s22, s47, 16
+; VI-NEXT:    s_or_b32 s19, s19, s22
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s22, s46, 16
+; VI-NEXT:    s_or_b32 s18, s18, s22
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s22, s45, 16
+; VI-NEXT:    s_or_b32 s17, s17, s22
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s22, s44, 16
+; VI-NEXT:    s_or_b32 s16, s16, s22
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s22, s43, 16
+; VI-NEXT:    s_or_b32 s15, s15, s22
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s22, s42, 16
+; VI-NEXT:    s_or_b32 s14, s14, s22
+; VI-NEXT:    s_and_b32 s13, 0xffff, s13
+; VI-NEXT:    s_lshl_b32 s22, s41, 16
+; VI-NEXT:    s_or_b32 s13, s13, s22
+; VI-NEXT:    s_and_b32 s12, 0xffff, s12
+; VI-NEXT:    s_lshl_b32 s22, s40, 16
+; VI-NEXT:    s_or_b32 s12, s12, s22
+; VI-NEXT:    s_and_b32 s11, 0xffff, s11
+; VI-NEXT:    s_lshl_b32 s22, s29, 16
+; VI-NEXT:    s_or_b32 s11, s11, s22
+; VI-NEXT:    s_and_b32 s10, 0xffff, s10
+; VI-NEXT:    s_lshl_b32 s22, s28, 16
+; VI-NEXT:    s_or_b32 s10, s10, s22
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s13, s13, 16
+; VI-NEXT:    s_lshl_b32 s22, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s22
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s12, s12, 16
+; VI-NEXT:    s_lshl_b32 s22, s26, 16
+; VI-NEXT:    s_or_b32 s8, s8, s22
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s11, s11, 16
+; VI-NEXT:    s_lshl_b32 s22, s25, 16
+; VI-NEXT:    s_or_b32 s6, s6, s22
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s10, s10, 16
-; VI-NEXT:    s_or_b32 s14, s26, s14
-; VI-NEXT:    s_or_b32 s9, s9, s13
-; VI-NEXT:    s_or_b32 s8, s8, s12
-; VI-NEXT:    s_or_b32 s6, s6, s11
-; VI-NEXT:    s_or_b32 s7, s7, s10
+; VI-NEXT:    s_lshl_b32 s22, s24, 16
+; VI-NEXT:    s_or_b32 s7, s7, s22
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s15
-; VI-NEXT:    v_mov_b32_e32 v13, s14
+; VI-NEXT:    v_mov_b32_e32 v2, s21
+; VI-NEXT:    v_mov_b32_e32 v3, s20
+; VI-NEXT:    v_mov_b32_e32 v4, s19
+; VI-NEXT:    v_mov_b32_e32 v5, s18
+; VI-NEXT:    v_mov_b32_e32 v6, s17
+; VI-NEXT:    v_mov_b32_e32 v7, s16
+; VI-NEXT:    v_mov_b32_e32 v8, s15
+; VI-NEXT:    v_mov_b32_e32 v9, s14
+; VI-NEXT:    v_mov_b32_e32 v10, s13
+; VI-NEXT:    v_mov_b32_e32 v11, s12
+; VI-NEXT:    v_mov_b32_e32 v12, s11
+; VI-NEXT:    v_mov_b32_e32 v13, s10
 ; VI-NEXT:    v_mov_b32_e32 v14, s9
 ; VI-NEXT:    v_mov_b32_e32 v15, s8
 ; VI-NEXT:    v_mov_b32_e32 v16, s6
@@ -16602,55 +16851,73 @@ define inreg <36 x i16> @bitcast_v9i64_to_v36i16_scalar(<9 x i64> inreg %a, i32 
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
 ; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
-; VI-NEXT:    ; implicit-def: $sgpr13
-; VI-NEXT:    ; implicit-def: $sgpr12
-; VI-NEXT:    ; implicit-def: $sgpr11
-; VI-NEXT:    ; implicit-def: $sgpr10
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
+; VI-NEXT:    ; implicit-def: $sgpr26
+; VI-NEXT:    ; implicit-def: $sgpr25
+; VI-NEXT:    ; implicit-def: $sgpr24
 ; VI-NEXT:    s_branch .LBB41_2
 ;
 ; GFX9-LABEL: bitcast_v9i64_to_v36i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v5, s16
+; GFX9-NEXT:    v_mov_b32_e32 v6, s17
+; GFX9-NEXT:    v_mov_b32_e32 v7, s18
+; GFX9-NEXT:    v_mov_b32_e32 v8, s19
+; GFX9-NEXT:    v_mov_b32_e32 v9, s20
+; GFX9-NEXT:    v_mov_b32_e32 v10, s21
+; GFX9-NEXT:    v_mov_b32_e32 v11, s22
+; GFX9-NEXT:    v_mov_b32_e32 v12, s23
+; GFX9-NEXT:    v_mov_b32_e32 v13, s24
+; GFX9-NEXT:    v_mov_b32_e32 v14, s25
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s10, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s11, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s24, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s25, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB41_3
 ; GFX9-NEXT:  .LBB41_2: ; %cmp.true
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
-; GFX9-NEXT:    s_add_u32 s28, s28, 3
-; GFX9-NEXT:    s_addc_u32 s29, s29, 0
-; GFX9-NEXT:    s_add_u32 s26, s26, 3
-; GFX9-NEXT:    s_addc_u32 s27, s27, 0
-; GFX9-NEXT:    s_add_u32 s24, s24, 3
-; GFX9-NEXT:    s_addc_u32 s25, s25, 0
 ; GFX9-NEXT:    s_add_u32 s22, s22, 3
 ; GFX9-NEXT:    s_addc_u32 s23, s23, 0
 ; GFX9-NEXT:    s_add_u32 s20, s20, 3
@@ -16659,61 +16926,71 @@ define inreg <36 x i16> @bitcast_v9i64_to_v36i16_scalar(<9 x i64> inreg %a, i32 
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
-; GFX9-NEXT:    s_lshr_b32 s10, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s11, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s16, 16
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
+; GFX9-NEXT:    s_lshr_b32 s24, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s25, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s6, 16
 ; GFX9-NEXT:  .LBB41_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s28, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s29, s14
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s13
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s12
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s11
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s10
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s28
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s27
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s26
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s25
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s24
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s15
-; GFX9-NEXT:    v_mov_b32_e32 v13, s14
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB41_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr59
@@ -16728,12 +17005,12 @@ define inreg <36 x i16> @bitcast_v9i64_to_v36i16_scalar(<9 x i64> inreg %a, i32 
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
-; GFX9-NEXT:    ; implicit-def: $sgpr13
-; GFX9-NEXT:    ; implicit-def: $sgpr12
-; GFX9-NEXT:    ; implicit-def: $sgpr11
-; GFX9-NEXT:    ; implicit-def: $sgpr10
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
+; GFX9-NEXT:    ; implicit-def: $sgpr27
+; GFX9-NEXT:    ; implicit-def: $sgpr26
+; GFX9-NEXT:    ; implicit-def: $sgpr25
+; GFX9-NEXT:    ; implicit-def: $sgpr24
 ; GFX9-NEXT:    s_branch .LBB41_2
 ;
 ; GFX11-LABEL: bitcast_v9i64_to_v36i16_scalar:
@@ -18926,7 +19203,35 @@ define inreg <36 x half> @bitcast_v9i64_to_v36f16_scalar(<9 x i64> inreg %a, i32
 ; SI-LABEL: bitcast_v9i64_to_v36f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v6, s16
+; SI-NEXT:    v_mov_b32_e32 v7, s17
+; SI-NEXT:    v_mov_b32_e32 v8, s18
+; SI-NEXT:    v_mov_b32_e32 v9, s19
+; SI-NEXT:    v_mov_b32_e32 v10, s20
+; SI-NEXT:    v_mov_b32_e32 v11, s21
+; SI-NEXT:    v_mov_b32_e32 v12, s22
+; SI-NEXT:    v_mov_b32_e32 v13, s23
+; SI-NEXT:    v_mov_b32_e32 v14, s24
+; SI-NEXT:    v_mov_b32_e32 v15, s25
+; SI-NEXT:    v_mov_b32_e32 v16, s26
+; SI-NEXT:    v_mov_b32_e32 v17, s27
+; SI-NEXT:    v_mov_b32_e32 v18, s28
+; SI-NEXT:    v_mov_b32_e32 v19, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; SI-NEXT:    v_readfirstlane_b32 s22, v6
+; SI-NEXT:    v_readfirstlane_b32 s23, v7
+; SI-NEXT:    v_readfirstlane_b32 s20, v8
+; SI-NEXT:    v_readfirstlane_b32 s21, v9
+; SI-NEXT:    v_readfirstlane_b32 s18, v10
+; SI-NEXT:    v_readfirstlane_b32 s19, v11
+; SI-NEXT:    v_readfirstlane_b32 s16, v12
+; SI-NEXT:    v_readfirstlane_b32 s17, v13
+; SI-NEXT:    v_readfirstlane_b32 s14, v14
+; SI-NEXT:    v_readfirstlane_b32 s15, v15
+; SI-NEXT:    v_readfirstlane_b32 s12, v16
+; SI-NEXT:    v_readfirstlane_b32 s13, v17
+; SI-NEXT:    v_readfirstlane_b32 s10, v18
+; SI-NEXT:    v_readfirstlane_b32 s11, v19
 ; SI-NEXT:    v_readfirstlane_b32 s7, v1
 ; SI-NEXT:    v_readfirstlane_b32 s8, v2
 ; SI-NEXT:    v_readfirstlane_b32 s6, v3
@@ -18942,82 +19247,82 @@ define inreg <36 x half> @bitcast_v9i64_to_v36f16_scalar(<9 x i64> inreg %a, i32
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s4
 ; SI-NEXT:    s_lshr_b32 s4, s7, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v6, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s11, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v8, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    s_lshr_b32 s4, s10, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v10, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    s_lshr_b32 s4, s13, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    s_lshr_b32 s4, s12, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
 ; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, s4
 ; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s9
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
 ; SI-NEXT:    v_cvt_f32_f16_e32 v7, s8
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, s11
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, s10
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, s13
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s22
 ; SI-NEXT:    s_cbranch_execnz .LBB45_3
 ; SI-NEXT:  .LBB45_2: ; %cmp.true
-; SI-NEXT:    s_add_u32 s4, s16, 3
-; SI-NEXT:    s_addc_u32 s5, s17, 0
-; SI-NEXT:    s_lshr_b32 s10, s4, 16
-; SI-NEXT:    s_lshr_b32 s11, s5, 16
-; SI-NEXT:    s_add_u32 s12, s18, 3
-; SI-NEXT:    s_addc_u32 s13, s19, 0
-; SI-NEXT:    s_lshr_b32 s14, s12, 16
-; SI-NEXT:    s_lshr_b32 s15, s13, 16
-; SI-NEXT:    s_add_u32 s16, s20, 3
-; SI-NEXT:    s_addc_u32 s17, s21, 0
-; SI-NEXT:    s_lshr_b32 s18, s16, 16
-; SI-NEXT:    s_lshr_b32 s19, s17, 16
-; SI-NEXT:    s_add_u32 s20, s22, 3
-; SI-NEXT:    s_addc_u32 s21, s23, 0
-; SI-NEXT:    s_lshr_b32 s22, s20, 16
-; SI-NEXT:    s_lshr_b32 s23, s21, 16
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_lshr_b32 s40, s24, 16
-; SI-NEXT:    s_lshr_b32 s41, s25, 16
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_lshr_b32 s42, s26, 16
-; SI-NEXT:    s_lshr_b32 s43, s27, 16
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_lshr_b32 s44, s28, 16
-; SI-NEXT:    s_lshr_b32 s45, s29, 16
+; SI-NEXT:    s_add_u32 s4, s22, 3
+; SI-NEXT:    s_addc_u32 s5, s23, 0
+; SI-NEXT:    s_lshr_b32 s22, s4, 16
+; SI-NEXT:    s_lshr_b32 s23, s5, 16
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
+; SI-NEXT:    s_lshr_b32 s24, s20, 16
+; SI-NEXT:    s_lshr_b32 s25, s21, 16
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_lshr_b32 s26, s18, 16
+; SI-NEXT:    s_lshr_b32 s27, s19, 16
+; SI-NEXT:    s_add_u32 s16, s16, 3
+; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_lshr_b32 s28, s16, 16
+; SI-NEXT:    s_lshr_b32 s29, s17, 16
+; SI-NEXT:    s_add_u32 s14, s14, 3
+; SI-NEXT:    s_addc_u32 s15, s15, 0
+; SI-NEXT:    s_lshr_b32 s40, s14, 16
+; SI-NEXT:    s_lshr_b32 s41, s15, 16
+; SI-NEXT:    s_add_u32 s12, s12, 3
+; SI-NEXT:    s_addc_u32 s13, s13, 0
+; SI-NEXT:    s_lshr_b32 s42, s12, 16
+; SI-NEXT:    s_lshr_b32 s43, s13, 16
+; SI-NEXT:    s_add_u32 s10, s10, 3
+; SI-NEXT:    s_addc_u32 s11, s11, 0
+; SI-NEXT:    s_lshr_b32 s44, s10, 16
+; SI-NEXT:    s_lshr_b32 s45, s11, 16
 ; SI-NEXT:    s_add_u32 s7, s7, 3
 ; SI-NEXT:    s_addc_u32 s8, s8, 0
 ; SI-NEXT:    s_lshr_b32 s46, s7, 16
@@ -19030,18 +19335,18 @@ define inreg <36 x half> @bitcast_v9i64_to_v36f16_scalar(<9 x i64> inreg %a, i32
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
 ; SI-NEXT:    v_cvt_f32_f16_e32 v7, s8
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, s11
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, s10
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, s13
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s20
 ; SI-NEXT:    v_cvt_f32_f16_e32 v33, s5
 ; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s57
@@ -19054,14 +19359,14 @@ define inreg <36 x half> @bitcast_v9i64_to_v36f16_scalar(<9 x i64> inreg %a, i32
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s42
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s41
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s10
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s22
 ; SI-NEXT:  .LBB45_3: ; %end
 ; SI-NEXT:    v_cvt_f16_f32_e32 v36, v36
 ; SI-NEXT:    v_cvt_f16_f32_e32 v35, v35
@@ -19231,7 +19536,35 @@ define inreg <36 x half> @bitcast_v9i64_to_v36f16_scalar(<9 x i64> inreg %a, i32
 ; VI-LABEL: bitcast_v9i64_to_v36f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v5, s16
+; VI-NEXT:    v_mov_b32_e32 v6, s17
+; VI-NEXT:    v_mov_b32_e32 v7, s18
+; VI-NEXT:    v_mov_b32_e32 v8, s19
+; VI-NEXT:    v_mov_b32_e32 v9, s20
+; VI-NEXT:    v_mov_b32_e32 v10, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s23
+; VI-NEXT:    v_mov_b32_e32 v13, s24
+; VI-NEXT:    v_mov_b32_e32 v14, s25
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_mov_b32_e32 v16, s27
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; VI-NEXT:    v_readfirstlane_b32 s23, v5
+; VI-NEXT:    v_readfirstlane_b32 s22, v6
+; VI-NEXT:    v_readfirstlane_b32 s21, v7
+; VI-NEXT:    v_readfirstlane_b32 s20, v8
+; VI-NEXT:    v_readfirstlane_b32 s19, v9
+; VI-NEXT:    v_readfirstlane_b32 s18, v10
+; VI-NEXT:    v_readfirstlane_b32 s17, v11
+; VI-NEXT:    v_readfirstlane_b32 s16, v12
+; VI-NEXT:    v_readfirstlane_b32 s15, v13
+; VI-NEXT:    v_readfirstlane_b32 s14, v14
+; VI-NEXT:    v_readfirstlane_b32 s13, v15
+; VI-NEXT:    v_readfirstlane_b32 s12, v16
+; VI-NEXT:    v_readfirstlane_b32 s11, v17
+; VI-NEXT:    v_readfirstlane_b32 s10, v18
 ; VI-NEXT:    v_readfirstlane_b32 s9, v0
 ; VI-NEXT:    v_readfirstlane_b32 s8, v1
 ; VI-NEXT:    v_readfirstlane_b32 s6, v2
@@ -19239,131 +19572,131 @@ define inreg <36 x half> @bitcast_v9i64_to_v36f16_scalar(<9 x i64> inreg %a, i32
 ; VI-NEXT:    v_readfirstlane_b32 s7, v3
 ; VI-NEXT:    s_cbranch_scc0 .LBB45_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s10, s7, 16
-; VI-NEXT:    s_lshr_b32 s11, s6, 16
-; VI-NEXT:    s_lshr_b32 s12, s8, 16
-; VI-NEXT:    s_lshr_b32 s13, s9, 16
-; VI-NEXT:    s_lshr_b32 s14, s29, 16
-; VI-NEXT:    s_lshr_b32 s15, s28, 16
-; VI-NEXT:    s_lshr_b32 s40, s27, 16
-; VI-NEXT:    s_lshr_b32 s41, s26, 16
-; VI-NEXT:    s_lshr_b32 s42, s25, 16
-; VI-NEXT:    s_lshr_b32 s43, s24, 16
-; VI-NEXT:    s_lshr_b32 s44, s23, 16
-; VI-NEXT:    s_lshr_b32 s45, s22, 16
-; VI-NEXT:    s_lshr_b32 s46, s21, 16
-; VI-NEXT:    s_lshr_b32 s47, s20, 16
-; VI-NEXT:    s_lshr_b32 s56, s19, 16
-; VI-NEXT:    s_lshr_b32 s57, s18, 16
-; VI-NEXT:    s_lshr_b32 s58, s17, 16
-; VI-NEXT:    s_lshr_b32 s59, s16, 16
+; VI-NEXT:    s_lshr_b32 s24, s7, 16
+; VI-NEXT:    s_lshr_b32 s25, s6, 16
+; VI-NEXT:    s_lshr_b32 s26, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s9, 16
+; VI-NEXT:    s_lshr_b32 s28, s10, 16
+; VI-NEXT:    s_lshr_b32 s29, s11, 16
+; VI-NEXT:    s_lshr_b32 s40, s12, 16
+; VI-NEXT:    s_lshr_b32 s41, s13, 16
+; VI-NEXT:    s_lshr_b32 s42, s14, 16
+; VI-NEXT:    s_lshr_b32 s43, s15, 16
+; VI-NEXT:    s_lshr_b32 s44, s16, 16
+; VI-NEXT:    s_lshr_b32 s45, s17, 16
+; VI-NEXT:    s_lshr_b32 s46, s18, 16
+; VI-NEXT:    s_lshr_b32 s47, s19, 16
+; VI-NEXT:    s_lshr_b32 s56, s20, 16
+; VI-NEXT:    s_lshr_b32 s57, s21, 16
+; VI-NEXT:    s_lshr_b32 s58, s22, 16
+; VI-NEXT:    s_lshr_b32 s59, s23, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB45_3
 ; VI-NEXT:  .LBB45_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
 ; VI-NEXT:    s_addc_u32 s7, s7, 0
 ; VI-NEXT:    s_add_u32 s9, s9, 3
 ; VI-NEXT:    s_addc_u32 s8, s8, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s10, s7, 16
-; VI-NEXT:    s_lshr_b32 s11, s6, 16
-; VI-NEXT:    s_lshr_b32 s12, s8, 16
-; VI-NEXT:    s_lshr_b32 s13, s9, 16
-; VI-NEXT:    s_lshr_b32 s14, s29, 16
-; VI-NEXT:    s_lshr_b32 s15, s28, 16
-; VI-NEXT:    s_lshr_b32 s40, s27, 16
-; VI-NEXT:    s_lshr_b32 s41, s26, 16
-; VI-NEXT:    s_lshr_b32 s42, s25, 16
-; VI-NEXT:    s_lshr_b32 s43, s24, 16
-; VI-NEXT:    s_lshr_b32 s44, s23, 16
-; VI-NEXT:    s_lshr_b32 s45, s22, 16
-; VI-NEXT:    s_lshr_b32 s46, s21, 16
-; VI-NEXT:    s_lshr_b32 s47, s20, 16
-; VI-NEXT:    s_lshr_b32 s56, s19, 16
-; VI-NEXT:    s_lshr_b32 s57, s18, 16
-; VI-NEXT:    s_lshr_b32 s58, s17, 16
-; VI-NEXT:    s_lshr_b32 s59, s16, 16
+; VI-NEXT:    s_add_u32 s11, s11, 3
+; VI-NEXT:    s_addc_u32 s10, s10, 0
+; VI-NEXT:    s_add_u32 s13, s13, 3
+; VI-NEXT:    s_addc_u32 s12, s12, 0
+; VI-NEXT:    s_add_u32 s15, s15, 3
+; VI-NEXT:    s_addc_u32 s14, s14, 0
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_lshr_b32 s24, s7, 16
+; VI-NEXT:    s_lshr_b32 s25, s6, 16
+; VI-NEXT:    s_lshr_b32 s26, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s9, 16
+; VI-NEXT:    s_lshr_b32 s28, s10, 16
+; VI-NEXT:    s_lshr_b32 s29, s11, 16
+; VI-NEXT:    s_lshr_b32 s40, s12, 16
+; VI-NEXT:    s_lshr_b32 s41, s13, 16
+; VI-NEXT:    s_lshr_b32 s42, s14, 16
+; VI-NEXT:    s_lshr_b32 s43, s15, 16
+; VI-NEXT:    s_lshr_b32 s44, s16, 16
+; VI-NEXT:    s_lshr_b32 s45, s17, 16
+; VI-NEXT:    s_lshr_b32 s46, s18, 16
+; VI-NEXT:    s_lshr_b32 s47, s19, 16
+; VI-NEXT:    s_lshr_b32 s56, s20, 16
+; VI-NEXT:    s_lshr_b32 s57, s21, 16
+; VI-NEXT:    s_lshr_b32 s58, s22, 16
+; VI-NEXT:    s_lshr_b32 s59, s23, 16
 ; VI-NEXT:  .LBB45_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s23
 ; VI-NEXT:    s_lshl_b32 s5, s59, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s58, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s57, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s56, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s47, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s46, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s45, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s44, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s22, s58, 16
+; VI-NEXT:    s_or_b32 s5, s5, s22
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s22, s57, 16
 ; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s43, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s42, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s41, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s40, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
-; VI-NEXT:    s_or_b32 s15, s26, s15
-; VI-NEXT:    s_and_b32 s26, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s22, s56, 16
+; VI-NEXT:    s_or_b32 s20, s20, s22
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s22, s47, 16
+; VI-NEXT:    s_or_b32 s19, s19, s22
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s22, s46, 16
+; VI-NEXT:    s_or_b32 s18, s18, s22
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s22, s45, 16
+; VI-NEXT:    s_or_b32 s17, s17, s22
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s22, s44, 16
+; VI-NEXT:    s_or_b32 s16, s16, s22
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s22, s43, 16
+; VI-NEXT:    s_or_b32 s15, s15, s22
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s22, s42, 16
+; VI-NEXT:    s_or_b32 s14, s14, s22
+; VI-NEXT:    s_and_b32 s13, 0xffff, s13
+; VI-NEXT:    s_lshl_b32 s22, s41, 16
+; VI-NEXT:    s_or_b32 s13, s13, s22
+; VI-NEXT:    s_and_b32 s12, 0xffff, s12
+; VI-NEXT:    s_lshl_b32 s22, s40, 16
+; VI-NEXT:    s_or_b32 s12, s12, s22
+; VI-NEXT:    s_and_b32 s11, 0xffff, s11
+; VI-NEXT:    s_lshl_b32 s22, s29, 16
+; VI-NEXT:    s_or_b32 s11, s11, s22
+; VI-NEXT:    s_and_b32 s10, 0xffff, s10
+; VI-NEXT:    s_lshl_b32 s22, s28, 16
+; VI-NEXT:    s_or_b32 s10, s10, s22
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s13, s13, 16
+; VI-NEXT:    s_lshl_b32 s22, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s22
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s12, s12, 16
+; VI-NEXT:    s_lshl_b32 s22, s26, 16
+; VI-NEXT:    s_or_b32 s8, s8, s22
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s11, s11, 16
+; VI-NEXT:    s_lshl_b32 s22, s25, 16
+; VI-NEXT:    s_or_b32 s6, s6, s22
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s10, s10, 16
-; VI-NEXT:    s_or_b32 s14, s26, s14
-; VI-NEXT:    s_or_b32 s9, s9, s13
-; VI-NEXT:    s_or_b32 s8, s8, s12
-; VI-NEXT:    s_or_b32 s6, s6, s11
-; VI-NEXT:    s_or_b32 s7, s7, s10
+; VI-NEXT:    s_lshl_b32 s22, s24, 16
+; VI-NEXT:    s_or_b32 s7, s7, s22
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s15
-; VI-NEXT:    v_mov_b32_e32 v13, s14
+; VI-NEXT:    v_mov_b32_e32 v2, s21
+; VI-NEXT:    v_mov_b32_e32 v3, s20
+; VI-NEXT:    v_mov_b32_e32 v4, s19
+; VI-NEXT:    v_mov_b32_e32 v5, s18
+; VI-NEXT:    v_mov_b32_e32 v6, s17
+; VI-NEXT:    v_mov_b32_e32 v7, s16
+; VI-NEXT:    v_mov_b32_e32 v8, s15
+; VI-NEXT:    v_mov_b32_e32 v9, s14
+; VI-NEXT:    v_mov_b32_e32 v10, s13
+; VI-NEXT:    v_mov_b32_e32 v11, s12
+; VI-NEXT:    v_mov_b32_e32 v12, s11
+; VI-NEXT:    v_mov_b32_e32 v13, s10
 ; VI-NEXT:    v_mov_b32_e32 v14, s9
 ; VI-NEXT:    v_mov_b32_e32 v15, s8
 ; VI-NEXT:    v_mov_b32_e32 v16, s6
@@ -19382,55 +19715,73 @@ define inreg <36 x half> @bitcast_v9i64_to_v36f16_scalar(<9 x i64> inreg %a, i32
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
 ; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
-; VI-NEXT:    ; implicit-def: $sgpr13
-; VI-NEXT:    ; implicit-def: $sgpr12
-; VI-NEXT:    ; implicit-def: $sgpr11
-; VI-NEXT:    ; implicit-def: $sgpr10
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
+; VI-NEXT:    ; implicit-def: $sgpr26
+; VI-NEXT:    ; implicit-def: $sgpr25
+; VI-NEXT:    ; implicit-def: $sgpr24
 ; VI-NEXT:    s_branch .LBB45_2
 ;
 ; GFX9-LABEL: bitcast_v9i64_to_v36f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v5, s16
+; GFX9-NEXT:    v_mov_b32_e32 v6, s17
+; GFX9-NEXT:    v_mov_b32_e32 v7, s18
+; GFX9-NEXT:    v_mov_b32_e32 v8, s19
+; GFX9-NEXT:    v_mov_b32_e32 v9, s20
+; GFX9-NEXT:    v_mov_b32_e32 v10, s21
+; GFX9-NEXT:    v_mov_b32_e32 v11, s22
+; GFX9-NEXT:    v_mov_b32_e32 v12, s23
+; GFX9-NEXT:    v_mov_b32_e32 v13, s24
+; GFX9-NEXT:    v_mov_b32_e32 v14, s25
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s10, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s11, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s24, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s25, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB45_3
 ; GFX9-NEXT:  .LBB45_2: ; %cmp.true
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
-; GFX9-NEXT:    s_add_u32 s28, s28, 3
-; GFX9-NEXT:    s_addc_u32 s29, s29, 0
-; GFX9-NEXT:    s_add_u32 s26, s26, 3
-; GFX9-NEXT:    s_addc_u32 s27, s27, 0
-; GFX9-NEXT:    s_add_u32 s24, s24, 3
-; GFX9-NEXT:    s_addc_u32 s25, s25, 0
 ; GFX9-NEXT:    s_add_u32 s22, s22, 3
 ; GFX9-NEXT:    s_addc_u32 s23, s23, 0
 ; GFX9-NEXT:    s_add_u32 s20, s20, 3
@@ -19439,61 +19790,71 @@ define inreg <36 x half> @bitcast_v9i64_to_v36f16_scalar(<9 x i64> inreg %a, i32
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
-; GFX9-NEXT:    s_lshr_b32 s10, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s11, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s16, 16
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
+; GFX9-NEXT:    s_lshr_b32 s24, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s25, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s6, 16
 ; GFX9-NEXT:  .LBB45_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s28, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s29, s14
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s13
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s12
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s11
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s10
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s28
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s27
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s26
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s25
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s24
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s15
-; GFX9-NEXT:    v_mov_b32_e32 v13, s14
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB45_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr59
@@ -19508,12 +19869,12 @@ define inreg <36 x half> @bitcast_v9i64_to_v36f16_scalar(<9 x i64> inreg %a, i32
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
-; GFX9-NEXT:    ; implicit-def: $sgpr13
-; GFX9-NEXT:    ; implicit-def: $sgpr12
-; GFX9-NEXT:    ; implicit-def: $sgpr11
-; GFX9-NEXT:    ; implicit-def: $sgpr10
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
+; GFX9-NEXT:    ; implicit-def: $sgpr27
+; GFX9-NEXT:    ; implicit-def: $sgpr26
+; GFX9-NEXT:    ; implicit-def: $sgpr25
+; GFX9-NEXT:    ; implicit-def: $sgpr24
 ; GFX9-NEXT:    s_branch .LBB45_2
 ;
 ; GFX11-LABEL: bitcast_v9i64_to_v36f16_scalar:
@@ -24437,296 +24798,325 @@ define inreg <36 x half> @bitcast_v9f64_to_v36f16_scalar(<9 x double> inreg %a, 
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
-; SI-NEXT:    v_readfirstlane_b32 s6, v1
-; SI-NEXT:    v_readfirstlane_b32 s7, v2
-; SI-NEXT:    v_readfirstlane_b32 s4, v3
-; SI-NEXT:    s_and_b64 s[8:9], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s5, v4
+; SI-NEXT:    v_mov_b32_e32 v18, s16
+; SI-NEXT:    v_mov_b32_e32 v19, s17
+; SI-NEXT:    v_mov_b32_e32 v16, s18
+; SI-NEXT:    v_mov_b32_e32 v17, s19
+; SI-NEXT:    v_mov_b32_e32 v14, s20
+; SI-NEXT:    v_mov_b32_e32 v15, s21
+; SI-NEXT:    v_mov_b32_e32 v12, s22
+; SI-NEXT:    v_mov_b32_e32 v13, s23
+; SI-NEXT:    v_mov_b32_e32 v10, s24
+; SI-NEXT:    v_mov_b32_e32 v11, s25
+; SI-NEXT:    v_mov_b32_e32 v8, s26
+; SI-NEXT:    v_mov_b32_e32 v9, s27
+; SI-NEXT:    v_mov_b32_e32 v6, s28
+; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
+; SI-NEXT:    v_mov_b32_e32 v7, s29
+; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_cbranch_scc0 .LBB53_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s8, s5, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s8
-; SI-NEXT:    s_lshr_b32 s8, s4, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s8
-; SI-NEXT:    s_lshr_b32 s8, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s8
-; SI-NEXT:    s_lshr_b32 s8, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s8
-; SI-NEXT:    s_lshr_b32 s8, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s8
-; SI-NEXT:    s_lshr_b32 s8, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s8
-; SI-NEXT:    s_lshr_b32 s8, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s8
-; SI-NEXT:    s_lshr_b32 s8, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s8
-; SI-NEXT:    s_lshr_b32 s8, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s8
-; SI-NEXT:    s_lshr_b32 s8, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s8
-; SI-NEXT:    s_lshr_b32 s8, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s8
-; SI-NEXT:    s_lshr_b32 s8, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s8
-; SI-NEXT:    s_lshr_b32 s8, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s8
-; SI-NEXT:    s_lshr_b32 s8, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s8
-; SI-NEXT:    s_lshr_b32 s8, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s8
-; SI-NEXT:    s_lshr_b32 s8, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s8
-; SI-NEXT:    s_lshr_b32 s8, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s8
-; SI-NEXT:    s_lshr_b32 s8, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s5
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v17
+; SI-NEXT:    s_waitcnt expcnt(6)
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v16
+; SI-NEXT:    s_waitcnt expcnt(4)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
+; SI-NEXT:    s_waitcnt expcnt(2)
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v18
 ; SI-NEXT:    s_cbranch_execnz .LBB53_3
 ; SI-NEXT:  .LBB53_2: ; %cmp.true
-; SI-NEXT:    v_add_f64 v[1:2], s[16:17], 1.0
-; SI-NEXT:    v_add_f64 v[28:29], s[18:19], 1.0
-; SI-NEXT:    v_add_f64 v[25:26], s[20:21], 1.0
-; SI-NEXT:    v_add_f64 v[21:22], s[22:23], 1.0
-; SI-NEXT:    v_add_f64 v[17:18], s[24:25], 1.0
-; SI-NEXT:    v_add_f64 v[13:14], s[26:27], 1.0
-; SI-NEXT:    v_add_f64 v[10:11], s[28:29], 1.0
-; SI-NEXT:    v_add_f64 v[6:7], s[6:7], 1.0
-; SI-NEXT:    v_add_f64 v[4:5], s[4:5], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v28
-; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v29
-; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v25
-; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v26
-; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
-; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v17
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v13
-; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v10
-; SI-NEXT:    v_lshrrev_b32_e32 v8, 16, v11
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v6
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v7
-; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v4
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v5
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v13
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v17
+; SI-NEXT:    v_add_f64 v[18:19], v[18:19], 1.0
+; SI-NEXT:    v_add_f64 v[16:17], v[16:17], 1.0
+; SI-NEXT:    v_add_f64 v[14:15], v[14:15], 1.0
+; SI-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
+; SI-NEXT:    v_add_f64 v[10:11], v[10:11], 1.0
+; SI-NEXT:    v_add_f64 v[8:9], v[8:9], 1.0
+; SI-NEXT:    v_add_f64 v[5:6], v[6:7], 1.0
+; SI-NEXT:    v_add_f64 v[1:2], v[1:2], 1.0
+; SI-NEXT:    v_add_f64 v[3:4], v[3:4], 1.0
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v22, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v5, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
 ; SI-NEXT:    v_cvt_f32_f16_e32 v22, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v24
 ; SI-NEXT:    v_cvt_f32_f16_e32 v26, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v25
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v28
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v52
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v49
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v39
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v38
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v34
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v32
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v33
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v39
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v46
 ; SI-NEXT:  .LBB53_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v36, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v35, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v34, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v33, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v32, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v31, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v30
-; SI-NEXT:    v_lshlrev_b32_e32 v36, 16, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v29, v29
-; SI-NEXT:    v_cvt_f16_f32_e32 v28, v28
-; SI-NEXT:    v_or_b32_e32 v35, v35, v36
-; SI-NEXT:    v_lshlrev_b32_e32 v34, 16, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; SI-NEXT:    v_cvt_f16_f32_e32 v25, v25
-; SI-NEXT:    buffer_store_dword v35, v0, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v46
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v45
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v44
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v43
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v33, v33, v34
-; SI-NEXT:    v_lshlrev_b32_e32 v32, 16, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v23, v23
-; SI-NEXT:    buffer_store_dword v33, v35, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 8, v0
-; SI-NEXT:    v_or_b32_e32 v31, v31, v32
-; SI-NEXT:    v_lshlrev_b32_e32 v30, 16, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v21, v21
-; SI-NEXT:    buffer_store_dword v31, v33, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 12, v0
-; SI-NEXT:    v_or_b32_e32 v29, v29, v30
-; SI-NEXT:    v_lshlrev_b32_e32 v28, 16, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v19, v19
-; SI-NEXT:    buffer_store_dword v29, v31, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v29, vcc, 16, v0
-; SI-NEXT:    v_or_b32_e32 v27, v27, v28
-; SI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v17, v17
-; SI-NEXT:    buffer_store_dword v27, v29, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v27, vcc, 20, v0
-; SI-NEXT:    v_or_b32_e32 v25, v26, v25
-; SI-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v15, v15
-; SI-NEXT:    buffer_store_dword v25, v27, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v25, vcc, 24, v0
-; SI-NEXT:    v_or_b32_e32 v23, v24, v23
-; SI-NEXT:    v_lshlrev_b32_e32 v21, 16, v21
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v13
-; SI-NEXT:    buffer_store_dword v23, v25, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v23, vcc, 28, v0
-; SI-NEXT:    v_or_b32_e32 v21, v22, v21
-; SI-NEXT:    v_lshlrev_b32_e32 v19, 16, v19
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v10
-; SI-NEXT:    buffer_store_dword v21, v23, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v21, vcc, 32, v0
-; SI-NEXT:    v_or_b32_e32 v19, v20, v19
-; SI-NEXT:    v_lshlrev_b32_e32 v17, 16, v17
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; SI-NEXT:    buffer_store_dword v19, v21, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v19, vcc, 36, v0
-; SI-NEXT:    v_or_b32_e32 v17, v18, v17
-; SI-NEXT:    v_lshlrev_b32_e32 v15, 16, v15
-; SI-NEXT:    buffer_store_dword v17, v19, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v17, vcc, 40, v0
-; SI-NEXT:    v_or_b32_e32 v15, v16, v15
-; SI-NEXT:    v_lshlrev_b32_e32 v13, 16, v13
-; SI-NEXT:    buffer_store_dword v15, v17, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v15, vcc, 44, v0
-; SI-NEXT:    v_or_b32_e32 v13, v14, v13
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    buffer_store_dword v13, v15, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 48, v0
-; SI-NEXT:    v_or_b32_e32 v10, v12, v10
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v8
-; SI-NEXT:    buffer_store_dword v10, v13, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v11
-; SI-NEXT:    v_add_i32_e32 v11, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
-; SI-NEXT:    v_or_b32_e32 v8, v10, v8
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v6
-; SI-NEXT:    buffer_store_dword v8, v11, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v9
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; SI-NEXT:    buffer_store_dword v6, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v7
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v4, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v5
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
 ; SI-NEXT:    v_or_b32_e32 v2, v4, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v5, s[0:3], 0 offen
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v42
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v3
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v41
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v40
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v55
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v54
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v51
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v52
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v49
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v50
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v39
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v48
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v37
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v38
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v35
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v36
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v33
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v34
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v30
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v32
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v28
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v31
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v26
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v24
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v27
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v22
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v25
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v20
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v23
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v5
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v21
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x44, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB53_4:
-; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr43
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr49
+; SI-NEXT:    ; implicit-def: $vgpr48
+; SI-NEXT:    ; implicit-def: $vgpr39
+; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr37
 ; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; implicit-def: $vgpr35
 ; SI-NEXT:    ; implicit-def: $vgpr34
-; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr33
 ; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr30
-; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    ; implicit-def: $vgpr28
+; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr26
-; SI-NEXT:    ; implicit-def: $vgpr25
+; SI-NEXT:    ; implicit-def: $vgpr27
 ; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr23
+; SI-NEXT:    ; implicit-def: $vgpr25
 ; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; implicit-def: $vgpr23
 ; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr14
-; SI-NEXT:    ; implicit-def: $vgpr13
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr10
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr8
-; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr6
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr4
+; SI-NEXT:    ; implicit-def: $vgpr21
 ; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr1
 ; SI-NEXT:    s_branch .LBB53_2
 ;
 ; VI-LABEL: bitcast_v9f64_to_v36f16_scalar:

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.640bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.640bit.ll
@@ -2837,177 +2837,205 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; SI-LABEL: bitcast_v20i32_to_v40i16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v8, s16
+; SI-NEXT:    v_mov_b32_e32 v9, s17
+; SI-NEXT:    v_mov_b32_e32 v10, s18
+; SI-NEXT:    v_mov_b32_e32 v11, s19
+; SI-NEXT:    v_mov_b32_e32 v12, s20
+; SI-NEXT:    v_mov_b32_e32 v13, s21
+; SI-NEXT:    v_mov_b32_e32 v14, s22
+; SI-NEXT:    v_mov_b32_e32 v15, s23
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v8
+; SI-NEXT:    v_mov_b32_e32 v8, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v9
+; SI-NEXT:    v_mov_b32_e32 v9, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; SI-NEXT:    v_readfirstlane_b32 s20, v10
+; SI-NEXT:    v_readfirstlane_b32 s21, v11
+; SI-NEXT:    v_readfirstlane_b32 s18, v12
+; SI-NEXT:    v_readfirstlane_b32 s19, v13
+; SI-NEXT:    v_readfirstlane_b32 s16, v14
+; SI-NEXT:    v_readfirstlane_b32 s17, v15
+; SI-NEXT:    v_readfirstlane_b32 s14, v16
+; SI-NEXT:    v_readfirstlane_b32 s15, v17
+; SI-NEXT:    v_readfirstlane_b32 s12, v18
+; SI-NEXT:    v_readfirstlane_b32 s13, v19
+; SI-NEXT:    v_readfirstlane_b32 s10, v8
+; SI-NEXT:    v_readfirstlane_b32 s11, v9
 ; SI-NEXT:    v_readfirstlane_b32 s8, v1
 ; SI-NEXT:    v_readfirstlane_b32 s9, v2
 ; SI-NEXT:    v_readfirstlane_b32 s6, v3
 ; SI-NEXT:    v_readfirstlane_b32 s7, v4
 ; SI-NEXT:    v_readfirstlane_b32 s4, v5
-; SI-NEXT:    s_and_b64 s[10:11], vcc, exec
+; SI-NEXT:    s_and_b64 s[24:25], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v6
 ; SI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s72, s5, 16
 ; SI-NEXT:    s_lshr_b32 s73, s7, 16
 ; SI-NEXT:    s_lshr_b32 s74, s9, 16
-; SI-NEXT:    s_lshr_b32 s75, s29, 16
-; SI-NEXT:    s_lshr_b32 s76, s27, 16
-; SI-NEXT:    s_lshr_b32 s77, s25, 16
-; SI-NEXT:    s_lshr_b32 s78, s23, 16
-; SI-NEXT:    s_lshr_b32 s79, s21, 16
-; SI-NEXT:    s_lshr_b32 s88, s19, 16
-; SI-NEXT:    s_lshr_b32 s89, s17, 16
-; SI-NEXT:    s_lshr_b64 s[10:11], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[6:7], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[8:9], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[16:17], 16
+; SI-NEXT:    s_lshr_b32 s75, s11, 16
+; SI-NEXT:    s_lshr_b32 s76, s13, 16
+; SI-NEXT:    s_lshr_b32 s77, s15, 16
+; SI-NEXT:    s_lshr_b32 s78, s17, 16
+; SI-NEXT:    s_lshr_b32 s79, s19, 16
+; SI-NEXT:    s_lshr_b32 s88, s21, 16
+; SI-NEXT:    s_lshr_b32 s89, s23, 16
+; SI-NEXT:    s_lshr_b64 s[24:25], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[8:9], 16
+; SI-NEXT:    s_lshr_b64 s[40:41], s[10:11], 16
+; SI-NEXT:    s_lshr_b64 s[42:43], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[46:47], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[22:23], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB13_3
 ; SI-NEXT:  .LBB13_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
 ; SI-NEXT:    s_add_i32 s23, s23, 3
 ; SI-NEXT:    s_add_i32 s22, s22, 3
-; SI-NEXT:    s_add_i32 s25, s25, 3
-; SI-NEXT:    s_add_i32 s24, s24, 3
-; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s26, s26, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
+; SI-NEXT:    s_add_i32 s15, s15, 3
+; SI-NEXT:    s_add_i32 s14, s14, 3
+; SI-NEXT:    s_add_i32 s13, s13, 3
+; SI-NEXT:    s_add_i32 s12, s12, 3
+; SI-NEXT:    s_add_i32 s11, s11, 3
+; SI-NEXT:    s_add_i32 s10, s10, 3
 ; SI-NEXT:    s_add_i32 s9, s9, 3
 ; SI-NEXT:    s_add_i32 s8, s8, 3
 ; SI-NEXT:    s_add_i32 s7, s7, 3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s5, s5, 3
 ; SI-NEXT:    s_add_i32 s4, s4, 3
-; SI-NEXT:    s_lshr_b64 s[10:11], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[6:7], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[8:9], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[24:25], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[8:9], 16
+; SI-NEXT:    s_lshr_b64 s[40:41], s[10:11], 16
+; SI-NEXT:    s_lshr_b64 s[42:43], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[46:47], s[16:17], 16
 ; SI-NEXT:    s_lshr_b32 s72, s5, 16
 ; SI-NEXT:    s_lshr_b32 s73, s7, 16
 ; SI-NEXT:    s_lshr_b32 s74, s9, 16
-; SI-NEXT:    s_lshr_b32 s75, s29, 16
-; SI-NEXT:    s_lshr_b32 s76, s27, 16
-; SI-NEXT:    s_lshr_b32 s77, s25, 16
-; SI-NEXT:    s_lshr_b32 s78, s23, 16
-; SI-NEXT:    s_lshr_b32 s79, s21, 16
-; SI-NEXT:    s_lshr_b32 s88, s19, 16
-; SI-NEXT:    s_lshr_b32 s89, s17, 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[16:17], 16
+; SI-NEXT:    s_lshr_b32 s75, s11, 16
+; SI-NEXT:    s_lshr_b32 s76, s13, 16
+; SI-NEXT:    s_lshr_b32 s77, s15, 16
+; SI-NEXT:    s_lshr_b32 s78, s17, 16
+; SI-NEXT:    s_lshr_b32 s79, s19, 16
+; SI-NEXT:    s_lshr_b32 s88, s21, 16
+; SI-NEXT:    s_lshr_b32 s89, s23, 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[22:23], 16
 ; SI-NEXT:  .LBB13_3: ; %end
-; SI-NEXT:    s_lshl_b32 s11, s60, 16
-; SI-NEXT:    s_and_b32 s13, s16, 0xffff
-; SI-NEXT:    s_or_b32 s11, s13, s11
-; SI-NEXT:    v_mov_b32_e32 v1, s11
-; SI-NEXT:    s_and_b32 s11, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s89, 16
-; SI-NEXT:    s_or_b32 s11, s11, s13
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_lshl_b32 s11, s58, 16
-; SI-NEXT:    s_and_b32 s13, s18, 0xffff
-; SI-NEXT:    s_or_b32 s11, s13, s11
+; SI-NEXT:    s_lshl_b32 s25, s60, 16
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_or_b32 s22, s22, s25
+; SI-NEXT:    v_mov_b32_e32 v1, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s89, 16
+; SI-NEXT:    s_or_b32 s22, s22, s23
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_lshl_b32 s22, s58, 16
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s88, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s88, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s20, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s56, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s56, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s79, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s79, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s46, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s46, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s78, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
+; SI-NEXT:    s_lshl_b32 s17, s78, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s16, s16, s17
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s44, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s14, s14, 0xffff
+; SI-NEXT:    s_lshl_b32 s16, s44, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s14, s14, s16
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s77, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s14, s15, 0xffff
+; SI-NEXT:    s_lshl_b32 s15, s77, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s14, s14, s15
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s42, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s12, s12, 0xffff
+; SI-NEXT:    s_lshl_b32 s14, s42, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s12, s12, s14
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s27, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s12, s13, 0xffff
 ; SI-NEXT:    s_lshl_b32 s13, s76, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s12, s12, s13
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s40, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s10, s10, 0xffff
+; SI-NEXT:    s_lshl_b32 s12, s40, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s10, s10, s12
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s75, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s10
+; SI-NEXT:    s_and_b32 s10, s11, 0xffff
+; SI-NEXT:    s_lshl_b32 s11, s75, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s10, s10, s11
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
+; SI-NEXT:    v_mov_b32_e32 v2, s10
 ; SI-NEXT:    s_and_b32 s8, s8, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s14, 16
+; SI-NEXT:    s_lshl_b32 s10, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s8, s8, s11
+; SI-NEXT:    s_or_b32 s8, s8, s10
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
@@ -3019,7 +3047,7 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s12, 16
+; SI-NEXT:    s_lshl_b32 s8, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 60, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3033,7 +3061,7 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s10, 16
+; SI-NEXT:    s_lshl_b32 s6, s24, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x44, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3064,18 +3092,46 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr76
 ; SI-NEXT:    ; implicit-def: $sgpr40
 ; SI-NEXT:    ; implicit-def: $sgpr75
-; SI-NEXT:    ; implicit-def: $sgpr14
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr74
-; SI-NEXT:    ; implicit-def: $sgpr12
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr73
-; SI-NEXT:    ; implicit-def: $sgpr10
+; SI-NEXT:    ; implicit-def: $sgpr24
 ; SI-NEXT:    ; implicit-def: $sgpr72
 ; SI-NEXT:    s_branch .LBB13_2
 ;
 ; VI-LABEL: bitcast_v20i32_to_v40i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v7, s16
+; VI-NEXT:    v_mov_b32_e32 v8, s17
+; VI-NEXT:    v_mov_b32_e32 v9, s18
+; VI-NEXT:    v_mov_b32_e32 v10, s19
+; VI-NEXT:    v_mov_b32_e32 v11, s20
+; VI-NEXT:    v_mov_b32_e32 v12, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s22
+; VI-NEXT:    v_mov_b32_e32 v14, s23
+; VI-NEXT:    v_mov_b32_e32 v15, s24
+; VI-NEXT:    v_mov_b32_e32 v16, s25
+; VI-NEXT:    v_mov_b32_e32 v17, s26
+; VI-NEXT:    v_mov_b32_e32 v18, s27
+; VI-NEXT:    v_mov_b32_e32 v19, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v7
+; VI-NEXT:    v_mov_b32_e32 v7, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; VI-NEXT:    v_readfirstlane_b32 s24, v8
+; VI-NEXT:    v_readfirstlane_b32 s23, v9
+; VI-NEXT:    v_readfirstlane_b32 s22, v10
+; VI-NEXT:    v_readfirstlane_b32 s21, v11
+; VI-NEXT:    v_readfirstlane_b32 s20, v12
+; VI-NEXT:    v_readfirstlane_b32 s19, v13
+; VI-NEXT:    v_readfirstlane_b32 s18, v14
+; VI-NEXT:    v_readfirstlane_b32 s17, v15
+; VI-NEXT:    v_readfirstlane_b32 s16, v16
+; VI-NEXT:    v_readfirstlane_b32 s15, v17
+; VI-NEXT:    v_readfirstlane_b32 s14, v18
+; VI-NEXT:    v_readfirstlane_b32 s13, v19
+; VI-NEXT:    v_readfirstlane_b32 s12, v7
 ; VI-NEXT:    v_readfirstlane_b32 s11, v0
 ; VI-NEXT:    v_readfirstlane_b32 s10, v1
 ; VI-NEXT:    v_readfirstlane_b32 s9, v2
@@ -3085,26 +3141,26 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; VI-NEXT:    v_readfirstlane_b32 s7, v5
 ; VI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s12, s7, 16
-; VI-NEXT:    s_lshr_b32 s13, s6, 16
-; VI-NEXT:    s_lshr_b32 s14, s8, 16
-; VI-NEXT:    s_lshr_b32 s15, s9, 16
+; VI-NEXT:    s_lshr_b32 s26, s7, 16
+; VI-NEXT:    s_lshr_b32 s27, s6, 16
+; VI-NEXT:    s_lshr_b32 s28, s8, 16
+; VI-NEXT:    s_lshr_b32 s29, s9, 16
 ; VI-NEXT:    s_lshr_b32 s40, s10, 16
 ; VI-NEXT:    s_lshr_b32 s41, s11, 16
-; VI-NEXT:    s_lshr_b32 s42, s29, 16
-; VI-NEXT:    s_lshr_b32 s43, s28, 16
-; VI-NEXT:    s_lshr_b32 s44, s27, 16
-; VI-NEXT:    s_lshr_b32 s45, s26, 16
-; VI-NEXT:    s_lshr_b32 s46, s25, 16
-; VI-NEXT:    s_lshr_b32 s47, s24, 16
-; VI-NEXT:    s_lshr_b32 s56, s23, 16
-; VI-NEXT:    s_lshr_b32 s57, s22, 16
-; VI-NEXT:    s_lshr_b32 s58, s21, 16
-; VI-NEXT:    s_lshr_b32 s59, s20, 16
-; VI-NEXT:    s_lshr_b32 s60, s19, 16
-; VI-NEXT:    s_lshr_b32 s61, s18, 16
-; VI-NEXT:    s_lshr_b32 s62, s17, 16
-; VI-NEXT:    s_lshr_b32 s63, s16, 16
+; VI-NEXT:    s_lshr_b32 s42, s12, 16
+; VI-NEXT:    s_lshr_b32 s43, s13, 16
+; VI-NEXT:    s_lshr_b32 s44, s14, 16
+; VI-NEXT:    s_lshr_b32 s45, s15, 16
+; VI-NEXT:    s_lshr_b32 s46, s16, 16
+; VI-NEXT:    s_lshr_b32 s47, s17, 16
+; VI-NEXT:    s_lshr_b32 s56, s18, 16
+; VI-NEXT:    s_lshr_b32 s57, s19, 16
+; VI-NEXT:    s_lshr_b32 s58, s20, 16
+; VI-NEXT:    s_lshr_b32 s59, s21, 16
+; VI-NEXT:    s_lshr_b32 s60, s22, 16
+; VI-NEXT:    s_lshr_b32 s61, s23, 16
+; VI-NEXT:    s_lshr_b32 s62, s24, 16
+; VI-NEXT:    s_lshr_b32 s63, s25, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB13_3
 ; VI-NEXT:  .LBB13_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -3113,115 +3169,115 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; VI-NEXT:    s_add_i32 s9, s9, 3
 ; VI-NEXT:    s_add_i32 s10, s10, 3
 ; VI-NEXT:    s_add_i32 s11, s11, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s12, s12, 3
+; VI-NEXT:    s_add_i32 s13, s13, 3
+; VI-NEXT:    s_add_i32 s14, s14, 3
+; VI-NEXT:    s_add_i32 s15, s15, 3
 ; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s12, s7, 16
-; VI-NEXT:    s_lshr_b32 s13, s6, 16
-; VI-NEXT:    s_lshr_b32 s14, s8, 16
-; VI-NEXT:    s_lshr_b32 s15, s9, 16
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_lshr_b32 s26, s7, 16
+; VI-NEXT:    s_lshr_b32 s27, s6, 16
+; VI-NEXT:    s_lshr_b32 s28, s8, 16
+; VI-NEXT:    s_lshr_b32 s29, s9, 16
 ; VI-NEXT:    s_lshr_b32 s40, s10, 16
 ; VI-NEXT:    s_lshr_b32 s41, s11, 16
-; VI-NEXT:    s_lshr_b32 s42, s29, 16
-; VI-NEXT:    s_lshr_b32 s43, s28, 16
-; VI-NEXT:    s_lshr_b32 s44, s27, 16
-; VI-NEXT:    s_lshr_b32 s45, s26, 16
-; VI-NEXT:    s_lshr_b32 s46, s25, 16
-; VI-NEXT:    s_lshr_b32 s47, s24, 16
-; VI-NEXT:    s_lshr_b32 s56, s23, 16
-; VI-NEXT:    s_lshr_b32 s57, s22, 16
-; VI-NEXT:    s_lshr_b32 s58, s21, 16
-; VI-NEXT:    s_lshr_b32 s59, s20, 16
-; VI-NEXT:    s_lshr_b32 s60, s19, 16
-; VI-NEXT:    s_lshr_b32 s61, s18, 16
-; VI-NEXT:    s_lshr_b32 s62, s17, 16
-; VI-NEXT:    s_lshr_b32 s63, s16, 16
+; VI-NEXT:    s_lshr_b32 s42, s12, 16
+; VI-NEXT:    s_lshr_b32 s43, s13, 16
+; VI-NEXT:    s_lshr_b32 s44, s14, 16
+; VI-NEXT:    s_lshr_b32 s45, s15, 16
+; VI-NEXT:    s_lshr_b32 s46, s16, 16
+; VI-NEXT:    s_lshr_b32 s47, s17, 16
+; VI-NEXT:    s_lshr_b32 s56, s18, 16
+; VI-NEXT:    s_lshr_b32 s57, s19, 16
+; VI-NEXT:    s_lshr_b32 s58, s20, 16
+; VI-NEXT:    s_lshr_b32 s59, s21, 16
+; VI-NEXT:    s_lshr_b32 s60, s22, 16
+; VI-NEXT:    s_lshr_b32 s61, s23, 16
+; VI-NEXT:    s_lshr_b32 s62, s24, 16
+; VI-NEXT:    s_lshr_b32 s63, s25, 16
 ; VI-NEXT:  .LBB13_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s25
 ; VI-NEXT:    s_lshl_b32 s5, s63, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s62, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s61, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s60, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s59, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s58, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s57, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s56, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s47, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s46, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s24, s62, 16
+; VI-NEXT:    s_or_b32 s5, s5, s24
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s24, s61, 16
 ; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s45, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s44, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s43, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s24, s60, 16
+; VI-NEXT:    s_or_b32 s22, s22, s24
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s24, s59, 16
+; VI-NEXT:    s_or_b32 s21, s21, s24
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s24, s58, 16
+; VI-NEXT:    s_or_b32 s20, s20, s24
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s24, s57, 16
+; VI-NEXT:    s_or_b32 s19, s19, s24
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s24, s56, 16
+; VI-NEXT:    s_or_b32 s18, s18, s24
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s24, s47, 16
+; VI-NEXT:    s_or_b32 s17, s17, s24
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s24, s46, 16
+; VI-NEXT:    s_or_b32 s16, s16, s24
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s24, s45, 16
+; VI-NEXT:    s_or_b32 s15, s15, s24
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s24, s44, 16
+; VI-NEXT:    s_or_b32 s14, s14, s24
+; VI-NEXT:    s_and_b32 s13, 0xffff, s13
+; VI-NEXT:    s_lshl_b32 s24, s43, 16
+; VI-NEXT:    s_or_b32 s13, s13, s24
+; VI-NEXT:    s_and_b32 s12, 0xffff, s12
+; VI-NEXT:    s_lshl_b32 s24, s42, 16
+; VI-NEXT:    s_or_b32 s12, s12, s24
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s24, s41, 16
+; VI-NEXT:    s_or_b32 s11, s11, s24
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
+; VI-NEXT:    s_lshl_b32 s24, s40, 16
+; VI-NEXT:    s_or_b32 s10, s10, s24
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
+; VI-NEXT:    s_lshl_b32 s24, s29, 16
+; VI-NEXT:    s_or_b32 s9, s9, s24
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
+; VI-NEXT:    s_lshl_b32 s24, s28, 16
+; VI-NEXT:    s_or_b32 s8, s8, s24
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s13, s13, 16
+; VI-NEXT:    s_lshl_b32 s24, s27, 16
+; VI-NEXT:    s_or_b32 s6, s6, s24
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s12, s12, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
-; VI-NEXT:    s_or_b32 s9, s9, s15
-; VI-NEXT:    s_or_b32 s8, s8, s14
-; VI-NEXT:    s_or_b32 s6, s6, s13
-; VI-NEXT:    s_or_b32 s7, s7, s12
+; VI-NEXT:    s_lshl_b32 s24, s26, 16
+; VI-NEXT:    s_or_b32 s7, s7, s24
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s23
+; VI-NEXT:    v_mov_b32_e32 v3, s22
+; VI-NEXT:    v_mov_b32_e32 v4, s21
+; VI-NEXT:    v_mov_b32_e32 v5, s20
+; VI-NEXT:    v_mov_b32_e32 v6, s19
+; VI-NEXT:    v_mov_b32_e32 v7, s18
+; VI-NEXT:    v_mov_b32_e32 v8, s17
+; VI-NEXT:    v_mov_b32_e32 v9, s16
+; VI-NEXT:    v_mov_b32_e32 v10, s15
+; VI-NEXT:    v_mov_b32_e32 v11, s14
+; VI-NEXT:    v_mov_b32_e32 v12, s13
+; VI-NEXT:    v_mov_b32_e32 v13, s12
 ; VI-NEXT:    v_mov_b32_e32 v14, s11
 ; VI-NEXT:    v_mov_b32_e32 v15, s10
 ; VI-NEXT:    v_mov_b32_e32 v16, s9
@@ -3246,57 +3302,75 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
 ; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
-; VI-NEXT:    ; implicit-def: $sgpr13
-; VI-NEXT:    ; implicit-def: $sgpr12
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
+; VI-NEXT:    ; implicit-def: $sgpr26
 ; VI-NEXT:    s_branch .LBB13_2
 ;
 ; GFX9-LABEL: bitcast_v20i32_to_v40i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v7, s16
+; GFX9-NEXT:    v_mov_b32_e32 v8, s17
+; GFX9-NEXT:    v_mov_b32_e32 v9, s18
+; GFX9-NEXT:    v_mov_b32_e32 v10, s19
+; GFX9-NEXT:    v_mov_b32_e32 v11, s20
+; GFX9-NEXT:    v_mov_b32_e32 v12, s21
+; GFX9-NEXT:    v_mov_b32_e32 v13, s22
+; GFX9-NEXT:    v_mov_b32_e32 v14, s23
+; GFX9-NEXT:    v_mov_b32_e32 v15, s24
+; GFX9-NEXT:    v_mov_b32_e32 v16, s25
+; GFX9-NEXT:    v_mov_b32_e32 v17, s26
+; GFX9-NEXT:    v_mov_b32_e32 v18, s27
+; GFX9-NEXT:    v_mov_b32_e32 v19, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v7
+; GFX9-NEXT:    v_mov_b32_e32 v7, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s12, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB13_3
 ; GFX9-NEXT:  .LBB13_2: ; %cmp.true
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
-; GFX9-NEXT:    s_add_i32 s29, s29, 3
-; GFX9-NEXT:    s_add_i32 s28, s28, 3
-; GFX9-NEXT:    s_add_i32 s27, s27, 3
-; GFX9-NEXT:    s_add_i32 s26, s26, 3
 ; GFX9-NEXT:    s_add_i32 s25, s25, 3
 ; GFX9-NEXT:    s_add_i32 s24, s24, 3
 ; GFX9-NEXT:    s_add_i32 s23, s23, 3
@@ -3307,67 +3381,77 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
-; GFX9-NEXT:    s_lshr_b32 s12, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s16, 16
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
+; GFX9-NEXT:    s_lshr_b32 s26, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s6, 16
 ; GFX9-NEXT:  .LBB13_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s14
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s13
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s12
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s28
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s27
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB13_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr63
@@ -3386,38 +3470,65 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
-; GFX9-NEXT:    ; implicit-def: $sgpr13
-; GFX9-NEXT:    ; implicit-def: $sgpr12
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
+; GFX9-NEXT:    ; implicit-def: $sgpr27
+; GFX9-NEXT:    ; implicit-def: $sgpr26
 ; GFX9-NEXT:    s_branch .LBB13_2
 ;
 ; GFX11-LABEL: bitcast_v20i32_to_v40i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v3, s0 :: v_dual_mov_b32 v4, s1
+; GFX11-NEXT:    v_dual_mov_b32 v5, s2 :: v_dual_mov_b32 v6, s3
+; GFX11-NEXT:    v_dual_mov_b32 v7, s16 :: v_dual_mov_b32 v8, s17
+; GFX11-NEXT:    v_dual_mov_b32 v9, s18 :: v_dual_mov_b32 v10, s19
+; GFX11-NEXT:    v_dual_mov_b32 v11, s20 :: v_dual_mov_b32 v12, s21
+; GFX11-NEXT:    v_dual_mov_b32 v13, s22 :: v_dual_mov_b32 v14, s23
+; GFX11-NEXT:    v_dual_mov_b32 v15, s24 :: v_dual_mov_b32 v16, s25
+; GFX11-NEXT:    v_dual_mov_b32 v17, s26 :: v_dual_mov_b32 v18, s27
+; GFX11-NEXT:    v_dual_mov_b32 v19, s28 :: v_dual_mov_b32 v20, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v1
 ; GFX11-NEXT:    s_mov_b32 s58, 0
-; GFX11-NEXT:    s_and_b32 s6, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s20, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s7, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s8, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s20, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s21, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s46, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s47, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s56, s1, 16
@@ -3425,42 +3536,42 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s58
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB13_3
 ; GFX11-NEXT:  .LBB13_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
-; GFX11-NEXT:    s_add_i32 s26, s26, 3
-; GFX11-NEXT:    s_add_i32 s25, s25, 3
-; GFX11-NEXT:    s_add_i32 s24, s24, 3
-; GFX11-NEXT:    s_add_i32 s23, s23, 3
-; GFX11-NEXT:    s_add_i32 s22, s22, 3
-; GFX11-NEXT:    s_add_i32 s21, s21, 3
-; GFX11-NEXT:    s_add_i32 s20, s20, 3
-; GFX11-NEXT:    s_add_i32 s19, s19, 3
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
+; GFX11-NEXT:    s_add_i32 s19, s19, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s7, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s8, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s20, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s21, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s46, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s47, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s56, s1, 16
@@ -3471,32 +3582,32 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s56
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s47
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s22, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s23, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s24, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s25, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s26, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s27, s10
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s28, s9
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s29, s8
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s7
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s6
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s24
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s23
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s22
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s21
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s20
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s15 :: v_dual_mov_b32 v11, s14
-; GFX11-NEXT:    v_dual_mov_b32 v12, s13 :: v_dual_mov_b32 v13, s12
-; GFX11-NEXT:    v_dual_mov_b32 v14, s11 :: v_dual_mov_b32 v15, s10
-; GFX11-NEXT:    v_dual_mov_b32 v16, s9 :: v_dual_mov_b32 v17, s8
-; GFX11-NEXT:    v_dual_mov_b32 v18, s5 :: v_dual_mov_b32 v19, s4
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s19 :: v_dual_mov_b32 v19, s18
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB13_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr57
@@ -3509,16 +3620,16 @@ define inreg <40 x i16> @bitcast_v20i32_to_v40i16_scalar(<20 x i32> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
-; GFX11-NEXT:    ; implicit-def: $sgpr9
-; GFX11-NEXT:    ; implicit-def: $sgpr8
-; GFX11-NEXT:    ; implicit-def: $sgpr7
-; GFX11-NEXT:    ; implicit-def: $sgpr6
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
+; GFX11-NEXT:    ; implicit-def: $sgpr23
+; GFX11-NEXT:    ; implicit-def: $sgpr22
+; GFX11-NEXT:    ; implicit-def: $sgpr21
+; GFX11-NEXT:    ; implicit-def: $sgpr20
 ; GFX11-NEXT:    s_branch .LBB13_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -3823,7 +3934,7 @@ define <20 x i32> @bitcast_v40i16_to_v20i32(<40 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v15, vcc, s6, v15
 ; SI-NEXT:    v_add_i32_e32 v17, vcc, s6, v17
 ; SI-NEXT:    v_add_i32_e32 v18, vcc, s6, v18
-; SI-NEXT:    v_add_i32_e32 v19, vcc, s6, v19
+; SI-NEXT:    v_add_i32_e32 v19, vcc, 0x30000, v19
 ; SI-NEXT:  .LBB14_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
@@ -6094,7 +6205,35 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; SI-LABEL: bitcast_v20i32_to_v40f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v8, s16
+; SI-NEXT:    v_mov_b32_e32 v9, s17
+; SI-NEXT:    v_mov_b32_e32 v10, s18
+; SI-NEXT:    v_mov_b32_e32 v11, s19
+; SI-NEXT:    v_mov_b32_e32 v12, s20
+; SI-NEXT:    v_mov_b32_e32 v13, s21
+; SI-NEXT:    v_mov_b32_e32 v14, s22
+; SI-NEXT:    v_mov_b32_e32 v15, s23
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s23, v8
+; SI-NEXT:    v_mov_b32_e32 v8, s28
+; SI-NEXT:    v_readfirstlane_b32 s24, v9
+; SI-NEXT:    v_mov_b32_e32 v9, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; SI-NEXT:    v_readfirstlane_b32 s25, v10
+; SI-NEXT:    v_readfirstlane_b32 s22, v11
+; SI-NEXT:    v_readfirstlane_b32 s21, v12
+; SI-NEXT:    v_readfirstlane_b32 s20, v13
+; SI-NEXT:    v_readfirstlane_b32 s19, v14
+; SI-NEXT:    v_readfirstlane_b32 s18, v15
+; SI-NEXT:    v_readfirstlane_b32 s17, v16
+; SI-NEXT:    v_readfirstlane_b32 s16, v17
+; SI-NEXT:    v_readfirstlane_b32 s15, v18
+; SI-NEXT:    v_readfirstlane_b32 s14, v19
+; SI-NEXT:    v_readfirstlane_b32 s13, v8
+; SI-NEXT:    v_readfirstlane_b32 s12, v9
 ; SI-NEXT:    v_readfirstlane_b32 s11, v1
 ; SI-NEXT:    v_readfirstlane_b32 s10, v2
 ; SI-NEXT:    v_readfirstlane_b32 s8, v3
@@ -6116,33 +6255,33 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v8, s4
 ; SI-NEXT:    s_lshr_b32 s4, s11, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v10, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s12, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    s_lshr_b32 s4, s13, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v14, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s4
 ; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, s4
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v48, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s9
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
@@ -6150,56 +6289,56 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, s8
 ; SI-NEXT:    v_cvt_f32_f16_e32 v11, s10
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s23
 ; SI-NEXT:    s_cbranch_execnz .LBB17_3
 ; SI-NEXT:  .LBB17_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
 ; SI-NEXT:    s_add_i32 s23, s23, 3
 ; SI-NEXT:    s_add_i32 s24, s24, 3
 ; SI-NEXT:    s_add_i32 s25, s25, 3
-; SI-NEXT:    s_add_i32 s26, s26, 3
-; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
+; SI-NEXT:    s_add_i32 s15, s15, 3
+; SI-NEXT:    s_add_i32 s14, s14, 3
+; SI-NEXT:    s_add_i32 s13, s13, 3
+; SI-NEXT:    s_add_i32 s12, s12, 3
 ; SI-NEXT:    s_add_i32 s11, s11, 3
 ; SI-NEXT:    s_add_i32 s10, s10, 3
 ; SI-NEXT:    s_add_i32 s8, s8, 3
 ; SI-NEXT:    s_add_i32 s7, s7, 3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s9, s9, 3
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    s_lshr_b32 s5, s17, 16
-; SI-NEXT:    s_lshr_b32 s12, s18, 16
-; SI-NEXT:    s_lshr_b32 s13, s19, 16
-; SI-NEXT:    s_lshr_b32 s14, s20, 16
-; SI-NEXT:    s_lshr_b32 s15, s21, 16
-; SI-NEXT:    s_lshr_b32 s40, s22, 16
-; SI-NEXT:    s_lshr_b32 s41, s23, 16
-; SI-NEXT:    s_lshr_b32 s42, s24, 16
-; SI-NEXT:    s_lshr_b32 s43, s25, 16
-; SI-NEXT:    s_lshr_b32 s44, s26, 16
-; SI-NEXT:    s_lshr_b32 s45, s27, 16
-; SI-NEXT:    s_lshr_b32 s46, s28, 16
-; SI-NEXT:    s_lshr_b32 s47, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    s_lshr_b32 s5, s24, 16
+; SI-NEXT:    s_lshr_b32 s26, s25, 16
+; SI-NEXT:    s_lshr_b32 s27, s22, 16
+; SI-NEXT:    s_lshr_b32 s28, s21, 16
+; SI-NEXT:    s_lshr_b32 s29, s20, 16
+; SI-NEXT:    s_lshr_b32 s40, s19, 16
+; SI-NEXT:    s_lshr_b32 s41, s18, 16
+; SI-NEXT:    s_lshr_b32 s42, s17, 16
+; SI-NEXT:    s_lshr_b32 s43, s16, 16
+; SI-NEXT:    s_lshr_b32 s44, s15, 16
+; SI-NEXT:    s_lshr_b32 s45, s14, 16
+; SI-NEXT:    s_lshr_b32 s46, s13, 16
+; SI-NEXT:    s_lshr_b32 s47, s12, 16
 ; SI-NEXT:    s_lshr_b32 s56, s11, 16
 ; SI-NEXT:    s_lshr_b32 s57, s10, 16
 ; SI-NEXT:    s_lshr_b32 s58, s8, 16
@@ -6212,20 +6351,20 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, s8
 ; SI-NEXT:    v_cvt_f32_f16_e32 v11, s10
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s23
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s61
 ; SI-NEXT:    v_cvt_f32_f16_e32 v2, s60
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s59
@@ -6240,10 +6379,10 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v23, s42
 ; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
 ; SI-NEXT:    v_cvt_f32_f16_e32 v27, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s26
 ; SI-NEXT:    v_cvt_f32_f16_e32 v38, s5
 ; SI-NEXT:    v_cvt_f32_f16_e32 v48, s4
 ; SI-NEXT:  .LBB17_3: ; %end
@@ -6433,7 +6572,35 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; VI-LABEL: bitcast_v20i32_to_v40f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v7, s16
+; VI-NEXT:    v_mov_b32_e32 v8, s17
+; VI-NEXT:    v_mov_b32_e32 v9, s18
+; VI-NEXT:    v_mov_b32_e32 v10, s19
+; VI-NEXT:    v_mov_b32_e32 v11, s20
+; VI-NEXT:    v_mov_b32_e32 v12, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s22
+; VI-NEXT:    v_mov_b32_e32 v14, s23
+; VI-NEXT:    v_mov_b32_e32 v15, s24
+; VI-NEXT:    v_mov_b32_e32 v16, s25
+; VI-NEXT:    v_mov_b32_e32 v17, s26
+; VI-NEXT:    v_mov_b32_e32 v18, s27
+; VI-NEXT:    v_mov_b32_e32 v19, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v7
+; VI-NEXT:    v_mov_b32_e32 v7, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; VI-NEXT:    v_readfirstlane_b32 s24, v8
+; VI-NEXT:    v_readfirstlane_b32 s23, v9
+; VI-NEXT:    v_readfirstlane_b32 s22, v10
+; VI-NEXT:    v_readfirstlane_b32 s21, v11
+; VI-NEXT:    v_readfirstlane_b32 s20, v12
+; VI-NEXT:    v_readfirstlane_b32 s19, v13
+; VI-NEXT:    v_readfirstlane_b32 s18, v14
+; VI-NEXT:    v_readfirstlane_b32 s17, v15
+; VI-NEXT:    v_readfirstlane_b32 s16, v16
+; VI-NEXT:    v_readfirstlane_b32 s15, v17
+; VI-NEXT:    v_readfirstlane_b32 s14, v18
+; VI-NEXT:    v_readfirstlane_b32 s13, v19
+; VI-NEXT:    v_readfirstlane_b32 s12, v7
 ; VI-NEXT:    v_readfirstlane_b32 s11, v0
 ; VI-NEXT:    v_readfirstlane_b32 s10, v1
 ; VI-NEXT:    v_readfirstlane_b32 s9, v2
@@ -6443,26 +6610,26 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; VI-NEXT:    v_readfirstlane_b32 s7, v5
 ; VI-NEXT:    s_cbranch_scc0 .LBB17_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s12, s7, 16
-; VI-NEXT:    s_lshr_b32 s13, s6, 16
-; VI-NEXT:    s_lshr_b32 s14, s8, 16
-; VI-NEXT:    s_lshr_b32 s15, s9, 16
+; VI-NEXT:    s_lshr_b32 s26, s7, 16
+; VI-NEXT:    s_lshr_b32 s27, s6, 16
+; VI-NEXT:    s_lshr_b32 s28, s8, 16
+; VI-NEXT:    s_lshr_b32 s29, s9, 16
 ; VI-NEXT:    s_lshr_b32 s40, s10, 16
 ; VI-NEXT:    s_lshr_b32 s41, s11, 16
-; VI-NEXT:    s_lshr_b32 s42, s29, 16
-; VI-NEXT:    s_lshr_b32 s43, s28, 16
-; VI-NEXT:    s_lshr_b32 s44, s27, 16
-; VI-NEXT:    s_lshr_b32 s45, s26, 16
-; VI-NEXT:    s_lshr_b32 s46, s25, 16
-; VI-NEXT:    s_lshr_b32 s47, s24, 16
-; VI-NEXT:    s_lshr_b32 s56, s23, 16
-; VI-NEXT:    s_lshr_b32 s57, s22, 16
-; VI-NEXT:    s_lshr_b32 s58, s21, 16
-; VI-NEXT:    s_lshr_b32 s59, s20, 16
-; VI-NEXT:    s_lshr_b32 s60, s19, 16
-; VI-NEXT:    s_lshr_b32 s61, s18, 16
-; VI-NEXT:    s_lshr_b32 s62, s17, 16
-; VI-NEXT:    s_lshr_b32 s63, s16, 16
+; VI-NEXT:    s_lshr_b32 s42, s12, 16
+; VI-NEXT:    s_lshr_b32 s43, s13, 16
+; VI-NEXT:    s_lshr_b32 s44, s14, 16
+; VI-NEXT:    s_lshr_b32 s45, s15, 16
+; VI-NEXT:    s_lshr_b32 s46, s16, 16
+; VI-NEXT:    s_lshr_b32 s47, s17, 16
+; VI-NEXT:    s_lshr_b32 s56, s18, 16
+; VI-NEXT:    s_lshr_b32 s57, s19, 16
+; VI-NEXT:    s_lshr_b32 s58, s20, 16
+; VI-NEXT:    s_lshr_b32 s59, s21, 16
+; VI-NEXT:    s_lshr_b32 s60, s22, 16
+; VI-NEXT:    s_lshr_b32 s61, s23, 16
+; VI-NEXT:    s_lshr_b32 s62, s24, 16
+; VI-NEXT:    s_lshr_b32 s63, s25, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB17_3
 ; VI-NEXT:  .LBB17_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -6471,115 +6638,115 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; VI-NEXT:    s_add_i32 s9, s9, 3
 ; VI-NEXT:    s_add_i32 s10, s10, 3
 ; VI-NEXT:    s_add_i32 s11, s11, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s12, s12, 3
+; VI-NEXT:    s_add_i32 s13, s13, 3
+; VI-NEXT:    s_add_i32 s14, s14, 3
+; VI-NEXT:    s_add_i32 s15, s15, 3
 ; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s12, s7, 16
-; VI-NEXT:    s_lshr_b32 s13, s6, 16
-; VI-NEXT:    s_lshr_b32 s14, s8, 16
-; VI-NEXT:    s_lshr_b32 s15, s9, 16
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_lshr_b32 s26, s7, 16
+; VI-NEXT:    s_lshr_b32 s27, s6, 16
+; VI-NEXT:    s_lshr_b32 s28, s8, 16
+; VI-NEXT:    s_lshr_b32 s29, s9, 16
 ; VI-NEXT:    s_lshr_b32 s40, s10, 16
 ; VI-NEXT:    s_lshr_b32 s41, s11, 16
-; VI-NEXT:    s_lshr_b32 s42, s29, 16
-; VI-NEXT:    s_lshr_b32 s43, s28, 16
-; VI-NEXT:    s_lshr_b32 s44, s27, 16
-; VI-NEXT:    s_lshr_b32 s45, s26, 16
-; VI-NEXT:    s_lshr_b32 s46, s25, 16
-; VI-NEXT:    s_lshr_b32 s47, s24, 16
-; VI-NEXT:    s_lshr_b32 s56, s23, 16
-; VI-NEXT:    s_lshr_b32 s57, s22, 16
-; VI-NEXT:    s_lshr_b32 s58, s21, 16
-; VI-NEXT:    s_lshr_b32 s59, s20, 16
-; VI-NEXT:    s_lshr_b32 s60, s19, 16
-; VI-NEXT:    s_lshr_b32 s61, s18, 16
-; VI-NEXT:    s_lshr_b32 s62, s17, 16
-; VI-NEXT:    s_lshr_b32 s63, s16, 16
+; VI-NEXT:    s_lshr_b32 s42, s12, 16
+; VI-NEXT:    s_lshr_b32 s43, s13, 16
+; VI-NEXT:    s_lshr_b32 s44, s14, 16
+; VI-NEXT:    s_lshr_b32 s45, s15, 16
+; VI-NEXT:    s_lshr_b32 s46, s16, 16
+; VI-NEXT:    s_lshr_b32 s47, s17, 16
+; VI-NEXT:    s_lshr_b32 s56, s18, 16
+; VI-NEXT:    s_lshr_b32 s57, s19, 16
+; VI-NEXT:    s_lshr_b32 s58, s20, 16
+; VI-NEXT:    s_lshr_b32 s59, s21, 16
+; VI-NEXT:    s_lshr_b32 s60, s22, 16
+; VI-NEXT:    s_lshr_b32 s61, s23, 16
+; VI-NEXT:    s_lshr_b32 s62, s24, 16
+; VI-NEXT:    s_lshr_b32 s63, s25, 16
 ; VI-NEXT:  .LBB17_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s25
 ; VI-NEXT:    s_lshl_b32 s5, s63, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s62, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s61, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s60, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s59, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s58, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s57, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s56, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s47, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s46, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s24, s62, 16
+; VI-NEXT:    s_or_b32 s5, s5, s24
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s24, s61, 16
 ; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s45, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s44, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s43, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s24, s60, 16
+; VI-NEXT:    s_or_b32 s22, s22, s24
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s24, s59, 16
+; VI-NEXT:    s_or_b32 s21, s21, s24
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s24, s58, 16
+; VI-NEXT:    s_or_b32 s20, s20, s24
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s24, s57, 16
+; VI-NEXT:    s_or_b32 s19, s19, s24
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s24, s56, 16
+; VI-NEXT:    s_or_b32 s18, s18, s24
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s24, s47, 16
+; VI-NEXT:    s_or_b32 s17, s17, s24
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s24, s46, 16
+; VI-NEXT:    s_or_b32 s16, s16, s24
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s24, s45, 16
+; VI-NEXT:    s_or_b32 s15, s15, s24
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s24, s44, 16
+; VI-NEXT:    s_or_b32 s14, s14, s24
+; VI-NEXT:    s_and_b32 s13, 0xffff, s13
+; VI-NEXT:    s_lshl_b32 s24, s43, 16
+; VI-NEXT:    s_or_b32 s13, s13, s24
+; VI-NEXT:    s_and_b32 s12, 0xffff, s12
+; VI-NEXT:    s_lshl_b32 s24, s42, 16
+; VI-NEXT:    s_or_b32 s12, s12, s24
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s24, s41, 16
+; VI-NEXT:    s_or_b32 s11, s11, s24
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
+; VI-NEXT:    s_lshl_b32 s24, s40, 16
+; VI-NEXT:    s_or_b32 s10, s10, s24
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
+; VI-NEXT:    s_lshl_b32 s24, s29, 16
+; VI-NEXT:    s_or_b32 s9, s9, s24
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
+; VI-NEXT:    s_lshl_b32 s24, s28, 16
+; VI-NEXT:    s_or_b32 s8, s8, s24
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s13, s13, 16
+; VI-NEXT:    s_lshl_b32 s24, s27, 16
+; VI-NEXT:    s_or_b32 s6, s6, s24
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s12, s12, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
-; VI-NEXT:    s_or_b32 s9, s9, s15
-; VI-NEXT:    s_or_b32 s8, s8, s14
-; VI-NEXT:    s_or_b32 s6, s6, s13
-; VI-NEXT:    s_or_b32 s7, s7, s12
+; VI-NEXT:    s_lshl_b32 s24, s26, 16
+; VI-NEXT:    s_or_b32 s7, s7, s24
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s23
+; VI-NEXT:    v_mov_b32_e32 v3, s22
+; VI-NEXT:    v_mov_b32_e32 v4, s21
+; VI-NEXT:    v_mov_b32_e32 v5, s20
+; VI-NEXT:    v_mov_b32_e32 v6, s19
+; VI-NEXT:    v_mov_b32_e32 v7, s18
+; VI-NEXT:    v_mov_b32_e32 v8, s17
+; VI-NEXT:    v_mov_b32_e32 v9, s16
+; VI-NEXT:    v_mov_b32_e32 v10, s15
+; VI-NEXT:    v_mov_b32_e32 v11, s14
+; VI-NEXT:    v_mov_b32_e32 v12, s13
+; VI-NEXT:    v_mov_b32_e32 v13, s12
 ; VI-NEXT:    v_mov_b32_e32 v14, s11
 ; VI-NEXT:    v_mov_b32_e32 v15, s10
 ; VI-NEXT:    v_mov_b32_e32 v16, s9
@@ -6604,57 +6771,75 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
 ; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
-; VI-NEXT:    ; implicit-def: $sgpr13
-; VI-NEXT:    ; implicit-def: $sgpr12
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
+; VI-NEXT:    ; implicit-def: $sgpr26
 ; VI-NEXT:    s_branch .LBB17_2
 ;
 ; GFX9-LABEL: bitcast_v20i32_to_v40f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v7, s16
+; GFX9-NEXT:    v_mov_b32_e32 v8, s17
+; GFX9-NEXT:    v_mov_b32_e32 v9, s18
+; GFX9-NEXT:    v_mov_b32_e32 v10, s19
+; GFX9-NEXT:    v_mov_b32_e32 v11, s20
+; GFX9-NEXT:    v_mov_b32_e32 v12, s21
+; GFX9-NEXT:    v_mov_b32_e32 v13, s22
+; GFX9-NEXT:    v_mov_b32_e32 v14, s23
+; GFX9-NEXT:    v_mov_b32_e32 v15, s24
+; GFX9-NEXT:    v_mov_b32_e32 v16, s25
+; GFX9-NEXT:    v_mov_b32_e32 v17, s26
+; GFX9-NEXT:    v_mov_b32_e32 v18, s27
+; GFX9-NEXT:    v_mov_b32_e32 v19, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v7
+; GFX9-NEXT:    v_mov_b32_e32 v7, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s12, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB17_3
 ; GFX9-NEXT:  .LBB17_2: ; %cmp.true
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
-; GFX9-NEXT:    s_add_i32 s29, s29, 3
-; GFX9-NEXT:    s_add_i32 s28, s28, 3
-; GFX9-NEXT:    s_add_i32 s27, s27, 3
-; GFX9-NEXT:    s_add_i32 s26, s26, 3
 ; GFX9-NEXT:    s_add_i32 s25, s25, 3
 ; GFX9-NEXT:    s_add_i32 s24, s24, 3
 ; GFX9-NEXT:    s_add_i32 s23, s23, 3
@@ -6665,67 +6850,77 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
-; GFX9-NEXT:    s_lshr_b32 s12, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s16, 16
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
+; GFX9-NEXT:    s_lshr_b32 s26, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s6, 16
 ; GFX9-NEXT:  .LBB17_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s14
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s13
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s12
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s28
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s27
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB17_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr63
@@ -6744,38 +6939,65 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
-; GFX9-NEXT:    ; implicit-def: $sgpr13
-; GFX9-NEXT:    ; implicit-def: $sgpr12
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
+; GFX9-NEXT:    ; implicit-def: $sgpr27
+; GFX9-NEXT:    ; implicit-def: $sgpr26
 ; GFX9-NEXT:    s_branch .LBB17_2
 ;
 ; GFX11-LABEL: bitcast_v20i32_to_v40f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v3, s0 :: v_dual_mov_b32 v4, s1
+; GFX11-NEXT:    v_dual_mov_b32 v5, s2 :: v_dual_mov_b32 v6, s3
+; GFX11-NEXT:    v_dual_mov_b32 v7, s16 :: v_dual_mov_b32 v8, s17
+; GFX11-NEXT:    v_dual_mov_b32 v9, s18 :: v_dual_mov_b32 v10, s19
+; GFX11-NEXT:    v_dual_mov_b32 v11, s20 :: v_dual_mov_b32 v12, s21
+; GFX11-NEXT:    v_dual_mov_b32 v13, s22 :: v_dual_mov_b32 v14, s23
+; GFX11-NEXT:    v_dual_mov_b32 v15, s24 :: v_dual_mov_b32 v16, s25
+; GFX11-NEXT:    v_dual_mov_b32 v17, s26 :: v_dual_mov_b32 v18, s27
+; GFX11-NEXT:    v_dual_mov_b32 v19, s28 :: v_dual_mov_b32 v20, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v1
 ; GFX11-NEXT:    s_mov_b32 s58, 0
-; GFX11-NEXT:    s_and_b32 s6, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s20, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s7, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s8, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s20, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s21, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s46, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s47, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s56, s1, 16
@@ -6783,42 +7005,42 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s58
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB17_3
 ; GFX11-NEXT:  .LBB17_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
-; GFX11-NEXT:    s_add_i32 s26, s26, 3
-; GFX11-NEXT:    s_add_i32 s25, s25, 3
-; GFX11-NEXT:    s_add_i32 s24, s24, 3
-; GFX11-NEXT:    s_add_i32 s23, s23, 3
-; GFX11-NEXT:    s_add_i32 s22, s22, 3
-; GFX11-NEXT:    s_add_i32 s21, s21, 3
-; GFX11-NEXT:    s_add_i32 s20, s20, 3
-; GFX11-NEXT:    s_add_i32 s19, s19, 3
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
+; GFX11-NEXT:    s_add_i32 s19, s19, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s7, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s8, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s20, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s21, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s46, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s47, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s56, s1, 16
@@ -6829,32 +7051,32 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s56
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s47
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s22, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s23, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s24, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s25, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s26, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s27, s10
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s28, s9
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s29, s8
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s7
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s6
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s24
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s23
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s22
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s21
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s20
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s15 :: v_dual_mov_b32 v11, s14
-; GFX11-NEXT:    v_dual_mov_b32 v12, s13 :: v_dual_mov_b32 v13, s12
-; GFX11-NEXT:    v_dual_mov_b32 v14, s11 :: v_dual_mov_b32 v15, s10
-; GFX11-NEXT:    v_dual_mov_b32 v16, s9 :: v_dual_mov_b32 v17, s8
-; GFX11-NEXT:    v_dual_mov_b32 v18, s5 :: v_dual_mov_b32 v19, s4
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s19 :: v_dual_mov_b32 v19, s18
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB17_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr57
@@ -6867,16 +7089,16 @@ define inreg <40 x half> @bitcast_v20i32_to_v40f16_scalar(<20 x i32> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
-; GFX11-NEXT:    ; implicit-def: $sgpr9
-; GFX11-NEXT:    ; implicit-def: $sgpr8
-; GFX11-NEXT:    ; implicit-def: $sgpr7
-; GFX11-NEXT:    ; implicit-def: $sgpr6
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
+; GFX11-NEXT:    ; implicit-def: $sgpr23
+; GFX11-NEXT:    ; implicit-def: $sgpr22
+; GFX11-NEXT:    ; implicit-def: $sgpr21
+; GFX11-NEXT:    ; implicit-def: $sgpr20
 ; GFX11-NEXT:    s_branch .LBB17_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -12019,7 +12241,7 @@ define <20 x float> @bitcast_v40i16_to_v20f32(<40 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v15, vcc, s6, v15
 ; SI-NEXT:    v_add_i32_e32 v17, vcc, s6, v17
 ; SI-NEXT:    v_add_i32_e32 v18, vcc, s6, v18
-; SI-NEXT:    v_add_i32_e32 v19, vcc, s6, v19
+; SI-NEXT:    v_add_i32_e32 v19, vcc, 0x30000, v19
 ; SI-NEXT:  .LBB30_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
@@ -14271,316 +14493,348 @@ define inreg <40 x half> @bitcast_v20f32_to_v40f16_scalar(<20 x float> inreg %a,
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
-; SI-NEXT:    v_readfirstlane_b32 s11, v1
-; SI-NEXT:    v_readfirstlane_b32 s10, v2
-; SI-NEXT:    v_readfirstlane_b32 s8, v3
-; SI-NEXT:    v_readfirstlane_b32 s7, v4
-; SI-NEXT:    v_readfirstlane_b32 s6, v5
+; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v60, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v60, s16
+; SI-NEXT:    v_mov_b32_e32 v59, s17
+; SI-NEXT:    v_mov_b32_e32 v58, s18
+; SI-NEXT:    v_mov_b32_e32 v57, s19
+; SI-NEXT:    v_mov_b32_e32 v56, s20
+; SI-NEXT:    v_mov_b32_e32 v47, s21
+; SI-NEXT:    v_mov_b32_e32 v46, s22
+; SI-NEXT:    v_mov_b32_e32 v45, s23
+; SI-NEXT:    v_mov_b32_e32 v44, s24
+; SI-NEXT:    v_mov_b32_e32 v41, s25
+; SI-NEXT:    v_mov_b32_e32 v40, s26
+; SI-NEXT:    v_mov_b32_e32 v55, s27
+; SI-NEXT:    v_mov_b32_e32 v42, s28
 ; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s9, v6
-; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    v_mov_b32_e32 v43, s29
 ; SI-NEXT:    s_cbranch_scc0 .LBB33_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s4, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s4
-; SI-NEXT:    s_lshr_b32 s4, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s4
-; SI-NEXT:    s_lshr_b32 s4, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s4
-; SI-NEXT:    s_lshr_b32 s4, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s4
-; SI-NEXT:    s_lshr_b32 s4, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s4
-; SI-NEXT:    s_lshr_b32 s4, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v47
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v59
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v8, 16, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v47
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v60
 ; SI-NEXT:    s_cbranch_execnz .LBB33_3
 ; SI-NEXT:  .LBB33_2: ; %cmp.true
-; SI-NEXT:    v_add_f32_e64 v1, s16, 1.0
-; SI-NEXT:    v_add_f32_e64 v2, s17, 1.0
-; SI-NEXT:    v_add_f32_e64 v4, s18, 1.0
-; SI-NEXT:    v_add_f32_e64 v6, s19, 1.0
-; SI-NEXT:    v_add_f32_e64 v8, s20, 1.0
-; SI-NEXT:    v_add_f32_e64 v10, s21, 1.0
-; SI-NEXT:    v_add_f32_e64 v12, s22, 1.0
-; SI-NEXT:    v_add_f32_e64 v14, s23, 1.0
-; SI-NEXT:    v_add_f32_e64 v16, s24, 1.0
-; SI-NEXT:    v_add_f32_e64 v19, s25, 1.0
-; SI-NEXT:    v_add_f32_e64 v20, s26, 1.0
-; SI-NEXT:    v_add_f32_e64 v18, s27, 1.0
-; SI-NEXT:    v_add_f32_e64 v17, s28, 1.0
-; SI-NEXT:    v_add_f32_e64 v15, s29, 1.0
-; SI-NEXT:    v_add_f32_e64 v13, s11, 1.0
-; SI-NEXT:    v_add_f32_e64 v11, s10, 1.0
-; SI-NEXT:    v_add_f32_e64 v9, s8, 1.0
-; SI-NEXT:    v_add_f32_e64 v7, s7, 1.0
-; SI-NEXT:    v_add_f32_e64 v5, s6, 1.0
-; SI-NEXT:    v_add_f32_e64 v3, s9, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v4
-; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v6
-; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v8
-; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v10
-; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v19
-; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v20
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v17
-; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v15
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v11
-; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v9
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v7
-; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v5
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v13
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v42
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v41
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v40
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, v55
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v52
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v49
+; SI-NEXT:    v_add_f32_e32 v7, 1.0, v60
+; SI-NEXT:    v_add_f32_e32 v8, 1.0, v59
+; SI-NEXT:    v_add_f32_e32 v10, 1.0, v58
+; SI-NEXT:    v_add_f32_e32 v12, 1.0, v57
+; SI-NEXT:    v_add_f32_e32 v14, 1.0, v56
+; SI-NEXT:    v_add_f32_e32 v16, 1.0, v47
+; SI-NEXT:    v_add_f32_e32 v18, 1.0, v46
+; SI-NEXT:    v_add_f32_e32 v20, 1.0, v45
+; SI-NEXT:    v_add_f32_e32 v22, 1.0, v44
+; SI-NEXT:    v_add_f32_e32 v25, 1.0, v41
+; SI-NEXT:    v_add_f32_e32 v26, 1.0, v40
+; SI-NEXT:    v_add_f32_e32 v24, 1.0, v55
+; SI-NEXT:    v_add_f32_e32 v23, 1.0, v42
+; SI-NEXT:    v_add_f32_e32 v21, 1.0, v43
+; SI-NEXT:    v_add_f32_e32 v1, 1.0, v1
+; SI-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; SI-NEXT:    v_add_f32_e32 v3, 1.0, v3
+; SI-NEXT:    v_add_f32_e32 v4, 1.0, v4
+; SI-NEXT:    v_add_f32_e32 v5, 1.0, v5
+; SI-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v26
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v1
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, v21
 ; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v47
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v40
 ; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
 ; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
 ; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v33
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
 ; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
 ; SI-NEXT:  .LBB33_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v48, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v39, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v38, v38
-; SI-NEXT:    v_cvt_f16_f32_e32 v37, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v36, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v35, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v34, v34
-; SI-NEXT:    v_lshlrev_b32_e32 v48, 16, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v33, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v31, v31
-; SI-NEXT:    v_or_b32_e32 v39, v39, v48
-; SI-NEXT:    v_lshlrev_b32_e32 v38, 16, v38
-; SI-NEXT:    v_cvt_f16_f32_e32 v32, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v29, v29
-; SI-NEXT:    buffer_store_dword v39, v0, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v54
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v53
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v52
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v51
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v39, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v37, v37, v38
-; SI-NEXT:    v_lshlrev_b32_e32 v36, 16, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; SI-NEXT:    buffer_store_dword v37, v39, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v37, vcc, 8, v0
-; SI-NEXT:    v_or_b32_e32 v35, v35, v36
-; SI-NEXT:    v_lshlrev_b32_e32 v34, 16, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v28, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v25, v25
-; SI-NEXT:    buffer_store_dword v35, v37, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 12, v0
-; SI-NEXT:    v_or_b32_e32 v33, v33, v34
-; SI-NEXT:    v_lshlrev_b32_e32 v31, 16, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v23, v23
-; SI-NEXT:    buffer_store_dword v33, v35, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 16, v0
-; SI-NEXT:    v_or_b32_e32 v31, v32, v31
-; SI-NEXT:    v_lshlrev_b32_e32 v29, 16, v29
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v21, v21
-; SI-NEXT:    buffer_store_dword v31, v33, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 20, v0
-; SI-NEXT:    v_or_b32_e32 v29, v30, v29
-; SI-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v19, v19
-; SI-NEXT:    buffer_store_dword v29, v31, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v29, vcc, 24, v0
-; SI-NEXT:    v_or_b32_e32 v27, v28, v27
-; SI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v16
-; SI-NEXT:    buffer_store_dword v27, v29, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v27, vcc, 28, v0
-; SI-NEXT:    v_or_b32_e32 v25, v26, v25
-; SI-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v18
-; SI-NEXT:    buffer_store_dword v25, v27, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v25, vcc, 32, v0
-; SI-NEXT:    v_or_b32_e32 v23, v24, v23
-; SI-NEXT:    v_lshlrev_b32_e32 v21, 16, v21
-; SI-NEXT:    buffer_store_dword v23, v25, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v23, vcc, 36, v0
-; SI-NEXT:    v_or_b32_e32 v21, v22, v21
-; SI-NEXT:    v_lshlrev_b32_e32 v19, 16, v19
-; SI-NEXT:    buffer_store_dword v21, v23, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v21, vcc, 40, v0
-; SI-NEXT:    v_or_b32_e32 v19, v20, v19
-; SI-NEXT:    v_lshlrev_b32_e32 v16, 16, v16
-; SI-NEXT:    buffer_store_dword v19, v21, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v19, vcc, 44, v0
-; SI-NEXT:    v_or_b32_e32 v16, v18, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; SI-NEXT:    buffer_store_dword v16, v19, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v17
-; SI-NEXT:    v_add_i32_e32 v17, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
-; SI-NEXT:    v_or_b32_e32 v14, v16, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; SI-NEXT:    buffer_store_dword v14, v17, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v15
-; SI-NEXT:    v_add_i32_e32 v15, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
-; SI-NEXT:    v_or_b32_e32 v12, v14, v12
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v10
-; SI-NEXT:    buffer_store_dword v12, v15, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v13
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v12, v10
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v8
-; SI-NEXT:    buffer_store_dword v10, v13, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v11
-; SI-NEXT:    v_add_i32_e32 v11, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
-; SI-NEXT:    v_or_b32_e32 v8, v10, v8
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v6
-; SI-NEXT:    buffer_store_dword v8, v11, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v9
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; SI-NEXT:    buffer_store_dword v6, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v7
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v4, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v5
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
 ; SI-NEXT:    v_or_b32_e32 v2, v4, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v5, s[0:3], 0 offen
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v50
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v3
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v49
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v39
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v37
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v38
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v35
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v36
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v33
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v34
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v31
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v32
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v29
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v30
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v27
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v28
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v25
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v26
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v22
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v24
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v20
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v23
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v18
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v21
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v16
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v19
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v14
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v17
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v12
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v15
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v10
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v13
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v8
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v11
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v7
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v9
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x4c, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v60, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB33_4:
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr49
+; SI-NEXT:    ; implicit-def: $vgpr50
 ; SI-NEXT:    ; implicit-def: $vgpr39
 ; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr37
 ; SI-NEXT:    ; implicit-def: $vgpr38
-; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr37
 ; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; implicit-def: $vgpr35
 ; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; implicit-def: $vgpr33
 ; SI-NEXT:    ; implicit-def: $vgpr32
 ; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    ; implicit-def: $vgpr30
@@ -14590,12 +14844,12 @@ define inreg <40 x half> @bitcast_v20f32_to_v40f16_scalar(<20 x float> inreg %a,
 ; SI-NEXT:    ; implicit-def: $vgpr26
 ; SI-NEXT:    ; implicit-def: $vgpr25
 ; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr23
 ; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; implicit-def: $vgpr23
 ; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr19
+; SI-NEXT:    ; implicit-def: $vgpr21
 ; SI-NEXT:    ; implicit-def: $vgpr18
+; SI-NEXT:    ; implicit-def: $vgpr19
 ; SI-NEXT:    ; implicit-def: $vgpr16
 ; SI-NEXT:    ; implicit-def: $vgpr17
 ; SI-NEXT:    ; implicit-def: $vgpr14
@@ -14606,13 +14860,7 @@ define inreg <40 x half> @bitcast_v20f32_to_v40f16_scalar(<20 x float> inreg %a,
 ; SI-NEXT:    ; implicit-def: $vgpr11
 ; SI-NEXT:    ; implicit-def: $vgpr8
 ; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr6
 ; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr1
 ; SI-NEXT:    s_branch .LBB33_2
 ;
 ; VI-LABEL: bitcast_v20f32_to_v40f16_scalar:
@@ -18539,36 +18787,64 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; SI-LABEL: bitcast_v10i64_to_v40i16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v8, s16
+; SI-NEXT:    v_mov_b32_e32 v9, s17
+; SI-NEXT:    v_mov_b32_e32 v10, s18
+; SI-NEXT:    v_mov_b32_e32 v11, s19
+; SI-NEXT:    v_mov_b32_e32 v12, s20
+; SI-NEXT:    v_mov_b32_e32 v13, s21
+; SI-NEXT:    v_mov_b32_e32 v14, s22
+; SI-NEXT:    v_mov_b32_e32 v15, s23
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v8
+; SI-NEXT:    v_mov_b32_e32 v8, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v9
+; SI-NEXT:    v_mov_b32_e32 v9, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; SI-NEXT:    v_readfirstlane_b32 s20, v10
+; SI-NEXT:    v_readfirstlane_b32 s21, v11
+; SI-NEXT:    v_readfirstlane_b32 s18, v12
+; SI-NEXT:    v_readfirstlane_b32 s19, v13
+; SI-NEXT:    v_readfirstlane_b32 s16, v14
+; SI-NEXT:    v_readfirstlane_b32 s17, v15
+; SI-NEXT:    v_readfirstlane_b32 s14, v16
+; SI-NEXT:    v_readfirstlane_b32 s15, v17
+; SI-NEXT:    v_readfirstlane_b32 s12, v18
+; SI-NEXT:    v_readfirstlane_b32 s13, v19
+; SI-NEXT:    v_readfirstlane_b32 s10, v8
+; SI-NEXT:    v_readfirstlane_b32 s11, v9
 ; SI-NEXT:    v_readfirstlane_b32 s8, v1
 ; SI-NEXT:    v_readfirstlane_b32 s9, v2
 ; SI-NEXT:    v_readfirstlane_b32 s6, v3
 ; SI-NEXT:    v_readfirstlane_b32 s7, v4
 ; SI-NEXT:    v_readfirstlane_b32 s4, v5
-; SI-NEXT:    s_and_b64 s[10:11], vcc, exec
+; SI-NEXT:    s_and_b64 s[24:25], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v6
 ; SI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s72, s5, 16
 ; SI-NEXT:    s_lshr_b32 s73, s7, 16
 ; SI-NEXT:    s_lshr_b32 s74, s9, 16
-; SI-NEXT:    s_lshr_b32 s75, s29, 16
-; SI-NEXT:    s_lshr_b32 s76, s27, 16
-; SI-NEXT:    s_lshr_b32 s77, s25, 16
-; SI-NEXT:    s_lshr_b32 s78, s23, 16
-; SI-NEXT:    s_lshr_b32 s79, s21, 16
-; SI-NEXT:    s_lshr_b32 s88, s19, 16
-; SI-NEXT:    s_lshr_b32 s89, s17, 16
-; SI-NEXT:    s_lshr_b64 s[10:11], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[6:7], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[8:9], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[16:17], 16
+; SI-NEXT:    s_lshr_b32 s75, s11, 16
+; SI-NEXT:    s_lshr_b32 s76, s13, 16
+; SI-NEXT:    s_lshr_b32 s77, s15, 16
+; SI-NEXT:    s_lshr_b32 s78, s17, 16
+; SI-NEXT:    s_lshr_b32 s79, s19, 16
+; SI-NEXT:    s_lshr_b32 s88, s21, 16
+; SI-NEXT:    s_lshr_b32 s89, s23, 16
+; SI-NEXT:    s_lshr_b64 s[24:25], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[8:9], 16
+; SI-NEXT:    s_lshr_b64 s[40:41], s[10:11], 16
+; SI-NEXT:    s_lshr_b64 s[42:43], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[46:47], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[22:23], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB41_3
 ; SI-NEXT:  .LBB41_2: ; %cmp.true
 ; SI-NEXT:    s_add_u32 s4, s4, 3
@@ -18577,139 +18853,139 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; SI-NEXT:    s_addc_u32 s7, s7, 0
 ; SI-NEXT:    s_add_u32 s8, s8, 3
 ; SI-NEXT:    s_addc_u32 s9, s9, 0
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_add_u32 s20, s20, 3
-; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s10, s10, 3
+; SI-NEXT:    s_addc_u32 s11, s11, 0
+; SI-NEXT:    s_add_u32 s12, s12, 3
+; SI-NEXT:    s_addc_u32 s13, s13, 0
+; SI-NEXT:    s_add_u32 s14, s14, 3
+; SI-NEXT:    s_addc_u32 s15, s15, 0
 ; SI-NEXT:    s_add_u32 s16, s16, 3
 ; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
+; SI-NEXT:    s_add_u32 s22, s22, 3
+; SI-NEXT:    s_addc_u32 s23, s23, 0
 ; SI-NEXT:    s_lshr_b32 s72, s5, 16
 ; SI-NEXT:    s_lshr_b32 s73, s7, 16
 ; SI-NEXT:    s_lshr_b32 s74, s9, 16
-; SI-NEXT:    s_lshr_b32 s75, s29, 16
-; SI-NEXT:    s_lshr_b32 s76, s27, 16
-; SI-NEXT:    s_lshr_b32 s77, s25, 16
-; SI-NEXT:    s_lshr_b32 s78, s23, 16
-; SI-NEXT:    s_lshr_b32 s79, s21, 16
-; SI-NEXT:    s_lshr_b32 s88, s19, 16
-; SI-NEXT:    s_lshr_b32 s89, s17, 16
-; SI-NEXT:    s_lshr_b64 s[10:11], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[6:7], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[8:9], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[16:17], 16
+; SI-NEXT:    s_lshr_b32 s75, s11, 16
+; SI-NEXT:    s_lshr_b32 s76, s13, 16
+; SI-NEXT:    s_lshr_b32 s77, s15, 16
+; SI-NEXT:    s_lshr_b32 s78, s17, 16
+; SI-NEXT:    s_lshr_b32 s79, s19, 16
+; SI-NEXT:    s_lshr_b32 s88, s21, 16
+; SI-NEXT:    s_lshr_b32 s89, s23, 16
+; SI-NEXT:    s_lshr_b64 s[24:25], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[8:9], 16
+; SI-NEXT:    s_lshr_b64 s[40:41], s[10:11], 16
+; SI-NEXT:    s_lshr_b64 s[42:43], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[46:47], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[22:23], 16
 ; SI-NEXT:  .LBB41_3: ; %end
-; SI-NEXT:    s_lshl_b32 s11, s60, 16
-; SI-NEXT:    s_and_b32 s13, s16, 0xffff
-; SI-NEXT:    s_or_b32 s11, s13, s11
-; SI-NEXT:    v_mov_b32_e32 v1, s11
-; SI-NEXT:    s_and_b32 s11, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s89, 16
-; SI-NEXT:    s_or_b32 s11, s11, s13
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_lshl_b32 s11, s58, 16
-; SI-NEXT:    s_and_b32 s13, s18, 0xffff
-; SI-NEXT:    s_or_b32 s11, s13, s11
+; SI-NEXT:    s_lshl_b32 s25, s60, 16
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_or_b32 s22, s22, s25
+; SI-NEXT:    v_mov_b32_e32 v1, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s89, 16
+; SI-NEXT:    s_or_b32 s22, s22, s23
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_lshl_b32 s22, s58, 16
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s88, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s88, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s20, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s56, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s56, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s79, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s79, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s46, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s46, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s78, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
+; SI-NEXT:    s_lshl_b32 s17, s78, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s16, s16, s17
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s44, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s14, s14, 0xffff
+; SI-NEXT:    s_lshl_b32 s16, s44, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s14, s14, s16
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s77, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s14, s15, 0xffff
+; SI-NEXT:    s_lshl_b32 s15, s77, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s14, s14, s15
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s42, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s12, s12, 0xffff
+; SI-NEXT:    s_lshl_b32 s14, s42, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s12, s12, s14
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s27, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s12, s13, 0xffff
 ; SI-NEXT:    s_lshl_b32 s13, s76, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s12, s12, s13
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s40, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s10, s10, 0xffff
+; SI-NEXT:    s_lshl_b32 s12, s40, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s10, s10, s12
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
-; SI-NEXT:    s_and_b32 s11, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s75, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s10
+; SI-NEXT:    s_and_b32 s10, s11, 0xffff
+; SI-NEXT:    s_lshl_b32 s11, s75, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s11, s11, s13
+; SI-NEXT:    s_or_b32 s10, s10, s11
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s11
+; SI-NEXT:    v_mov_b32_e32 v2, s10
 ; SI-NEXT:    s_and_b32 s8, s8, 0xffff
-; SI-NEXT:    s_lshl_b32 s11, s14, 16
+; SI-NEXT:    s_lshl_b32 s10, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s8, s8, s11
+; SI-NEXT:    s_or_b32 s8, s8, s10
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
@@ -18721,7 +18997,7 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s12, 16
+; SI-NEXT:    s_lshl_b32 s8, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 60, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -18735,7 +19011,7 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s10, 16
+; SI-NEXT:    s_lshl_b32 s6, s24, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x44, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -18766,18 +19042,46 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr76
 ; SI-NEXT:    ; implicit-def: $sgpr40
 ; SI-NEXT:    ; implicit-def: $sgpr75
-; SI-NEXT:    ; implicit-def: $sgpr14
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr74
-; SI-NEXT:    ; implicit-def: $sgpr12
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr73
-; SI-NEXT:    ; implicit-def: $sgpr10
+; SI-NEXT:    ; implicit-def: $sgpr24
 ; SI-NEXT:    ; implicit-def: $sgpr72
 ; SI-NEXT:    s_branch .LBB41_2
 ;
 ; VI-LABEL: bitcast_v10i64_to_v40i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v7, s16
+; VI-NEXT:    v_mov_b32_e32 v8, s17
+; VI-NEXT:    v_mov_b32_e32 v9, s18
+; VI-NEXT:    v_mov_b32_e32 v10, s19
+; VI-NEXT:    v_mov_b32_e32 v11, s20
+; VI-NEXT:    v_mov_b32_e32 v12, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s22
+; VI-NEXT:    v_mov_b32_e32 v14, s23
+; VI-NEXT:    v_mov_b32_e32 v15, s24
+; VI-NEXT:    v_mov_b32_e32 v16, s25
+; VI-NEXT:    v_mov_b32_e32 v17, s26
+; VI-NEXT:    v_mov_b32_e32 v18, s27
+; VI-NEXT:    v_mov_b32_e32 v19, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v7
+; VI-NEXT:    v_mov_b32_e32 v7, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; VI-NEXT:    v_readfirstlane_b32 s24, v8
+; VI-NEXT:    v_readfirstlane_b32 s23, v9
+; VI-NEXT:    v_readfirstlane_b32 s22, v10
+; VI-NEXT:    v_readfirstlane_b32 s21, v11
+; VI-NEXT:    v_readfirstlane_b32 s20, v12
+; VI-NEXT:    v_readfirstlane_b32 s19, v13
+; VI-NEXT:    v_readfirstlane_b32 s18, v14
+; VI-NEXT:    v_readfirstlane_b32 s17, v15
+; VI-NEXT:    v_readfirstlane_b32 s16, v16
+; VI-NEXT:    v_readfirstlane_b32 s15, v17
+; VI-NEXT:    v_readfirstlane_b32 s14, v18
+; VI-NEXT:    v_readfirstlane_b32 s13, v19
+; VI-NEXT:    v_readfirstlane_b32 s12, v7
 ; VI-NEXT:    v_readfirstlane_b32 s11, v0
 ; VI-NEXT:    v_readfirstlane_b32 s10, v1
 ; VI-NEXT:    v_readfirstlane_b32 s9, v2
@@ -18787,26 +19091,26 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; VI-NEXT:    v_readfirstlane_b32 s7, v5
 ; VI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s12, s7, 16
-; VI-NEXT:    s_lshr_b32 s13, s6, 16
-; VI-NEXT:    s_lshr_b32 s14, s8, 16
-; VI-NEXT:    s_lshr_b32 s15, s9, 16
+; VI-NEXT:    s_lshr_b32 s26, s7, 16
+; VI-NEXT:    s_lshr_b32 s27, s6, 16
+; VI-NEXT:    s_lshr_b32 s28, s8, 16
+; VI-NEXT:    s_lshr_b32 s29, s9, 16
 ; VI-NEXT:    s_lshr_b32 s40, s10, 16
 ; VI-NEXT:    s_lshr_b32 s41, s11, 16
-; VI-NEXT:    s_lshr_b32 s42, s29, 16
-; VI-NEXT:    s_lshr_b32 s43, s28, 16
-; VI-NEXT:    s_lshr_b32 s44, s27, 16
-; VI-NEXT:    s_lshr_b32 s45, s26, 16
-; VI-NEXT:    s_lshr_b32 s46, s25, 16
-; VI-NEXT:    s_lshr_b32 s47, s24, 16
-; VI-NEXT:    s_lshr_b32 s56, s23, 16
-; VI-NEXT:    s_lshr_b32 s57, s22, 16
-; VI-NEXT:    s_lshr_b32 s58, s21, 16
-; VI-NEXT:    s_lshr_b32 s59, s20, 16
-; VI-NEXT:    s_lshr_b32 s60, s19, 16
-; VI-NEXT:    s_lshr_b32 s61, s18, 16
-; VI-NEXT:    s_lshr_b32 s62, s17, 16
-; VI-NEXT:    s_lshr_b32 s63, s16, 16
+; VI-NEXT:    s_lshr_b32 s42, s12, 16
+; VI-NEXT:    s_lshr_b32 s43, s13, 16
+; VI-NEXT:    s_lshr_b32 s44, s14, 16
+; VI-NEXT:    s_lshr_b32 s45, s15, 16
+; VI-NEXT:    s_lshr_b32 s46, s16, 16
+; VI-NEXT:    s_lshr_b32 s47, s17, 16
+; VI-NEXT:    s_lshr_b32 s56, s18, 16
+; VI-NEXT:    s_lshr_b32 s57, s19, 16
+; VI-NEXT:    s_lshr_b32 s58, s20, 16
+; VI-NEXT:    s_lshr_b32 s59, s21, 16
+; VI-NEXT:    s_lshr_b32 s60, s22, 16
+; VI-NEXT:    s_lshr_b32 s61, s23, 16
+; VI-NEXT:    s_lshr_b32 s62, s24, 16
+; VI-NEXT:    s_lshr_b32 s63, s25, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB41_3
 ; VI-NEXT:  .LBB41_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -18815,115 +19119,115 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; VI-NEXT:    s_addc_u32 s8, s8, 0
 ; VI-NEXT:    s_add_u32 s11, s11, 3
 ; VI-NEXT:    s_addc_u32 s10, s10, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s12, s7, 16
-; VI-NEXT:    s_lshr_b32 s13, s6, 16
-; VI-NEXT:    s_lshr_b32 s14, s8, 16
-; VI-NEXT:    s_lshr_b32 s15, s9, 16
+; VI-NEXT:    s_add_u32 s13, s13, 3
+; VI-NEXT:    s_addc_u32 s12, s12, 0
+; VI-NEXT:    s_add_u32 s15, s15, 3
+; VI-NEXT:    s_addc_u32 s14, s14, 0
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_lshr_b32 s26, s7, 16
+; VI-NEXT:    s_lshr_b32 s27, s6, 16
+; VI-NEXT:    s_lshr_b32 s28, s8, 16
+; VI-NEXT:    s_lshr_b32 s29, s9, 16
 ; VI-NEXT:    s_lshr_b32 s40, s10, 16
 ; VI-NEXT:    s_lshr_b32 s41, s11, 16
-; VI-NEXT:    s_lshr_b32 s42, s29, 16
-; VI-NEXT:    s_lshr_b32 s43, s28, 16
-; VI-NEXT:    s_lshr_b32 s44, s27, 16
-; VI-NEXT:    s_lshr_b32 s45, s26, 16
-; VI-NEXT:    s_lshr_b32 s46, s25, 16
-; VI-NEXT:    s_lshr_b32 s47, s24, 16
-; VI-NEXT:    s_lshr_b32 s56, s23, 16
-; VI-NEXT:    s_lshr_b32 s57, s22, 16
-; VI-NEXT:    s_lshr_b32 s58, s21, 16
-; VI-NEXT:    s_lshr_b32 s59, s20, 16
-; VI-NEXT:    s_lshr_b32 s60, s19, 16
-; VI-NEXT:    s_lshr_b32 s61, s18, 16
-; VI-NEXT:    s_lshr_b32 s62, s17, 16
-; VI-NEXT:    s_lshr_b32 s63, s16, 16
+; VI-NEXT:    s_lshr_b32 s42, s12, 16
+; VI-NEXT:    s_lshr_b32 s43, s13, 16
+; VI-NEXT:    s_lshr_b32 s44, s14, 16
+; VI-NEXT:    s_lshr_b32 s45, s15, 16
+; VI-NEXT:    s_lshr_b32 s46, s16, 16
+; VI-NEXT:    s_lshr_b32 s47, s17, 16
+; VI-NEXT:    s_lshr_b32 s56, s18, 16
+; VI-NEXT:    s_lshr_b32 s57, s19, 16
+; VI-NEXT:    s_lshr_b32 s58, s20, 16
+; VI-NEXT:    s_lshr_b32 s59, s21, 16
+; VI-NEXT:    s_lshr_b32 s60, s22, 16
+; VI-NEXT:    s_lshr_b32 s61, s23, 16
+; VI-NEXT:    s_lshr_b32 s62, s24, 16
+; VI-NEXT:    s_lshr_b32 s63, s25, 16
 ; VI-NEXT:  .LBB41_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s25
 ; VI-NEXT:    s_lshl_b32 s5, s63, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s62, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s61, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s60, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s59, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s58, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s57, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s56, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s47, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s46, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s24, s62, 16
+; VI-NEXT:    s_or_b32 s5, s5, s24
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s24, s61, 16
 ; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s45, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s44, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s43, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s24, s60, 16
+; VI-NEXT:    s_or_b32 s22, s22, s24
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s24, s59, 16
+; VI-NEXT:    s_or_b32 s21, s21, s24
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s24, s58, 16
+; VI-NEXT:    s_or_b32 s20, s20, s24
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s24, s57, 16
+; VI-NEXT:    s_or_b32 s19, s19, s24
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s24, s56, 16
+; VI-NEXT:    s_or_b32 s18, s18, s24
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s24, s47, 16
+; VI-NEXT:    s_or_b32 s17, s17, s24
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s24, s46, 16
+; VI-NEXT:    s_or_b32 s16, s16, s24
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s24, s45, 16
+; VI-NEXT:    s_or_b32 s15, s15, s24
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s24, s44, 16
+; VI-NEXT:    s_or_b32 s14, s14, s24
+; VI-NEXT:    s_and_b32 s13, 0xffff, s13
+; VI-NEXT:    s_lshl_b32 s24, s43, 16
+; VI-NEXT:    s_or_b32 s13, s13, s24
+; VI-NEXT:    s_and_b32 s12, 0xffff, s12
+; VI-NEXT:    s_lshl_b32 s24, s42, 16
+; VI-NEXT:    s_or_b32 s12, s12, s24
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s24, s41, 16
+; VI-NEXT:    s_or_b32 s11, s11, s24
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
+; VI-NEXT:    s_lshl_b32 s24, s40, 16
+; VI-NEXT:    s_or_b32 s10, s10, s24
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
+; VI-NEXT:    s_lshl_b32 s24, s29, 16
+; VI-NEXT:    s_or_b32 s9, s9, s24
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
+; VI-NEXT:    s_lshl_b32 s24, s28, 16
+; VI-NEXT:    s_or_b32 s8, s8, s24
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s13, s13, 16
+; VI-NEXT:    s_lshl_b32 s24, s27, 16
+; VI-NEXT:    s_or_b32 s6, s6, s24
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s12, s12, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
-; VI-NEXT:    s_or_b32 s9, s9, s15
-; VI-NEXT:    s_or_b32 s8, s8, s14
-; VI-NEXT:    s_or_b32 s6, s6, s13
-; VI-NEXT:    s_or_b32 s7, s7, s12
+; VI-NEXT:    s_lshl_b32 s24, s26, 16
+; VI-NEXT:    s_or_b32 s7, s7, s24
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s23
+; VI-NEXT:    v_mov_b32_e32 v3, s22
+; VI-NEXT:    v_mov_b32_e32 v4, s21
+; VI-NEXT:    v_mov_b32_e32 v5, s20
+; VI-NEXT:    v_mov_b32_e32 v6, s19
+; VI-NEXT:    v_mov_b32_e32 v7, s18
+; VI-NEXT:    v_mov_b32_e32 v8, s17
+; VI-NEXT:    v_mov_b32_e32 v9, s16
+; VI-NEXT:    v_mov_b32_e32 v10, s15
+; VI-NEXT:    v_mov_b32_e32 v11, s14
+; VI-NEXT:    v_mov_b32_e32 v12, s13
+; VI-NEXT:    v_mov_b32_e32 v13, s12
 ; VI-NEXT:    v_mov_b32_e32 v14, s11
 ; VI-NEXT:    v_mov_b32_e32 v15, s10
 ; VI-NEXT:    v_mov_b32_e32 v16, s9
@@ -18948,57 +19252,75 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
 ; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
-; VI-NEXT:    ; implicit-def: $sgpr13
-; VI-NEXT:    ; implicit-def: $sgpr12
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
+; VI-NEXT:    ; implicit-def: $sgpr26
 ; VI-NEXT:    s_branch .LBB41_2
 ;
 ; GFX9-LABEL: bitcast_v10i64_to_v40i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v7, s16
+; GFX9-NEXT:    v_mov_b32_e32 v8, s17
+; GFX9-NEXT:    v_mov_b32_e32 v9, s18
+; GFX9-NEXT:    v_mov_b32_e32 v10, s19
+; GFX9-NEXT:    v_mov_b32_e32 v11, s20
+; GFX9-NEXT:    v_mov_b32_e32 v12, s21
+; GFX9-NEXT:    v_mov_b32_e32 v13, s22
+; GFX9-NEXT:    v_mov_b32_e32 v14, s23
+; GFX9-NEXT:    v_mov_b32_e32 v15, s24
+; GFX9-NEXT:    v_mov_b32_e32 v16, s25
+; GFX9-NEXT:    v_mov_b32_e32 v17, s26
+; GFX9-NEXT:    v_mov_b32_e32 v18, s27
+; GFX9-NEXT:    v_mov_b32_e32 v19, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v7
+; GFX9-NEXT:    v_mov_b32_e32 v7, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s12, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB41_3
 ; GFX9-NEXT:  .LBB41_2: ; %cmp.true
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
-; GFX9-NEXT:    s_add_u32 s28, s28, 3
-; GFX9-NEXT:    s_addc_u32 s29, s29, 0
-; GFX9-NEXT:    s_add_u32 s26, s26, 3
-; GFX9-NEXT:    s_addc_u32 s27, s27, 0
 ; GFX9-NEXT:    s_add_u32 s24, s24, 3
 ; GFX9-NEXT:    s_addc_u32 s25, s25, 0
 ; GFX9-NEXT:    s_add_u32 s22, s22, 3
@@ -19009,67 +19331,77 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
-; GFX9-NEXT:    s_lshr_b32 s12, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s16, 16
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
+; GFX9-NEXT:    s_lshr_b32 s26, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s6, 16
 ; GFX9-NEXT:  .LBB41_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s14
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s13
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s12
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s28
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s27
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB41_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr63
@@ -19088,38 +19420,65 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
-; GFX9-NEXT:    ; implicit-def: $sgpr13
-; GFX9-NEXT:    ; implicit-def: $sgpr12
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
+; GFX9-NEXT:    ; implicit-def: $sgpr27
+; GFX9-NEXT:    ; implicit-def: $sgpr26
 ; GFX9-NEXT:    s_branch .LBB41_2
 ;
 ; GFX11-LABEL: bitcast_v10i64_to_v40i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v3, s0 :: v_dual_mov_b32 v4, s1
+; GFX11-NEXT:    v_dual_mov_b32 v5, s2 :: v_dual_mov_b32 v6, s3
+; GFX11-NEXT:    v_dual_mov_b32 v7, s16 :: v_dual_mov_b32 v8, s17
+; GFX11-NEXT:    v_dual_mov_b32 v9, s18 :: v_dual_mov_b32 v10, s19
+; GFX11-NEXT:    v_dual_mov_b32 v11, s20 :: v_dual_mov_b32 v12, s21
+; GFX11-NEXT:    v_dual_mov_b32 v13, s22 :: v_dual_mov_b32 v14, s23
+; GFX11-NEXT:    v_dual_mov_b32 v15, s24 :: v_dual_mov_b32 v16, s25
+; GFX11-NEXT:    v_dual_mov_b32 v17, s26 :: v_dual_mov_b32 v18, s27
+; GFX11-NEXT:    v_dual_mov_b32 v19, s28 :: v_dual_mov_b32 v20, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v1
 ; GFX11-NEXT:    s_mov_b32 s58, 0
-; GFX11-NEXT:    s_and_b32 s6, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s20, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s7, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s8, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s20, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s21, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s46, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s47, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s56, s1, 16
@@ -19127,42 +19486,42 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s58
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB41_3
 ; GFX11-NEXT:  .LBB41_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s5, s5, 3
-; GFX11-NEXT:    s_addc_u32 s4, s4, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
-; GFX11-NEXT:    s_add_u32 s24, s24, 3
-; GFX11-NEXT:    s_addc_u32 s25, s25, 0
-; GFX11-NEXT:    s_add_u32 s22, s22, 3
-; GFX11-NEXT:    s_addc_u32 s23, s23, 0
-; GFX11-NEXT:    s_add_u32 s20, s20, 3
-; GFX11-NEXT:    s_addc_u32 s21, s21, 0
-; GFX11-NEXT:    s_add_u32 s18, s18, 3
-; GFX11-NEXT:    s_addc_u32 s19, s19, 0
+; GFX11-NEXT:    s_add_u32 s19, s19, 3
+; GFX11-NEXT:    s_addc_u32 s18, s18, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s7, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s8, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s20, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s21, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s46, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s47, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s56, s1, 16
@@ -19173,32 +19532,32 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s56
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s47
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s22, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s23, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s24, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s25, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s26, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s27, s10
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s28, s9
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s29, s8
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s7
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s6
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s24
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s23
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s22
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s21
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s20
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s15 :: v_dual_mov_b32 v11, s14
-; GFX11-NEXT:    v_dual_mov_b32 v12, s13 :: v_dual_mov_b32 v13, s12
-; GFX11-NEXT:    v_dual_mov_b32 v14, s11 :: v_dual_mov_b32 v15, s10
-; GFX11-NEXT:    v_dual_mov_b32 v16, s9 :: v_dual_mov_b32 v17, s8
-; GFX11-NEXT:    v_dual_mov_b32 v18, s5 :: v_dual_mov_b32 v19, s4
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s19 :: v_dual_mov_b32 v19, s18
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB41_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr57
@@ -19211,16 +19570,16 @@ define inreg <40 x i16> @bitcast_v10i64_to_v40i16_scalar(<10 x i64> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
-; GFX11-NEXT:    ; implicit-def: $sgpr9
-; GFX11-NEXT:    ; implicit-def: $sgpr8
-; GFX11-NEXT:    ; implicit-def: $sgpr7
-; GFX11-NEXT:    ; implicit-def: $sgpr6
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
+; GFX11-NEXT:    ; implicit-def: $sgpr23
+; GFX11-NEXT:    ; implicit-def: $sgpr22
+; GFX11-NEXT:    ; implicit-def: $sgpr21
+; GFX11-NEXT:    ; implicit-def: $sgpr20
 ; GFX11-NEXT:    s_branch .LBB41_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -19525,7 +19884,7 @@ define <10 x i64> @bitcast_v40i16_to_v10i64(<40 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v15, vcc, s6, v15
 ; SI-NEXT:    v_add_i32_e32 v17, vcc, s6, v17
 ; SI-NEXT:    v_add_i32_e32 v18, vcc, s6, v18
-; SI-NEXT:    v_add_i32_e32 v19, vcc, s6, v19
+; SI-NEXT:    v_add_i32_e32 v19, vcc, 0x30000, v19
 ; SI-NEXT:  .LBB42_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
@@ -21806,7 +22165,35 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; SI-LABEL: bitcast_v10i64_to_v40f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v8, s16
+; SI-NEXT:    v_mov_b32_e32 v9, s17
+; SI-NEXT:    v_mov_b32_e32 v10, s18
+; SI-NEXT:    v_mov_b32_e32 v11, s19
+; SI-NEXT:    v_mov_b32_e32 v12, s20
+; SI-NEXT:    v_mov_b32_e32 v13, s21
+; SI-NEXT:    v_mov_b32_e32 v14, s22
+; SI-NEXT:    v_mov_b32_e32 v15, s23
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v8
+; SI-NEXT:    v_mov_b32_e32 v8, s28
+; SI-NEXT:    v_readfirstlane_b32 s25, v9
+; SI-NEXT:    v_mov_b32_e32 v9, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; SI-NEXT:    v_readfirstlane_b32 s23, v10
+; SI-NEXT:    v_readfirstlane_b32 s24, v11
+; SI-NEXT:    v_readfirstlane_b32 s20, v12
+; SI-NEXT:    v_readfirstlane_b32 s21, v13
+; SI-NEXT:    v_readfirstlane_b32 s18, v14
+; SI-NEXT:    v_readfirstlane_b32 s19, v15
+; SI-NEXT:    v_readfirstlane_b32 s16, v16
+; SI-NEXT:    v_readfirstlane_b32 s17, v17
+; SI-NEXT:    v_readfirstlane_b32 s14, v18
+; SI-NEXT:    v_readfirstlane_b32 s15, v19
+; SI-NEXT:    v_readfirstlane_b32 s12, v8
+; SI-NEXT:    v_readfirstlane_b32 s13, v9
 ; SI-NEXT:    v_readfirstlane_b32 s10, v1
 ; SI-NEXT:    v_readfirstlane_b32 s11, v2
 ; SI-NEXT:    v_readfirstlane_b32 s7, v3
@@ -21828,33 +22215,33 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v8, s4
 ; SI-NEXT:    s_lshr_b32 s4, s10, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v10, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s13, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    s_lshr_b32 s4, s12, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v14, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    s_lshr_b32 s4, s16, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
 ; SI-NEXT:    s_lshr_b32 s4, s21, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
 ; SI-NEXT:    s_lshr_b32 s4, s20, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v38, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v48, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s9
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
@@ -21862,50 +22249,50 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, s7
 ; SI-NEXT:    v_cvt_f32_f16_e32 v11, s11
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, s13
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s18
 ; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
 ; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s22
 ; SI-NEXT:    s_cbranch_execnz .LBB45_3
 ; SI-NEXT:  .LBB45_2: ; %cmp.true
-; SI-NEXT:    s_add_u32 s4, s16, 3
-; SI-NEXT:    s_addc_u32 s5, s17, 0
-; SI-NEXT:    s_lshr_b32 s12, s4, 16
-; SI-NEXT:    s_lshr_b32 s13, s5, 16
-; SI-NEXT:    s_add_u32 s14, s18, 3
-; SI-NEXT:    s_addc_u32 s15, s19, 0
-; SI-NEXT:    s_lshr_b32 s16, s14, 16
-; SI-NEXT:    s_lshr_b32 s17, s15, 16
-; SI-NEXT:    s_add_u32 s18, s20, 3
-; SI-NEXT:    s_addc_u32 s19, s21, 0
-; SI-NEXT:    s_lshr_b32 s20, s18, 16
-; SI-NEXT:    s_lshr_b32 s21, s19, 16
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_lshr_b32 s40, s22, 16
-; SI-NEXT:    s_lshr_b32 s41, s23, 16
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_lshr_b32 s42, s24, 16
-; SI-NEXT:    s_lshr_b32 s43, s25, 16
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_lshr_b32 s44, s26, 16
-; SI-NEXT:    s_lshr_b32 s45, s27, 16
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_lshr_b32 s46, s28, 16
-; SI-NEXT:    s_lshr_b32 s47, s29, 16
+; SI-NEXT:    s_add_u32 s4, s22, 3
+; SI-NEXT:    s_addc_u32 s5, s25, 0
+; SI-NEXT:    s_lshr_b32 s22, s4, 16
+; SI-NEXT:    s_lshr_b32 s25, s5, 16
+; SI-NEXT:    s_add_u32 s23, s23, 3
+; SI-NEXT:    s_addc_u32 s24, s24, 0
+; SI-NEXT:    s_lshr_b32 s26, s23, 16
+; SI-NEXT:    s_lshr_b32 s27, s24, 16
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
+; SI-NEXT:    s_lshr_b32 s28, s20, 16
+; SI-NEXT:    s_lshr_b32 s29, s21, 16
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_lshr_b32 s40, s18, 16
+; SI-NEXT:    s_lshr_b32 s41, s19, 16
+; SI-NEXT:    s_add_u32 s16, s16, 3
+; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_lshr_b32 s42, s16, 16
+; SI-NEXT:    s_lshr_b32 s43, s17, 16
+; SI-NEXT:    s_add_u32 s14, s14, 3
+; SI-NEXT:    s_addc_u32 s15, s15, 0
+; SI-NEXT:    s_lshr_b32 s44, s14, 16
+; SI-NEXT:    s_lshr_b32 s45, s15, 16
+; SI-NEXT:    s_add_u32 s12, s12, 3
+; SI-NEXT:    s_addc_u32 s13, s13, 0
+; SI-NEXT:    s_lshr_b32 s46, s12, 16
+; SI-NEXT:    s_lshr_b32 s47, s13, 16
 ; SI-NEXT:    s_add_u32 s10, s10, 3
 ; SI-NEXT:    s_addc_u32 s11, s11, 0
 ; SI-NEXT:    s_lshr_b32 s56, s10, 16
@@ -21924,18 +22311,18 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, s7
 ; SI-NEXT:    v_cvt_f32_f16_e32 v11, s11
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, s13
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s23
 ; SI-NEXT:    v_cvt_f32_f16_e32 v37, s5
 ; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s61
@@ -21952,12 +22339,12 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v23, s42
 ; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
 ; SI-NEXT:    v_cvt_f32_f16_e32 v27, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s16
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s22
 ; SI-NEXT:  .LBB45_3: ; %end
 ; SI-NEXT:    v_cvt_f16_f32_e32 v48, v48
 ; SI-NEXT:    v_cvt_f16_f32_e32 v39, v39
@@ -22145,7 +22532,35 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; VI-LABEL: bitcast_v10i64_to_v40f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v7, s16
+; VI-NEXT:    v_mov_b32_e32 v8, s17
+; VI-NEXT:    v_mov_b32_e32 v9, s18
+; VI-NEXT:    v_mov_b32_e32 v10, s19
+; VI-NEXT:    v_mov_b32_e32 v11, s20
+; VI-NEXT:    v_mov_b32_e32 v12, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s22
+; VI-NEXT:    v_mov_b32_e32 v14, s23
+; VI-NEXT:    v_mov_b32_e32 v15, s24
+; VI-NEXT:    v_mov_b32_e32 v16, s25
+; VI-NEXT:    v_mov_b32_e32 v17, s26
+; VI-NEXT:    v_mov_b32_e32 v18, s27
+; VI-NEXT:    v_mov_b32_e32 v19, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v7
+; VI-NEXT:    v_mov_b32_e32 v7, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
+; VI-NEXT:    v_readfirstlane_b32 s24, v8
+; VI-NEXT:    v_readfirstlane_b32 s23, v9
+; VI-NEXT:    v_readfirstlane_b32 s22, v10
+; VI-NEXT:    v_readfirstlane_b32 s21, v11
+; VI-NEXT:    v_readfirstlane_b32 s20, v12
+; VI-NEXT:    v_readfirstlane_b32 s19, v13
+; VI-NEXT:    v_readfirstlane_b32 s18, v14
+; VI-NEXT:    v_readfirstlane_b32 s17, v15
+; VI-NEXT:    v_readfirstlane_b32 s16, v16
+; VI-NEXT:    v_readfirstlane_b32 s15, v17
+; VI-NEXT:    v_readfirstlane_b32 s14, v18
+; VI-NEXT:    v_readfirstlane_b32 s13, v19
+; VI-NEXT:    v_readfirstlane_b32 s12, v7
 ; VI-NEXT:    v_readfirstlane_b32 s11, v0
 ; VI-NEXT:    v_readfirstlane_b32 s10, v1
 ; VI-NEXT:    v_readfirstlane_b32 s9, v2
@@ -22155,26 +22570,26 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; VI-NEXT:    v_readfirstlane_b32 s7, v5
 ; VI-NEXT:    s_cbranch_scc0 .LBB45_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s12, s7, 16
-; VI-NEXT:    s_lshr_b32 s13, s6, 16
-; VI-NEXT:    s_lshr_b32 s14, s8, 16
-; VI-NEXT:    s_lshr_b32 s15, s9, 16
+; VI-NEXT:    s_lshr_b32 s26, s7, 16
+; VI-NEXT:    s_lshr_b32 s27, s6, 16
+; VI-NEXT:    s_lshr_b32 s28, s8, 16
+; VI-NEXT:    s_lshr_b32 s29, s9, 16
 ; VI-NEXT:    s_lshr_b32 s40, s10, 16
 ; VI-NEXT:    s_lshr_b32 s41, s11, 16
-; VI-NEXT:    s_lshr_b32 s42, s29, 16
-; VI-NEXT:    s_lshr_b32 s43, s28, 16
-; VI-NEXT:    s_lshr_b32 s44, s27, 16
-; VI-NEXT:    s_lshr_b32 s45, s26, 16
-; VI-NEXT:    s_lshr_b32 s46, s25, 16
-; VI-NEXT:    s_lshr_b32 s47, s24, 16
-; VI-NEXT:    s_lshr_b32 s56, s23, 16
-; VI-NEXT:    s_lshr_b32 s57, s22, 16
-; VI-NEXT:    s_lshr_b32 s58, s21, 16
-; VI-NEXT:    s_lshr_b32 s59, s20, 16
-; VI-NEXT:    s_lshr_b32 s60, s19, 16
-; VI-NEXT:    s_lshr_b32 s61, s18, 16
-; VI-NEXT:    s_lshr_b32 s62, s17, 16
-; VI-NEXT:    s_lshr_b32 s63, s16, 16
+; VI-NEXT:    s_lshr_b32 s42, s12, 16
+; VI-NEXT:    s_lshr_b32 s43, s13, 16
+; VI-NEXT:    s_lshr_b32 s44, s14, 16
+; VI-NEXT:    s_lshr_b32 s45, s15, 16
+; VI-NEXT:    s_lshr_b32 s46, s16, 16
+; VI-NEXT:    s_lshr_b32 s47, s17, 16
+; VI-NEXT:    s_lshr_b32 s56, s18, 16
+; VI-NEXT:    s_lshr_b32 s57, s19, 16
+; VI-NEXT:    s_lshr_b32 s58, s20, 16
+; VI-NEXT:    s_lshr_b32 s59, s21, 16
+; VI-NEXT:    s_lshr_b32 s60, s22, 16
+; VI-NEXT:    s_lshr_b32 s61, s23, 16
+; VI-NEXT:    s_lshr_b32 s62, s24, 16
+; VI-NEXT:    s_lshr_b32 s63, s25, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB45_3
 ; VI-NEXT:  .LBB45_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -22183,115 +22598,115 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; VI-NEXT:    s_addc_u32 s8, s8, 0
 ; VI-NEXT:    s_add_u32 s11, s11, 3
 ; VI-NEXT:    s_addc_u32 s10, s10, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s12, s7, 16
-; VI-NEXT:    s_lshr_b32 s13, s6, 16
-; VI-NEXT:    s_lshr_b32 s14, s8, 16
-; VI-NEXT:    s_lshr_b32 s15, s9, 16
+; VI-NEXT:    s_add_u32 s13, s13, 3
+; VI-NEXT:    s_addc_u32 s12, s12, 0
+; VI-NEXT:    s_add_u32 s15, s15, 3
+; VI-NEXT:    s_addc_u32 s14, s14, 0
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_lshr_b32 s26, s7, 16
+; VI-NEXT:    s_lshr_b32 s27, s6, 16
+; VI-NEXT:    s_lshr_b32 s28, s8, 16
+; VI-NEXT:    s_lshr_b32 s29, s9, 16
 ; VI-NEXT:    s_lshr_b32 s40, s10, 16
 ; VI-NEXT:    s_lshr_b32 s41, s11, 16
-; VI-NEXT:    s_lshr_b32 s42, s29, 16
-; VI-NEXT:    s_lshr_b32 s43, s28, 16
-; VI-NEXT:    s_lshr_b32 s44, s27, 16
-; VI-NEXT:    s_lshr_b32 s45, s26, 16
-; VI-NEXT:    s_lshr_b32 s46, s25, 16
-; VI-NEXT:    s_lshr_b32 s47, s24, 16
-; VI-NEXT:    s_lshr_b32 s56, s23, 16
-; VI-NEXT:    s_lshr_b32 s57, s22, 16
-; VI-NEXT:    s_lshr_b32 s58, s21, 16
-; VI-NEXT:    s_lshr_b32 s59, s20, 16
-; VI-NEXT:    s_lshr_b32 s60, s19, 16
-; VI-NEXT:    s_lshr_b32 s61, s18, 16
-; VI-NEXT:    s_lshr_b32 s62, s17, 16
-; VI-NEXT:    s_lshr_b32 s63, s16, 16
+; VI-NEXT:    s_lshr_b32 s42, s12, 16
+; VI-NEXT:    s_lshr_b32 s43, s13, 16
+; VI-NEXT:    s_lshr_b32 s44, s14, 16
+; VI-NEXT:    s_lshr_b32 s45, s15, 16
+; VI-NEXT:    s_lshr_b32 s46, s16, 16
+; VI-NEXT:    s_lshr_b32 s47, s17, 16
+; VI-NEXT:    s_lshr_b32 s56, s18, 16
+; VI-NEXT:    s_lshr_b32 s57, s19, 16
+; VI-NEXT:    s_lshr_b32 s58, s20, 16
+; VI-NEXT:    s_lshr_b32 s59, s21, 16
+; VI-NEXT:    s_lshr_b32 s60, s22, 16
+; VI-NEXT:    s_lshr_b32 s61, s23, 16
+; VI-NEXT:    s_lshr_b32 s62, s24, 16
+; VI-NEXT:    s_lshr_b32 s63, s25, 16
 ; VI-NEXT:  .LBB45_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s25
 ; VI-NEXT:    s_lshl_b32 s5, s63, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s62, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s61, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s60, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s59, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s58, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s57, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s56, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s47, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s46, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s24, s62, 16
+; VI-NEXT:    s_or_b32 s5, s5, s24
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s24, s61, 16
 ; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s45, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s44, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s43, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s24, s60, 16
+; VI-NEXT:    s_or_b32 s22, s22, s24
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s24, s59, 16
+; VI-NEXT:    s_or_b32 s21, s21, s24
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s24, s58, 16
+; VI-NEXT:    s_or_b32 s20, s20, s24
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s24, s57, 16
+; VI-NEXT:    s_or_b32 s19, s19, s24
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s24, s56, 16
+; VI-NEXT:    s_or_b32 s18, s18, s24
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s24, s47, 16
+; VI-NEXT:    s_or_b32 s17, s17, s24
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s24, s46, 16
+; VI-NEXT:    s_or_b32 s16, s16, s24
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s24, s45, 16
+; VI-NEXT:    s_or_b32 s15, s15, s24
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s24, s44, 16
+; VI-NEXT:    s_or_b32 s14, s14, s24
+; VI-NEXT:    s_and_b32 s13, 0xffff, s13
+; VI-NEXT:    s_lshl_b32 s24, s43, 16
+; VI-NEXT:    s_or_b32 s13, s13, s24
+; VI-NEXT:    s_and_b32 s12, 0xffff, s12
+; VI-NEXT:    s_lshl_b32 s24, s42, 16
+; VI-NEXT:    s_or_b32 s12, s12, s24
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s24, s41, 16
+; VI-NEXT:    s_or_b32 s11, s11, s24
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
+; VI-NEXT:    s_lshl_b32 s24, s40, 16
+; VI-NEXT:    s_or_b32 s10, s10, s24
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
+; VI-NEXT:    s_lshl_b32 s24, s29, 16
+; VI-NEXT:    s_or_b32 s9, s9, s24
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
+; VI-NEXT:    s_lshl_b32 s24, s28, 16
+; VI-NEXT:    s_or_b32 s8, s8, s24
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s13, s13, 16
+; VI-NEXT:    s_lshl_b32 s24, s27, 16
+; VI-NEXT:    s_or_b32 s6, s6, s24
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s12, s12, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
-; VI-NEXT:    s_or_b32 s9, s9, s15
-; VI-NEXT:    s_or_b32 s8, s8, s14
-; VI-NEXT:    s_or_b32 s6, s6, s13
-; VI-NEXT:    s_or_b32 s7, s7, s12
+; VI-NEXT:    s_lshl_b32 s24, s26, 16
+; VI-NEXT:    s_or_b32 s7, s7, s24
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s23
+; VI-NEXT:    v_mov_b32_e32 v3, s22
+; VI-NEXT:    v_mov_b32_e32 v4, s21
+; VI-NEXT:    v_mov_b32_e32 v5, s20
+; VI-NEXT:    v_mov_b32_e32 v6, s19
+; VI-NEXT:    v_mov_b32_e32 v7, s18
+; VI-NEXT:    v_mov_b32_e32 v8, s17
+; VI-NEXT:    v_mov_b32_e32 v9, s16
+; VI-NEXT:    v_mov_b32_e32 v10, s15
+; VI-NEXT:    v_mov_b32_e32 v11, s14
+; VI-NEXT:    v_mov_b32_e32 v12, s13
+; VI-NEXT:    v_mov_b32_e32 v13, s12
 ; VI-NEXT:    v_mov_b32_e32 v14, s11
 ; VI-NEXT:    v_mov_b32_e32 v15, s10
 ; VI-NEXT:    v_mov_b32_e32 v16, s9
@@ -22316,57 +22731,75 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
 ; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
-; VI-NEXT:    ; implicit-def: $sgpr13
-; VI-NEXT:    ; implicit-def: $sgpr12
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
+; VI-NEXT:    ; implicit-def: $sgpr26
 ; VI-NEXT:    s_branch .LBB45_2
 ;
 ; GFX9-LABEL: bitcast_v10i64_to_v40f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v7, s16
+; GFX9-NEXT:    v_mov_b32_e32 v8, s17
+; GFX9-NEXT:    v_mov_b32_e32 v9, s18
+; GFX9-NEXT:    v_mov_b32_e32 v10, s19
+; GFX9-NEXT:    v_mov_b32_e32 v11, s20
+; GFX9-NEXT:    v_mov_b32_e32 v12, s21
+; GFX9-NEXT:    v_mov_b32_e32 v13, s22
+; GFX9-NEXT:    v_mov_b32_e32 v14, s23
+; GFX9-NEXT:    v_mov_b32_e32 v15, s24
+; GFX9-NEXT:    v_mov_b32_e32 v16, s25
+; GFX9-NEXT:    v_mov_b32_e32 v17, s26
+; GFX9-NEXT:    v_mov_b32_e32 v18, s27
+; GFX9-NEXT:    v_mov_b32_e32 v19, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v7
+; GFX9-NEXT:    v_mov_b32_e32 v7, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s12, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s26, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB45_3
 ; GFX9-NEXT:  .LBB45_2: ; %cmp.true
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
-; GFX9-NEXT:    s_add_u32 s28, s28, 3
-; GFX9-NEXT:    s_addc_u32 s29, s29, 0
-; GFX9-NEXT:    s_add_u32 s26, s26, 3
-; GFX9-NEXT:    s_addc_u32 s27, s27, 0
 ; GFX9-NEXT:    s_add_u32 s24, s24, 3
 ; GFX9-NEXT:    s_addc_u32 s25, s25, 0
 ; GFX9-NEXT:    s_add_u32 s22, s22, 3
@@ -22377,67 +22810,77 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
-; GFX9-NEXT:    s_lshr_b32 s12, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s13, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s16, 16
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
+; GFX9-NEXT:    s_lshr_b32 s26, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s27, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s6, 16
 ; GFX9-NEXT:  .LBB45_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s14
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s13
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s12
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s28
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s27
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB45_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr63
@@ -22456,38 +22899,65 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
-; GFX9-NEXT:    ; implicit-def: $sgpr13
-; GFX9-NEXT:    ; implicit-def: $sgpr12
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
+; GFX9-NEXT:    ; implicit-def: $sgpr27
+; GFX9-NEXT:    ; implicit-def: $sgpr26
 ; GFX9-NEXT:    s_branch .LBB45_2
 ;
 ; GFX11-LABEL: bitcast_v10i64_to_v40f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v3, s0 :: v_dual_mov_b32 v4, s1
+; GFX11-NEXT:    v_dual_mov_b32 v5, s2 :: v_dual_mov_b32 v6, s3
+; GFX11-NEXT:    v_dual_mov_b32 v7, s16 :: v_dual_mov_b32 v8, s17
+; GFX11-NEXT:    v_dual_mov_b32 v9, s18 :: v_dual_mov_b32 v10, s19
+; GFX11-NEXT:    v_dual_mov_b32 v11, s20 :: v_dual_mov_b32 v12, s21
+; GFX11-NEXT:    v_dual_mov_b32 v13, s22 :: v_dual_mov_b32 v14, s23
+; GFX11-NEXT:    v_dual_mov_b32 v15, s24 :: v_dual_mov_b32 v16, s25
+; GFX11-NEXT:    v_dual_mov_b32 v17, s26 :: v_dual_mov_b32 v18, s27
+; GFX11-NEXT:    v_dual_mov_b32 v19, s28 :: v_dual_mov_b32 v20, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v1
 ; GFX11-NEXT:    s_mov_b32 s58, 0
-; GFX11-NEXT:    s_and_b32 s6, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s20, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s7, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s8, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s20, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s21, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s46, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s47, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s56, s1, 16
@@ -22495,42 +22965,42 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s58
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB45_3
 ; GFX11-NEXT:  .LBB45_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s5, s5, 3
-; GFX11-NEXT:    s_addc_u32 s4, s4, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
-; GFX11-NEXT:    s_add_u32 s24, s24, 3
-; GFX11-NEXT:    s_addc_u32 s25, s25, 0
-; GFX11-NEXT:    s_add_u32 s22, s22, 3
-; GFX11-NEXT:    s_addc_u32 s23, s23, 0
-; GFX11-NEXT:    s_add_u32 s20, s20, 3
-; GFX11-NEXT:    s_addc_u32 s21, s21, 0
-; GFX11-NEXT:    s_add_u32 s18, s18, 3
-; GFX11-NEXT:    s_addc_u32 s19, s19, 0
+; GFX11-NEXT:    s_add_u32 s19, s19, 3
+; GFX11-NEXT:    s_addc_u32 s18, s18, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s6, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s7, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s8, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s20, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s21, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s46, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s47, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s56, s1, 16
@@ -22541,32 +23011,32 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s56
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s47
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s22, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s23, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s24, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s25, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s26, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s27, s10
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s28, s9
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s29, s8
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s7
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s6
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s24
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s23
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s22
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s21
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s20
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s15 :: v_dual_mov_b32 v11, s14
-; GFX11-NEXT:    v_dual_mov_b32 v12, s13 :: v_dual_mov_b32 v13, s12
-; GFX11-NEXT:    v_dual_mov_b32 v14, s11 :: v_dual_mov_b32 v15, s10
-; GFX11-NEXT:    v_dual_mov_b32 v16, s9 :: v_dual_mov_b32 v17, s8
-; GFX11-NEXT:    v_dual_mov_b32 v18, s5 :: v_dual_mov_b32 v19, s4
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s19 :: v_dual_mov_b32 v19, s18
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB45_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr57
@@ -22579,16 +23049,16 @@ define inreg <40 x half> @bitcast_v10i64_to_v40f16_scalar(<10 x i64> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
-; GFX11-NEXT:    ; implicit-def: $sgpr9
-; GFX11-NEXT:    ; implicit-def: $sgpr8
-; GFX11-NEXT:    ; implicit-def: $sgpr7
-; GFX11-NEXT:    ; implicit-def: $sgpr6
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
+; GFX11-NEXT:    ; implicit-def: $sgpr23
+; GFX11-NEXT:    ; implicit-def: $sgpr22
+; GFX11-NEXT:    ; implicit-def: $sgpr21
+; GFX11-NEXT:    ; implicit-def: $sgpr20
 ; GFX11-NEXT:    s_branch .LBB45_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -26261,7 +26731,7 @@ define <10 x double> @bitcast_v40i16_to_v10f64(<40 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v15, vcc, s6, v15
 ; SI-NEXT:    v_add_i32_e32 v17, vcc, s6, v17
 ; SI-NEXT:    v_add_i32_e32 v18, vcc, s6, v18
-; SI-NEXT:    v_add_i32_e32 v19, vcc, s6, v19
+; SI-NEXT:    v_add_i32_e32 v19, vcc, 0x30000, v19
 ; SI-NEXT:  .LBB50_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
@@ -28473,341 +28943,368 @@ define inreg <40 x half> @bitcast_v10f64_to_v40f16_scalar(<10 x double> inreg %a
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
-; SI-NEXT:    v_readfirstlane_b32 s8, v1
-; SI-NEXT:    v_readfirstlane_b32 s9, v2
-; SI-NEXT:    v_readfirstlane_b32 s6, v3
-; SI-NEXT:    v_readfirstlane_b32 s7, v4
-; SI-NEXT:    v_readfirstlane_b32 s4, v5
-; SI-NEXT:    s_and_b64 s[10:11], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s5, v6
-; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    v_mov_b32_e32 v20, s16
+; SI-NEXT:    v_mov_b32_e32 v21, s17
+; SI-NEXT:    v_mov_b32_e32 v18, s18
+; SI-NEXT:    v_mov_b32_e32 v19, s19
+; SI-NEXT:    v_mov_b32_e32 v16, s20
+; SI-NEXT:    v_mov_b32_e32 v17, s21
+; SI-NEXT:    v_mov_b32_e32 v14, s22
+; SI-NEXT:    v_mov_b32_e32 v15, s23
+; SI-NEXT:    v_mov_b32_e32 v12, s24
+; SI-NEXT:    v_mov_b32_e32 v13, s25
+; SI-NEXT:    v_mov_b32_e32 v8, s26
+; SI-NEXT:    v_mov_b32_e32 v9, s27
+; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
+; SI-NEXT:    v_mov_b32_e32 v10, s28
+; SI-NEXT:    v_mov_b32_e32 v11, s29
+; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v60, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_cbranch_scc0 .LBB53_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s10, s5, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s10
-; SI-NEXT:    s_lshr_b32 s10, s4, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s10
-; SI-NEXT:    s_lshr_b32 s10, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s10
-; SI-NEXT:    s_lshr_b32 s10, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s10
-; SI-NEXT:    s_lshr_b32 s10, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s10
-; SI-NEXT:    s_lshr_b32 s10, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s10
-; SI-NEXT:    s_lshr_b32 s10, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s10
-; SI-NEXT:    s_lshr_b32 s10, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s10
-; SI-NEXT:    s_lshr_b32 s10, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s10
-; SI-NEXT:    s_lshr_b32 s10, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s10
-; SI-NEXT:    s_lshr_b32 s10, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s10
-; SI-NEXT:    s_lshr_b32 s10, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s10
-; SI-NEXT:    s_lshr_b32 s10, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s10
-; SI-NEXT:    s_lshr_b32 s10, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s10
-; SI-NEXT:    s_lshr_b32 s10, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s10
-; SI-NEXT:    s_lshr_b32 s10, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s10
-; SI-NEXT:    s_lshr_b32 s10, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s10
-; SI-NEXT:    s_lshr_b32 s10, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s10
-; SI-NEXT:    s_lshr_b32 s10, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s10
-; SI-NEXT:    s_lshr_b32 s10, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s5
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v19
+; SI-NEXT:    s_waitcnt expcnt(6)
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v18
+; SI-NEXT:    s_waitcnt expcnt(4)
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v22, 16, v5
+; SI-NEXT:    s_waitcnt expcnt(2)
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v22
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v20
 ; SI-NEXT:    s_cbranch_execnz .LBB53_3
 ; SI-NEXT:  .LBB53_2: ; %cmp.true
-; SI-NEXT:    v_add_f64 v[1:2], s[16:17], 1.0
-; SI-NEXT:    v_add_f64 v[34:35], s[18:19], 1.0
-; SI-NEXT:    v_add_f64 v[29:30], s[20:21], 1.0
-; SI-NEXT:    v_add_f64 v[25:26], s[22:23], 1.0
-; SI-NEXT:    v_add_f64 v[21:22], s[24:25], 1.0
-; SI-NEXT:    v_add_f64 v[19:20], s[26:27], 1.0
-; SI-NEXT:    v_add_f64 v[14:15], s[28:29], 1.0
-; SI-NEXT:    v_add_f64 v[10:11], s[8:9], 1.0
-; SI-NEXT:    v_add_f64 v[6:7], s[6:7], 1.0
-; SI-NEXT:    v_add_f64 v[4:5], s[4:5], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v34
-; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v35
-; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v29
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v30
-; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v25
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v26
-; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
-; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v19
-; SI-NEXT:    v_lshrrev_b32_e32 v16, 16, v20
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
-; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v10
-; SI-NEXT:    v_lshrrev_b32_e32 v8, 16, v11
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v6
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v7
-; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v4
+; SI-NEXT:    v_add_f64 v[20:21], v[20:21], 1.0
+; SI-NEXT:    v_add_f64 v[18:19], v[18:19], 1.0
+; SI-NEXT:    v_add_f64 v[16:17], v[16:17], 1.0
+; SI-NEXT:    v_add_f64 v[14:15], v[14:15], 1.0
+; SI-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
+; SI-NEXT:    v_add_f64 v[7:8], v[8:9], 1.0
+; SI-NEXT:    v_add_f64 v[9:10], v[10:11], 1.0
+; SI-NEXT:    v_add_f64 v[1:2], v[1:2], 1.0
+; SI-NEXT:    v_add_f64 v[3:4], v[3:4], 1.0
+; SI-NEXT:    v_add_f64 v[5:6], v[5:6], 1.0
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v22, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v36
 ; SI-NEXT:    v_cvt_f32_f16_e32 v22, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v24
 ; SI-NEXT:    v_cvt_f32_f16_e32 v26, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
 ; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v35
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v34
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v43
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v42
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v41
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, v40
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v55
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v52
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v49
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v39
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v60
 ; SI-NEXT:  .LBB53_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v48, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v39, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v38, v38
-; SI-NEXT:    v_cvt_f16_f32_e32 v37, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v36, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v35, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v34, v34
-; SI-NEXT:    v_lshlrev_b32_e32 v48, 16, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v33, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v31, v31
-; SI-NEXT:    v_or_b32_e32 v39, v39, v48
-; SI-NEXT:    v_lshlrev_b32_e32 v38, 16, v38
-; SI-NEXT:    v_cvt_f16_f32_e32 v32, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v29, v29
-; SI-NEXT:    buffer_store_dword v39, v0, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v60
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v59
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v58
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v57
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v39, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v37, v37, v38
-; SI-NEXT:    v_lshlrev_b32_e32 v36, 16, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; SI-NEXT:    buffer_store_dword v37, v39, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v37, vcc, 8, v0
-; SI-NEXT:    v_or_b32_e32 v35, v35, v36
-; SI-NEXT:    v_lshlrev_b32_e32 v34, 16, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v28, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v25, v25
-; SI-NEXT:    buffer_store_dword v35, v37, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 12, v0
-; SI-NEXT:    v_or_b32_e32 v33, v33, v34
-; SI-NEXT:    v_lshlrev_b32_e32 v31, 16, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v23, v23
-; SI-NEXT:    buffer_store_dword v33, v35, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 16, v0
-; SI-NEXT:    v_or_b32_e32 v31, v32, v31
-; SI-NEXT:    v_lshlrev_b32_e32 v29, 16, v29
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v21, v21
-; SI-NEXT:    buffer_store_dword v31, v33, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 20, v0
-; SI-NEXT:    v_or_b32_e32 v29, v30, v29
-; SI-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v19, v19
-; SI-NEXT:    buffer_store_dword v29, v31, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v29, vcc, 24, v0
-; SI-NEXT:    v_or_b32_e32 v27, v28, v27
-; SI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v16
-; SI-NEXT:    buffer_store_dword v27, v29, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v27, vcc, 28, v0
-; SI-NEXT:    v_or_b32_e32 v25, v26, v25
-; SI-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v18
-; SI-NEXT:    buffer_store_dword v25, v27, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v25, vcc, 32, v0
-; SI-NEXT:    v_or_b32_e32 v23, v24, v23
-; SI-NEXT:    v_lshlrev_b32_e32 v21, 16, v21
-; SI-NEXT:    buffer_store_dword v23, v25, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v23, vcc, 36, v0
-; SI-NEXT:    v_or_b32_e32 v21, v22, v21
-; SI-NEXT:    v_lshlrev_b32_e32 v19, 16, v19
-; SI-NEXT:    buffer_store_dword v21, v23, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v21, vcc, 40, v0
-; SI-NEXT:    v_or_b32_e32 v19, v20, v19
-; SI-NEXT:    v_lshlrev_b32_e32 v16, 16, v16
-; SI-NEXT:    buffer_store_dword v19, v21, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v19, vcc, 44, v0
-; SI-NEXT:    v_or_b32_e32 v16, v18, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; SI-NEXT:    buffer_store_dword v16, v19, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v17
-; SI-NEXT:    v_add_i32_e32 v17, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
-; SI-NEXT:    v_or_b32_e32 v14, v16, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; SI-NEXT:    buffer_store_dword v14, v17, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v15
-; SI-NEXT:    v_add_i32_e32 v15, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
-; SI-NEXT:    v_or_b32_e32 v12, v14, v12
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v10
-; SI-NEXT:    buffer_store_dword v12, v15, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v13
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v12, v10
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v8
-; SI-NEXT:    buffer_store_dword v10, v13, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v11
-; SI-NEXT:    v_add_i32_e32 v11, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
-; SI-NEXT:    v_or_b32_e32 v8, v10, v8
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v6
-; SI-NEXT:    buffer_store_dword v8, v11, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v9
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; SI-NEXT:    buffer_store_dword v6, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v7
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v4, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v5
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
 ; SI-NEXT:    v_or_b32_e32 v2, v4, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v5, s[0:3], 0 offen
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v56
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v3
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v47
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v46
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v45
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v43
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v44
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v41
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v42
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v55
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v40
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v54
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v51
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v52
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v49
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v50
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v39
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v48
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v36
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v38
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v34
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v37
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v32
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v35
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v30
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v33
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v28
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v31
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v26
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v24
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v27
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v22
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v25
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v7
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v23
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x4c, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v60, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB53_4:
-; SI-NEXT:    ; implicit-def: $vgpr39
+; SI-NEXT:    ; implicit-def: $vgpr59
+; SI-NEXT:    ; implicit-def: $vgpr60
+; SI-NEXT:    ; implicit-def: $vgpr57
+; SI-NEXT:    ; implicit-def: $vgpr58
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr43
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr49
 ; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr39
 ; SI-NEXT:    ; implicit-def: $vgpr38
-; SI-NEXT:    ; implicit-def: $vgpr35
 ; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; implicit-def: $vgpr37
 ; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; implicit-def: $vgpr35
 ; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr33
 ; SI-NEXT:    ; implicit-def: $vgpr30
-; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr26
-; SI-NEXT:    ; implicit-def: $vgpr25
+; SI-NEXT:    ; implicit-def: $vgpr27
 ; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr23
+; SI-NEXT:    ; implicit-def: $vgpr25
 ; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr14
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr13
-; SI-NEXT:    ; implicit-def: $vgpr10
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr8
-; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr6
+; SI-NEXT:    ; implicit-def: $vgpr23
 ; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr1
 ; SI-NEXT:    s_branch .LBB53_2
 ;
 ; VI-LABEL: bitcast_v10f64_to_v40f16_scalar:

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.704bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.704bit.ll
@@ -3021,7 +3021,35 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; SI-LABEL: bitcast_v22i32_to_v44i16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v10, s16
+; SI-NEXT:    v_mov_b32_e32 v11, s17
+; SI-NEXT:    v_mov_b32_e32 v12, s18
+; SI-NEXT:    v_mov_b32_e32 v13, s19
+; SI-NEXT:    v_mov_b32_e32 v14, s20
+; SI-NEXT:    v_mov_b32_e32 v15, s21
+; SI-NEXT:    v_mov_b32_e32 v16, s22
+; SI-NEXT:    v_mov_b32_e32 v17, s23
+; SI-NEXT:    v_mov_b32_e32 v18, s24
+; SI-NEXT:    v_mov_b32_e32 v19, s25
+; SI-NEXT:    v_readfirstlane_b32 s24, v10
+; SI-NEXT:    v_mov_b32_e32 v10, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v11
+; SI-NEXT:    v_mov_b32_e32 v11, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v12
+; SI-NEXT:    v_mov_b32_e32 v12, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v13
+; SI-NEXT:    v_mov_b32_e32 v13, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; SI-NEXT:    v_readfirstlane_b32 s20, v14
+; SI-NEXT:    v_readfirstlane_b32 s21, v15
+; SI-NEXT:    v_readfirstlane_b32 s18, v16
+; SI-NEXT:    v_readfirstlane_b32 s19, v17
+; SI-NEXT:    v_readfirstlane_b32 s16, v18
+; SI-NEXT:    v_readfirstlane_b32 s17, v19
+; SI-NEXT:    v_readfirstlane_b32 s14, v10
+; SI-NEXT:    v_readfirstlane_b32 s15, v11
+; SI-NEXT:    v_readfirstlane_b32 s12, v12
+; SI-NEXT:    v_readfirstlane_b32 s13, v13
 ; SI-NEXT:    v_readfirstlane_b32 s10, v1
 ; SI-NEXT:    v_readfirstlane_b32 s11, v2
 ; SI-NEXT:    v_readfirstlane_b32 s8, v3
@@ -3029,7 +3057,7 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v5
 ; SI-NEXT:    v_readfirstlane_b32 s7, v6
 ; SI-NEXT:    v_readfirstlane_b32 s4, v7
-; SI-NEXT:    s_and_b64 s[12:13], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v8
 ; SI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
@@ -3037,40 +3065,40 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s77, s7, 16
 ; SI-NEXT:    s_lshr_b32 s78, s9, 16
 ; SI-NEXT:    s_lshr_b32 s79, s11, 16
-; SI-NEXT:    s_lshr_b32 s88, s29, 16
-; SI-NEXT:    s_lshr_b32 s89, s27, 16
-; SI-NEXT:    s_lshr_b32 s90, s25, 16
-; SI-NEXT:    s_lshr_b32 s91, s23, 16
+; SI-NEXT:    s_lshr_b32 s88, s13, 16
+; SI-NEXT:    s_lshr_b32 s89, s15, 16
+; SI-NEXT:    s_lshr_b32 s90, s17, 16
+; SI-NEXT:    s_lshr_b32 s91, s19, 16
 ; SI-NEXT:    s_lshr_b32 s92, s21, 16
-; SI-NEXT:    s_lshr_b32 s93, s19, 16
-; SI-NEXT:    s_lshr_b32 s94, s17, 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s93, s23, 16
+; SI-NEXT:    s_lshr_b32 s94, s25, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[40:41], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[42:43], s[10:11], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[46:47], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[18:19], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[24:25], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB13_3
 ; SI-NEXT:  .LBB13_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s23, s23, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
 ; SI-NEXT:    s_add_i32 s25, s25, 3
 ; SI-NEXT:    s_add_i32 s24, s24, 3
-; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s26, s26, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
+; SI-NEXT:    s_add_i32 s23, s23, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
+; SI-NEXT:    s_add_i32 s15, s15, 3
+; SI-NEXT:    s_add_i32 s14, s14, 3
+; SI-NEXT:    s_add_i32 s13, s13, 3
+; SI-NEXT:    s_add_i32 s12, s12, 3
 ; SI-NEXT:    s_add_i32 s11, s11, 3
 ; SI-NEXT:    s_add_i32 s10, s10, 3
 ; SI-NEXT:    s_add_i32 s9, s9, 3
@@ -3079,125 +3107,125 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s5, s5, 3
 ; SI-NEXT:    s_add_i32 s4, s4, 3
-; SI-NEXT:    s_lshr_b64 s[12:13], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[40:41], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[42:43], s[10:11], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[26:27], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[46:47], s[14:15], 16
 ; SI-NEXT:    s_lshr_b32 s76, s5, 16
 ; SI-NEXT:    s_lshr_b32 s77, s7, 16
 ; SI-NEXT:    s_lshr_b32 s78, s9, 16
 ; SI-NEXT:    s_lshr_b32 s79, s11, 16
-; SI-NEXT:    s_lshr_b32 s88, s29, 16
-; SI-NEXT:    s_lshr_b32 s89, s27, 16
-; SI-NEXT:    s_lshr_b32 s90, s25, 16
-; SI-NEXT:    s_lshr_b32 s91, s23, 16
+; SI-NEXT:    s_lshr_b32 s88, s13, 16
+; SI-NEXT:    s_lshr_b32 s89, s15, 16
+; SI-NEXT:    s_lshr_b32 s90, s17, 16
+; SI-NEXT:    s_lshr_b32 s91, s19, 16
 ; SI-NEXT:    s_lshr_b32 s92, s21, 16
-; SI-NEXT:    s_lshr_b32 s93, s19, 16
-; SI-NEXT:    s_lshr_b32 s94, s17, 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[22:23], 16
+; SI-NEXT:    s_lshr_b32 s93, s23, 16
+; SI-NEXT:    s_lshr_b32 s94, s25, 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[18:19], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[24:25], 16
 ; SI-NEXT:  .LBB13_3: ; %end
-; SI-NEXT:    s_lshl_b32 s13, s72, 16
-; SI-NEXT:    s_and_b32 s15, s16, 0xffff
-; SI-NEXT:    s_or_b32 s13, s15, s13
-; SI-NEXT:    v_mov_b32_e32 v1, s13
-; SI-NEXT:    s_and_b32 s13, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s94, 16
-; SI-NEXT:    s_or_b32 s13, s13, s15
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_lshl_b32 s13, s62, 16
-; SI-NEXT:    s_and_b32 s15, s18, 0xffff
-; SI-NEXT:    s_or_b32 s13, s15, s13
-; SI-NEXT:    v_mov_b32_e32 v3, s13
-; SI-NEXT:    s_and_b32 s13, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s93, 16
-; SI-NEXT:    s_or_b32 s13, s13, s15
-; SI-NEXT:    v_mov_b32_e32 v4, s13
-; SI-NEXT:    s_lshl_b32 s13, s60, 16
-; SI-NEXT:    s_and_b32 s15, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s72, 16
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_or_b32 s24, s24, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
+; SI-NEXT:    s_lshl_b32 s25, s94, 16
+; SI-NEXT:    s_or_b32 s24, s24, s25
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_lshl_b32 s24, s62, 16
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_or_b32 s22, s22, s24
+; SI-NEXT:    v_mov_b32_e32 v3, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s93, 16
+; SI-NEXT:    s_or_b32 s22, s22, s23
+; SI-NEXT:    v_mov_b32_e32 v4, s22
+; SI-NEXT:    s_lshl_b32 s22, s60, 16
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_or_b32 s13, s15, s13
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
 ; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s92, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s92, 16
 ; SI-NEXT:    buffer_store_dword v4, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s58, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s58, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s91, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s91, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s56, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s56, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s90, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
+; SI-NEXT:    s_lshl_b32 s17, s90, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s16, s16, s17
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s46, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s14, s14, 0xffff
+; SI-NEXT:    s_lshl_b32 s16, s46, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s14, s14, s16
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s27, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s14, s15, 0xffff
 ; SI-NEXT:    s_lshl_b32 s15, s89, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s14, s14, s15
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s44, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s12, s12, 0xffff
+; SI-NEXT:    s_lshl_b32 s14, s44, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s12, s12, s14
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s88, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s12, s13, 0xffff
+; SI-NEXT:    s_lshl_b32 s13, s88, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s12, s12, s13
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
+; SI-NEXT:    v_mov_b32_e32 v2, s12
 ; SI-NEXT:    s_and_b32 s10, s10, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s42, 16
+; SI-NEXT:    s_lshl_b32 s12, s42, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s10, s10, s13
+; SI-NEXT:    s_or_b32 s10, s10, s12
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s10
@@ -3223,7 +3251,7 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s14, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x44, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3237,7 +3265,7 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s12, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x4c, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3272,16 +3300,44 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr79
 ; SI-NEXT:    ; implicit-def: $sgpr40
 ; SI-NEXT:    ; implicit-def: $sgpr78
-; SI-NEXT:    ; implicit-def: $sgpr14
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr77
-; SI-NEXT:    ; implicit-def: $sgpr12
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr76
 ; SI-NEXT:    s_branch .LBB13_2
 ;
 ; VI-LABEL: bitcast_v22i32_to_v44i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v9, s16
+; VI-NEXT:    v_mov_b32_e32 v10, s17
+; VI-NEXT:    v_mov_b32_e32 v11, s18
+; VI-NEXT:    v_mov_b32_e32 v12, s19
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s21
+; VI-NEXT:    v_mov_b32_e32 v15, s22
+; VI-NEXT:    v_mov_b32_e32 v16, s23
+; VI-NEXT:    v_mov_b32_e32 v17, s24
+; VI-NEXT:    v_mov_b32_e32 v18, s25
+; VI-NEXT:    v_mov_b32_e32 v19, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v9
+; VI-NEXT:    v_mov_b32_e32 v9, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v10
+; VI-NEXT:    v_mov_b32_e32 v10, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v11
+; VI-NEXT:    v_mov_b32_e32 v11, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; VI-NEXT:    v_readfirstlane_b32 s24, v12
+; VI-NEXT:    v_readfirstlane_b32 s23, v13
+; VI-NEXT:    v_readfirstlane_b32 s22, v14
+; VI-NEXT:    v_readfirstlane_b32 s21, v15
+; VI-NEXT:    v_readfirstlane_b32 s20, v16
+; VI-NEXT:    v_readfirstlane_b32 s19, v17
+; VI-NEXT:    v_readfirstlane_b32 s18, v18
+; VI-NEXT:    v_readfirstlane_b32 s17, v19
+; VI-NEXT:    v_readfirstlane_b32 s16, v9
+; VI-NEXT:    v_readfirstlane_b32 s15, v10
+; VI-NEXT:    v_readfirstlane_b32 s14, v11
 ; VI-NEXT:    v_readfirstlane_b32 s13, v0
 ; VI-NEXT:    v_readfirstlane_b32 s12, v1
 ; VI-NEXT:    v_readfirstlane_b32 s11, v2
@@ -3293,28 +3349,28 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; VI-NEXT:    v_readfirstlane_b32 s7, v7
 ; VI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s14, s7, 16
-; VI-NEXT:    s_lshr_b32 s15, s6, 16
-; VI-NEXT:    s_lshr_b32 s40, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s41, s9, 16
 ; VI-NEXT:    s_lshr_b32 s42, s10, 16
 ; VI-NEXT:    s_lshr_b32 s43, s11, 16
 ; VI-NEXT:    s_lshr_b32 s44, s12, 16
 ; VI-NEXT:    s_lshr_b32 s45, s13, 16
-; VI-NEXT:    s_lshr_b32 s46, s29, 16
-; VI-NEXT:    s_lshr_b32 s47, s28, 16
-; VI-NEXT:    s_lshr_b32 s56, s27, 16
-; VI-NEXT:    s_lshr_b32 s57, s26, 16
-; VI-NEXT:    s_lshr_b32 s58, s25, 16
-; VI-NEXT:    s_lshr_b32 s59, s24, 16
-; VI-NEXT:    s_lshr_b32 s60, s23, 16
-; VI-NEXT:    s_lshr_b32 s61, s22, 16
-; VI-NEXT:    s_lshr_b32 s62, s21, 16
-; VI-NEXT:    s_lshr_b32 s63, s20, 16
-; VI-NEXT:    s_lshr_b32 s72, s19, 16
-; VI-NEXT:    s_lshr_b32 s73, s18, 16
-; VI-NEXT:    s_lshr_b32 s74, s17, 16
-; VI-NEXT:    s_lshr_b32 s75, s16, 16
+; VI-NEXT:    s_lshr_b32 s46, s14, 16
+; VI-NEXT:    s_lshr_b32 s47, s15, 16
+; VI-NEXT:    s_lshr_b32 s56, s16, 16
+; VI-NEXT:    s_lshr_b32 s57, s17, 16
+; VI-NEXT:    s_lshr_b32 s58, s18, 16
+; VI-NEXT:    s_lshr_b32 s59, s19, 16
+; VI-NEXT:    s_lshr_b32 s60, s20, 16
+; VI-NEXT:    s_lshr_b32 s61, s21, 16
+; VI-NEXT:    s_lshr_b32 s62, s22, 16
+; VI-NEXT:    s_lshr_b32 s63, s23, 16
+; VI-NEXT:    s_lshr_b32 s72, s24, 16
+; VI-NEXT:    s_lshr_b32 s73, s25, 16
+; VI-NEXT:    s_lshr_b32 s74, s26, 16
+; VI-NEXT:    s_lshr_b32 s75, s40, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB13_3
 ; VI-NEXT:  .LBB13_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -3325,123 +3381,123 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; VI-NEXT:    s_add_i32 s11, s11, 3
 ; VI-NEXT:    s_add_i32 s12, s12, 3
 ; VI-NEXT:    s_add_i32 s13, s13, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s14, s14, 3
+; VI-NEXT:    s_add_i32 s15, s15, 3
 ; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s14, s7, 16
-; VI-NEXT:    s_lshr_b32 s15, s6, 16
-; VI-NEXT:    s_lshr_b32 s40, s8, 16
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
+; VI-NEXT:    s_add_i32 s40, s40, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s41, s9, 16
 ; VI-NEXT:    s_lshr_b32 s42, s10, 16
 ; VI-NEXT:    s_lshr_b32 s43, s11, 16
 ; VI-NEXT:    s_lshr_b32 s44, s12, 16
 ; VI-NEXT:    s_lshr_b32 s45, s13, 16
-; VI-NEXT:    s_lshr_b32 s46, s29, 16
-; VI-NEXT:    s_lshr_b32 s47, s28, 16
-; VI-NEXT:    s_lshr_b32 s56, s27, 16
-; VI-NEXT:    s_lshr_b32 s57, s26, 16
-; VI-NEXT:    s_lshr_b32 s58, s25, 16
-; VI-NEXT:    s_lshr_b32 s59, s24, 16
-; VI-NEXT:    s_lshr_b32 s60, s23, 16
-; VI-NEXT:    s_lshr_b32 s61, s22, 16
-; VI-NEXT:    s_lshr_b32 s62, s21, 16
-; VI-NEXT:    s_lshr_b32 s63, s20, 16
-; VI-NEXT:    s_lshr_b32 s72, s19, 16
-; VI-NEXT:    s_lshr_b32 s73, s18, 16
-; VI-NEXT:    s_lshr_b32 s74, s17, 16
-; VI-NEXT:    s_lshr_b32 s75, s16, 16
+; VI-NEXT:    s_lshr_b32 s46, s14, 16
+; VI-NEXT:    s_lshr_b32 s47, s15, 16
+; VI-NEXT:    s_lshr_b32 s56, s16, 16
+; VI-NEXT:    s_lshr_b32 s57, s17, 16
+; VI-NEXT:    s_lshr_b32 s58, s18, 16
+; VI-NEXT:    s_lshr_b32 s59, s19, 16
+; VI-NEXT:    s_lshr_b32 s60, s20, 16
+; VI-NEXT:    s_lshr_b32 s61, s21, 16
+; VI-NEXT:    s_lshr_b32 s62, s22, 16
+; VI-NEXT:    s_lshr_b32 s63, s23, 16
+; VI-NEXT:    s_lshr_b32 s72, s24, 16
+; VI-NEXT:    s_lshr_b32 s73, s25, 16
+; VI-NEXT:    s_lshr_b32 s74, s26, 16
+; VI-NEXT:    s_lshr_b32 s75, s40, 16
 ; VI-NEXT:  .LBB13_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s40
 ; VI-NEXT:    s_lshl_b32 s5, s75, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s74, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s73, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s72, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s63, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s62, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s61, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s60, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s59, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s58, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s57, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s56, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s26, s74, 16
+; VI-NEXT:    s_or_b32 s5, s5, s26
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s26, s73, 16
 ; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s47, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s46, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s26, s72, 16
+; VI-NEXT:    s_or_b32 s24, s24, s26
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s26, s63, 16
+; VI-NEXT:    s_or_b32 s23, s23, s26
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s26, s62, 16
+; VI-NEXT:    s_or_b32 s22, s22, s26
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s26, s61, 16
+; VI-NEXT:    s_or_b32 s21, s21, s26
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s26, s60, 16
+; VI-NEXT:    s_or_b32 s20, s20, s26
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s26, s59, 16
+; VI-NEXT:    s_or_b32 s19, s19, s26
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s26, s58, 16
+; VI-NEXT:    s_or_b32 s18, s18, s26
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s26, s57, 16
+; VI-NEXT:    s_or_b32 s17, s17, s26
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s26, s56, 16
+; VI-NEXT:    s_or_b32 s16, s16, s26
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s26, s47, 16
+; VI-NEXT:    s_or_b32 s15, s15, s26
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s26, s46, 16
+; VI-NEXT:    s_or_b32 s14, s14, s26
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s28, s45, 16
-; VI-NEXT:    s_or_b32 s13, s13, s28
+; VI-NEXT:    s_lshl_b32 s26, s45, 16
+; VI-NEXT:    s_or_b32 s13, s13, s26
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s28, s44, 16
-; VI-NEXT:    s_or_b32 s12, s12, s28
+; VI-NEXT:    s_lshl_b32 s26, s44, 16
+; VI-NEXT:    s_or_b32 s12, s12, s26
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s43, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s26, s43, 16
+; VI-NEXT:    s_or_b32 s11, s11, s26
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
+; VI-NEXT:    s_lshl_b32 s26, s42, 16
+; VI-NEXT:    s_or_b32 s10, s10, s26
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s9, s9, s28
+; VI-NEXT:    s_lshl_b32 s26, s41, 16
+; VI-NEXT:    s_or_b32 s9, s9, s26
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
+; VI-NEXT:    s_lshl_b32 s26, s29, 16
+; VI-NEXT:    s_or_b32 s8, s8, s26
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
+; VI-NEXT:    s_lshl_b32 s26, s28, 16
+; VI-NEXT:    s_or_b32 s6, s6, s26
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
-; VI-NEXT:    s_or_b32 s8, s8, s28
-; VI-NEXT:    s_or_b32 s6, s6, s15
-; VI-NEXT:    s_or_b32 s7, s7, s14
+; VI-NEXT:    s_lshl_b32 s26, s27, 16
+; VI-NEXT:    s_or_b32 s7, s7, s26
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s25
+; VI-NEXT:    v_mov_b32_e32 v3, s24
+; VI-NEXT:    v_mov_b32_e32 v4, s23
+; VI-NEXT:    v_mov_b32_e32 v5, s22
+; VI-NEXT:    v_mov_b32_e32 v6, s21
+; VI-NEXT:    v_mov_b32_e32 v7, s20
+; VI-NEXT:    v_mov_b32_e32 v8, s19
+; VI-NEXT:    v_mov_b32_e32 v9, s18
+; VI-NEXT:    v_mov_b32_e32 v10, s17
+; VI-NEXT:    v_mov_b32_e32 v11, s16
+; VI-NEXT:    v_mov_b32_e32 v12, s15
+; VI-NEXT:    v_mov_b32_e32 v13, s14
 ; VI-NEXT:    v_mov_b32_e32 v14, s13
 ; VI-NEXT:    v_mov_b32_e32 v15, s12
 ; VI-NEXT:    v_mov_b32_e32 v16, s11
@@ -3471,60 +3527,78 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr43
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
-; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB13_2
 ;
 ; GFX9-LABEL: bitcast_v22i32_to_v44i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v9, s16
+; GFX9-NEXT:    v_mov_b32_e32 v10, s17
+; GFX9-NEXT:    v_mov_b32_e32 v11, s18
+; GFX9-NEXT:    v_mov_b32_e32 v12, s19
+; GFX9-NEXT:    v_mov_b32_e32 v13, s20
+; GFX9-NEXT:    v_mov_b32_e32 v14, s21
+; GFX9-NEXT:    v_mov_b32_e32 v15, s22
+; GFX9-NEXT:    v_mov_b32_e32 v16, s23
+; GFX9-NEXT:    v_mov_b32_e32 v17, s24
+; GFX9-NEXT:    v_mov_b32_e32 v18, s25
+; GFX9-NEXT:    v_mov_b32_e32 v19, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v9
+; GFX9-NEXT:    v_mov_b32_e32 v9, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v10
+; GFX9-NEXT:    v_mov_b32_e32 v10, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v11
+; GFX9-NEXT:    v_mov_b32_e32 v11, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s14, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB13_3
 ; GFX9-NEXT:  .LBB13_2: ; %cmp.true
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
-; GFX9-NEXT:    s_add_i32 s29, s29, 3
-; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
 ; GFX9-NEXT:    s_add_i32 s26, s26, 3
 ; GFX9-NEXT:    s_add_i32 s25, s25, 3
@@ -3537,73 +3611,83 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
-; GFX9-NEXT:    s_lshr_b32 s14, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s16, 16
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
+; GFX9-NEXT:    s_lshr_b32 s28, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s6, 16
 ; GFX9-NEXT:  .LBB13_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s14
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB13_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr75
@@ -3626,40 +3710,67 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
 ; GFX9-NEXT:    s_branch .LBB13_2
 ;
 ; GFX11-LABEL: bitcast_v22i32_to_v44i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v5, s0 :: v_dual_mov_b32 v6, s1
+; GFX11-NEXT:    v_dual_mov_b32 v7, s2 :: v_dual_mov_b32 v8, s3
+; GFX11-NEXT:    v_dual_mov_b32 v9, s16 :: v_dual_mov_b32 v10, s17
+; GFX11-NEXT:    v_dual_mov_b32 v11, s18 :: v_dual_mov_b32 v12, s19
+; GFX11-NEXT:    v_dual_mov_b32 v13, s20 :: v_dual_mov_b32 v14, s21
+; GFX11-NEXT:    v_dual_mov_b32 v15, s22 :: v_dual_mov_b32 v16, s23
+; GFX11-NEXT:    v_dual_mov_b32 v17, s24 :: v_dual_mov_b32 v18, s25
+; GFX11-NEXT:    v_dual_mov_b32 v19, s26 :: v_dual_mov_b32 v20, s27
+; GFX11-NEXT:    v_dual_mov_b32 v21, s28 :: v_dual_mov_b32 v22, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v3
 ; GFX11-NEXT:    s_mov_b32 s62, 0
-; GFX11-NEXT:    s_and_b32 s8, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s22, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s8, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s58, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s59, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s60, s1, 16
@@ -3667,46 +3778,46 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s62
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB13_3
 ; GFX11-NEXT:  .LBB13_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
-; GFX11-NEXT:    s_add_i32 s26, s26, 3
-; GFX11-NEXT:    s_add_i32 s25, s25, 3
-; GFX11-NEXT:    s_add_i32 s24, s24, 3
-; GFX11-NEXT:    s_add_i32 s23, s23, 3
-; GFX11-NEXT:    s_add_i32 s22, s22, 3
-; GFX11-NEXT:    s_add_i32 s21, s21, 3
 ; GFX11-NEXT:    s_add_i32 s20, s20, 3
+; GFX11-NEXT:    s_add_i32 s21, s21, 3
 ; GFX11-NEXT:    s_add_i32 s19, s19, 3
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s8, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s58, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s59, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s60, s1, 16
@@ -3717,35 +3828,35 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s60
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s59
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s26, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s27, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s28, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s29, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s10
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s9
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s8
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s24
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s23
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s22
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s15 :: v_dual_mov_b32 v15, s14
-; GFX11-NEXT:    v_dual_mov_b32 v16, s13 :: v_dual_mov_b32 v17, s12
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s7 :: v_dual_mov_b32 v21, s6
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s21 :: v_dual_mov_b32 v21, s20
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB13_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr61
@@ -3762,14 +3873,14 @@ define inreg <44 x i16> @bitcast_v22i32_to_v44i16_scalar(<22 x i32> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
-; GFX11-NEXT:    ; implicit-def: $sgpr9
-; GFX11-NEXT:    ; implicit-def: $sgpr8
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
+; GFX11-NEXT:    ; implicit-def: $sgpr23
+; GFX11-NEXT:    ; implicit-def: $sgpr22
 ; GFX11-NEXT:    s_branch .LBB13_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -4128,7 +4239,7 @@ define <22 x i32> @bitcast_v44i16_to_v22i32(<44 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v18, vcc, s6, v18
 ; SI-NEXT:    v_add_i32_e32 v19, vcc, s6, v19
 ; SI-NEXT:    v_add_i32_e32 v20, vcc, s6, v20
-; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
+; SI-NEXT:    v_add_i32_e32 v21, vcc, 0x30000, v21
 ; SI-NEXT:  .LBB14_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
@@ -6618,7 +6729,35 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; SI-LABEL: bitcast_v22i32_to_v44f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v10, s16
+; SI-NEXT:    v_mov_b32_e32 v11, s17
+; SI-NEXT:    v_mov_b32_e32 v12, s18
+; SI-NEXT:    v_mov_b32_e32 v13, s19
+; SI-NEXT:    v_mov_b32_e32 v14, s20
+; SI-NEXT:    v_mov_b32_e32 v15, s21
+; SI-NEXT:    v_mov_b32_e32 v16, s22
+; SI-NEXT:    v_mov_b32_e32 v17, s23
+; SI-NEXT:    v_mov_b32_e32 v18, s24
+; SI-NEXT:    v_mov_b32_e32 v19, s25
+; SI-NEXT:    v_readfirstlane_b32 s23, v10
+; SI-NEXT:    v_mov_b32_e32 v10, s26
+; SI-NEXT:    v_readfirstlane_b32 s24, v11
+; SI-NEXT:    v_mov_b32_e32 v11, s27
+; SI-NEXT:    v_readfirstlane_b32 s25, v12
+; SI-NEXT:    v_mov_b32_e32 v12, s28
+; SI-NEXT:    v_readfirstlane_b32 s26, v13
+; SI-NEXT:    v_mov_b32_e32 v13, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; SI-NEXT:    v_readfirstlane_b32 s27, v14
+; SI-NEXT:    v_readfirstlane_b32 s22, v15
+; SI-NEXT:    v_readfirstlane_b32 s21, v16
+; SI-NEXT:    v_readfirstlane_b32 s20, v17
+; SI-NEXT:    v_readfirstlane_b32 s19, v18
+; SI-NEXT:    v_readfirstlane_b32 s18, v19
+; SI-NEXT:    v_readfirstlane_b32 s17, v10
+; SI-NEXT:    v_readfirstlane_b32 s16, v11
+; SI-NEXT:    v_readfirstlane_b32 s15, v12
+; SI-NEXT:    v_readfirstlane_b32 s14, v13
 ; SI-NEXT:    v_readfirstlane_b32 s13, v1
 ; SI-NEXT:    v_readfirstlane_b32 s12, v2
 ; SI-NEXT:    v_readfirstlane_b32 s11, v3
@@ -6646,33 +6785,33 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
 ; SI-NEXT:    s_lshr_b32 s4, s13, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v14, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
 ; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
+; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
+; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s4
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s4
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v52, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s9
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
@@ -6682,36 +6821,36 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, s11
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s23
 ; SI-NEXT:    s_cbranch_execnz .LBB17_3
 ; SI-NEXT:  .LBB17_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
 ; SI-NEXT:    s_add_i32 s23, s23, 3
 ; SI-NEXT:    s_add_i32 s24, s24, 3
 ; SI-NEXT:    s_add_i32 s25, s25, 3
 ; SI-NEXT:    s_add_i32 s26, s26, 3
 ; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
+; SI-NEXT:    s_add_i32 s15, s15, 3
+; SI-NEXT:    s_add_i32 s14, s14, 3
 ; SI-NEXT:    s_add_i32 s13, s13, 3
 ; SI-NEXT:    s_add_i32 s12, s12, 3
 ; SI-NEXT:    s_add_i32 s11, s11, 3
@@ -6720,20 +6859,20 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; SI-NEXT:    s_add_i32 s7, s7, 3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s9, s9, 3
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    s_lshr_b32 s5, s17, 16
-; SI-NEXT:    s_lshr_b32 s14, s18, 16
-; SI-NEXT:    s_lshr_b32 s15, s19, 16
-; SI-NEXT:    s_lshr_b32 s40, s20, 16
-; SI-NEXT:    s_lshr_b32 s41, s21, 16
-; SI-NEXT:    s_lshr_b32 s42, s22, 16
-; SI-NEXT:    s_lshr_b32 s43, s23, 16
-; SI-NEXT:    s_lshr_b32 s44, s24, 16
-; SI-NEXT:    s_lshr_b32 s45, s25, 16
-; SI-NEXT:    s_lshr_b32 s46, s26, 16
-; SI-NEXT:    s_lshr_b32 s47, s27, 16
-; SI-NEXT:    s_lshr_b32 s56, s28, 16
-; SI-NEXT:    s_lshr_b32 s57, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    s_lshr_b32 s5, s24, 16
+; SI-NEXT:    s_lshr_b32 s28, s25, 16
+; SI-NEXT:    s_lshr_b32 s29, s26, 16
+; SI-NEXT:    s_lshr_b32 s40, s27, 16
+; SI-NEXT:    s_lshr_b32 s41, s22, 16
+; SI-NEXT:    s_lshr_b32 s42, s21, 16
+; SI-NEXT:    s_lshr_b32 s43, s20, 16
+; SI-NEXT:    s_lshr_b32 s44, s19, 16
+; SI-NEXT:    s_lshr_b32 s45, s18, 16
+; SI-NEXT:    s_lshr_b32 s46, s17, 16
+; SI-NEXT:    s_lshr_b32 s47, s16, 16
+; SI-NEXT:    s_lshr_b32 s56, s15, 16
+; SI-NEXT:    s_lshr_b32 s57, s14, 16
 ; SI-NEXT:    s_lshr_b32 s58, s13, 16
 ; SI-NEXT:    s_lshr_b32 s59, s12, 16
 ; SI-NEXT:    s_lshr_b32 s60, s11, 16
@@ -6750,20 +6889,20 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, s11
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s23
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s73
 ; SI-NEXT:    v_cvt_f32_f16_e32 v2, s72
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s63
@@ -6782,8 +6921,8 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v31, s42
 ; SI-NEXT:    v_cvt_f32_f16_e32 v33, s41
 ; SI-NEXT:    v_cvt_f32_f16_e32 v35, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s28
 ; SI-NEXT:    v_cvt_f32_f16_e32 v50, s5
 ; SI-NEXT:    v_cvt_f32_f16_e32 v52, s4
 ; SI-NEXT:  .LBB17_3: ; %end
@@ -6991,7 +7130,35 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; VI-LABEL: bitcast_v22i32_to_v44f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v9, s16
+; VI-NEXT:    v_mov_b32_e32 v10, s17
+; VI-NEXT:    v_mov_b32_e32 v11, s18
+; VI-NEXT:    v_mov_b32_e32 v12, s19
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s21
+; VI-NEXT:    v_mov_b32_e32 v15, s22
+; VI-NEXT:    v_mov_b32_e32 v16, s23
+; VI-NEXT:    v_mov_b32_e32 v17, s24
+; VI-NEXT:    v_mov_b32_e32 v18, s25
+; VI-NEXT:    v_mov_b32_e32 v19, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v9
+; VI-NEXT:    v_mov_b32_e32 v9, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v10
+; VI-NEXT:    v_mov_b32_e32 v10, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v11
+; VI-NEXT:    v_mov_b32_e32 v11, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; VI-NEXT:    v_readfirstlane_b32 s24, v12
+; VI-NEXT:    v_readfirstlane_b32 s23, v13
+; VI-NEXT:    v_readfirstlane_b32 s22, v14
+; VI-NEXT:    v_readfirstlane_b32 s21, v15
+; VI-NEXT:    v_readfirstlane_b32 s20, v16
+; VI-NEXT:    v_readfirstlane_b32 s19, v17
+; VI-NEXT:    v_readfirstlane_b32 s18, v18
+; VI-NEXT:    v_readfirstlane_b32 s17, v19
+; VI-NEXT:    v_readfirstlane_b32 s16, v9
+; VI-NEXT:    v_readfirstlane_b32 s15, v10
+; VI-NEXT:    v_readfirstlane_b32 s14, v11
 ; VI-NEXT:    v_readfirstlane_b32 s13, v0
 ; VI-NEXT:    v_readfirstlane_b32 s12, v1
 ; VI-NEXT:    v_readfirstlane_b32 s11, v2
@@ -7003,28 +7170,28 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; VI-NEXT:    v_readfirstlane_b32 s7, v7
 ; VI-NEXT:    s_cbranch_scc0 .LBB17_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s14, s7, 16
-; VI-NEXT:    s_lshr_b32 s15, s6, 16
-; VI-NEXT:    s_lshr_b32 s40, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s41, s9, 16
 ; VI-NEXT:    s_lshr_b32 s42, s10, 16
 ; VI-NEXT:    s_lshr_b32 s43, s11, 16
 ; VI-NEXT:    s_lshr_b32 s44, s12, 16
 ; VI-NEXT:    s_lshr_b32 s45, s13, 16
-; VI-NEXT:    s_lshr_b32 s46, s29, 16
-; VI-NEXT:    s_lshr_b32 s47, s28, 16
-; VI-NEXT:    s_lshr_b32 s56, s27, 16
-; VI-NEXT:    s_lshr_b32 s57, s26, 16
-; VI-NEXT:    s_lshr_b32 s58, s25, 16
-; VI-NEXT:    s_lshr_b32 s59, s24, 16
-; VI-NEXT:    s_lshr_b32 s60, s23, 16
-; VI-NEXT:    s_lshr_b32 s61, s22, 16
-; VI-NEXT:    s_lshr_b32 s62, s21, 16
-; VI-NEXT:    s_lshr_b32 s63, s20, 16
-; VI-NEXT:    s_lshr_b32 s72, s19, 16
-; VI-NEXT:    s_lshr_b32 s73, s18, 16
-; VI-NEXT:    s_lshr_b32 s74, s17, 16
-; VI-NEXT:    s_lshr_b32 s75, s16, 16
+; VI-NEXT:    s_lshr_b32 s46, s14, 16
+; VI-NEXT:    s_lshr_b32 s47, s15, 16
+; VI-NEXT:    s_lshr_b32 s56, s16, 16
+; VI-NEXT:    s_lshr_b32 s57, s17, 16
+; VI-NEXT:    s_lshr_b32 s58, s18, 16
+; VI-NEXT:    s_lshr_b32 s59, s19, 16
+; VI-NEXT:    s_lshr_b32 s60, s20, 16
+; VI-NEXT:    s_lshr_b32 s61, s21, 16
+; VI-NEXT:    s_lshr_b32 s62, s22, 16
+; VI-NEXT:    s_lshr_b32 s63, s23, 16
+; VI-NEXT:    s_lshr_b32 s72, s24, 16
+; VI-NEXT:    s_lshr_b32 s73, s25, 16
+; VI-NEXT:    s_lshr_b32 s74, s26, 16
+; VI-NEXT:    s_lshr_b32 s75, s40, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB17_3
 ; VI-NEXT:  .LBB17_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -7035,123 +7202,123 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; VI-NEXT:    s_add_i32 s11, s11, 3
 ; VI-NEXT:    s_add_i32 s12, s12, 3
 ; VI-NEXT:    s_add_i32 s13, s13, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s14, s14, 3
+; VI-NEXT:    s_add_i32 s15, s15, 3
 ; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s14, s7, 16
-; VI-NEXT:    s_lshr_b32 s15, s6, 16
-; VI-NEXT:    s_lshr_b32 s40, s8, 16
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
+; VI-NEXT:    s_add_i32 s40, s40, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s41, s9, 16
 ; VI-NEXT:    s_lshr_b32 s42, s10, 16
 ; VI-NEXT:    s_lshr_b32 s43, s11, 16
 ; VI-NEXT:    s_lshr_b32 s44, s12, 16
 ; VI-NEXT:    s_lshr_b32 s45, s13, 16
-; VI-NEXT:    s_lshr_b32 s46, s29, 16
-; VI-NEXT:    s_lshr_b32 s47, s28, 16
-; VI-NEXT:    s_lshr_b32 s56, s27, 16
-; VI-NEXT:    s_lshr_b32 s57, s26, 16
-; VI-NEXT:    s_lshr_b32 s58, s25, 16
-; VI-NEXT:    s_lshr_b32 s59, s24, 16
-; VI-NEXT:    s_lshr_b32 s60, s23, 16
-; VI-NEXT:    s_lshr_b32 s61, s22, 16
-; VI-NEXT:    s_lshr_b32 s62, s21, 16
-; VI-NEXT:    s_lshr_b32 s63, s20, 16
-; VI-NEXT:    s_lshr_b32 s72, s19, 16
-; VI-NEXT:    s_lshr_b32 s73, s18, 16
-; VI-NEXT:    s_lshr_b32 s74, s17, 16
-; VI-NEXT:    s_lshr_b32 s75, s16, 16
+; VI-NEXT:    s_lshr_b32 s46, s14, 16
+; VI-NEXT:    s_lshr_b32 s47, s15, 16
+; VI-NEXT:    s_lshr_b32 s56, s16, 16
+; VI-NEXT:    s_lshr_b32 s57, s17, 16
+; VI-NEXT:    s_lshr_b32 s58, s18, 16
+; VI-NEXT:    s_lshr_b32 s59, s19, 16
+; VI-NEXT:    s_lshr_b32 s60, s20, 16
+; VI-NEXT:    s_lshr_b32 s61, s21, 16
+; VI-NEXT:    s_lshr_b32 s62, s22, 16
+; VI-NEXT:    s_lshr_b32 s63, s23, 16
+; VI-NEXT:    s_lshr_b32 s72, s24, 16
+; VI-NEXT:    s_lshr_b32 s73, s25, 16
+; VI-NEXT:    s_lshr_b32 s74, s26, 16
+; VI-NEXT:    s_lshr_b32 s75, s40, 16
 ; VI-NEXT:  .LBB17_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s40
 ; VI-NEXT:    s_lshl_b32 s5, s75, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s74, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s73, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s72, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s63, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s62, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s61, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s60, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s59, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s58, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s57, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s56, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s26, s74, 16
+; VI-NEXT:    s_or_b32 s5, s5, s26
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s26, s73, 16
 ; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s47, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s46, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s26, s72, 16
+; VI-NEXT:    s_or_b32 s24, s24, s26
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s26, s63, 16
+; VI-NEXT:    s_or_b32 s23, s23, s26
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s26, s62, 16
+; VI-NEXT:    s_or_b32 s22, s22, s26
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s26, s61, 16
+; VI-NEXT:    s_or_b32 s21, s21, s26
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s26, s60, 16
+; VI-NEXT:    s_or_b32 s20, s20, s26
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s26, s59, 16
+; VI-NEXT:    s_or_b32 s19, s19, s26
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s26, s58, 16
+; VI-NEXT:    s_or_b32 s18, s18, s26
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s26, s57, 16
+; VI-NEXT:    s_or_b32 s17, s17, s26
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s26, s56, 16
+; VI-NEXT:    s_or_b32 s16, s16, s26
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s26, s47, 16
+; VI-NEXT:    s_or_b32 s15, s15, s26
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s26, s46, 16
+; VI-NEXT:    s_or_b32 s14, s14, s26
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s28, s45, 16
-; VI-NEXT:    s_or_b32 s13, s13, s28
+; VI-NEXT:    s_lshl_b32 s26, s45, 16
+; VI-NEXT:    s_or_b32 s13, s13, s26
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s28, s44, 16
-; VI-NEXT:    s_or_b32 s12, s12, s28
+; VI-NEXT:    s_lshl_b32 s26, s44, 16
+; VI-NEXT:    s_or_b32 s12, s12, s26
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s43, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s26, s43, 16
+; VI-NEXT:    s_or_b32 s11, s11, s26
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
+; VI-NEXT:    s_lshl_b32 s26, s42, 16
+; VI-NEXT:    s_or_b32 s10, s10, s26
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s9, s9, s28
+; VI-NEXT:    s_lshl_b32 s26, s41, 16
+; VI-NEXT:    s_or_b32 s9, s9, s26
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
+; VI-NEXT:    s_lshl_b32 s26, s29, 16
+; VI-NEXT:    s_or_b32 s8, s8, s26
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
+; VI-NEXT:    s_lshl_b32 s26, s28, 16
+; VI-NEXT:    s_or_b32 s6, s6, s26
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
-; VI-NEXT:    s_or_b32 s8, s8, s28
-; VI-NEXT:    s_or_b32 s6, s6, s15
-; VI-NEXT:    s_or_b32 s7, s7, s14
+; VI-NEXT:    s_lshl_b32 s26, s27, 16
+; VI-NEXT:    s_or_b32 s7, s7, s26
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s25
+; VI-NEXT:    v_mov_b32_e32 v3, s24
+; VI-NEXT:    v_mov_b32_e32 v4, s23
+; VI-NEXT:    v_mov_b32_e32 v5, s22
+; VI-NEXT:    v_mov_b32_e32 v6, s21
+; VI-NEXT:    v_mov_b32_e32 v7, s20
+; VI-NEXT:    v_mov_b32_e32 v8, s19
+; VI-NEXT:    v_mov_b32_e32 v9, s18
+; VI-NEXT:    v_mov_b32_e32 v10, s17
+; VI-NEXT:    v_mov_b32_e32 v11, s16
+; VI-NEXT:    v_mov_b32_e32 v12, s15
+; VI-NEXT:    v_mov_b32_e32 v13, s14
 ; VI-NEXT:    v_mov_b32_e32 v14, s13
 ; VI-NEXT:    v_mov_b32_e32 v15, s12
 ; VI-NEXT:    v_mov_b32_e32 v16, s11
@@ -7181,60 +7348,78 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr43
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
-; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB17_2
 ;
 ; GFX9-LABEL: bitcast_v22i32_to_v44f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v9, s16
+; GFX9-NEXT:    v_mov_b32_e32 v10, s17
+; GFX9-NEXT:    v_mov_b32_e32 v11, s18
+; GFX9-NEXT:    v_mov_b32_e32 v12, s19
+; GFX9-NEXT:    v_mov_b32_e32 v13, s20
+; GFX9-NEXT:    v_mov_b32_e32 v14, s21
+; GFX9-NEXT:    v_mov_b32_e32 v15, s22
+; GFX9-NEXT:    v_mov_b32_e32 v16, s23
+; GFX9-NEXT:    v_mov_b32_e32 v17, s24
+; GFX9-NEXT:    v_mov_b32_e32 v18, s25
+; GFX9-NEXT:    v_mov_b32_e32 v19, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v9
+; GFX9-NEXT:    v_mov_b32_e32 v9, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v10
+; GFX9-NEXT:    v_mov_b32_e32 v10, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v11
+; GFX9-NEXT:    v_mov_b32_e32 v11, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s14, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB17_3
 ; GFX9-NEXT:  .LBB17_2: ; %cmp.true
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
-; GFX9-NEXT:    s_add_i32 s29, s29, 3
-; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
 ; GFX9-NEXT:    s_add_i32 s26, s26, 3
 ; GFX9-NEXT:    s_add_i32 s25, s25, 3
@@ -7247,73 +7432,83 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
-; GFX9-NEXT:    s_lshr_b32 s14, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s16, 16
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
+; GFX9-NEXT:    s_lshr_b32 s28, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s6, 16
 ; GFX9-NEXT:  .LBB17_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s14
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB17_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr75
@@ -7336,40 +7531,67 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
 ; GFX9-NEXT:    s_branch .LBB17_2
 ;
 ; GFX11-LABEL: bitcast_v22i32_to_v44f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v5, s0 :: v_dual_mov_b32 v6, s1
+; GFX11-NEXT:    v_dual_mov_b32 v7, s2 :: v_dual_mov_b32 v8, s3
+; GFX11-NEXT:    v_dual_mov_b32 v9, s16 :: v_dual_mov_b32 v10, s17
+; GFX11-NEXT:    v_dual_mov_b32 v11, s18 :: v_dual_mov_b32 v12, s19
+; GFX11-NEXT:    v_dual_mov_b32 v13, s20 :: v_dual_mov_b32 v14, s21
+; GFX11-NEXT:    v_dual_mov_b32 v15, s22 :: v_dual_mov_b32 v16, s23
+; GFX11-NEXT:    v_dual_mov_b32 v17, s24 :: v_dual_mov_b32 v18, s25
+; GFX11-NEXT:    v_dual_mov_b32 v19, s26 :: v_dual_mov_b32 v20, s27
+; GFX11-NEXT:    v_dual_mov_b32 v21, s28 :: v_dual_mov_b32 v22, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v3
 ; GFX11-NEXT:    s_mov_b32 s62, 0
-; GFX11-NEXT:    s_and_b32 s8, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s22, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s8, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s58, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s59, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s60, s1, 16
@@ -7377,46 +7599,46 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s62
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB17_3
 ; GFX11-NEXT:  .LBB17_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
-; GFX11-NEXT:    s_add_i32 s26, s26, 3
-; GFX11-NEXT:    s_add_i32 s25, s25, 3
-; GFX11-NEXT:    s_add_i32 s24, s24, 3
-; GFX11-NEXT:    s_add_i32 s23, s23, 3
-; GFX11-NEXT:    s_add_i32 s22, s22, 3
-; GFX11-NEXT:    s_add_i32 s21, s21, 3
 ; GFX11-NEXT:    s_add_i32 s20, s20, 3
+; GFX11-NEXT:    s_add_i32 s21, s21, 3
 ; GFX11-NEXT:    s_add_i32 s19, s19, 3
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s8, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s58, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s59, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s60, s1, 16
@@ -7427,35 +7649,35 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s60
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s59
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s26, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s27, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s28, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s29, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s10
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s9
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s8
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s24
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s23
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s22
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s15 :: v_dual_mov_b32 v15, s14
-; GFX11-NEXT:    v_dual_mov_b32 v16, s13 :: v_dual_mov_b32 v17, s12
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s7 :: v_dual_mov_b32 v21, s6
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s21 :: v_dual_mov_b32 v21, s20
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB17_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr61
@@ -7472,14 +7694,14 @@ define inreg <44 x half> @bitcast_v22i32_to_v44f16_scalar(<22 x i32> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
-; GFX11-NEXT:    ; implicit-def: $sgpr9
-; GFX11-NEXT:    ; implicit-def: $sgpr8
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
+; GFX11-NEXT:    ; implicit-def: $sgpr23
+; GFX11-NEXT:    ; implicit-def: $sgpr22
 ; GFX11-NEXT:    s_branch .LBB17_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -13090,7 +13312,7 @@ define <22 x float> @bitcast_v44i16_to_v22f32(<44 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v18, vcc, s6, v18
 ; SI-NEXT:    v_add_i32_e32 v19, vcc, s6, v19
 ; SI-NEXT:    v_add_i32_e32 v20, vcc, s6, v20
-; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
+; SI-NEXT:    v_add_i32_e32 v21, vcc, 0x30000, v21
 ; SI-NEXT:  .LBB30_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
@@ -15559,360 +15781,137 @@ define inreg <44 x half> @bitcast_v22f32_to_v44f16_scalar(<22 x float> inreg %a,
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
-; SI-NEXT:    v_readfirstlane_b32 s13, v1
-; SI-NEXT:    v_readfirstlane_b32 s12, v2
-; SI-NEXT:    v_readfirstlane_b32 s11, v3
-; SI-NEXT:    v_readfirstlane_b32 s10, v4
-; SI-NEXT:    v_readfirstlane_b32 s8, v5
-; SI-NEXT:    v_readfirstlane_b32 s7, v6
-; SI-NEXT:    v_readfirstlane_b32 s6, v7
-; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s9, v8
-; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 ; 4-byte Folded Spill
-; SI-NEXT:    s_cbranch_scc0 .LBB33_4
-; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s4, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s4
-; SI-NEXT:    s_lshr_b32 s4, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s4
-; SI-NEXT:    s_lshr_b32 s4, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s4
-; SI-NEXT:    s_lshr_b32 s4, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s4
-; SI-NEXT:    s_lshr_b32 s4, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s4
-; SI-NEXT:    s_lshr_b32 s4, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s4
-; SI-NEXT:    s_lshr_b32 s4, s12, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
-; SI-NEXT:    s_lshr_b32 s4, s13, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s16
-; SI-NEXT:    s_cbranch_execnz .LBB33_3
-; SI-NEXT:  .LBB33_2: ; %cmp.true
-; SI-NEXT:    v_add_f32_e64 v1, s16, 1.0
-; SI-NEXT:    v_add_f32_e64 v2, s17, 1.0
-; SI-NEXT:    v_add_f32_e64 v4, s18, 1.0
-; SI-NEXT:    v_add_f32_e64 v6, s19, 1.0
-; SI-NEXT:    v_add_f32_e64 v8, s20, 1.0
-; SI-NEXT:    v_add_f32_e64 v10, s21, 1.0
-; SI-NEXT:    v_add_f32_e64 v12, s22, 1.0
-; SI-NEXT:    v_add_f32_e64 v14, s23, 1.0
-; SI-NEXT:    v_add_f32_e64 v16, s24, 1.0
-; SI-NEXT:    v_add_f32_e64 v18, s25, 1.0
-; SI-NEXT:    v_add_f32_e64 v20, s26, 1.0
-; SI-NEXT:    v_add_f32_e64 v22, s27, 1.0
-; SI-NEXT:    v_add_f32_e64 v21, s28, 1.0
-; SI-NEXT:    v_add_f32_e64 v19, s29, 1.0
-; SI-NEXT:    v_add_f32_e64 v17, s13, 1.0
-; SI-NEXT:    v_add_f32_e64 v15, s12, 1.0
-; SI-NEXT:    v_add_f32_e64 v13, s11, 1.0
-; SI-NEXT:    v_add_f32_e64 v11, s10, 1.0
-; SI-NEXT:    v_add_f32_e64 v9, s8, 1.0
-; SI-NEXT:    v_add_f32_e64 v7, s7, 1.0
-; SI-NEXT:    v_add_f32_e64 v5, s6, 1.0
-; SI-NEXT:    v_add_f32_e64 v3, s9, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v4
-; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v6
-; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v8
-; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v10
-; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v20
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v21
-; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v19
-; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v17
-; SI-NEXT:    s_waitcnt expcnt(6)
-; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v15
-; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v13
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v11
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v9
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v7
+; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    v_mov_b32_e32 v12, s16
+; SI-NEXT:    v_mov_b32_e32 v11, s17
+; SI-NEXT:    v_mov_b32_e32 v10, s18
 ; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v5
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_mov_b32_e32 v62, s19
+; SI-NEXT:    v_mov_b32_e32 v61, s20
+; SI-NEXT:    v_mov_b32_e32 v58, s21
+; SI-NEXT:    v_mov_b32_e32 v56, s22
+; SI-NEXT:    v_mov_b32_e32 v46, s23
+; SI-NEXT:    v_mov_b32_e32 v45, s24
+; SI-NEXT:    v_mov_b32_e32 v43, s25
+; SI-NEXT:    v_mov_b32_e32 v59, s26
+; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
+; SI-NEXT:    v_mov_b32_e32 v60, s27
+; SI-NEXT:    v_mov_b32_e32 v57, s28
+; SI-NEXT:    v_mov_b32_e32 v47, s29
+; SI-NEXT:    s_cbranch_scc0 .LBB33_2
+; SI-NEXT:  ; %bb.1: ; %cmp.false
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v5
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v13
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v21
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v47
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v46
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v45
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, v44
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v43
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v42
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v41
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v40
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v55
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
-; SI-NEXT:  .LBB33_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v52, v52
-; SI-NEXT:    v_cvt_f16_f32_e32 v51, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v50, v50
-; SI-NEXT:    v_cvt_f16_f32_e32 v49, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v48, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v39, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v38, v38
-; SI-NEXT:    v_lshlrev_b32_e32 v52, 16, v52
-; SI-NEXT:    v_cvt_f16_f32_e32 v37, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v35, v35
-; SI-NEXT:    v_or_b32_e32 v51, v51, v52
-; SI-NEXT:    v_lshlrev_b32_e32 v50, 16, v50
-; SI-NEXT:    v_cvt_f16_f32_e32 v36, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v33, v33
-; SI-NEXT:    buffer_store_dword v51, v0, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v1
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v51, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v49, v49, v50
-; SI-NEXT:    v_lshlrev_b32_e32 v48, 16, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v34, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v31, v31
-; SI-NEXT:    buffer_store_dword v49, v51, s[0:3], 0 offen
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v47
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v46
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v49, vcc, 8, v0
-; SI-NEXT:    v_or_b32_e32 v39, v39, v48
-; SI-NEXT:    v_lshlrev_b32_e32 v38, 16, v38
-; SI-NEXT:    v_cvt_f16_f32_e32 v32, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v29, v29
-; SI-NEXT:    buffer_store_dword v39, v49, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v61
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v62
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v39, vcc, 12, v0
-; SI-NEXT:    v_or_b32_e32 v37, v37, v38
-; SI-NEXT:    v_lshlrev_b32_e32 v35, 16, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; SI-NEXT:    buffer_store_dword v37, v39, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v37, vcc, 16, v0
-; SI-NEXT:    v_or_b32_e32 v35, v36, v35
-; SI-NEXT:    v_lshlrev_b32_e32 v33, 16, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v28, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v25, v25
-; SI-NEXT:    buffer_store_dword v35, v37, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 20, v0
-; SI-NEXT:    v_or_b32_e32 v33, v34, v33
-; SI-NEXT:    v_lshlrev_b32_e32 v31, 16, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v23, v23
-; SI-NEXT:    buffer_store_dword v33, v35, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 24, v0
-; SI-NEXT:    v_or_b32_e32 v31, v32, v31
-; SI-NEXT:    v_lshlrev_b32_e32 v29, 16, v29
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v20
-; SI-NEXT:    buffer_store_dword v31, v33, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 28, v0
-; SI-NEXT:    v_or_b32_e32 v29, v30, v29
-; SI-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v22
-; SI-NEXT:    buffer_store_dword v29, v31, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v29, vcc, 32, v0
-; SI-NEXT:    v_or_b32_e32 v27, v28, v27
-; SI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
-; SI-NEXT:    buffer_store_dword v27, v29, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v27, vcc, 36, v0
-; SI-NEXT:    v_or_b32_e32 v25, v26, v25
-; SI-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
-; SI-NEXT:    buffer_store_dword v25, v27, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v25, vcc, 40, v0
-; SI-NEXT:    v_or_b32_e32 v23, v24, v23
-; SI-NEXT:    v_lshlrev_b32_e32 v20, 16, v20
-; SI-NEXT:    buffer_store_dword v23, v25, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v23, vcc, 44, v0
-; SI-NEXT:    v_or_b32_e32 v20, v22, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v18
-; SI-NEXT:    buffer_store_dword v20, v23, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v21
-; SI-NEXT:    v_add_i32_e32 v21, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v18, 16, v18
-; SI-NEXT:    v_or_b32_e32 v18, v20, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v16
-; SI-NEXT:    buffer_store_dword v18, v21, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v19
-; SI-NEXT:    v_add_i32_e32 v19, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v16, 16, v16
-; SI-NEXT:    v_or_b32_e32 v16, v18, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; SI-NEXT:    buffer_store_dword v16, v19, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v17
-; SI-NEXT:    v_add_i32_e32 v17, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
-; SI-NEXT:    v_or_b32_e32 v14, v16, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; SI-NEXT:    buffer_store_dword v14, v17, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v15
-; SI-NEXT:    v_add_i32_e32 v15, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
-; SI-NEXT:    v_or_b32_e32 v12, v14, v12
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v10
-; SI-NEXT:    buffer_store_dword v12, v15, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v13
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v12, v10
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v8
-; SI-NEXT:    buffer_store_dword v10, v13, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v11
-; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
-; SI-NEXT:    v_or_b32_e32 v8, v10, v8
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v6
-; SI-NEXT:    buffer_store_dword v8, v11, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v9
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; SI-NEXT:    buffer_store_dword v6, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v7
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 0x4c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v4, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v5
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x50, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; SI-NEXT:    v_or_b32_e32 v2, v4, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v5, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v3
-; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x54, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
-; SI-NEXT:    v_or_b32_e32 v1, v2, v1
-; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
-; SI-NEXT:    s_setpc_b64 s[30:31]
-; SI-NEXT:  .LBB33_4:
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v4
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v47
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v56
+; SI-NEXT:    s_mov_b64 s[4:5], 0
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v61
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v62
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v12
+; SI-NEXT:    s_branch .LBB33_3
+; SI-NEXT:  .LBB33_2:
+; SI-NEXT:    ; implicit-def: $vgpr9
+; SI-NEXT:    ; kill: killed $vgpr9
+; SI-NEXT:    s_mov_b64 s[4:5], -1
+; SI-NEXT:    ; implicit-def: $vgpr9
+; SI-NEXT:    ; kill: killed $vgpr9
+; SI-NEXT:    ; implicit-def: $vgpr63
+; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr40
 ; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr50
 ; SI-NEXT:    ; implicit-def: $vgpr52
 ; SI-NEXT:    ; implicit-def: $vgpr49
-; SI-NEXT:    ; implicit-def: $vgpr50
-; SI-NEXT:    ; implicit-def: $vgpr39
 ; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr39
 ; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr37
 ; SI-NEXT:    ; implicit-def: $vgpr36
 ; SI-NEXT:    ; implicit-def: $vgpr35
 ; SI-NEXT:    ; implicit-def: $vgpr34
@@ -15920,36 +15919,308 @@ define inreg <44 x half> @bitcast_v22f32_to_v44f16_scalar(<22 x float> inreg %a,
 ; SI-NEXT:    ; implicit-def: $vgpr32
 ; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    ; implicit-def: $vgpr30
-; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr26
+; SI-NEXT:    ; implicit-def: $vgpr27
 ; SI-NEXT:    ; implicit-def: $vgpr25
+; SI-NEXT:    ; implicit-def: $vgpr13
 ; SI-NEXT:    ; implicit-def: $vgpr24
 ; SI-NEXT:    ; implicit-def: $vgpr23
 ; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr20
 ; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr18
+; SI-NEXT:    ; implicit-def: $vgpr20
 ; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr16
+; SI-NEXT:    ; implicit-def: $vgpr18
 ; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr14
+; SI-NEXT:    ; implicit-def: $vgpr16
 ; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr13
-; SI-NEXT:    ; implicit-def: $vgpr10
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr8
+; SI-NEXT:    ; implicit-def: $vgpr14
 ; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr6
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr1
-; SI-NEXT:    s_branch .LBB33_2
+; SI-NEXT:    ; kill: killed $vgpr9
+; SI-NEXT:    ; implicit-def: $vgpr9
+; SI-NEXT:    ; kill: killed $vgpr9
+; SI-NEXT:  .LBB33_3: ; %Flow
+; SI-NEXT:    s_andn2_b64 vcc, exec, s[4:5]
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v9, v14
+; SI-NEXT:    v_mov_b32_e32 v14, v16
+; SI-NEXT:    v_mov_b32_e32 v16, v18
+; SI-NEXT:    v_mov_b32_e32 v18, v20
+; SI-NEXT:    s_cbranch_vccnz .LBB33_5
+; SI-NEXT:  ; %bb.4: ; %cmp.true
+; SI-NEXT:    v_add_f32_e32 v9, 1.0, v12
+; SI-NEXT:    v_add_f32_e32 v11, 1.0, v11
+; SI-NEXT:    v_add_f32_e32 v10, 1.0, v10
+; SI-NEXT:    v_add_f32_e32 v14, 1.0, v62
+; SI-NEXT:    v_add_f32_e32 v16, 1.0, v61
+; SI-NEXT:    v_add_f32_e32 v18, 1.0, v58
+; SI-NEXT:    v_add_f32_e32 v20, 1.0, v56
+; SI-NEXT:    v_add_f32_e32 v22, 1.0, v46
+; SI-NEXT:    v_add_f32_e32 v24, 1.0, v45
+; SI-NEXT:    v_add_f32_e32 v26, 1.0, v43
+; SI-NEXT:    v_add_f32_e32 v28, 1.0, v59
+; SI-NEXT:    v_add_f32_e32 v30, 1.0, v60
+; SI-NEXT:    v_add_f32_e32 v29, 1.0, v57
+; SI-NEXT:    v_add_f32_e32 v27, 1.0, v47
+; SI-NEXT:    v_add_f32_e32 v1, 1.0, v1
+; SI-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; SI-NEXT:    v_add_f32_e32 v3, 1.0, v3
+; SI-NEXT:    v_add_f32_e32 v4, 1.0, v4
+; SI-NEXT:    v_add_f32_e32 v5, 1.0, v5
+; SI-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; SI-NEXT:    v_add_f32_e32 v7, 1.0, v7
+; SI-NEXT:    v_add_f32_e32 v8, 1.0, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v12, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v26
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v28
+; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v30
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v61
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v47
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v33
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v39
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v12
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:  .LBB33_5: ; %end
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v41
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v63
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v55
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v44
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
+; SI-NEXT:    v_or_b32_e32 v2, v4, v2
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v42
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v51
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v40
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v50
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v54
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v49
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v52
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v39
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v48
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v37
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v38
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v35
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v36
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v33
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v34
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v31
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v32
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v28
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v30
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v26
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v25
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v27
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v24
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v13
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v23
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v22
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v18
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v21
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v16
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v19
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v14
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v17
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v9
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v15
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x54, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
+; SI-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; VI-LABEL: bitcast_v22f32_to_v44f16_scalar:
 ; VI:       ; %bb.0:
@@ -20231,7 +20502,35 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; SI-LABEL: bitcast_v11i64_to_v44i16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v10, s16
+; SI-NEXT:    v_mov_b32_e32 v11, s17
+; SI-NEXT:    v_mov_b32_e32 v12, s18
+; SI-NEXT:    v_mov_b32_e32 v13, s19
+; SI-NEXT:    v_mov_b32_e32 v14, s20
+; SI-NEXT:    v_mov_b32_e32 v15, s21
+; SI-NEXT:    v_mov_b32_e32 v16, s22
+; SI-NEXT:    v_mov_b32_e32 v17, s23
+; SI-NEXT:    v_mov_b32_e32 v18, s24
+; SI-NEXT:    v_mov_b32_e32 v19, s25
+; SI-NEXT:    v_readfirstlane_b32 s24, v10
+; SI-NEXT:    v_mov_b32_e32 v10, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v11
+; SI-NEXT:    v_mov_b32_e32 v11, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v12
+; SI-NEXT:    v_mov_b32_e32 v12, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v13
+; SI-NEXT:    v_mov_b32_e32 v13, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; SI-NEXT:    v_readfirstlane_b32 s20, v14
+; SI-NEXT:    v_readfirstlane_b32 s21, v15
+; SI-NEXT:    v_readfirstlane_b32 s18, v16
+; SI-NEXT:    v_readfirstlane_b32 s19, v17
+; SI-NEXT:    v_readfirstlane_b32 s16, v18
+; SI-NEXT:    v_readfirstlane_b32 s17, v19
+; SI-NEXT:    v_readfirstlane_b32 s14, v10
+; SI-NEXT:    v_readfirstlane_b32 s15, v11
+; SI-NEXT:    v_readfirstlane_b32 s12, v12
+; SI-NEXT:    v_readfirstlane_b32 s13, v13
 ; SI-NEXT:    v_readfirstlane_b32 s10, v1
 ; SI-NEXT:    v_readfirstlane_b32 s11, v2
 ; SI-NEXT:    v_readfirstlane_b32 s8, v3
@@ -20239,7 +20538,7 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v5
 ; SI-NEXT:    v_readfirstlane_b32 s7, v6
 ; SI-NEXT:    v_readfirstlane_b32 s4, v7
-; SI-NEXT:    s_and_b64 s[12:13], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v8
 ; SI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
@@ -20247,24 +20546,24 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s77, s7, 16
 ; SI-NEXT:    s_lshr_b32 s78, s9, 16
 ; SI-NEXT:    s_lshr_b32 s79, s11, 16
-; SI-NEXT:    s_lshr_b32 s88, s29, 16
-; SI-NEXT:    s_lshr_b32 s89, s27, 16
-; SI-NEXT:    s_lshr_b32 s90, s25, 16
-; SI-NEXT:    s_lshr_b32 s91, s23, 16
+; SI-NEXT:    s_lshr_b32 s88, s13, 16
+; SI-NEXT:    s_lshr_b32 s89, s15, 16
+; SI-NEXT:    s_lshr_b32 s90, s17, 16
+; SI-NEXT:    s_lshr_b32 s91, s19, 16
 ; SI-NEXT:    s_lshr_b32 s92, s21, 16
-; SI-NEXT:    s_lshr_b32 s93, s19, 16
-; SI-NEXT:    s_lshr_b32 s94, s17, 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s93, s23, 16
+; SI-NEXT:    s_lshr_b32 s94, s25, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[40:41], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[42:43], s[10:11], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[46:47], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[18:19], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[24:25], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB41_3
 ; SI-NEXT:  .LBB41_2: ; %cmp.true
 ; SI-NEXT:    s_add_u32 s4, s4, 3
@@ -20275,139 +20574,139 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; SI-NEXT:    s_addc_u32 s9, s9, 0
 ; SI-NEXT:    s_add_u32 s10, s10, 3
 ; SI-NEXT:    s_addc_u32 s11, s11, 0
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_add_u32 s20, s20, 3
-; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s12, s12, 3
+; SI-NEXT:    s_addc_u32 s13, s13, 0
+; SI-NEXT:    s_add_u32 s14, s14, 3
+; SI-NEXT:    s_addc_u32 s15, s15, 0
 ; SI-NEXT:    s_add_u32 s16, s16, 3
 ; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
+; SI-NEXT:    s_add_u32 s22, s22, 3
+; SI-NEXT:    s_addc_u32 s23, s23, 0
+; SI-NEXT:    s_add_u32 s24, s24, 3
+; SI-NEXT:    s_addc_u32 s25, s25, 0
 ; SI-NEXT:    s_lshr_b32 s76, s5, 16
 ; SI-NEXT:    s_lshr_b32 s77, s7, 16
 ; SI-NEXT:    s_lshr_b32 s78, s9, 16
 ; SI-NEXT:    s_lshr_b32 s79, s11, 16
-; SI-NEXT:    s_lshr_b32 s88, s29, 16
-; SI-NEXT:    s_lshr_b32 s89, s27, 16
-; SI-NEXT:    s_lshr_b32 s90, s25, 16
-; SI-NEXT:    s_lshr_b32 s91, s23, 16
+; SI-NEXT:    s_lshr_b32 s88, s13, 16
+; SI-NEXT:    s_lshr_b32 s89, s15, 16
+; SI-NEXT:    s_lshr_b32 s90, s17, 16
+; SI-NEXT:    s_lshr_b32 s91, s19, 16
 ; SI-NEXT:    s_lshr_b32 s92, s21, 16
-; SI-NEXT:    s_lshr_b32 s93, s19, 16
-; SI-NEXT:    s_lshr_b32 s94, s17, 16
-; SI-NEXT:    s_lshr_b64 s[12:13], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s93, s23, 16
+; SI-NEXT:    s_lshr_b32 s94, s25, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[40:41], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[42:43], s[10:11], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[44:45], s[12:13], 16
+; SI-NEXT:    s_lshr_b64 s[46:47], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[18:19], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[24:25], 16
 ; SI-NEXT:  .LBB41_3: ; %end
-; SI-NEXT:    s_lshl_b32 s13, s72, 16
-; SI-NEXT:    s_and_b32 s15, s16, 0xffff
-; SI-NEXT:    s_or_b32 s13, s15, s13
-; SI-NEXT:    v_mov_b32_e32 v1, s13
-; SI-NEXT:    s_and_b32 s13, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s94, 16
-; SI-NEXT:    s_or_b32 s13, s13, s15
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_lshl_b32 s13, s62, 16
-; SI-NEXT:    s_and_b32 s15, s18, 0xffff
-; SI-NEXT:    s_or_b32 s13, s15, s13
-; SI-NEXT:    v_mov_b32_e32 v3, s13
-; SI-NEXT:    s_and_b32 s13, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s93, 16
-; SI-NEXT:    s_or_b32 s13, s13, s15
-; SI-NEXT:    v_mov_b32_e32 v4, s13
-; SI-NEXT:    s_lshl_b32 s13, s60, 16
-; SI-NEXT:    s_and_b32 s15, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s72, 16
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_or_b32 s24, s24, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
+; SI-NEXT:    s_lshl_b32 s25, s94, 16
+; SI-NEXT:    s_or_b32 s24, s24, s25
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_lshl_b32 s24, s62, 16
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_or_b32 s22, s22, s24
+; SI-NEXT:    v_mov_b32_e32 v3, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s93, 16
+; SI-NEXT:    s_or_b32 s22, s22, s23
+; SI-NEXT:    v_mov_b32_e32 v4, s22
+; SI-NEXT:    s_lshl_b32 s22, s60, 16
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_or_b32 s13, s15, s13
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
 ; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s92, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s92, 16
 ; SI-NEXT:    buffer_store_dword v4, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s58, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s58, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s91, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s91, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s56, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s56, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s90, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
+; SI-NEXT:    s_lshl_b32 s17, s90, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s16, s16, s17
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s46, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s14, s14, 0xffff
+; SI-NEXT:    s_lshl_b32 s16, s46, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s14, s14, s16
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s27, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s14, s15, 0xffff
 ; SI-NEXT:    s_lshl_b32 s15, s89, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s14, s14, s15
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s44, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s12, s12, 0xffff
+; SI-NEXT:    s_lshl_b32 s14, s44, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s12, s12, s14
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
-; SI-NEXT:    s_and_b32 s13, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s88, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s12
+; SI-NEXT:    s_and_b32 s12, s13, 0xffff
+; SI-NEXT:    s_lshl_b32 s13, s88, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s13, s13, s15
+; SI-NEXT:    s_or_b32 s12, s12, s13
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s13
+; SI-NEXT:    v_mov_b32_e32 v2, s12
 ; SI-NEXT:    s_and_b32 s10, s10, 0xffff
-; SI-NEXT:    s_lshl_b32 s13, s42, 16
+; SI-NEXT:    s_lshl_b32 s12, s42, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s10, s10, s13
+; SI-NEXT:    s_or_b32 s10, s10, s12
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s10
@@ -20433,7 +20732,7 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s14, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x44, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -20447,7 +20746,7 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s12, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x4c, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -20482,16 +20781,44 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr79
 ; SI-NEXT:    ; implicit-def: $sgpr40
 ; SI-NEXT:    ; implicit-def: $sgpr78
-; SI-NEXT:    ; implicit-def: $sgpr14
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr77
-; SI-NEXT:    ; implicit-def: $sgpr12
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr76
 ; SI-NEXT:    s_branch .LBB41_2
 ;
 ; VI-LABEL: bitcast_v11i64_to_v44i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v9, s16
+; VI-NEXT:    v_mov_b32_e32 v10, s17
+; VI-NEXT:    v_mov_b32_e32 v11, s18
+; VI-NEXT:    v_mov_b32_e32 v12, s19
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s21
+; VI-NEXT:    v_mov_b32_e32 v15, s22
+; VI-NEXT:    v_mov_b32_e32 v16, s23
+; VI-NEXT:    v_mov_b32_e32 v17, s24
+; VI-NEXT:    v_mov_b32_e32 v18, s25
+; VI-NEXT:    v_mov_b32_e32 v19, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v9
+; VI-NEXT:    v_mov_b32_e32 v9, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v10
+; VI-NEXT:    v_mov_b32_e32 v10, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v11
+; VI-NEXT:    v_mov_b32_e32 v11, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; VI-NEXT:    v_readfirstlane_b32 s24, v12
+; VI-NEXT:    v_readfirstlane_b32 s23, v13
+; VI-NEXT:    v_readfirstlane_b32 s22, v14
+; VI-NEXT:    v_readfirstlane_b32 s21, v15
+; VI-NEXT:    v_readfirstlane_b32 s20, v16
+; VI-NEXT:    v_readfirstlane_b32 s19, v17
+; VI-NEXT:    v_readfirstlane_b32 s18, v18
+; VI-NEXT:    v_readfirstlane_b32 s17, v19
+; VI-NEXT:    v_readfirstlane_b32 s16, v9
+; VI-NEXT:    v_readfirstlane_b32 s15, v10
+; VI-NEXT:    v_readfirstlane_b32 s14, v11
 ; VI-NEXT:    v_readfirstlane_b32 s13, v0
 ; VI-NEXT:    v_readfirstlane_b32 s12, v1
 ; VI-NEXT:    v_readfirstlane_b32 s11, v2
@@ -20503,28 +20830,28 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; VI-NEXT:    v_readfirstlane_b32 s7, v7
 ; VI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s14, s7, 16
-; VI-NEXT:    s_lshr_b32 s15, s6, 16
-; VI-NEXT:    s_lshr_b32 s40, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s41, s9, 16
 ; VI-NEXT:    s_lshr_b32 s42, s10, 16
 ; VI-NEXT:    s_lshr_b32 s43, s11, 16
 ; VI-NEXT:    s_lshr_b32 s44, s12, 16
 ; VI-NEXT:    s_lshr_b32 s45, s13, 16
-; VI-NEXT:    s_lshr_b32 s46, s29, 16
-; VI-NEXT:    s_lshr_b32 s47, s28, 16
-; VI-NEXT:    s_lshr_b32 s56, s27, 16
-; VI-NEXT:    s_lshr_b32 s57, s26, 16
-; VI-NEXT:    s_lshr_b32 s58, s25, 16
-; VI-NEXT:    s_lshr_b32 s59, s24, 16
-; VI-NEXT:    s_lshr_b32 s60, s23, 16
-; VI-NEXT:    s_lshr_b32 s61, s22, 16
-; VI-NEXT:    s_lshr_b32 s62, s21, 16
-; VI-NEXT:    s_lshr_b32 s63, s20, 16
-; VI-NEXT:    s_lshr_b32 s72, s19, 16
-; VI-NEXT:    s_lshr_b32 s73, s18, 16
-; VI-NEXT:    s_lshr_b32 s74, s17, 16
-; VI-NEXT:    s_lshr_b32 s75, s16, 16
+; VI-NEXT:    s_lshr_b32 s46, s14, 16
+; VI-NEXT:    s_lshr_b32 s47, s15, 16
+; VI-NEXT:    s_lshr_b32 s56, s16, 16
+; VI-NEXT:    s_lshr_b32 s57, s17, 16
+; VI-NEXT:    s_lshr_b32 s58, s18, 16
+; VI-NEXT:    s_lshr_b32 s59, s19, 16
+; VI-NEXT:    s_lshr_b32 s60, s20, 16
+; VI-NEXT:    s_lshr_b32 s61, s21, 16
+; VI-NEXT:    s_lshr_b32 s62, s22, 16
+; VI-NEXT:    s_lshr_b32 s63, s23, 16
+; VI-NEXT:    s_lshr_b32 s72, s24, 16
+; VI-NEXT:    s_lshr_b32 s73, s25, 16
+; VI-NEXT:    s_lshr_b32 s74, s26, 16
+; VI-NEXT:    s_lshr_b32 s75, s40, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB41_3
 ; VI-NEXT:  .LBB41_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -20535,123 +20862,123 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; VI-NEXT:    s_addc_u32 s10, s10, 0
 ; VI-NEXT:    s_add_u32 s13, s13, 3
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s14, s7, 16
-; VI-NEXT:    s_lshr_b32 s15, s6, 16
-; VI-NEXT:    s_lshr_b32 s40, s8, 16
+; VI-NEXT:    s_add_u32 s15, s15, 3
+; VI-NEXT:    s_addc_u32 s14, s14, 0
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s41, s9, 16
 ; VI-NEXT:    s_lshr_b32 s42, s10, 16
 ; VI-NEXT:    s_lshr_b32 s43, s11, 16
 ; VI-NEXT:    s_lshr_b32 s44, s12, 16
 ; VI-NEXT:    s_lshr_b32 s45, s13, 16
-; VI-NEXT:    s_lshr_b32 s46, s29, 16
-; VI-NEXT:    s_lshr_b32 s47, s28, 16
-; VI-NEXT:    s_lshr_b32 s56, s27, 16
-; VI-NEXT:    s_lshr_b32 s57, s26, 16
-; VI-NEXT:    s_lshr_b32 s58, s25, 16
-; VI-NEXT:    s_lshr_b32 s59, s24, 16
-; VI-NEXT:    s_lshr_b32 s60, s23, 16
-; VI-NEXT:    s_lshr_b32 s61, s22, 16
-; VI-NEXT:    s_lshr_b32 s62, s21, 16
-; VI-NEXT:    s_lshr_b32 s63, s20, 16
-; VI-NEXT:    s_lshr_b32 s72, s19, 16
-; VI-NEXT:    s_lshr_b32 s73, s18, 16
-; VI-NEXT:    s_lshr_b32 s74, s17, 16
-; VI-NEXT:    s_lshr_b32 s75, s16, 16
+; VI-NEXT:    s_lshr_b32 s46, s14, 16
+; VI-NEXT:    s_lshr_b32 s47, s15, 16
+; VI-NEXT:    s_lshr_b32 s56, s16, 16
+; VI-NEXT:    s_lshr_b32 s57, s17, 16
+; VI-NEXT:    s_lshr_b32 s58, s18, 16
+; VI-NEXT:    s_lshr_b32 s59, s19, 16
+; VI-NEXT:    s_lshr_b32 s60, s20, 16
+; VI-NEXT:    s_lshr_b32 s61, s21, 16
+; VI-NEXT:    s_lshr_b32 s62, s22, 16
+; VI-NEXT:    s_lshr_b32 s63, s23, 16
+; VI-NEXT:    s_lshr_b32 s72, s24, 16
+; VI-NEXT:    s_lshr_b32 s73, s25, 16
+; VI-NEXT:    s_lshr_b32 s74, s26, 16
+; VI-NEXT:    s_lshr_b32 s75, s40, 16
 ; VI-NEXT:  .LBB41_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s40
 ; VI-NEXT:    s_lshl_b32 s5, s75, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s74, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s73, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s72, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s63, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s62, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s61, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s60, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s59, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s58, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s57, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s56, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s26, s74, 16
+; VI-NEXT:    s_or_b32 s5, s5, s26
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s26, s73, 16
 ; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s47, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s46, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s26, s72, 16
+; VI-NEXT:    s_or_b32 s24, s24, s26
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s26, s63, 16
+; VI-NEXT:    s_or_b32 s23, s23, s26
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s26, s62, 16
+; VI-NEXT:    s_or_b32 s22, s22, s26
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s26, s61, 16
+; VI-NEXT:    s_or_b32 s21, s21, s26
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s26, s60, 16
+; VI-NEXT:    s_or_b32 s20, s20, s26
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s26, s59, 16
+; VI-NEXT:    s_or_b32 s19, s19, s26
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s26, s58, 16
+; VI-NEXT:    s_or_b32 s18, s18, s26
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s26, s57, 16
+; VI-NEXT:    s_or_b32 s17, s17, s26
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s26, s56, 16
+; VI-NEXT:    s_or_b32 s16, s16, s26
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s26, s47, 16
+; VI-NEXT:    s_or_b32 s15, s15, s26
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s26, s46, 16
+; VI-NEXT:    s_or_b32 s14, s14, s26
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s28, s45, 16
-; VI-NEXT:    s_or_b32 s13, s13, s28
+; VI-NEXT:    s_lshl_b32 s26, s45, 16
+; VI-NEXT:    s_or_b32 s13, s13, s26
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s28, s44, 16
-; VI-NEXT:    s_or_b32 s12, s12, s28
+; VI-NEXT:    s_lshl_b32 s26, s44, 16
+; VI-NEXT:    s_or_b32 s12, s12, s26
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s43, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s26, s43, 16
+; VI-NEXT:    s_or_b32 s11, s11, s26
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
+; VI-NEXT:    s_lshl_b32 s26, s42, 16
+; VI-NEXT:    s_or_b32 s10, s10, s26
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s9, s9, s28
+; VI-NEXT:    s_lshl_b32 s26, s41, 16
+; VI-NEXT:    s_or_b32 s9, s9, s26
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
+; VI-NEXT:    s_lshl_b32 s26, s29, 16
+; VI-NEXT:    s_or_b32 s8, s8, s26
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
+; VI-NEXT:    s_lshl_b32 s26, s28, 16
+; VI-NEXT:    s_or_b32 s6, s6, s26
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
-; VI-NEXT:    s_or_b32 s8, s8, s28
-; VI-NEXT:    s_or_b32 s6, s6, s15
-; VI-NEXT:    s_or_b32 s7, s7, s14
+; VI-NEXT:    s_lshl_b32 s26, s27, 16
+; VI-NEXT:    s_or_b32 s7, s7, s26
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s25
+; VI-NEXT:    v_mov_b32_e32 v3, s24
+; VI-NEXT:    v_mov_b32_e32 v4, s23
+; VI-NEXT:    v_mov_b32_e32 v5, s22
+; VI-NEXT:    v_mov_b32_e32 v6, s21
+; VI-NEXT:    v_mov_b32_e32 v7, s20
+; VI-NEXT:    v_mov_b32_e32 v8, s19
+; VI-NEXT:    v_mov_b32_e32 v9, s18
+; VI-NEXT:    v_mov_b32_e32 v10, s17
+; VI-NEXT:    v_mov_b32_e32 v11, s16
+; VI-NEXT:    v_mov_b32_e32 v12, s15
+; VI-NEXT:    v_mov_b32_e32 v13, s14
 ; VI-NEXT:    v_mov_b32_e32 v14, s13
 ; VI-NEXT:    v_mov_b32_e32 v15, s12
 ; VI-NEXT:    v_mov_b32_e32 v16, s11
@@ -20681,60 +21008,78 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr43
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
-; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB41_2
 ;
 ; GFX9-LABEL: bitcast_v11i64_to_v44i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v9, s16
+; GFX9-NEXT:    v_mov_b32_e32 v10, s17
+; GFX9-NEXT:    v_mov_b32_e32 v11, s18
+; GFX9-NEXT:    v_mov_b32_e32 v12, s19
+; GFX9-NEXT:    v_mov_b32_e32 v13, s20
+; GFX9-NEXT:    v_mov_b32_e32 v14, s21
+; GFX9-NEXT:    v_mov_b32_e32 v15, s22
+; GFX9-NEXT:    v_mov_b32_e32 v16, s23
+; GFX9-NEXT:    v_mov_b32_e32 v17, s24
+; GFX9-NEXT:    v_mov_b32_e32 v18, s25
+; GFX9-NEXT:    v_mov_b32_e32 v19, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v9
+; GFX9-NEXT:    v_mov_b32_e32 v9, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v10
+; GFX9-NEXT:    v_mov_b32_e32 v10, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v11
+; GFX9-NEXT:    v_mov_b32_e32 v11, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s14, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB41_3
 ; GFX9-NEXT:  .LBB41_2: ; %cmp.true
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
-; GFX9-NEXT:    s_add_u32 s28, s28, 3
-; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
 ; GFX9-NEXT:    s_addc_u32 s27, s27, 0
 ; GFX9-NEXT:    s_add_u32 s24, s24, 3
@@ -20747,73 +21092,83 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
-; GFX9-NEXT:    s_lshr_b32 s14, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s16, 16
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
+; GFX9-NEXT:    s_lshr_b32 s28, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s6, 16
 ; GFX9-NEXT:  .LBB41_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s14
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB41_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr75
@@ -20836,40 +21191,67 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
 ; GFX9-NEXT:    s_branch .LBB41_2
 ;
 ; GFX11-LABEL: bitcast_v11i64_to_v44i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v5, s0 :: v_dual_mov_b32 v6, s1
+; GFX11-NEXT:    v_dual_mov_b32 v7, s2 :: v_dual_mov_b32 v8, s3
+; GFX11-NEXT:    v_dual_mov_b32 v9, s16 :: v_dual_mov_b32 v10, s17
+; GFX11-NEXT:    v_dual_mov_b32 v11, s18 :: v_dual_mov_b32 v12, s19
+; GFX11-NEXT:    v_dual_mov_b32 v13, s20 :: v_dual_mov_b32 v14, s21
+; GFX11-NEXT:    v_dual_mov_b32 v15, s22 :: v_dual_mov_b32 v16, s23
+; GFX11-NEXT:    v_dual_mov_b32 v17, s24 :: v_dual_mov_b32 v18, s25
+; GFX11-NEXT:    v_dual_mov_b32 v19, s26 :: v_dual_mov_b32 v20, s27
+; GFX11-NEXT:    v_dual_mov_b32 v21, s28 :: v_dual_mov_b32 v22, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v3
 ; GFX11-NEXT:    s_mov_b32 s62, 0
-; GFX11-NEXT:    s_and_b32 s8, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s22, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s8, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s58, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s59, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s60, s1, 16
@@ -20877,46 +21259,46 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s62
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB41_3
 ; GFX11-NEXT:  .LBB41_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s7, s7, 3
-; GFX11-NEXT:    s_addc_u32 s6, s6, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
-; GFX11-NEXT:    s_add_u32 s24, s24, 3
-; GFX11-NEXT:    s_addc_u32 s25, s25, 0
-; GFX11-NEXT:    s_add_u32 s22, s22, 3
-; GFX11-NEXT:    s_addc_u32 s23, s23, 0
-; GFX11-NEXT:    s_add_u32 s20, s20, 3
-; GFX11-NEXT:    s_addc_u32 s21, s21, 0
+; GFX11-NEXT:    s_add_u32 s21, s21, 3
+; GFX11-NEXT:    s_addc_u32 s20, s20, 0
 ; GFX11-NEXT:    s_add_u32 s18, s18, 3
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s8, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s58, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s59, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s60, s1, 16
@@ -20927,35 +21309,35 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s60
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s59
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s26, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s27, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s28, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s29, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s10
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s9
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s8
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s24
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s23
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s22
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s15 :: v_dual_mov_b32 v15, s14
-; GFX11-NEXT:    v_dual_mov_b32 v16, s13 :: v_dual_mov_b32 v17, s12
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s7 :: v_dual_mov_b32 v21, s6
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s21 :: v_dual_mov_b32 v21, s20
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB41_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr61
@@ -20972,14 +21354,14 @@ define inreg <44 x i16> @bitcast_v11i64_to_v44i16_scalar(<11 x i64> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
-; GFX11-NEXT:    ; implicit-def: $sgpr9
-; GFX11-NEXT:    ; implicit-def: $sgpr8
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
+; GFX11-NEXT:    ; implicit-def: $sgpr23
+; GFX11-NEXT:    ; implicit-def: $sgpr22
 ; GFX11-NEXT:    s_branch .LBB41_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -21338,7 +21720,7 @@ define <11 x i64> @bitcast_v44i16_to_v11i64(<44 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v18, vcc, s6, v18
 ; SI-NEXT:    v_add_i32_e32 v19, vcc, s6, v19
 ; SI-NEXT:    v_add_i32_e32 v20, vcc, s6, v20
-; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
+; SI-NEXT:    v_add_i32_e32 v21, vcc, 0x30000, v21
 ; SI-NEXT:  .LBB42_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
@@ -23840,7 +24222,35 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; SI-LABEL: bitcast_v11i64_to_v44f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v10, s16
+; SI-NEXT:    v_mov_b32_e32 v11, s17
+; SI-NEXT:    v_mov_b32_e32 v12, s18
+; SI-NEXT:    v_mov_b32_e32 v13, s19
+; SI-NEXT:    v_mov_b32_e32 v14, s20
+; SI-NEXT:    v_mov_b32_e32 v15, s21
+; SI-NEXT:    v_mov_b32_e32 v16, s22
+; SI-NEXT:    v_mov_b32_e32 v17, s23
+; SI-NEXT:    v_mov_b32_e32 v18, s24
+; SI-NEXT:    v_mov_b32_e32 v19, s25
+; SI-NEXT:    v_readfirstlane_b32 s22, v10
+; SI-NEXT:    v_mov_b32_e32 v10, s26
+; SI-NEXT:    v_readfirstlane_b32 s26, v11
+; SI-NEXT:    v_mov_b32_e32 v11, s27
+; SI-NEXT:    v_readfirstlane_b32 s23, v12
+; SI-NEXT:    v_mov_b32_e32 v12, s28
+; SI-NEXT:    v_readfirstlane_b32 s27, v13
+; SI-NEXT:    v_mov_b32_e32 v13, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; SI-NEXT:    v_readfirstlane_b32 s24, v14
+; SI-NEXT:    v_readfirstlane_b32 s25, v15
+; SI-NEXT:    v_readfirstlane_b32 s20, v16
+; SI-NEXT:    v_readfirstlane_b32 s21, v17
+; SI-NEXT:    v_readfirstlane_b32 s18, v18
+; SI-NEXT:    v_readfirstlane_b32 s19, v19
+; SI-NEXT:    v_readfirstlane_b32 s16, v10
+; SI-NEXT:    v_readfirstlane_b32 s17, v11
+; SI-NEXT:    v_readfirstlane_b32 s14, v12
+; SI-NEXT:    v_readfirstlane_b32 s15, v13
 ; SI-NEXT:    v_readfirstlane_b32 s12, v1
 ; SI-NEXT:    v_readfirstlane_b32 s13, v2
 ; SI-NEXT:    v_readfirstlane_b32 s10, v3
@@ -23868,33 +24278,33 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
 ; SI-NEXT:    s_lshr_b32 s4, s12, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v14, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s4
 ; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
 ; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s4
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s4
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
+; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s4
+; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v52, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s9
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, s6
@@ -23904,50 +24314,50 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, s10
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s22
 ; SI-NEXT:    s_cbranch_execnz .LBB45_3
 ; SI-NEXT:  .LBB45_2: ; %cmp.true
-; SI-NEXT:    s_add_u32 s4, s16, 3
-; SI-NEXT:    s_addc_u32 s5, s17, 0
-; SI-NEXT:    s_lshr_b32 s14, s4, 16
-; SI-NEXT:    s_lshr_b32 s15, s5, 16
-; SI-NEXT:    s_add_u32 s16, s18, 3
-; SI-NEXT:    s_addc_u32 s17, s19, 0
-; SI-NEXT:    s_lshr_b32 s18, s16, 16
-; SI-NEXT:    s_lshr_b32 s19, s17, 16
-; SI-NEXT:    s_add_u32 s20, s20, 3
-; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_lshr_b32 s40, s20, 16
-; SI-NEXT:    s_lshr_b32 s41, s21, 16
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_lshr_b32 s42, s22, 16
-; SI-NEXT:    s_lshr_b32 s43, s23, 16
+; SI-NEXT:    s_add_u32 s4, s22, 3
+; SI-NEXT:    s_addc_u32 s5, s26, 0
+; SI-NEXT:    s_lshr_b32 s22, s4, 16
+; SI-NEXT:    s_lshr_b32 s26, s5, 16
+; SI-NEXT:    s_add_u32 s23, s23, 3
+; SI-NEXT:    s_addc_u32 s27, s27, 0
+; SI-NEXT:    s_lshr_b32 s28, s23, 16
+; SI-NEXT:    s_lshr_b32 s29, s27, 16
 ; SI-NEXT:    s_add_u32 s24, s24, 3
 ; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_lshr_b32 s44, s24, 16
-; SI-NEXT:    s_lshr_b32 s45, s25, 16
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_lshr_b32 s46, s26, 16
-; SI-NEXT:    s_lshr_b32 s47, s27, 16
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_lshr_b32 s56, s28, 16
-; SI-NEXT:    s_lshr_b32 s57, s29, 16
+; SI-NEXT:    s_lshr_b32 s40, s24, 16
+; SI-NEXT:    s_lshr_b32 s41, s25, 16
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
+; SI-NEXT:    s_lshr_b32 s42, s20, 16
+; SI-NEXT:    s_lshr_b32 s43, s21, 16
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_lshr_b32 s44, s18, 16
+; SI-NEXT:    s_lshr_b32 s45, s19, 16
+; SI-NEXT:    s_add_u32 s16, s16, 3
+; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_lshr_b32 s46, s16, 16
+; SI-NEXT:    s_lshr_b32 s47, s17, 16
+; SI-NEXT:    s_add_u32 s14, s14, 3
+; SI-NEXT:    s_addc_u32 s15, s15, 0
+; SI-NEXT:    s_lshr_b32 s56, s14, 16
+; SI-NEXT:    s_lshr_b32 s57, s15, 16
 ; SI-NEXT:    s_add_u32 s12, s12, 3
 ; SI-NEXT:    s_addc_u32 s13, s13, 0
 ; SI-NEXT:    s_lshr_b32 s58, s12, 16
@@ -23972,18 +24382,18 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, s10
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, s15
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s23
 ; SI-NEXT:    v_cvt_f32_f16_e32 v49, s5
 ; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s73
@@ -24004,10 +24414,10 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v31, s42
 ; SI-NEXT:    v_cvt_f32_f16_e32 v33, s41
 ; SI-NEXT:    v_cvt_f32_f16_e32 v35, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s14
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s22
 ; SI-NEXT:  .LBB45_3: ; %end
 ; SI-NEXT:    v_cvt_f16_f32_e32 v52, v52
 ; SI-NEXT:    v_cvt_f16_f32_e32 v51, v51
@@ -24213,7 +24623,35 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; VI-LABEL: bitcast_v11i64_to_v44f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v9, s16
+; VI-NEXT:    v_mov_b32_e32 v10, s17
+; VI-NEXT:    v_mov_b32_e32 v11, s18
+; VI-NEXT:    v_mov_b32_e32 v12, s19
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s21
+; VI-NEXT:    v_mov_b32_e32 v15, s22
+; VI-NEXT:    v_mov_b32_e32 v16, s23
+; VI-NEXT:    v_mov_b32_e32 v17, s24
+; VI-NEXT:    v_mov_b32_e32 v18, s25
+; VI-NEXT:    v_mov_b32_e32 v19, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v9
+; VI-NEXT:    v_mov_b32_e32 v9, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v10
+; VI-NEXT:    v_mov_b32_e32 v10, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v11
+; VI-NEXT:    v_mov_b32_e32 v11, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; VI-NEXT:    v_readfirstlane_b32 s24, v12
+; VI-NEXT:    v_readfirstlane_b32 s23, v13
+; VI-NEXT:    v_readfirstlane_b32 s22, v14
+; VI-NEXT:    v_readfirstlane_b32 s21, v15
+; VI-NEXT:    v_readfirstlane_b32 s20, v16
+; VI-NEXT:    v_readfirstlane_b32 s19, v17
+; VI-NEXT:    v_readfirstlane_b32 s18, v18
+; VI-NEXT:    v_readfirstlane_b32 s17, v19
+; VI-NEXT:    v_readfirstlane_b32 s16, v9
+; VI-NEXT:    v_readfirstlane_b32 s15, v10
+; VI-NEXT:    v_readfirstlane_b32 s14, v11
 ; VI-NEXT:    v_readfirstlane_b32 s13, v0
 ; VI-NEXT:    v_readfirstlane_b32 s12, v1
 ; VI-NEXT:    v_readfirstlane_b32 s11, v2
@@ -24225,28 +24663,28 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; VI-NEXT:    v_readfirstlane_b32 s7, v7
 ; VI-NEXT:    s_cbranch_scc0 .LBB45_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s14, s7, 16
-; VI-NEXT:    s_lshr_b32 s15, s6, 16
-; VI-NEXT:    s_lshr_b32 s40, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s41, s9, 16
 ; VI-NEXT:    s_lshr_b32 s42, s10, 16
 ; VI-NEXT:    s_lshr_b32 s43, s11, 16
 ; VI-NEXT:    s_lshr_b32 s44, s12, 16
 ; VI-NEXT:    s_lshr_b32 s45, s13, 16
-; VI-NEXT:    s_lshr_b32 s46, s29, 16
-; VI-NEXT:    s_lshr_b32 s47, s28, 16
-; VI-NEXT:    s_lshr_b32 s56, s27, 16
-; VI-NEXT:    s_lshr_b32 s57, s26, 16
-; VI-NEXT:    s_lshr_b32 s58, s25, 16
-; VI-NEXT:    s_lshr_b32 s59, s24, 16
-; VI-NEXT:    s_lshr_b32 s60, s23, 16
-; VI-NEXT:    s_lshr_b32 s61, s22, 16
-; VI-NEXT:    s_lshr_b32 s62, s21, 16
-; VI-NEXT:    s_lshr_b32 s63, s20, 16
-; VI-NEXT:    s_lshr_b32 s72, s19, 16
-; VI-NEXT:    s_lshr_b32 s73, s18, 16
-; VI-NEXT:    s_lshr_b32 s74, s17, 16
-; VI-NEXT:    s_lshr_b32 s75, s16, 16
+; VI-NEXT:    s_lshr_b32 s46, s14, 16
+; VI-NEXT:    s_lshr_b32 s47, s15, 16
+; VI-NEXT:    s_lshr_b32 s56, s16, 16
+; VI-NEXT:    s_lshr_b32 s57, s17, 16
+; VI-NEXT:    s_lshr_b32 s58, s18, 16
+; VI-NEXT:    s_lshr_b32 s59, s19, 16
+; VI-NEXT:    s_lshr_b32 s60, s20, 16
+; VI-NEXT:    s_lshr_b32 s61, s21, 16
+; VI-NEXT:    s_lshr_b32 s62, s22, 16
+; VI-NEXT:    s_lshr_b32 s63, s23, 16
+; VI-NEXT:    s_lshr_b32 s72, s24, 16
+; VI-NEXT:    s_lshr_b32 s73, s25, 16
+; VI-NEXT:    s_lshr_b32 s74, s26, 16
+; VI-NEXT:    s_lshr_b32 s75, s40, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB45_3
 ; VI-NEXT:  .LBB45_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -24257,123 +24695,123 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; VI-NEXT:    s_addc_u32 s10, s10, 0
 ; VI-NEXT:    s_add_u32 s13, s13, 3
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s14, s7, 16
-; VI-NEXT:    s_lshr_b32 s15, s6, 16
-; VI-NEXT:    s_lshr_b32 s40, s8, 16
+; VI-NEXT:    s_add_u32 s15, s15, 3
+; VI-NEXT:    s_addc_u32 s14, s14, 0
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s41, s9, 16
 ; VI-NEXT:    s_lshr_b32 s42, s10, 16
 ; VI-NEXT:    s_lshr_b32 s43, s11, 16
 ; VI-NEXT:    s_lshr_b32 s44, s12, 16
 ; VI-NEXT:    s_lshr_b32 s45, s13, 16
-; VI-NEXT:    s_lshr_b32 s46, s29, 16
-; VI-NEXT:    s_lshr_b32 s47, s28, 16
-; VI-NEXT:    s_lshr_b32 s56, s27, 16
-; VI-NEXT:    s_lshr_b32 s57, s26, 16
-; VI-NEXT:    s_lshr_b32 s58, s25, 16
-; VI-NEXT:    s_lshr_b32 s59, s24, 16
-; VI-NEXT:    s_lshr_b32 s60, s23, 16
-; VI-NEXT:    s_lshr_b32 s61, s22, 16
-; VI-NEXT:    s_lshr_b32 s62, s21, 16
-; VI-NEXT:    s_lshr_b32 s63, s20, 16
-; VI-NEXT:    s_lshr_b32 s72, s19, 16
-; VI-NEXT:    s_lshr_b32 s73, s18, 16
-; VI-NEXT:    s_lshr_b32 s74, s17, 16
-; VI-NEXT:    s_lshr_b32 s75, s16, 16
+; VI-NEXT:    s_lshr_b32 s46, s14, 16
+; VI-NEXT:    s_lshr_b32 s47, s15, 16
+; VI-NEXT:    s_lshr_b32 s56, s16, 16
+; VI-NEXT:    s_lshr_b32 s57, s17, 16
+; VI-NEXT:    s_lshr_b32 s58, s18, 16
+; VI-NEXT:    s_lshr_b32 s59, s19, 16
+; VI-NEXT:    s_lshr_b32 s60, s20, 16
+; VI-NEXT:    s_lshr_b32 s61, s21, 16
+; VI-NEXT:    s_lshr_b32 s62, s22, 16
+; VI-NEXT:    s_lshr_b32 s63, s23, 16
+; VI-NEXT:    s_lshr_b32 s72, s24, 16
+; VI-NEXT:    s_lshr_b32 s73, s25, 16
+; VI-NEXT:    s_lshr_b32 s74, s26, 16
+; VI-NEXT:    s_lshr_b32 s75, s40, 16
 ; VI-NEXT:  .LBB45_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s40
 ; VI-NEXT:    s_lshl_b32 s5, s75, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s74, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s73, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s72, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s63, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s62, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s61, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s60, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s59, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s58, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s57, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s56, 16
+; VI-NEXT:    s_and_b32 s5, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s26, s74, 16
+; VI-NEXT:    s_or_b32 s5, s5, s26
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s26, s73, 16
 ; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s47, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s46, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s26, s72, 16
+; VI-NEXT:    s_or_b32 s24, s24, s26
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s26, s63, 16
+; VI-NEXT:    s_or_b32 s23, s23, s26
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s26, s62, 16
+; VI-NEXT:    s_or_b32 s22, s22, s26
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s26, s61, 16
+; VI-NEXT:    s_or_b32 s21, s21, s26
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s26, s60, 16
+; VI-NEXT:    s_or_b32 s20, s20, s26
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s26, s59, 16
+; VI-NEXT:    s_or_b32 s19, s19, s26
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s26, s58, 16
+; VI-NEXT:    s_or_b32 s18, s18, s26
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s26, s57, 16
+; VI-NEXT:    s_or_b32 s17, s17, s26
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s26, s56, 16
+; VI-NEXT:    s_or_b32 s16, s16, s26
+; VI-NEXT:    s_and_b32 s15, 0xffff, s15
+; VI-NEXT:    s_lshl_b32 s26, s47, 16
+; VI-NEXT:    s_or_b32 s15, s15, s26
+; VI-NEXT:    s_and_b32 s14, 0xffff, s14
+; VI-NEXT:    s_lshl_b32 s26, s46, 16
+; VI-NEXT:    s_or_b32 s14, s14, s26
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s28, s45, 16
-; VI-NEXT:    s_or_b32 s13, s13, s28
+; VI-NEXT:    s_lshl_b32 s26, s45, 16
+; VI-NEXT:    s_or_b32 s13, s13, s26
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s28, s44, 16
-; VI-NEXT:    s_or_b32 s12, s12, s28
+; VI-NEXT:    s_lshl_b32 s26, s44, 16
+; VI-NEXT:    s_or_b32 s12, s12, s26
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s43, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s26, s43, 16
+; VI-NEXT:    s_or_b32 s11, s11, s26
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
+; VI-NEXT:    s_lshl_b32 s26, s42, 16
+; VI-NEXT:    s_or_b32 s10, s10, s26
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s9, s9, s28
+; VI-NEXT:    s_lshl_b32 s26, s41, 16
+; VI-NEXT:    s_or_b32 s9, s9, s26
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
+; VI-NEXT:    s_lshl_b32 s26, s29, 16
+; VI-NEXT:    s_or_b32 s8, s8, s26
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s15, s15, 16
+; VI-NEXT:    s_lshl_b32 s26, s28, 16
+; VI-NEXT:    s_or_b32 s6, s6, s26
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s14, s14, 16
-; VI-NEXT:    s_or_b32 s8, s8, s28
-; VI-NEXT:    s_or_b32 s6, s6, s15
-; VI-NEXT:    s_or_b32 s7, s7, s14
+; VI-NEXT:    s_lshl_b32 s26, s27, 16
+; VI-NEXT:    s_or_b32 s7, s7, s26
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s25
+; VI-NEXT:    v_mov_b32_e32 v3, s24
+; VI-NEXT:    v_mov_b32_e32 v4, s23
+; VI-NEXT:    v_mov_b32_e32 v5, s22
+; VI-NEXT:    v_mov_b32_e32 v6, s21
+; VI-NEXT:    v_mov_b32_e32 v7, s20
+; VI-NEXT:    v_mov_b32_e32 v8, s19
+; VI-NEXT:    v_mov_b32_e32 v9, s18
+; VI-NEXT:    v_mov_b32_e32 v10, s17
+; VI-NEXT:    v_mov_b32_e32 v11, s16
+; VI-NEXT:    v_mov_b32_e32 v12, s15
+; VI-NEXT:    v_mov_b32_e32 v13, s14
 ; VI-NEXT:    v_mov_b32_e32 v14, s13
 ; VI-NEXT:    v_mov_b32_e32 v15, s12
 ; VI-NEXT:    v_mov_b32_e32 v16, s11
@@ -24403,60 +24841,78 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr43
 ; VI-NEXT:    ; implicit-def: $sgpr42
 ; VI-NEXT:    ; implicit-def: $sgpr41
-; VI-NEXT:    ; implicit-def: $sgpr40
-; VI-NEXT:    ; implicit-def: $sgpr15
-; VI-NEXT:    ; implicit-def: $sgpr14
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB45_2
 ;
 ; GFX9-LABEL: bitcast_v11i64_to_v44f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v9, s16
+; GFX9-NEXT:    v_mov_b32_e32 v10, s17
+; GFX9-NEXT:    v_mov_b32_e32 v11, s18
+; GFX9-NEXT:    v_mov_b32_e32 v12, s19
+; GFX9-NEXT:    v_mov_b32_e32 v13, s20
+; GFX9-NEXT:    v_mov_b32_e32 v14, s21
+; GFX9-NEXT:    v_mov_b32_e32 v15, s22
+; GFX9-NEXT:    v_mov_b32_e32 v16, s23
+; GFX9-NEXT:    v_mov_b32_e32 v17, s24
+; GFX9-NEXT:    v_mov_b32_e32 v18, s25
+; GFX9-NEXT:    v_mov_b32_e32 v19, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v9
+; GFX9-NEXT:    v_mov_b32_e32 v9, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v10
+; GFX9-NEXT:    v_mov_b32_e32 v10, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v11
+; GFX9-NEXT:    v_mov_b32_e32 v11, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v10
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s14, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s28, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB45_3
 ; GFX9-NEXT:  .LBB45_2: ; %cmp.true
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
-; GFX9-NEXT:    s_add_u32 s28, s28, 3
-; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
 ; GFX9-NEXT:    s_addc_u32 s27, s27, 0
 ; GFX9-NEXT:    s_add_u32 s24, s24, 3
@@ -24469,73 +24925,83 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
-; GFX9-NEXT:    s_lshr_b32 s14, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s15, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s16, 16
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
+; GFX9-NEXT:    s_lshr_b32 s28, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s29, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s6, 16
 ; GFX9-NEXT:  .LBB45_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s40
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s15
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s14
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s29
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB45_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr75
@@ -24558,40 +25024,67 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; GFX9-NEXT:    ; implicit-def: $sgpr42
 ; GFX9-NEXT:    ; implicit-def: $sgpr41
 ; GFX9-NEXT:    ; implicit-def: $sgpr40
-; GFX9-NEXT:    ; implicit-def: $sgpr15
-; GFX9-NEXT:    ; implicit-def: $sgpr14
+; GFX9-NEXT:    ; implicit-def: $sgpr29
+; GFX9-NEXT:    ; implicit-def: $sgpr28
 ; GFX9-NEXT:    s_branch .LBB45_2
 ;
 ; GFX11-LABEL: bitcast_v11i64_to_v44f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v5, s0 :: v_dual_mov_b32 v6, s1
+; GFX11-NEXT:    v_dual_mov_b32 v7, s2 :: v_dual_mov_b32 v8, s3
+; GFX11-NEXT:    v_dual_mov_b32 v9, s16 :: v_dual_mov_b32 v10, s17
+; GFX11-NEXT:    v_dual_mov_b32 v11, s18 :: v_dual_mov_b32 v12, s19
+; GFX11-NEXT:    v_dual_mov_b32 v13, s20 :: v_dual_mov_b32 v14, s21
+; GFX11-NEXT:    v_dual_mov_b32 v15, s22 :: v_dual_mov_b32 v16, s23
+; GFX11-NEXT:    v_dual_mov_b32 v17, s24 :: v_dual_mov_b32 v18, s25
+; GFX11-NEXT:    v_dual_mov_b32 v19, s26 :: v_dual_mov_b32 v20, s27
+; GFX11-NEXT:    v_dual_mov_b32 v21, s28 :: v_dual_mov_b32 v22, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v3
 ; GFX11-NEXT:    s_mov_b32 s62, 0
-; GFX11-NEXT:    s_and_b32 s8, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s22, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s8, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s58, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s59, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s60, s1, 16
@@ -24599,46 +25092,46 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s62
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB45_3
 ; GFX11-NEXT:  .LBB45_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s7, s7, 3
-; GFX11-NEXT:    s_addc_u32 s6, s6, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
-; GFX11-NEXT:    s_add_u32 s24, s24, 3
-; GFX11-NEXT:    s_addc_u32 s25, s25, 0
-; GFX11-NEXT:    s_add_u32 s22, s22, 3
-; GFX11-NEXT:    s_addc_u32 s23, s23, 0
-; GFX11-NEXT:    s_add_u32 s20, s20, 3
-; GFX11-NEXT:    s_addc_u32 s21, s21, 0
+; GFX11-NEXT:    s_add_u32 s21, s21, 3
+; GFX11-NEXT:    s_addc_u32 s20, s20, 0
 ; GFX11-NEXT:    s_add_u32 s18, s18, 3
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s8, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s9, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s10, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s22, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s23, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s58, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s59, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s60, s1, 16
@@ -24649,35 +25142,35 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s60
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s59
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s26, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s27, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s28, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s29, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s10
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s9
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s8
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s24
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s23
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s22
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s15 :: v_dual_mov_b32 v15, s14
-; GFX11-NEXT:    v_dual_mov_b32 v16, s13 :: v_dual_mov_b32 v17, s12
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s7 :: v_dual_mov_b32 v21, s6
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s21 :: v_dual_mov_b32 v21, s20
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB45_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr61
@@ -24694,14 +25187,14 @@ define inreg <44 x half> @bitcast_v11i64_to_v44f16_scalar(<11 x i64> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
-; GFX11-NEXT:    ; implicit-def: $sgpr9
-; GFX11-NEXT:    ; implicit-def: $sgpr8
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
+; GFX11-NEXT:    ; implicit-def: $sgpr23
+; GFX11-NEXT:    ; implicit-def: $sgpr22
 ; GFX11-NEXT:    s_branch .LBB45_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -27798,21 +28291,21 @@ define inreg <44 x i16> @bitcast_v11f64_to_v44i16_scalar(<11 x double> inreg %a,
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; VI-NEXT:    v_mov_b32_e32 v22, s16
-; VI-NEXT:    v_mov_b32_e32 v23, s17
-; VI-NEXT:    v_mov_b32_e32 v20, s18
-; VI-NEXT:    v_mov_b32_e32 v21, s19
-; VI-NEXT:    v_mov_b32_e32 v18, s20
-; VI-NEXT:    v_mov_b32_e32 v19, s21
-; VI-NEXT:    v_mov_b32_e32 v14, s22
-; VI-NEXT:    v_mov_b32_e32 v15, s23
+; VI-NEXT:    v_mov_b32_e32 v21, s16
+; VI-NEXT:    v_mov_b32_e32 v22, s17
+; VI-NEXT:    v_mov_b32_e32 v19, s18
+; VI-NEXT:    v_mov_b32_e32 v20, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s20
+; VI-NEXT:    v_mov_b32_e32 v18, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s23
 ; VI-NEXT:    v_mov_b32_e32 v9, s24
 ; VI-NEXT:    v_mov_b32_e32 v10, s25
-; VI-NEXT:    v_mov_b32_e32 v16, s26
-; VI-NEXT:    v_mov_b32_e32 v17, s27
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_mov_b32_e32 v16, s27
 ; VI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; VI-NEXT:    v_mov_b32_e32 v12, s28
-; VI-NEXT:    v_mov_b32_e32 v13, s29
+; VI-NEXT:    v_mov_b32_e32 v13, s28
+; VI-NEXT:    v_mov_b32_e32 v14, s29
 ; VI-NEXT:    s_cbranch_scc0 .LBB49_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
 ; VI-NEXT:    v_lshrrev_b32_e32 v30, 16, v7
@@ -27823,33 +28316,33 @@ define inreg <44 x i16> @bitcast_v11f64_to_v44i16_scalar(<11 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v35, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v13
-; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v12
-; VI-NEXT:    v_lshrrev_b32_e32 v11, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v14
+; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v10
+; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v10
 ; VI-NEXT:    v_lshrrev_b32_e32 v8, 16, v9
-; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v15
-; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v14
-; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v19
-; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
-; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v20
-; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v23
-; VI-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
+; VI-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
+; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
+; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v19
+; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; VI-NEXT:    v_lshrrev_b32_e32 v24, 16, v21
 ; VI-NEXT:    s_cbranch_execnz .LBB49_3
 ; VI-NEXT:  .LBB49_2: ; %cmp.true
 ; VI-NEXT:    v_add_f64 v[6:7], v[6:7], 1.0
 ; VI-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; VI-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; VI-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; VI-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
-; VI-NEXT:    v_add_f64 v[16:17], v[16:17], 1.0
+; VI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; VI-NEXT:    v_add_f64 v[9:10], v[9:10], 1.0
-; VI-NEXT:    v_add_f64 v[14:15], v[14:15], 1.0
-; VI-NEXT:    v_add_f64 v[18:19], v[18:19], 1.0
-; VI-NEXT:    v_add_f64 v[20:21], v[20:21], 1.0
-; VI-NEXT:    v_add_f64 v[22:23], v[22:23], 1.0
+; VI-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
+; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; VI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; VI-NEXT:    v_lshrrev_b32_e32 v30, 16, v7
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v6
 ; VI-NEXT:    v_lshrrev_b32_e32 v32, 16, v5
@@ -27858,56 +28351,56 @@ define inreg <44 x i16> @bitcast_v11f64_to_v44i16_scalar(<11 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v35, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v13
-; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v12
-; VI-NEXT:    v_lshrrev_b32_e32 v11, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v14
+; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v10
+; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v10
 ; VI-NEXT:    v_lshrrev_b32_e32 v8, 16, v9
-; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v15
-; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v14
-; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v19
-; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
-; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v20
-; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v23
-; VI-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
+; VI-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
+; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
+; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v19
+; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; VI-NEXT:    v_lshrrev_b32_e32 v24, 16, v21
 ; VI-NEXT:  .LBB49_3: ; %end
 ; VI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
-; VI-NEXT:    v_or_b32_sdwa v24, v22, v24 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v22, 16, v25
-; VI-NEXT:    v_or_b32_sdwa v25, v23, v22 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v22, 16, v26
-; VI-NEXT:    v_or_b32_sdwa v26, v20, v22 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v20, 16, v27
-; VI-NEXT:    v_or_b32_sdwa v27, v21, v20 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v20, 16, v28
-; VI-NEXT:    v_or_b32_sdwa v28, v18, v20 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v18, 16, v29
-; VI-NEXT:    v_or_b32_sdwa v29, v19, v18 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v18, 16, v51
-; VI-NEXT:    v_or_b32_sdwa v22, v14, v18 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v50
-; VI-NEXT:    v_or_b32_sdwa v23, v15, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v39
-; VI-NEXT:    v_or_b32_sdwa v12, v12, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v38
+; VI-NEXT:    v_or_b32_sdwa v24, v21, v24 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v21, 16, v25
+; VI-NEXT:    v_or_b32_sdwa v25, v22, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v21, 16, v26
+; VI-NEXT:    v_or_b32_sdwa v26, v19, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v27
+; VI-NEXT:    v_or_b32_sdwa v27, v20, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v28
+; VI-NEXT:    v_or_b32_sdwa v28, v17, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v29
+; VI-NEXT:    v_or_b32_sdwa v29, v18, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v51
+; VI-NEXT:    v_or_b32_sdwa v22, v11, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v23
+; VI-NEXT:    v_or_b32_sdwa v23, v12, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v12, 16, v39
 ; VI-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
-; VI-NEXT:    v_or_b32_sdwa v13, v13, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v37
+; VI-NEXT:    v_or_b32_sdwa v12, v13, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v38
 ; VI-NEXT:    v_or_b32_sdwa v8, v9, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v9, 16, v49
+; VI-NEXT:    v_lshlrev_b32_e32 v9, 16, v50
+; VI-NEXT:    v_or_b32_sdwa v13, v14, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v37
+; VI-NEXT:    v_or_b32_sdwa v9, v10, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v10, 16, v49
 ; VI-NEXT:    v_or_b32_sdwa v14, v0, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v36
-; VI-NEXT:    v_or_b32_sdwa v9, v10, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v10, 16, v48
+; VI-NEXT:    v_or_b32_sdwa v10, v15, v10 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v48
 ; VI-NEXT:    v_or_b32_sdwa v15, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v35
-; VI-NEXT:    v_or_b32_sdwa v10, v16, v10 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v11
+; VI-NEXT:    v_or_b32_sdwa v11, v16, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v16, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v34
-; VI-NEXT:    v_or_b32_sdwa v11, v17, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v17, v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v33
 ; VI-NEXT:    v_or_b32_sdwa v18, v4, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -27934,11 +28427,11 @@ define inreg <44 x i16> @bitcast_v11f64_to_v44i16_scalar(<11 x double> inreg %a,
 ; VI-NEXT:    ; implicit-def: $vgpr28
 ; VI-NEXT:    ; implicit-def: $vgpr29
 ; VI-NEXT:    ; implicit-def: $vgpr51
-; VI-NEXT:    ; implicit-def: $vgpr50
+; VI-NEXT:    ; implicit-def: $vgpr23
 ; VI-NEXT:    ; implicit-def: $vgpr8
+; VI-NEXT:    ; implicit-def: $vgpr50
 ; VI-NEXT:    ; implicit-def: $vgpr49
 ; VI-NEXT:    ; implicit-def: $vgpr48
-; VI-NEXT:    ; implicit-def: $vgpr11
 ; VI-NEXT:    ; implicit-def: $vgpr39
 ; VI-NEXT:    ; implicit-def: $vgpr38
 ; VI-NEXT:    ; implicit-def: $vgpr37
@@ -27955,21 +28448,21 @@ define inreg <44 x i16> @bitcast_v11f64_to_v44i16_scalar(<11 x double> inreg %a,
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX9-NEXT:    v_mov_b32_e32 v22, s16
-; GFX9-NEXT:    v_mov_b32_e32 v23, s17
-; GFX9-NEXT:    v_mov_b32_e32 v20, s18
-; GFX9-NEXT:    v_mov_b32_e32 v21, s19
-; GFX9-NEXT:    v_mov_b32_e32 v18, s20
-; GFX9-NEXT:    v_mov_b32_e32 v19, s21
-; GFX9-NEXT:    v_mov_b32_e32 v14, s22
-; GFX9-NEXT:    v_mov_b32_e32 v15, s23
+; GFX9-NEXT:    v_mov_b32_e32 v21, s16
+; GFX9-NEXT:    v_mov_b32_e32 v22, s17
+; GFX9-NEXT:    v_mov_b32_e32 v19, s18
+; GFX9-NEXT:    v_mov_b32_e32 v20, s19
+; GFX9-NEXT:    v_mov_b32_e32 v17, s20
+; GFX9-NEXT:    v_mov_b32_e32 v18, s21
+; GFX9-NEXT:    v_mov_b32_e32 v11, s22
+; GFX9-NEXT:    v_mov_b32_e32 v12, s23
 ; GFX9-NEXT:    v_mov_b32_e32 v9, s24
 ; GFX9-NEXT:    v_mov_b32_e32 v10, s25
-; GFX9-NEXT:    v_mov_b32_e32 v16, s26
-; GFX9-NEXT:    v_mov_b32_e32 v17, s27
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_mov_b32_e32 v12, s28
-; GFX9-NEXT:    v_mov_b32_e32 v13, s29
+; GFX9-NEXT:    v_mov_b32_e32 v13, s28
+; GFX9-NEXT:    v_mov_b32_e32 v14, s29
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB49_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v7
@@ -27980,33 +28473,33 @@ define inreg <44 x i16> @bitcast_v11f64_to_v44i16_scalar(<11 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v35, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v12
-; GFX9-NEXT:    v_lshrrev_b32_e32 v11, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v14
+; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v10
+; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v10
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v9
-; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v19
-; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
-; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v20
-; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v23
-; GFX9-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
+; GFX9-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
+; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
+; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v19
+; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; GFX9-NEXT:    v_lshrrev_b32_e32 v24, 16, v21
 ; GFX9-NEXT:    s_cbranch_execnz .LBB49_3
 ; GFX9-NEXT:  .LBB49_2: ; %cmp.true
 ; GFX9-NEXT:    v_add_f64 v[6:7], v[6:7], 1.0
 ; GFX9-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
-; GFX9-NEXT:    v_add_f64 v[16:17], v[16:17], 1.0
+; GFX9-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; GFX9-NEXT:    v_add_f64 v[9:10], v[9:10], 1.0
-; GFX9-NEXT:    v_add_f64 v[14:15], v[14:15], 1.0
-; GFX9-NEXT:    v_add_f64 v[18:19], v[18:19], 1.0
-; GFX9-NEXT:    v_add_f64 v[20:21], v[20:21], 1.0
-; GFX9-NEXT:    v_add_f64 v[22:23], v[22:23], 1.0
+; GFX9-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
+; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; GFX9-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v7
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v6
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v32, 16, v5
@@ -28015,62 +28508,62 @@ define inreg <44 x i16> @bitcast_v11f64_to_v44i16_scalar(<11 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v35, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v12
-; GFX9-NEXT:    v_lshrrev_b32_e32 v11, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v14
+; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v10
+; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v10
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v9
-; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v19
-; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
-; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v20
-; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v23
-; GFX9-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
+; GFX9-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
+; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
+; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v19
+; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; GFX9-NEXT:    v_lshrrev_b32_e32 v24, 16, v21
 ; GFX9-NEXT:  .LBB49_3: ; %end
-; GFX9-NEXT:    v_and_b32_e32 v22, 0xffff, v22
-; GFX9-NEXT:    v_lshl_or_b32 v24, v24, 16, v22
-; GFX9-NEXT:    v_and_b32_e32 v22, 0xffff, v23
-; GFX9-NEXT:    v_and_b32_e32 v14, 0xffff, v14
-; GFX9-NEXT:    v_lshl_or_b32 v25, v25, 16, v22
-; GFX9-NEXT:    v_lshl_or_b32 v22, v51, 16, v14
-; GFX9-NEXT:    v_and_b32_e32 v14, 0xffff, v15
-; GFX9-NEXT:    v_lshl_or_b32 v23, v50, 16, v14
-; GFX9-NEXT:    v_and_b32_e32 v14, 0xffff, v17
+; GFX9-NEXT:    v_and_b32_e32 v21, 0xffff, v21
+; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v11
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX9-NEXT:    v_lshl_or_b32 v11, v11, 16, v14
+; GFX9-NEXT:    v_lshl_or_b32 v24, v24, 16, v21
+; GFX9-NEXT:    v_and_b32_e32 v21, 0xffff, v22
+; GFX9-NEXT:    v_lshl_or_b32 v22, v51, 16, v11
+; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v12
+; GFX9-NEXT:    v_and_b32_e32 v9, 0xffff, v9
+; GFX9-NEXT:    v_and_b32_e32 v12, 0xffff, v13
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v14
 ; GFX9-NEXT:    v_lshl_or_b32 v14, v37, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v1
-; GFX9-NEXT:    v_and_b32_e32 v9, 0xffff, v9
-; GFX9-NEXT:    v_lshl_or_b32 v15, v36, 16, v0
-; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
-; GFX9-NEXT:    v_and_b32_e32 v18, 0xffff, v18
+; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v8, v8, 16, v9
 ; GFX9-NEXT:    v_and_b32_e32 v9, 0xffff, v10
-; GFX9-NEXT:    v_and_b32_e32 v10, 0xffff, v16
+; GFX9-NEXT:    v_and_b32_e32 v10, 0xffff, v15
+; GFX9-NEXT:    v_lshl_or_b32 v15, v36, 16, v0
+; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
+; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v17
+; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v18
+; GFX9-NEXT:    v_lshl_or_b32 v23, v23, 16, v11
+; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v16
 ; GFX9-NEXT:    v_lshl_or_b32 v16, v35, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v3
-; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v18
-; GFX9-NEXT:    v_and_b32_e32 v18, 0xffff, v19
+; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v19
+; GFX9-NEXT:    v_lshl_or_b32 v29, v29, 16, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v17, v34, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v4
-; GFX9-NEXT:    v_and_b32_e32 v20, 0xffff, v20
-; GFX9-NEXT:    v_lshl_or_b32 v29, v29, 16, v18
+; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v19
+; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v20
 ; GFX9-NEXT:    v_lshl_or_b32 v18, v33, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v5
-; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v20
-; GFX9-NEXT:    v_and_b32_e32 v20, 0xffff, v21
+; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v19
 ; GFX9-NEXT:    v_lshl_or_b32 v19, v32, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v6
-; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v20
-; GFX9-NEXT:    v_and_b32_e32 v12, 0xffff, v12
-; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v13
+; GFX9-NEXT:    v_lshl_or_b32 v25, v25, 16, v21
 ; GFX9-NEXT:    v_lshl_or_b32 v20, v31, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v7
-; GFX9-NEXT:    v_lshl_or_b32 v9, v49, 16, v9
-; GFX9-NEXT:    v_lshl_or_b32 v10, v48, 16, v10
+; GFX9-NEXT:    v_lshl_or_b32 v9, v50, 16, v9
+; GFX9-NEXT:    v_lshl_or_b32 v10, v49, 16, v10
+; GFX9-NEXT:    v_lshl_or_b32 v11, v48, 16, v11
 ; GFX9-NEXT:    v_lshl_or_b32 v12, v39, 16, v12
 ; GFX9-NEXT:    v_lshl_or_b32 v13, v38, 16, v13
 ; GFX9-NEXT:    v_lshl_or_b32 v21, v30, 16, v0
@@ -28091,11 +28584,11 @@ define inreg <44 x i16> @bitcast_v11f64_to_v44i16_scalar(<11 x double> inreg %a,
 ; GFX9-NEXT:    ; implicit-def: $vgpr28
 ; GFX9-NEXT:    ; implicit-def: $vgpr29
 ; GFX9-NEXT:    ; implicit-def: $vgpr51
-; GFX9-NEXT:    ; implicit-def: $vgpr50
+; GFX9-NEXT:    ; implicit-def: $vgpr23
 ; GFX9-NEXT:    ; implicit-def: $vgpr8
+; GFX9-NEXT:    ; implicit-def: $vgpr50
 ; GFX9-NEXT:    ; implicit-def: $vgpr49
 ; GFX9-NEXT:    ; implicit-def: $vgpr48
-; GFX9-NEXT:    ; implicit-def: $vgpr11
 ; GFX9-NEXT:    ; implicit-def: $vgpr39
 ; GFX9-NEXT:    ; implicit-def: $vgpr38
 ; GFX9-NEXT:    ; implicit-def: $vgpr37
@@ -28753,7 +29246,7 @@ define <11 x double> @bitcast_v44i16_to_v11f64(<44 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v18, vcc, s6, v18
 ; SI-NEXT:    v_add_i32_e32 v19, vcc, s6, v19
 ; SI-NEXT:    v_add_i32_e32 v20, vcc, s6, v20
-; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
+; SI-NEXT:    v_add_i32_e32 v21, vcc, 0x30000, v21
 ; SI-NEXT:  .LBB50_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
@@ -31178,408 +31671,444 @@ define inreg <44 x half> @bitcast_v11f64_to_v44f16_scalar(<11 x double> inreg %a
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
-; SI-NEXT:    v_readfirstlane_b32 s10, v1
-; SI-NEXT:    v_readfirstlane_b32 s11, v2
-; SI-NEXT:    v_readfirstlane_b32 s8, v3
-; SI-NEXT:    v_readfirstlane_b32 s9, v4
-; SI-NEXT:    v_readfirstlane_b32 s6, v5
-; SI-NEXT:    v_readfirstlane_b32 s7, v6
-; SI-NEXT:    v_readfirstlane_b32 s4, v7
-; SI-NEXT:    s_and_b64 s[12:13], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s5, v8
-; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v56, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    v_mov_b32_e32 v21, s16
+; SI-NEXT:    v_mov_b32_e32 v22, s17
+; SI-NEXT:    v_mov_b32_e32 v19, s18
+; SI-NEXT:    v_mov_b32_e32 v20, s19
+; SI-NEXT:    v_mov_b32_e32 v17, s20
+; SI-NEXT:    v_mov_b32_e32 v18, s21
+; SI-NEXT:    v_mov_b32_e32 v15, s22
+; SI-NEXT:    v_mov_b32_e32 v16, s23
+; SI-NEXT:    v_mov_b32_e32 v11, s24
+; SI-NEXT:    v_mov_b32_e32 v12, s25
+; SI-NEXT:    v_mov_b32_e32 v13, s26
+; SI-NEXT:    v_mov_b32_e32 v14, s27
+; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
+; SI-NEXT:    v_mov_b32_e32 v9, s28
+; SI-NEXT:    v_mov_b32_e32 v10, s29
+; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_cbranch_scc0 .LBB53_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s12, s5, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s12
-; SI-NEXT:    s_lshr_b32 s12, s4, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s12
-; SI-NEXT:    s_lshr_b32 s12, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s12
-; SI-NEXT:    s_lshr_b32 s12, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s12
-; SI-NEXT:    s_lshr_b32 s12, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s12
-; SI-NEXT:    s_lshr_b32 s12, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s12
-; SI-NEXT:    s_lshr_b32 s12, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s12
-; SI-NEXT:    s_lshr_b32 s12, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s12
-; SI-NEXT:    s_lshr_b32 s12, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s12
-; SI-NEXT:    s_lshr_b32 s12, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s12
-; SI-NEXT:    s_lshr_b32 s12, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s12
-; SI-NEXT:    s_lshr_b32 s12, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s12
-; SI-NEXT:    s_lshr_b32 s12, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s12
-; SI-NEXT:    s_lshr_b32 s12, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s12
-; SI-NEXT:    s_lshr_b32 s12, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s12
-; SI-NEXT:    s_lshr_b32 s12, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s12
-; SI-NEXT:    s_lshr_b32 s12, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s12
-; SI-NEXT:    s_lshr_b32 s12, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s12
-; SI-NEXT:    s_lshr_b32 s12, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s12
-; SI-NEXT:    s_lshr_b32 s12, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s12
-; SI-NEXT:    s_lshr_b32 s12, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s12
-; SI-NEXT:    s_lshr_b32 s12, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s5
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v20
+; SI-NEXT:    s_waitcnt expcnt(6)
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v19
+; SI-NEXT:    s_waitcnt expcnt(4)
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v22
+; SI-NEXT:    s_waitcnt expcnt(2)
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v3
+; SI-NEXT:    buffer_store_dword v23, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v10
+; SI-NEXT:    buffer_store_dword v23, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v13
+; SI-NEXT:    buffer_store_dword v23, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v20
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v21
 ; SI-NEXT:    s_cbranch_execnz .LBB53_3
 ; SI-NEXT:  .LBB53_2: ; %cmp.true
-; SI-NEXT:    v_add_f64 v[1:2], s[16:17], 1.0
-; SI-NEXT:    v_add_f64 v[36:37], s[18:19], 1.0
-; SI-NEXT:    v_add_f64 v[33:34], s[20:21], 1.0
-; SI-NEXT:    v_add_f64 v[29:30], s[22:23], 1.0
-; SI-NEXT:    v_add_f64 v[25:26], s[24:25], 1.0
-; SI-NEXT:    v_add_f64 v[21:22], s[26:27], 1.0
-; SI-NEXT:    v_add_f64 v[18:19], s[28:29], 1.0
-; SI-NEXT:    v_add_f64 v[14:15], s[10:11], 1.0
-; SI-NEXT:    v_add_f64 v[10:11], s[8:9], 1.0
-; SI-NEXT:    v_add_f64 v[6:7], s[6:7], 1.0
-; SI-NEXT:    v_add_f64 v[4:5], s[4:5], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v36
-; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v37
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v33
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v34
-; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v29
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v30
-; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v25
-; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v26
-; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
-; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v16, 16, v19
-; SI-NEXT:    s_waitcnt expcnt(6)
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
-; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v10
-; SI-NEXT:    v_lshrrev_b32_e32 v8, 16, v11
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v6
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v7
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v4
-; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v5
+; SI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
+; SI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; SI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; SI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; SI-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
+; SI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; SI-NEXT:    v_add_f64 v[9:10], v[9:10], 1.0
+; SI-NEXT:    v_add_f64 v[1:2], v[1:2], 1.0
+; SI-NEXT:    v_add_f64 v[3:4], v[3:4], 1.0
+; SI-NEXT:    v_add_f64 v[5:6], v[5:6], 1.0
+; SI-NEXT:    v_add_f64 v[7:8], v[7:8], 1.0
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v21
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v25
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v36
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v47
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v46
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v45
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, v44
+; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v8
 ; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v43
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v42
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v41
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v40
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
 ; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
 ; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
 ; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, v56
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v47
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v61
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v63
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
 ; SI-NEXT:  .LBB53_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v52, v52
-; SI-NEXT:    v_cvt_f16_f32_e32 v51, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v50, v50
-; SI-NEXT:    v_cvt_f16_f32_e32 v49, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v48, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v39, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v38, v38
-; SI-NEXT:    v_lshlrev_b32_e32 v52, 16, v52
-; SI-NEXT:    v_cvt_f16_f32_e32 v37, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v36, v36
-; SI-NEXT:    v_or_b32_e32 v51, v51, v52
-; SI-NEXT:    v_lshlrev_b32_e32 v50, 16, v50
-; SI-NEXT:    v_cvt_f16_f32_e32 v35, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v33, v33
-; SI-NEXT:    buffer_store_dword v51, v0, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v51, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v49, v49, v50
-; SI-NEXT:    v_lshlrev_b32_e32 v48, 16, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v34, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v31, v31
-; SI-NEXT:    buffer_store_dword v49, v51, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v49, vcc, 8, v0
-; SI-NEXT:    v_or_b32_e32 v39, v39, v48
-; SI-NEXT:    v_lshlrev_b32_e32 v38, 16, v38
-; SI-NEXT:    v_cvt_f16_f32_e32 v32, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v29, v29
-; SI-NEXT:    buffer_store_dword v39, v49, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v39, vcc, 12, v0
-; SI-NEXT:    v_or_b32_e32 v37, v37, v38
-; SI-NEXT:    v_lshlrev_b32_e32 v36, 16, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; SI-NEXT:    buffer_store_dword v37, v39, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v37, vcc, 16, v0
-; SI-NEXT:    v_or_b32_e32 v35, v35, v36
-; SI-NEXT:    v_lshlrev_b32_e32 v33, 16, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v28, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v25, v25
-; SI-NEXT:    buffer_store_dword v35, v37, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 20, v0
-; SI-NEXT:    v_or_b32_e32 v33, v34, v33
-; SI-NEXT:    v_lshlrev_b32_e32 v31, 16, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v23, v23
-; SI-NEXT:    buffer_store_dword v33, v35, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 24, v0
-; SI-NEXT:    v_or_b32_e32 v31, v32, v31
-; SI-NEXT:    v_lshlrev_b32_e32 v29, 16, v29
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v21, v21
-; SI-NEXT:    buffer_store_dword v31, v33, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 28, v0
-; SI-NEXT:    v_or_b32_e32 v29, v30, v29
-; SI-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v18
-; SI-NEXT:    buffer_store_dword v29, v31, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v29, vcc, 32, v0
-; SI-NEXT:    v_or_b32_e32 v27, v28, v27
-; SI-NEXT:    v_lshlrev_b32_e32 v25, 16, v25
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v20
-; SI-NEXT:    buffer_store_dword v27, v29, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v27, vcc, 36, v0
-; SI-NEXT:    v_or_b32_e32 v25, v26, v25
-; SI-NEXT:    v_lshlrev_b32_e32 v23, 16, v23
-; SI-NEXT:    buffer_store_dword v25, v27, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v25, vcc, 40, v0
-; SI-NEXT:    v_or_b32_e32 v23, v24, v23
-; SI-NEXT:    v_lshlrev_b32_e32 v21, 16, v21
-; SI-NEXT:    buffer_store_dword v23, v25, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v23, vcc, 44, v0
-; SI-NEXT:    v_or_b32_e32 v21, v22, v21
-; SI-NEXT:    v_lshlrev_b32_e32 v18, 16, v18
-; SI-NEXT:    buffer_store_dword v21, v23, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v21, vcc, 48, v0
-; SI-NEXT:    v_or_b32_e32 v18, v20, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v16
-; SI-NEXT:    buffer_store_dword v18, v21, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v19
-; SI-NEXT:    v_add_i32_e32 v19, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v16, 16, v16
-; SI-NEXT:    v_or_b32_e32 v16, v18, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; SI-NEXT:    buffer_store_dword v16, v19, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v17
-; SI-NEXT:    v_add_i32_e32 v17, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
-; SI-NEXT:    v_or_b32_e32 v14, v16, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; SI-NEXT:    buffer_store_dword v14, v17, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v15
-; SI-NEXT:    v_add_i32_e32 v15, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
-; SI-NEXT:    v_or_b32_e32 v12, v14, v12
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v10
-; SI-NEXT:    buffer_store_dword v12, v15, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v13
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v12, v10
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v8
-; SI-NEXT:    buffer_store_dword v10, v13, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v11
-; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
-; SI-NEXT:    v_or_b32_e32 v8, v10, v8
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v6
-; SI-NEXT:    buffer_store_dword v8, v11, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v9
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; SI-NEXT:    buffer_store_dword v6, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v7
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 0x4c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v4, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v5
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x50, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; SI-NEXT:    v_or_b32_e32 v2, v4, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v5, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v3
-; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x54, v0
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v63
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v25
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v61
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v24
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    buffer_load_dword v56, off, s[0:3], s32 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
+; SI-NEXT:    v_or_b32_e32 v2, v4, v2
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v59
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v23
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v57
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v62
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v56
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v60
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v47
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v58
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v45
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v46
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v43
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v44
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v41
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v42
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v55
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v40
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v54
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v50
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v52
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v51
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v38
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v49
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v36
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v39
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v34
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v37
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v32
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v35
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v30
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v33
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v28
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v31
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v26
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v27
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x54, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v29
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB53_4:
-; SI-NEXT:    ; implicit-def: $vgpr51
-; SI-NEXT:    ; implicit-def: $vgpr52
-; SI-NEXT:    ; implicit-def: $vgpr49
-; SI-NEXT:    ; implicit-def: $vgpr50
-; SI-NEXT:    ; implicit-def: $vgpr39
-; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr37
-; SI-NEXT:    ; implicit-def: $vgpr38
-; SI-NEXT:    ; implicit-def: $vgpr35
-; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr34
-; SI-NEXT:    ; implicit-def: $vgpr33
-; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr31
-; SI-NEXT:    ; implicit-def: $vgpr30
-; SI-NEXT:    ; implicit-def: $vgpr29
-; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr27
 ; SI-NEXT:    ; implicit-def: $vgpr26
+; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr25
+; SI-NEXT:    ; implicit-def: $vgpr63
 ; SI-NEXT:    ; implicit-def: $vgpr24
+; SI-NEXT:    ; implicit-def: $vgpr61
 ; SI-NEXT:    ; implicit-def: $vgpr23
-; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr14
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr13
-; SI-NEXT:    ; implicit-def: $vgpr10
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr8
-; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr6
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr1
+; SI-NEXT:    ; implicit-def: $vgpr59
+; SI-NEXT:    ; implicit-def: $vgpr62
+; SI-NEXT:    ; implicit-def: $vgpr57
+; SI-NEXT:    ; implicit-def: $vgpr60
+; SI-NEXT:    ; implicit-def: $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr58
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr43
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr48
+; SI-NEXT:    ; implicit-def: $vgpr49
+; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr39
+; SI-NEXT:    ; implicit-def: $vgpr36
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr32
+; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; implicit-def: $vgpr30
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr28
+; SI-NEXT:    ; kill: killed $vgpr26
+; SI-NEXT:    ; implicit-def: $vgpr26
+; SI-NEXT:    ; kill: killed $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    s_branch .LBB53_2
 ;
 ; VI-LABEL: bitcast_v11f64_to_v44f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; VI-NEXT:    v_mov_b32_e32 v22, s16
-; VI-NEXT:    v_mov_b32_e32 v23, s17
-; VI-NEXT:    v_mov_b32_e32 v20, s18
-; VI-NEXT:    v_mov_b32_e32 v21, s19
-; VI-NEXT:    v_mov_b32_e32 v18, s20
-; VI-NEXT:    v_mov_b32_e32 v19, s21
-; VI-NEXT:    v_mov_b32_e32 v14, s22
-; VI-NEXT:    v_mov_b32_e32 v15, s23
+; VI-NEXT:    v_mov_b32_e32 v21, s16
+; VI-NEXT:    v_mov_b32_e32 v22, s17
+; VI-NEXT:    v_mov_b32_e32 v19, s18
+; VI-NEXT:    v_mov_b32_e32 v20, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s20
+; VI-NEXT:    v_mov_b32_e32 v18, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s23
 ; VI-NEXT:    v_mov_b32_e32 v9, s24
 ; VI-NEXT:    v_mov_b32_e32 v10, s25
-; VI-NEXT:    v_mov_b32_e32 v16, s26
-; VI-NEXT:    v_mov_b32_e32 v17, s27
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_mov_b32_e32 v16, s27
 ; VI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; VI-NEXT:    v_mov_b32_e32 v12, s28
-; VI-NEXT:    v_mov_b32_e32 v13, s29
+; VI-NEXT:    v_mov_b32_e32 v13, s28
+; VI-NEXT:    v_mov_b32_e32 v14, s29
 ; VI-NEXT:    s_cbranch_scc0 .LBB53_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
 ; VI-NEXT:    v_lshrrev_b32_e32 v30, 16, v7
@@ -31590,33 +32119,33 @@ define inreg <44 x half> @bitcast_v11f64_to_v44f16_scalar(<11 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v35, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v13
-; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v12
-; VI-NEXT:    v_lshrrev_b32_e32 v11, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v14
+; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v10
+; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v10
 ; VI-NEXT:    v_lshrrev_b32_e32 v8, 16, v9
-; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v15
-; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v14
-; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v19
-; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
-; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v20
-; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v23
-; VI-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
+; VI-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
+; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
+; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v19
+; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; VI-NEXT:    v_lshrrev_b32_e32 v24, 16, v21
 ; VI-NEXT:    s_cbranch_execnz .LBB53_3
 ; VI-NEXT:  .LBB53_2: ; %cmp.true
 ; VI-NEXT:    v_add_f64 v[6:7], v[6:7], 1.0
 ; VI-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; VI-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; VI-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; VI-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
-; VI-NEXT:    v_add_f64 v[16:17], v[16:17], 1.0
+; VI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; VI-NEXT:    v_add_f64 v[9:10], v[9:10], 1.0
-; VI-NEXT:    v_add_f64 v[14:15], v[14:15], 1.0
-; VI-NEXT:    v_add_f64 v[18:19], v[18:19], 1.0
-; VI-NEXT:    v_add_f64 v[20:21], v[20:21], 1.0
-; VI-NEXT:    v_add_f64 v[22:23], v[22:23], 1.0
+; VI-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
+; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; VI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; VI-NEXT:    v_lshrrev_b32_e32 v30, 16, v7
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v6
 ; VI-NEXT:    v_lshrrev_b32_e32 v32, 16, v5
@@ -31625,56 +32154,56 @@ define inreg <44 x half> @bitcast_v11f64_to_v44f16_scalar(<11 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v35, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v13
-; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v12
-; VI-NEXT:    v_lshrrev_b32_e32 v11, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v14
+; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v10
+; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v10
 ; VI-NEXT:    v_lshrrev_b32_e32 v8, 16, v9
-; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v15
-; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v14
-; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v19
-; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
-; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v20
-; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v23
-; VI-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
+; VI-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
+; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
+; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v19
+; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; VI-NEXT:    v_lshrrev_b32_e32 v24, 16, v21
 ; VI-NEXT:  .LBB53_3: ; %end
 ; VI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
-; VI-NEXT:    v_or_b32_sdwa v24, v22, v24 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v22, 16, v25
-; VI-NEXT:    v_or_b32_sdwa v25, v23, v22 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v22, 16, v26
-; VI-NEXT:    v_or_b32_sdwa v26, v20, v22 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v20, 16, v27
-; VI-NEXT:    v_or_b32_sdwa v27, v21, v20 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v20, 16, v28
-; VI-NEXT:    v_or_b32_sdwa v28, v18, v20 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v18, 16, v29
-; VI-NEXT:    v_or_b32_sdwa v29, v19, v18 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v18, 16, v51
-; VI-NEXT:    v_or_b32_sdwa v22, v14, v18 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v50
-; VI-NEXT:    v_or_b32_sdwa v23, v15, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v39
-; VI-NEXT:    v_or_b32_sdwa v12, v12, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v38
+; VI-NEXT:    v_or_b32_sdwa v24, v21, v24 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v21, 16, v25
+; VI-NEXT:    v_or_b32_sdwa v25, v22, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v21, 16, v26
+; VI-NEXT:    v_or_b32_sdwa v26, v19, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v27
+; VI-NEXT:    v_or_b32_sdwa v27, v20, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v28
+; VI-NEXT:    v_or_b32_sdwa v28, v17, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v29
+; VI-NEXT:    v_or_b32_sdwa v29, v18, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v51
+; VI-NEXT:    v_or_b32_sdwa v22, v11, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v23
+; VI-NEXT:    v_or_b32_sdwa v23, v12, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v12, 16, v39
 ; VI-NEXT:    v_lshlrev_b32_e32 v8, 16, v8
-; VI-NEXT:    v_or_b32_sdwa v13, v13, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v37
+; VI-NEXT:    v_or_b32_sdwa v12, v13, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v38
 ; VI-NEXT:    v_or_b32_sdwa v8, v9, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v9, 16, v49
+; VI-NEXT:    v_lshlrev_b32_e32 v9, 16, v50
+; VI-NEXT:    v_or_b32_sdwa v13, v14, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v37
+; VI-NEXT:    v_or_b32_sdwa v9, v10, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v10, 16, v49
 ; VI-NEXT:    v_or_b32_sdwa v14, v0, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v36
-; VI-NEXT:    v_or_b32_sdwa v9, v10, v9 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v10, 16, v48
+; VI-NEXT:    v_or_b32_sdwa v10, v15, v10 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v48
 ; VI-NEXT:    v_or_b32_sdwa v15, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v35
-; VI-NEXT:    v_or_b32_sdwa v10, v16, v10 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v11
+; VI-NEXT:    v_or_b32_sdwa v11, v16, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v16, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v34
-; VI-NEXT:    v_or_b32_sdwa v11, v17, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v17, v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v33
 ; VI-NEXT:    v_or_b32_sdwa v18, v4, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -31701,11 +32230,11 @@ define inreg <44 x half> @bitcast_v11f64_to_v44f16_scalar(<11 x double> inreg %a
 ; VI-NEXT:    ; implicit-def: $vgpr28
 ; VI-NEXT:    ; implicit-def: $vgpr29
 ; VI-NEXT:    ; implicit-def: $vgpr51
-; VI-NEXT:    ; implicit-def: $vgpr50
+; VI-NEXT:    ; implicit-def: $vgpr23
 ; VI-NEXT:    ; implicit-def: $vgpr8
+; VI-NEXT:    ; implicit-def: $vgpr50
 ; VI-NEXT:    ; implicit-def: $vgpr49
 ; VI-NEXT:    ; implicit-def: $vgpr48
-; VI-NEXT:    ; implicit-def: $vgpr11
 ; VI-NEXT:    ; implicit-def: $vgpr39
 ; VI-NEXT:    ; implicit-def: $vgpr38
 ; VI-NEXT:    ; implicit-def: $vgpr37
@@ -31722,21 +32251,21 @@ define inreg <44 x half> @bitcast_v11f64_to_v44f16_scalar(<11 x double> inreg %a
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX9-NEXT:    v_mov_b32_e32 v22, s16
-; GFX9-NEXT:    v_mov_b32_e32 v23, s17
-; GFX9-NEXT:    v_mov_b32_e32 v20, s18
-; GFX9-NEXT:    v_mov_b32_e32 v21, s19
-; GFX9-NEXT:    v_mov_b32_e32 v18, s20
-; GFX9-NEXT:    v_mov_b32_e32 v19, s21
-; GFX9-NEXT:    v_mov_b32_e32 v14, s22
-; GFX9-NEXT:    v_mov_b32_e32 v15, s23
+; GFX9-NEXT:    v_mov_b32_e32 v21, s16
+; GFX9-NEXT:    v_mov_b32_e32 v22, s17
+; GFX9-NEXT:    v_mov_b32_e32 v19, s18
+; GFX9-NEXT:    v_mov_b32_e32 v20, s19
+; GFX9-NEXT:    v_mov_b32_e32 v17, s20
+; GFX9-NEXT:    v_mov_b32_e32 v18, s21
+; GFX9-NEXT:    v_mov_b32_e32 v11, s22
+; GFX9-NEXT:    v_mov_b32_e32 v12, s23
 ; GFX9-NEXT:    v_mov_b32_e32 v9, s24
 ; GFX9-NEXT:    v_mov_b32_e32 v10, s25
-; GFX9-NEXT:    v_mov_b32_e32 v16, s26
-; GFX9-NEXT:    v_mov_b32_e32 v17, s27
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_mov_b32_e32 v12, s28
-; GFX9-NEXT:    v_mov_b32_e32 v13, s29
+; GFX9-NEXT:    v_mov_b32_e32 v13, s28
+; GFX9-NEXT:    v_mov_b32_e32 v14, s29
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB53_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v7
@@ -31747,33 +32276,33 @@ define inreg <44 x half> @bitcast_v11f64_to_v44f16_scalar(<11 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v35, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v12
-; GFX9-NEXT:    v_lshrrev_b32_e32 v11, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v14
+; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v10
+; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v10
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v9
-; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v19
-; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
-; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v20
-; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v23
-; GFX9-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
+; GFX9-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
+; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
+; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v19
+; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; GFX9-NEXT:    v_lshrrev_b32_e32 v24, 16, v21
 ; GFX9-NEXT:    s_cbranch_execnz .LBB53_3
 ; GFX9-NEXT:  .LBB53_2: ; %cmp.true
 ; GFX9-NEXT:    v_add_f64 v[6:7], v[6:7], 1.0
 ; GFX9-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
-; GFX9-NEXT:    v_add_f64 v[16:17], v[16:17], 1.0
+; GFX9-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; GFX9-NEXT:    v_add_f64 v[9:10], v[9:10], 1.0
-; GFX9-NEXT:    v_add_f64 v[14:15], v[14:15], 1.0
-; GFX9-NEXT:    v_add_f64 v[18:19], v[18:19], 1.0
-; GFX9-NEXT:    v_add_f64 v[20:21], v[20:21], 1.0
-; GFX9-NEXT:    v_add_f64 v[22:23], v[22:23], 1.0
+; GFX9-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
+; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; GFX9-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v7
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v6
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v32, 16, v5
@@ -31782,62 +32311,62 @@ define inreg <44 x half> @bitcast_v11f64_to_v44f16_scalar(<11 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v35, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v12
-; GFX9-NEXT:    v_lshrrev_b32_e32 v11, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v14
+; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v10
+; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v10
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v9
-; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v19
-; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
-; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v20
-; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v23
-; GFX9-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
+; GFX9-NEXT:    v_lshrrev_b32_e32 v23, 16, v12
+; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
+; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
+; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v19
+; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; GFX9-NEXT:    v_lshrrev_b32_e32 v24, 16, v21
 ; GFX9-NEXT:  .LBB53_3: ; %end
-; GFX9-NEXT:    v_and_b32_e32 v22, 0xffff, v22
-; GFX9-NEXT:    v_lshl_or_b32 v24, v24, 16, v22
-; GFX9-NEXT:    v_and_b32_e32 v22, 0xffff, v23
-; GFX9-NEXT:    v_and_b32_e32 v14, 0xffff, v14
-; GFX9-NEXT:    v_lshl_or_b32 v25, v25, 16, v22
-; GFX9-NEXT:    v_lshl_or_b32 v22, v51, 16, v14
-; GFX9-NEXT:    v_and_b32_e32 v14, 0xffff, v15
-; GFX9-NEXT:    v_lshl_or_b32 v23, v50, 16, v14
-; GFX9-NEXT:    v_and_b32_e32 v14, 0xffff, v17
+; GFX9-NEXT:    v_and_b32_e32 v21, 0xffff, v21
+; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v11
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX9-NEXT:    v_lshl_or_b32 v11, v11, 16, v14
+; GFX9-NEXT:    v_lshl_or_b32 v24, v24, 16, v21
+; GFX9-NEXT:    v_and_b32_e32 v21, 0xffff, v22
+; GFX9-NEXT:    v_lshl_or_b32 v22, v51, 16, v11
+; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v12
+; GFX9-NEXT:    v_and_b32_e32 v9, 0xffff, v9
+; GFX9-NEXT:    v_and_b32_e32 v12, 0xffff, v13
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v14
 ; GFX9-NEXT:    v_lshl_or_b32 v14, v37, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v1
-; GFX9-NEXT:    v_and_b32_e32 v9, 0xffff, v9
-; GFX9-NEXT:    v_lshl_or_b32 v15, v36, 16, v0
-; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
-; GFX9-NEXT:    v_and_b32_e32 v18, 0xffff, v18
+; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v8, v8, 16, v9
 ; GFX9-NEXT:    v_and_b32_e32 v9, 0xffff, v10
-; GFX9-NEXT:    v_and_b32_e32 v10, 0xffff, v16
+; GFX9-NEXT:    v_and_b32_e32 v10, 0xffff, v15
+; GFX9-NEXT:    v_lshl_or_b32 v15, v36, 16, v0
+; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
+; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v17
+; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v18
+; GFX9-NEXT:    v_lshl_or_b32 v23, v23, 16, v11
+; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v16
 ; GFX9-NEXT:    v_lshl_or_b32 v16, v35, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v3
-; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v18
-; GFX9-NEXT:    v_and_b32_e32 v18, 0xffff, v19
+; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v19
+; GFX9-NEXT:    v_lshl_or_b32 v29, v29, 16, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v17, v34, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v4
-; GFX9-NEXT:    v_and_b32_e32 v20, 0xffff, v20
-; GFX9-NEXT:    v_lshl_or_b32 v29, v29, 16, v18
+; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v19
+; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v20
 ; GFX9-NEXT:    v_lshl_or_b32 v18, v33, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v5
-; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v20
-; GFX9-NEXT:    v_and_b32_e32 v20, 0xffff, v21
+; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v19
 ; GFX9-NEXT:    v_lshl_or_b32 v19, v32, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v6
-; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v20
-; GFX9-NEXT:    v_and_b32_e32 v12, 0xffff, v12
-; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v13
+; GFX9-NEXT:    v_lshl_or_b32 v25, v25, 16, v21
 ; GFX9-NEXT:    v_lshl_or_b32 v20, v31, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v7
-; GFX9-NEXT:    v_lshl_or_b32 v9, v49, 16, v9
-; GFX9-NEXT:    v_lshl_or_b32 v10, v48, 16, v10
+; GFX9-NEXT:    v_lshl_or_b32 v9, v50, 16, v9
+; GFX9-NEXT:    v_lshl_or_b32 v10, v49, 16, v10
+; GFX9-NEXT:    v_lshl_or_b32 v11, v48, 16, v11
 ; GFX9-NEXT:    v_lshl_or_b32 v12, v39, 16, v12
 ; GFX9-NEXT:    v_lshl_or_b32 v13, v38, 16, v13
 ; GFX9-NEXT:    v_lshl_or_b32 v21, v30, 16, v0
@@ -31858,11 +32387,11 @@ define inreg <44 x half> @bitcast_v11f64_to_v44f16_scalar(<11 x double> inreg %a
 ; GFX9-NEXT:    ; implicit-def: $vgpr28
 ; GFX9-NEXT:    ; implicit-def: $vgpr29
 ; GFX9-NEXT:    ; implicit-def: $vgpr51
-; GFX9-NEXT:    ; implicit-def: $vgpr50
+; GFX9-NEXT:    ; implicit-def: $vgpr23
 ; GFX9-NEXT:    ; implicit-def: $vgpr8
+; GFX9-NEXT:    ; implicit-def: $vgpr50
 ; GFX9-NEXT:    ; implicit-def: $vgpr49
 ; GFX9-NEXT:    ; implicit-def: $vgpr48
-; GFX9-NEXT:    ; implicit-def: $vgpr11
 ; GFX9-NEXT:    ; implicit-def: $vgpr39
 ; GFX9-NEXT:    ; implicit-def: $vgpr38
 ; GFX9-NEXT:    ; implicit-def: $vgpr37

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.768bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.768bit.ll
@@ -3190,13 +3190,41 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_store_dword v12, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_writelane_b32 v12, s30, 0
-; SI-NEXT:    v_writelane_b32 v12, s31, 1
+; SI-NEXT:    v_writelane_b32 v20, s30, 0
+; SI-NEXT:    v_mov_b32_e32 v12, s16
+; SI-NEXT:    v_mov_b32_e32 v13, s17
+; SI-NEXT:    v_mov_b32_e32 v14, s18
+; SI-NEXT:    v_mov_b32_e32 v15, s19
+; SI-NEXT:    v_mov_b32_e32 v16, s20
+; SI-NEXT:    v_mov_b32_e32 v17, s21
+; SI-NEXT:    v_writelane_b32 v20, s31, 1
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s40, v12
+; SI-NEXT:    v_mov_b32_e32 v12, s24
+; SI-NEXT:    v_readfirstlane_b32 s41, v13
+; SI-NEXT:    v_mov_b32_e32 v13, s25
+; SI-NEXT:    v_readfirstlane_b32 s24, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; SI-NEXT:    v_writelane_b32 v12, s34, 2
+; SI-NEXT:    v_writelane_b32 v20, s34, 2
+; SI-NEXT:    v_readfirstlane_b32 s20, v18
+; SI-NEXT:    v_readfirstlane_b32 s21, v19
+; SI-NEXT:    v_readfirstlane_b32 s18, v12
+; SI-NEXT:    v_readfirstlane_b32 s19, v13
+; SI-NEXT:    v_readfirstlane_b32 s16, v14
+; SI-NEXT:    v_readfirstlane_b32 s17, v15
+; SI-NEXT:    v_readfirstlane_b32 s14, v16
+; SI-NEXT:    v_readfirstlane_b32 s15, v17
 ; SI-NEXT:    v_readfirstlane_b32 s12, v1
 ; SI-NEXT:    v_readfirstlane_b32 s13, v2
 ; SI-NEXT:    v_readfirstlane_b32 s10, v3
@@ -3206,9 +3234,9 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v7
 ; SI-NEXT:    v_readfirstlane_b32 s7, v8
 ; SI-NEXT:    v_readfirstlane_b32 s4, v9
-; SI-NEXT:    s_and_b64 s[14:15], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v10
-; SI-NEXT:    v_writelane_b32 v12, s35, 3
+; SI-NEXT:    v_writelane_b32 v20, s35, 3
 ; SI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s88, s5, 16
@@ -3216,41 +3244,41 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s90, s9, 16
 ; SI-NEXT:    s_lshr_b32 s91, s11, 16
 ; SI-NEXT:    s_lshr_b32 s92, s13, 16
-; SI-NEXT:    s_lshr_b32 s93, s29, 16
-; SI-NEXT:    s_lshr_b32 s94, s27, 16
-; SI-NEXT:    s_lshr_b32 s95, s25, 16
-; SI-NEXT:    s_lshr_b32 s30, s23, 16
-; SI-NEXT:    s_lshr_b32 s31, s21, 16
-; SI-NEXT:    s_lshr_b32 s34, s19, 16
-; SI-NEXT:    s_lshr_b32 s35, s17, 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s93, s15, 16
+; SI-NEXT:    s_lshr_b32 s94, s17, 16
+; SI-NEXT:    s_lshr_b32 s95, s19, 16
+; SI-NEXT:    s_lshr_b32 s30, s21, 16
+; SI-NEXT:    s_lshr_b32 s31, s23, 16
+; SI-NEXT:    s_lshr_b32 s34, s25, 16
+; SI-NEXT:    s_lshr_b32 s35, s41, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[42:43], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[44:45], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[12:13], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[40:41], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB13_3
 ; SI-NEXT:  .LBB13_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s23, s23, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s41, s41, 3
+; SI-NEXT:    s_add_i32 s40, s40, 3
 ; SI-NEXT:    s_add_i32 s25, s25, 3
 ; SI-NEXT:    s_add_i32 s24, s24, 3
-; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s26, s26, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
+; SI-NEXT:    s_add_i32 s23, s23, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
+; SI-NEXT:    s_add_i32 s15, s15, 3
+; SI-NEXT:    s_add_i32 s14, s14, 3
 ; SI-NEXT:    s_add_i32 s13, s13, 3
 ; SI-NEXT:    s_add_i32 s12, s12, 3
 ; SI-NEXT:    s_add_i32 s11, s11, 3
@@ -3261,128 +3289,128 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s5, s5, 3
 ; SI-NEXT:    s_add_i32 s4, s4, 3
-; SI-NEXT:    s_lshr_b64 s[14:15], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[42:43], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[44:45], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[12:13], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[18:19], 16
 ; SI-NEXT:    s_lshr_b32 s88, s5, 16
 ; SI-NEXT:    s_lshr_b32 s89, s7, 16
 ; SI-NEXT:    s_lshr_b32 s90, s9, 16
 ; SI-NEXT:    s_lshr_b32 s91, s11, 16
 ; SI-NEXT:    s_lshr_b32 s92, s13, 16
-; SI-NEXT:    s_lshr_b32 s93, s29, 16
-; SI-NEXT:    s_lshr_b32 s94, s27, 16
-; SI-NEXT:    s_lshr_b32 s95, s25, 16
-; SI-NEXT:    s_lshr_b32 s30, s23, 16
-; SI-NEXT:    s_lshr_b32 s31, s21, 16
-; SI-NEXT:    s_lshr_b32 s34, s19, 16
-; SI-NEXT:    s_lshr_b32 s35, s17, 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[16:17], 16
+; SI-NEXT:    s_lshr_b32 s93, s15, 16
+; SI-NEXT:    s_lshr_b32 s94, s17, 16
+; SI-NEXT:    s_lshr_b32 s95, s19, 16
+; SI-NEXT:    s_lshr_b32 s30, s21, 16
+; SI-NEXT:    s_lshr_b32 s31, s23, 16
+; SI-NEXT:    s_lshr_b32 s34, s25, 16
+; SI-NEXT:    s_lshr_b32 s35, s41, 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[40:41], 16
 ; SI-NEXT:  .LBB13_3: ; %end
-; SI-NEXT:    s_lshl_b32 s15, s76, 16
-; SI-NEXT:    s_and_b32 s16, s16, 0xffff
-; SI-NEXT:    s_or_b32 s15, s16, s15
-; SI-NEXT:    v_mov_b32_e32 v1, s15
-; SI-NEXT:    s_and_b32 s15, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s35, 16
-; SI-NEXT:    s_or_b32 s15, s15, s16
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_lshl_b32 s15, s74, 16
-; SI-NEXT:    s_and_b32 s16, s18, 0xffff
-; SI-NEXT:    s_or_b32 s15, s16, s15
-; SI-NEXT:    v_mov_b32_e32 v3, s15
-; SI-NEXT:    s_and_b32 s15, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s34, 16
+; SI-NEXT:    s_lshl_b32 s27, s76, 16
+; SI-NEXT:    s_and_b32 s29, s40, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s27
+; SI-NEXT:    s_and_b32 s27, s41, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s35, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_lshl_b32 s27, s74, 16
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_or_b32 s24, s24, s27
+; SI-NEXT:    v_mov_b32_e32 v3, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
+; SI-NEXT:    s_lshl_b32 s25, s34, 16
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s24, s24, s25
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s20, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s24, s72, 16
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s22, s22, s24
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s31, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s31, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s22, s22, s23
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s62, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s22, s62, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s30, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s30, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s60, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s60, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s95, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s95, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s58, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s58, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s27, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s94, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
+; SI-NEXT:    s_lshl_b32 s17, s94, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s16, s16, s17
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s28, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s14, s14, 0xffff
 ; SI-NEXT:    s_lshl_b32 s16, s56, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s14, s14, s16
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s93, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s14, s15, 0xffff
+; SI-NEXT:    s_lshl_b32 s15, s93, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s14, s14, s15
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
+; SI-NEXT:    v_mov_b32_e32 v2, s14
 ; SI-NEXT:    s_and_b32 s12, s12, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s46, 16
+; SI-NEXT:    s_lshl_b32 s14, s46, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s12, s12, s15
+; SI-NEXT:    s_or_b32 s12, s12, s14
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s12
@@ -3422,7 +3450,7 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s40, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x4c, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3436,7 +3464,7 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s14, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x54, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3450,12 +3478,12 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x5c, v0
 ; SI-NEXT:    v_mov_b32_e32 v1, s4
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    v_readlane_b32 s35, v12, 3
-; SI-NEXT:    v_readlane_b32 s34, v12, 2
-; SI-NEXT:    v_readlane_b32 s31, v12, 1
-; SI-NEXT:    v_readlane_b32 s30, v12, 0
+; SI-NEXT:    v_readlane_b32 s35, v20, 3
+; SI-NEXT:    v_readlane_b32 s34, v20, 2
+; SI-NEXT:    v_readlane_b32 s31, v20, 1
+; SI-NEXT:    v_readlane_b32 s30, v20, 0
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 ; 4-byte Folded Reload
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -3480,16 +3508,44 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr91
 ; SI-NEXT:    ; implicit-def: $sgpr42
 ; SI-NEXT:    ; implicit-def: $sgpr90
-; SI-NEXT:    ; implicit-def: $sgpr40
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr89
-; SI-NEXT:    ; implicit-def: $sgpr14
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr88
 ; SI-NEXT:    s_branch .LBB13_2
 ;
 ; VI-LABEL: bitcast_v24i32_to_v48i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v11, s16
+; VI-NEXT:    v_mov_b32_e32 v12, s17
+; VI-NEXT:    v_mov_b32_e32 v13, s18
+; VI-NEXT:    v_mov_b32_e32 v14, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s20
+; VI-NEXT:    v_mov_b32_e32 v16, s21
+; VI-NEXT:    v_mov_b32_e32 v17, s22
+; VI-NEXT:    v_mov_b32_e32 v18, s23
+; VI-NEXT:    v_mov_b32_e32 v19, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v11
+; VI-NEXT:    v_mov_b32_e32 v11, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v12
+; VI-NEXT:    v_mov_b32_e32 v12, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v13
+; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v14
+; VI-NEXT:    v_mov_b32_e32 v14, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; VI-NEXT:    v_readfirstlane_b32 s24, v16
+; VI-NEXT:    v_readfirstlane_b32 s23, v17
+; VI-NEXT:    v_readfirstlane_b32 s22, v18
+; VI-NEXT:    v_readfirstlane_b32 s21, v19
+; VI-NEXT:    v_readfirstlane_b32 s20, v11
+; VI-NEXT:    v_readfirstlane_b32 s19, v12
+; VI-NEXT:    v_readfirstlane_b32 s18, v13
+; VI-NEXT:    v_readfirstlane_b32 s17, v14
+; VI-NEXT:    v_readfirstlane_b32 s16, v15
 ; VI-NEXT:    v_readfirstlane_b32 s15, v0
 ; VI-NEXT:    v_readfirstlane_b32 s14, v1
 ; VI-NEXT:    v_readfirstlane_b32 s13, v2
@@ -3503,9 +3559,9 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; VI-NEXT:    v_readfirstlane_b32 s7, v9
 ; VI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s40, s7, 16
-; VI-NEXT:    s_lshr_b32 s41, s6, 16
-; VI-NEXT:    s_lshr_b32 s42, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s43, s9, 16
 ; VI-NEXT:    s_lshr_b32 s44, s10, 16
 ; VI-NEXT:    s_lshr_b32 s45, s11, 16
@@ -3513,20 +3569,20 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s47, s13, 16
 ; VI-NEXT:    s_lshr_b32 s56, s14, 16
 ; VI-NEXT:    s_lshr_b32 s57, s15, 16
-; VI-NEXT:    s_lshr_b32 s58, s29, 16
-; VI-NEXT:    s_lshr_b32 s59, s28, 16
-; VI-NEXT:    s_lshr_b32 s60, s27, 16
-; VI-NEXT:    s_lshr_b32 s61, s26, 16
-; VI-NEXT:    s_lshr_b32 s62, s25, 16
-; VI-NEXT:    s_lshr_b32 s63, s24, 16
-; VI-NEXT:    s_lshr_b32 s72, s23, 16
-; VI-NEXT:    s_lshr_b32 s73, s22, 16
-; VI-NEXT:    s_lshr_b32 s74, s21, 16
-; VI-NEXT:    s_lshr_b32 s75, s20, 16
-; VI-NEXT:    s_lshr_b32 s76, s19, 16
-; VI-NEXT:    s_lshr_b32 s77, s18, 16
-; VI-NEXT:    s_lshr_b32 s78, s17, 16
-; VI-NEXT:    s_lshr_b32 s79, s16, 16
+; VI-NEXT:    s_lshr_b32 s58, s16, 16
+; VI-NEXT:    s_lshr_b32 s59, s17, 16
+; VI-NEXT:    s_lshr_b32 s60, s18, 16
+; VI-NEXT:    s_lshr_b32 s61, s19, 16
+; VI-NEXT:    s_lshr_b32 s62, s20, 16
+; VI-NEXT:    s_lshr_b32 s63, s21, 16
+; VI-NEXT:    s_lshr_b32 s72, s22, 16
+; VI-NEXT:    s_lshr_b32 s73, s23, 16
+; VI-NEXT:    s_lshr_b32 s74, s24, 16
+; VI-NEXT:    s_lshr_b32 s75, s25, 16
+; VI-NEXT:    s_lshr_b32 s76, s26, 16
+; VI-NEXT:    s_lshr_b32 s77, s40, 16
+; VI-NEXT:    s_lshr_b32 s78, s41, 16
+; VI-NEXT:    s_lshr_b32 s79, s42, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB13_3
 ; VI-NEXT:  .LBB13_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -3539,23 +3595,23 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; VI-NEXT:    s_add_i32 s13, s13, 3
 ; VI-NEXT:    s_add_i32 s14, s14, 3
 ; VI-NEXT:    s_add_i32 s15, s15, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
 ; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s40, s7, 16
-; VI-NEXT:    s_lshr_b32 s41, s6, 16
-; VI-NEXT:    s_lshr_b32 s42, s8, 16
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
+; VI-NEXT:    s_add_i32 s40, s40, 3
+; VI-NEXT:    s_add_i32 s41, s41, 3
+; VI-NEXT:    s_add_i32 s42, s42, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s43, s9, 16
 ; VI-NEXT:    s_lshr_b32 s44, s10, 16
 ; VI-NEXT:    s_lshr_b32 s45, s11, 16
@@ -3563,107 +3619,107 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s47, s13, 16
 ; VI-NEXT:    s_lshr_b32 s56, s14, 16
 ; VI-NEXT:    s_lshr_b32 s57, s15, 16
-; VI-NEXT:    s_lshr_b32 s58, s29, 16
-; VI-NEXT:    s_lshr_b32 s59, s28, 16
-; VI-NEXT:    s_lshr_b32 s60, s27, 16
-; VI-NEXT:    s_lshr_b32 s61, s26, 16
-; VI-NEXT:    s_lshr_b32 s62, s25, 16
-; VI-NEXT:    s_lshr_b32 s63, s24, 16
-; VI-NEXT:    s_lshr_b32 s72, s23, 16
-; VI-NEXT:    s_lshr_b32 s73, s22, 16
-; VI-NEXT:    s_lshr_b32 s74, s21, 16
-; VI-NEXT:    s_lshr_b32 s75, s20, 16
-; VI-NEXT:    s_lshr_b32 s76, s19, 16
-; VI-NEXT:    s_lshr_b32 s77, s18, 16
-; VI-NEXT:    s_lshr_b32 s78, s17, 16
-; VI-NEXT:    s_lshr_b32 s79, s16, 16
+; VI-NEXT:    s_lshr_b32 s58, s16, 16
+; VI-NEXT:    s_lshr_b32 s59, s17, 16
+; VI-NEXT:    s_lshr_b32 s60, s18, 16
+; VI-NEXT:    s_lshr_b32 s61, s19, 16
+; VI-NEXT:    s_lshr_b32 s62, s20, 16
+; VI-NEXT:    s_lshr_b32 s63, s21, 16
+; VI-NEXT:    s_lshr_b32 s72, s22, 16
+; VI-NEXT:    s_lshr_b32 s73, s23, 16
+; VI-NEXT:    s_lshr_b32 s74, s24, 16
+; VI-NEXT:    s_lshr_b32 s75, s25, 16
+; VI-NEXT:    s_lshr_b32 s76, s26, 16
+; VI-NEXT:    s_lshr_b32 s77, s40, 16
+; VI-NEXT:    s_lshr_b32 s78, s41, 16
+; VI-NEXT:    s_lshr_b32 s79, s42, 16
 ; VI-NEXT:  .LBB13_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s42
 ; VI-NEXT:    s_lshl_b32 s5, s79, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s78, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s77, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s76, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s75, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s74, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s73, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s72, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s63, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s62, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s61, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s60, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s59, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s58, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s5, 0xffff, s41
+; VI-NEXT:    s_lshl_b32 s41, s78, 16
+; VI-NEXT:    s_or_b32 s5, s5, s41
+; VI-NEXT:    s_and_b32 s40, 0xffff, s40
+; VI-NEXT:    s_lshl_b32 s41, s77, 16
+; VI-NEXT:    s_or_b32 s40, s40, s41
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s41, s76, 16
+; VI-NEXT:    s_or_b32 s26, s26, s41
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s41, s75, 16
+; VI-NEXT:    s_or_b32 s25, s25, s41
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s41, s74, 16
+; VI-NEXT:    s_or_b32 s24, s24, s41
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s41, s73, 16
+; VI-NEXT:    s_or_b32 s23, s23, s41
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s41, s72, 16
+; VI-NEXT:    s_or_b32 s22, s22, s41
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s41, s63, 16
+; VI-NEXT:    s_or_b32 s21, s21, s41
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s41, s62, 16
+; VI-NEXT:    s_or_b32 s20, s20, s41
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s41, s61, 16
+; VI-NEXT:    s_or_b32 s19, s19, s41
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s41, s60, 16
+; VI-NEXT:    s_or_b32 s18, s18, s41
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s41, s59, 16
+; VI-NEXT:    s_or_b32 s17, s17, s41
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s41, s58, 16
+; VI-NEXT:    s_or_b32 s16, s16, s41
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s28, s57, 16
-; VI-NEXT:    s_or_b32 s15, s15, s28
+; VI-NEXT:    s_lshl_b32 s41, s57, 16
+; VI-NEXT:    s_or_b32 s15, s15, s41
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s28, s56, 16
-; VI-NEXT:    s_or_b32 s14, s14, s28
+; VI-NEXT:    s_lshl_b32 s41, s56, 16
+; VI-NEXT:    s_or_b32 s14, s14, s41
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s28, s47, 16
-; VI-NEXT:    s_or_b32 s13, s13, s28
+; VI-NEXT:    s_lshl_b32 s41, s47, 16
+; VI-NEXT:    s_or_b32 s13, s13, s41
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s28, s46, 16
-; VI-NEXT:    s_or_b32 s12, s12, s28
+; VI-NEXT:    s_lshl_b32 s41, s46, 16
+; VI-NEXT:    s_or_b32 s12, s12, s41
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s45, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s41, s45, 16
+; VI-NEXT:    s_or_b32 s11, s11, s41
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s44, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
+; VI-NEXT:    s_lshl_b32 s41, s44, 16
+; VI-NEXT:    s_or_b32 s10, s10, s41
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s28, s43, 16
-; VI-NEXT:    s_or_b32 s9, s9, s28
+; VI-NEXT:    s_lshl_b32 s41, s43, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s8, s8, s28
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
-; VI-NEXT:    s_or_b32 s7, s7, s28
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s41
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s40
+; VI-NEXT:    v_mov_b32_e32 v3, s26
+; VI-NEXT:    v_mov_b32_e32 v4, s25
+; VI-NEXT:    v_mov_b32_e32 v5, s24
+; VI-NEXT:    v_mov_b32_e32 v6, s23
+; VI-NEXT:    v_mov_b32_e32 v7, s22
+; VI-NEXT:    v_mov_b32_e32 v8, s21
+; VI-NEXT:    v_mov_b32_e32 v9, s20
+; VI-NEXT:    v_mov_b32_e32 v10, s19
+; VI-NEXT:    v_mov_b32_e32 v11, s18
+; VI-NEXT:    v_mov_b32_e32 v12, s17
+; VI-NEXT:    v_mov_b32_e32 v13, s16
 ; VI-NEXT:    v_mov_b32_e32 v14, s15
 ; VI-NEXT:    v_mov_b32_e32 v15, s14
 ; VI-NEXT:    v_mov_b32_e32 v16, s13
@@ -3697,64 +3753,82 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr45
 ; VI-NEXT:    ; implicit-def: $sgpr44
 ; VI-NEXT:    ; implicit-def: $sgpr43
-; VI-NEXT:    ; implicit-def: $sgpr42
-; VI-NEXT:    ; implicit-def: $sgpr41
-; VI-NEXT:    ; implicit-def: $sgpr40
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB13_2
 ;
 ; GFX9-LABEL: bitcast_v24i32_to_v48i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v11, s16
+; GFX9-NEXT:    v_mov_b32_e32 v12, s17
+; GFX9-NEXT:    v_mov_b32_e32 v13, s18
+; GFX9-NEXT:    v_mov_b32_e32 v14, s19
+; GFX9-NEXT:    v_mov_b32_e32 v15, s20
+; GFX9-NEXT:    v_mov_b32_e32 v16, s21
+; GFX9-NEXT:    v_mov_b32_e32 v17, s22
+; GFX9-NEXT:    v_mov_b32_e32 v18, s23
+; GFX9-NEXT:    v_mov_b32_e32 v19, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v11
+; GFX9-NEXT:    v_mov_b32_e32 v11, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v12
+; GFX9-NEXT:    v_mov_b32_e32 v12, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v13
+; GFX9-NEXT:    v_mov_b32_e32 v13, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v14
+; GFX9-NEXT:    v_mov_b32_e32 v14, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s40, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB13_3
 ; GFX9-NEXT:  .LBB13_2: ; %cmp.true
-; GFX9-NEXT:    s_add_i32 s15, s15, 3
-; GFX9-NEXT:    s_add_i32 s14, s14, 3
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_add_i32 s29, s29, 3
 ; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
@@ -3769,79 +3843,89 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
-; GFX9-NEXT:    s_lshr_b32 s40, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s16, 16
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
+; GFX9-NEXT:    s_lshr_b32 s40, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s6, 16
 ; GFX9-NEXT:  .LBB13_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s40
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB13_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr79
@@ -3873,37 +3957,64 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; GFX11-LABEL: bitcast_v24i32_to_v48i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v7, s0 :: v_dual_mov_b32 v8, s1
+; GFX11-NEXT:    v_dual_mov_b32 v9, s2 :: v_dual_mov_b32 v10, s3
+; GFX11-NEXT:    v_dual_mov_b32 v11, s16 :: v_dual_mov_b32 v12, s17
+; GFX11-NEXT:    v_dual_mov_b32 v13, s18 :: v_dual_mov_b32 v14, s19
+; GFX11-NEXT:    v_dual_mov_b32 v15, s20 :: v_dual_mov_b32 v16, s21
+; GFX11-NEXT:    v_dual_mov_b32 v17, s22 :: v_dual_mov_b32 v18, s23
+; GFX11-NEXT:    v_dual_mov_b32 v19, s24 :: v_dual_mov_b32 v20, s25
+; GFX11-NEXT:    v_dual_mov_b32 v21, s26 :: v_dual_mov_b32 v22, s27
+; GFX11-NEXT:    v_dual_mov_b32 v23, s28 :: v_dual_mov_b32 v24, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v5
 ; GFX11-NEXT:    s_mov_b32 s74, 0
-; GFX11-NEXT:    s_and_b32 s10, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s24, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s10, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s62, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s63, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s72, s1, 16
@@ -3911,50 +4022,50 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s74
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB13_3
 ; GFX11-NEXT:  .LBB13_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s8, s8, 3
-; GFX11-NEXT:    s_add_i32 s9, s9, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
-; GFX11-NEXT:    s_add_i32 s26, s26, 3
-; GFX11-NEXT:    s_add_i32 s25, s25, 3
-; GFX11-NEXT:    s_add_i32 s24, s24, 3
-; GFX11-NEXT:    s_add_i32 s23, s23, 3
 ; GFX11-NEXT:    s_add_i32 s22, s22, 3
+; GFX11-NEXT:    s_add_i32 s23, s23, 3
 ; GFX11-NEXT:    s_add_i32 s21, s21, 3
 ; GFX11-NEXT:    s_add_i32 s20, s20, 3
 ; GFX11-NEXT:    s_add_i32 s19, s19, 3
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s10, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s62, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s63, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s72, s1, 16
@@ -3965,38 +4076,38 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s72
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s63
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s10
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s24
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s9 :: v_dual_mov_b32 v23, s8
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s23 :: v_dual_mov_b32 v23, s22
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB13_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr73
@@ -4017,12 +4128,12 @@ define inreg <48 x i16> @bitcast_v24i32_to_v48i16_scalar(<24 x i32> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
 ; GFX11-NEXT:    s_branch .LBB13_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -4420,7 +4531,7 @@ define <24 x i32> @bitcast_v48i16_to_v24i32(<48 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v20, vcc, s6, v20
 ; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
 ; SI-NEXT:    v_add_i32_e32 v22, vcc, s6, v22
-; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
+; SI-NEXT:    v_add_i32_e32 v23, vcc, 0x30000, v23
 ; SI-NEXT:  .LBB14_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
@@ -7204,7 +7315,35 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; SI-LABEL: bitcast_v24i32_to_v48f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v12, s16
+; SI-NEXT:    v_mov_b32_e32 v13, s17
+; SI-NEXT:    v_mov_b32_e32 v14, s18
+; SI-NEXT:    v_mov_b32_e32 v15, s19
+; SI-NEXT:    v_mov_b32_e32 v16, s20
+; SI-NEXT:    v_mov_b32_e32 v17, s21
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s23, v12
+; SI-NEXT:    v_mov_b32_e32 v12, s24
+; SI-NEXT:    v_readfirstlane_b32 s24, v13
+; SI-NEXT:    v_mov_b32_e32 v13, s25
+; SI-NEXT:    v_readfirstlane_b32 s25, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s26
+; SI-NEXT:    v_readfirstlane_b32 s26, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s27
+; SI-NEXT:    v_readfirstlane_b32 s27, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s28
+; SI-NEXT:    v_readfirstlane_b32 s28, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
+; SI-NEXT:    v_readfirstlane_b32 s29, v18
+; SI-NEXT:    v_readfirstlane_b32 s22, v19
+; SI-NEXT:    v_readfirstlane_b32 s21, v12
+; SI-NEXT:    v_readfirstlane_b32 s20, v13
+; SI-NEXT:    v_readfirstlane_b32 s19, v14
+; SI-NEXT:    v_readfirstlane_b32 s18, v15
+; SI-NEXT:    v_readfirstlane_b32 s17, v16
+; SI-NEXT:    v_readfirstlane_b32 s16, v17
 ; SI-NEXT:    v_readfirstlane_b32 s15, v1
 ; SI-NEXT:    v_readfirstlane_b32 s14, v2
 ; SI-NEXT:    v_readfirstlane_b32 s13, v3
@@ -7239,33 +7378,33 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
 ; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
 ; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
+; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
+; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
+; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
+; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s4
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v40, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s9
@@ -7278,29 +7417,22 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, s23
 ; SI-NEXT:    s_cbranch_execnz .LBB17_3
 ; SI-NEXT:  .LBB17_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
 ; SI-NEXT:    s_add_i32 s23, s23, 3
 ; SI-NEXT:    s_add_i32 s24, s24, 3
 ; SI-NEXT:    s_add_i32 s25, s25, 3
@@ -7308,6 +7440,13 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; SI-NEXT:    s_add_i32 s27, s27, 3
 ; SI-NEXT:    s_add_i32 s28, s28, 3
 ; SI-NEXT:    s_add_i32 s29, s29, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
 ; SI-NEXT:    s_add_i32 s15, s15, 3
 ; SI-NEXT:    s_add_i32 s14, s14, 3
 ; SI-NEXT:    s_add_i32 s13, s13, 3
@@ -7318,20 +7457,20 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; SI-NEXT:    s_add_i32 s7, s7, 3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s9, s9, 3
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    s_lshr_b32 s5, s17, 16
-; SI-NEXT:    s_lshr_b32 s40, s18, 16
-; SI-NEXT:    s_lshr_b32 s41, s19, 16
-; SI-NEXT:    s_lshr_b32 s42, s20, 16
-; SI-NEXT:    s_lshr_b32 s43, s21, 16
-; SI-NEXT:    s_lshr_b32 s44, s22, 16
-; SI-NEXT:    s_lshr_b32 s45, s23, 16
-; SI-NEXT:    s_lshr_b32 s46, s24, 16
-; SI-NEXT:    s_lshr_b32 s47, s25, 16
-; SI-NEXT:    s_lshr_b32 s56, s26, 16
-; SI-NEXT:    s_lshr_b32 s57, s27, 16
-; SI-NEXT:    s_lshr_b32 s58, s28, 16
-; SI-NEXT:    s_lshr_b32 s59, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    s_lshr_b32 s5, s24, 16
+; SI-NEXT:    s_lshr_b32 s40, s25, 16
+; SI-NEXT:    s_lshr_b32 s41, s26, 16
+; SI-NEXT:    s_lshr_b32 s42, s27, 16
+; SI-NEXT:    s_lshr_b32 s43, s28, 16
+; SI-NEXT:    s_lshr_b32 s44, s29, 16
+; SI-NEXT:    s_lshr_b32 s45, s22, 16
+; SI-NEXT:    s_lshr_b32 s46, s21, 16
+; SI-NEXT:    s_lshr_b32 s47, s20, 16
+; SI-NEXT:    s_lshr_b32 s56, s19, 16
+; SI-NEXT:    s_lshr_b32 s57, s18, 16
+; SI-NEXT:    s_lshr_b32 s58, s17, 16
+; SI-NEXT:    s_lshr_b32 s59, s16, 16
 ; SI-NEXT:    s_lshr_b32 s60, s15, 16
 ; SI-NEXT:    s_lshr_b32 s61, s14, 16
 ; SI-NEXT:    s_lshr_b32 s62, s13, 16
@@ -7352,20 +7491,20 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, s23
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s77
 ; SI-NEXT:    v_cvt_f32_f16_e32 v2, s76
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s75
@@ -7616,7 +7755,35 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; VI-LABEL: bitcast_v24i32_to_v48f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v11, s16
+; VI-NEXT:    v_mov_b32_e32 v12, s17
+; VI-NEXT:    v_mov_b32_e32 v13, s18
+; VI-NEXT:    v_mov_b32_e32 v14, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s20
+; VI-NEXT:    v_mov_b32_e32 v16, s21
+; VI-NEXT:    v_mov_b32_e32 v17, s22
+; VI-NEXT:    v_mov_b32_e32 v18, s23
+; VI-NEXT:    v_mov_b32_e32 v19, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v11
+; VI-NEXT:    v_mov_b32_e32 v11, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v12
+; VI-NEXT:    v_mov_b32_e32 v12, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v13
+; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v14
+; VI-NEXT:    v_mov_b32_e32 v14, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; VI-NEXT:    v_readfirstlane_b32 s24, v16
+; VI-NEXT:    v_readfirstlane_b32 s23, v17
+; VI-NEXT:    v_readfirstlane_b32 s22, v18
+; VI-NEXT:    v_readfirstlane_b32 s21, v19
+; VI-NEXT:    v_readfirstlane_b32 s20, v11
+; VI-NEXT:    v_readfirstlane_b32 s19, v12
+; VI-NEXT:    v_readfirstlane_b32 s18, v13
+; VI-NEXT:    v_readfirstlane_b32 s17, v14
+; VI-NEXT:    v_readfirstlane_b32 s16, v15
 ; VI-NEXT:    v_readfirstlane_b32 s15, v0
 ; VI-NEXT:    v_readfirstlane_b32 s14, v1
 ; VI-NEXT:    v_readfirstlane_b32 s13, v2
@@ -7630,9 +7797,9 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; VI-NEXT:    v_readfirstlane_b32 s7, v9
 ; VI-NEXT:    s_cbranch_scc0 .LBB17_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s40, s7, 16
-; VI-NEXT:    s_lshr_b32 s41, s6, 16
-; VI-NEXT:    s_lshr_b32 s42, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s43, s9, 16
 ; VI-NEXT:    s_lshr_b32 s44, s10, 16
 ; VI-NEXT:    s_lshr_b32 s45, s11, 16
@@ -7640,20 +7807,20 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s47, s13, 16
 ; VI-NEXT:    s_lshr_b32 s56, s14, 16
 ; VI-NEXT:    s_lshr_b32 s57, s15, 16
-; VI-NEXT:    s_lshr_b32 s58, s29, 16
-; VI-NEXT:    s_lshr_b32 s59, s28, 16
-; VI-NEXT:    s_lshr_b32 s60, s27, 16
-; VI-NEXT:    s_lshr_b32 s61, s26, 16
-; VI-NEXT:    s_lshr_b32 s62, s25, 16
-; VI-NEXT:    s_lshr_b32 s63, s24, 16
-; VI-NEXT:    s_lshr_b32 s72, s23, 16
-; VI-NEXT:    s_lshr_b32 s73, s22, 16
-; VI-NEXT:    s_lshr_b32 s74, s21, 16
-; VI-NEXT:    s_lshr_b32 s75, s20, 16
-; VI-NEXT:    s_lshr_b32 s76, s19, 16
-; VI-NEXT:    s_lshr_b32 s77, s18, 16
-; VI-NEXT:    s_lshr_b32 s78, s17, 16
-; VI-NEXT:    s_lshr_b32 s79, s16, 16
+; VI-NEXT:    s_lshr_b32 s58, s16, 16
+; VI-NEXT:    s_lshr_b32 s59, s17, 16
+; VI-NEXT:    s_lshr_b32 s60, s18, 16
+; VI-NEXT:    s_lshr_b32 s61, s19, 16
+; VI-NEXT:    s_lshr_b32 s62, s20, 16
+; VI-NEXT:    s_lshr_b32 s63, s21, 16
+; VI-NEXT:    s_lshr_b32 s72, s22, 16
+; VI-NEXT:    s_lshr_b32 s73, s23, 16
+; VI-NEXT:    s_lshr_b32 s74, s24, 16
+; VI-NEXT:    s_lshr_b32 s75, s25, 16
+; VI-NEXT:    s_lshr_b32 s76, s26, 16
+; VI-NEXT:    s_lshr_b32 s77, s40, 16
+; VI-NEXT:    s_lshr_b32 s78, s41, 16
+; VI-NEXT:    s_lshr_b32 s79, s42, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB17_3
 ; VI-NEXT:  .LBB17_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -7666,23 +7833,23 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; VI-NEXT:    s_add_i32 s13, s13, 3
 ; VI-NEXT:    s_add_i32 s14, s14, 3
 ; VI-NEXT:    s_add_i32 s15, s15, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
 ; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s40, s7, 16
-; VI-NEXT:    s_lshr_b32 s41, s6, 16
-; VI-NEXT:    s_lshr_b32 s42, s8, 16
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
+; VI-NEXT:    s_add_i32 s40, s40, 3
+; VI-NEXT:    s_add_i32 s41, s41, 3
+; VI-NEXT:    s_add_i32 s42, s42, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s43, s9, 16
 ; VI-NEXT:    s_lshr_b32 s44, s10, 16
 ; VI-NEXT:    s_lshr_b32 s45, s11, 16
@@ -7690,107 +7857,107 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s47, s13, 16
 ; VI-NEXT:    s_lshr_b32 s56, s14, 16
 ; VI-NEXT:    s_lshr_b32 s57, s15, 16
-; VI-NEXT:    s_lshr_b32 s58, s29, 16
-; VI-NEXT:    s_lshr_b32 s59, s28, 16
-; VI-NEXT:    s_lshr_b32 s60, s27, 16
-; VI-NEXT:    s_lshr_b32 s61, s26, 16
-; VI-NEXT:    s_lshr_b32 s62, s25, 16
-; VI-NEXT:    s_lshr_b32 s63, s24, 16
-; VI-NEXT:    s_lshr_b32 s72, s23, 16
-; VI-NEXT:    s_lshr_b32 s73, s22, 16
-; VI-NEXT:    s_lshr_b32 s74, s21, 16
-; VI-NEXT:    s_lshr_b32 s75, s20, 16
-; VI-NEXT:    s_lshr_b32 s76, s19, 16
-; VI-NEXT:    s_lshr_b32 s77, s18, 16
-; VI-NEXT:    s_lshr_b32 s78, s17, 16
-; VI-NEXT:    s_lshr_b32 s79, s16, 16
+; VI-NEXT:    s_lshr_b32 s58, s16, 16
+; VI-NEXT:    s_lshr_b32 s59, s17, 16
+; VI-NEXT:    s_lshr_b32 s60, s18, 16
+; VI-NEXT:    s_lshr_b32 s61, s19, 16
+; VI-NEXT:    s_lshr_b32 s62, s20, 16
+; VI-NEXT:    s_lshr_b32 s63, s21, 16
+; VI-NEXT:    s_lshr_b32 s72, s22, 16
+; VI-NEXT:    s_lshr_b32 s73, s23, 16
+; VI-NEXT:    s_lshr_b32 s74, s24, 16
+; VI-NEXT:    s_lshr_b32 s75, s25, 16
+; VI-NEXT:    s_lshr_b32 s76, s26, 16
+; VI-NEXT:    s_lshr_b32 s77, s40, 16
+; VI-NEXT:    s_lshr_b32 s78, s41, 16
+; VI-NEXT:    s_lshr_b32 s79, s42, 16
 ; VI-NEXT:  .LBB17_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s42
 ; VI-NEXT:    s_lshl_b32 s5, s79, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s78, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s77, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s76, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s75, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s74, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s73, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s72, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s63, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s62, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s61, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s60, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s59, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s58, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s5, 0xffff, s41
+; VI-NEXT:    s_lshl_b32 s41, s78, 16
+; VI-NEXT:    s_or_b32 s5, s5, s41
+; VI-NEXT:    s_and_b32 s40, 0xffff, s40
+; VI-NEXT:    s_lshl_b32 s41, s77, 16
+; VI-NEXT:    s_or_b32 s40, s40, s41
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s41, s76, 16
+; VI-NEXT:    s_or_b32 s26, s26, s41
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s41, s75, 16
+; VI-NEXT:    s_or_b32 s25, s25, s41
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s41, s74, 16
+; VI-NEXT:    s_or_b32 s24, s24, s41
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s41, s73, 16
+; VI-NEXT:    s_or_b32 s23, s23, s41
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s41, s72, 16
+; VI-NEXT:    s_or_b32 s22, s22, s41
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s41, s63, 16
+; VI-NEXT:    s_or_b32 s21, s21, s41
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s41, s62, 16
+; VI-NEXT:    s_or_b32 s20, s20, s41
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s41, s61, 16
+; VI-NEXT:    s_or_b32 s19, s19, s41
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s41, s60, 16
+; VI-NEXT:    s_or_b32 s18, s18, s41
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s41, s59, 16
+; VI-NEXT:    s_or_b32 s17, s17, s41
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s41, s58, 16
+; VI-NEXT:    s_or_b32 s16, s16, s41
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s28, s57, 16
-; VI-NEXT:    s_or_b32 s15, s15, s28
+; VI-NEXT:    s_lshl_b32 s41, s57, 16
+; VI-NEXT:    s_or_b32 s15, s15, s41
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s28, s56, 16
-; VI-NEXT:    s_or_b32 s14, s14, s28
+; VI-NEXT:    s_lshl_b32 s41, s56, 16
+; VI-NEXT:    s_or_b32 s14, s14, s41
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s28, s47, 16
-; VI-NEXT:    s_or_b32 s13, s13, s28
+; VI-NEXT:    s_lshl_b32 s41, s47, 16
+; VI-NEXT:    s_or_b32 s13, s13, s41
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s28, s46, 16
-; VI-NEXT:    s_or_b32 s12, s12, s28
+; VI-NEXT:    s_lshl_b32 s41, s46, 16
+; VI-NEXT:    s_or_b32 s12, s12, s41
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s45, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s41, s45, 16
+; VI-NEXT:    s_or_b32 s11, s11, s41
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s44, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
+; VI-NEXT:    s_lshl_b32 s41, s44, 16
+; VI-NEXT:    s_or_b32 s10, s10, s41
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s28, s43, 16
-; VI-NEXT:    s_or_b32 s9, s9, s28
+; VI-NEXT:    s_lshl_b32 s41, s43, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s8, s8, s28
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
-; VI-NEXT:    s_or_b32 s7, s7, s28
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s41
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s40
+; VI-NEXT:    v_mov_b32_e32 v3, s26
+; VI-NEXT:    v_mov_b32_e32 v4, s25
+; VI-NEXT:    v_mov_b32_e32 v5, s24
+; VI-NEXT:    v_mov_b32_e32 v6, s23
+; VI-NEXT:    v_mov_b32_e32 v7, s22
+; VI-NEXT:    v_mov_b32_e32 v8, s21
+; VI-NEXT:    v_mov_b32_e32 v9, s20
+; VI-NEXT:    v_mov_b32_e32 v10, s19
+; VI-NEXT:    v_mov_b32_e32 v11, s18
+; VI-NEXT:    v_mov_b32_e32 v12, s17
+; VI-NEXT:    v_mov_b32_e32 v13, s16
 ; VI-NEXT:    v_mov_b32_e32 v14, s15
 ; VI-NEXT:    v_mov_b32_e32 v15, s14
 ; VI-NEXT:    v_mov_b32_e32 v16, s13
@@ -7824,64 +7991,82 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr45
 ; VI-NEXT:    ; implicit-def: $sgpr44
 ; VI-NEXT:    ; implicit-def: $sgpr43
-; VI-NEXT:    ; implicit-def: $sgpr42
-; VI-NEXT:    ; implicit-def: $sgpr41
-; VI-NEXT:    ; implicit-def: $sgpr40
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB17_2
 ;
 ; GFX9-LABEL: bitcast_v24i32_to_v48f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v11, s16
+; GFX9-NEXT:    v_mov_b32_e32 v12, s17
+; GFX9-NEXT:    v_mov_b32_e32 v13, s18
+; GFX9-NEXT:    v_mov_b32_e32 v14, s19
+; GFX9-NEXT:    v_mov_b32_e32 v15, s20
+; GFX9-NEXT:    v_mov_b32_e32 v16, s21
+; GFX9-NEXT:    v_mov_b32_e32 v17, s22
+; GFX9-NEXT:    v_mov_b32_e32 v18, s23
+; GFX9-NEXT:    v_mov_b32_e32 v19, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v11
+; GFX9-NEXT:    v_mov_b32_e32 v11, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v12
+; GFX9-NEXT:    v_mov_b32_e32 v12, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v13
+; GFX9-NEXT:    v_mov_b32_e32 v13, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v14
+; GFX9-NEXT:    v_mov_b32_e32 v14, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s40, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB17_3
 ; GFX9-NEXT:  .LBB17_2: ; %cmp.true
-; GFX9-NEXT:    s_add_i32 s15, s15, 3
-; GFX9-NEXT:    s_add_i32 s14, s14, 3
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_add_i32 s29, s29, 3
 ; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
@@ -7896,79 +8081,89 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
-; GFX9-NEXT:    s_lshr_b32 s40, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s16, 16
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
+; GFX9-NEXT:    s_lshr_b32 s40, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s6, 16
 ; GFX9-NEXT:  .LBB17_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s40
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB17_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr79
@@ -8000,37 +8195,64 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; GFX11-LABEL: bitcast_v24i32_to_v48f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v7, s0 :: v_dual_mov_b32 v8, s1
+; GFX11-NEXT:    v_dual_mov_b32 v9, s2 :: v_dual_mov_b32 v10, s3
+; GFX11-NEXT:    v_dual_mov_b32 v11, s16 :: v_dual_mov_b32 v12, s17
+; GFX11-NEXT:    v_dual_mov_b32 v13, s18 :: v_dual_mov_b32 v14, s19
+; GFX11-NEXT:    v_dual_mov_b32 v15, s20 :: v_dual_mov_b32 v16, s21
+; GFX11-NEXT:    v_dual_mov_b32 v17, s22 :: v_dual_mov_b32 v18, s23
+; GFX11-NEXT:    v_dual_mov_b32 v19, s24 :: v_dual_mov_b32 v20, s25
+; GFX11-NEXT:    v_dual_mov_b32 v21, s26 :: v_dual_mov_b32 v22, s27
+; GFX11-NEXT:    v_dual_mov_b32 v23, s28 :: v_dual_mov_b32 v24, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v5
 ; GFX11-NEXT:    s_mov_b32 s74, 0
-; GFX11-NEXT:    s_and_b32 s10, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s24, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s10, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s62, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s63, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s72, s1, 16
@@ -8038,50 +8260,50 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s74
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB17_3
 ; GFX11-NEXT:  .LBB17_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s8, s8, 3
-; GFX11-NEXT:    s_add_i32 s9, s9, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
-; GFX11-NEXT:    s_add_i32 s26, s26, 3
-; GFX11-NEXT:    s_add_i32 s25, s25, 3
-; GFX11-NEXT:    s_add_i32 s24, s24, 3
-; GFX11-NEXT:    s_add_i32 s23, s23, 3
 ; GFX11-NEXT:    s_add_i32 s22, s22, 3
+; GFX11-NEXT:    s_add_i32 s23, s23, 3
 ; GFX11-NEXT:    s_add_i32 s21, s21, 3
 ; GFX11-NEXT:    s_add_i32 s20, s20, 3
 ; GFX11-NEXT:    s_add_i32 s19, s19, 3
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s10, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s62, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s63, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s72, s1, 16
@@ -8092,38 +8314,38 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s72
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s63
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s10
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s24
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s9 :: v_dual_mov_b32 v23, s8
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s23 :: v_dual_mov_b32 v23, s22
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB17_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr73
@@ -8144,12 +8366,12 @@ define inreg <48 x half> @bitcast_v24i32_to_v48f16_scalar(<24 x i32> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
 ; GFX11-NEXT:    s_branch .LBB17_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -14250,7 +14472,7 @@ define <24 x float> @bitcast_v48i16_to_v24f32(<48 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v20, vcc, s6, v20
 ; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
 ; SI-NEXT:    v_add_i32_e32 v22, vcc, s6, v22
-; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
+; SI-NEXT:    v_add_i32_e32 v23, vcc, 0x30000, v23
 ; SI-NEXT:  .LBB30_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
@@ -17011,440 +17233,502 @@ define inreg <48 x half> @bitcast_v24f32_to_v48f16_scalar(<24 x float> inreg %a,
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; SI-NEXT:    v_readfirstlane_b32 s15, v1
-; SI-NEXT:    v_readfirstlane_b32 s14, v2
-; SI-NEXT:    v_readfirstlane_b32 s13, v3
-; SI-NEXT:    v_readfirstlane_b32 s12, v4
-; SI-NEXT:    v_readfirstlane_b32 s11, v5
-; SI-NEXT:    v_readfirstlane_b32 s10, v6
-; SI-NEXT:    v_readfirstlane_b32 s8, v7
-; SI-NEXT:    v_readfirstlane_b32 s7, v8
-; SI-NEXT:    v_readfirstlane_b32 s6, v9
+; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    v_mov_b32_e32 v18, s16
+; SI-NEXT:    v_mov_b32_e32 v15, s17
+; SI-NEXT:    v_mov_b32_e32 v13, s18
+; SI-NEXT:    v_mov_b32_e32 v12, s19
+; SI-NEXT:    s_waitcnt expcnt(1)
+; SI-NEXT:    v_mov_b32_e32 v62, s20
+; SI-NEXT:    v_mov_b32_e32 v59, s21
+; SI-NEXT:    v_mov_b32_e32 v58, s22
+; SI-NEXT:    v_mov_b32_e32 v57, s23
+; SI-NEXT:    v_mov_b32_e32 v16, s24
 ; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s9, v10
-; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v60, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_mov_b32_e32 v14, s26
+; SI-NEXT:    v_mov_b32_e32 v11, s27
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v63, s28
+; SI-NEXT:    v_mov_b32_e32 v60, s29
 ; SI-NEXT:    s_cbranch_scc0 .LBB33_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s4, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s4
-; SI-NEXT:    s_lshr_b32 s4, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s4
-; SI-NEXT:    s_lshr_b32 s4, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s4
-; SI-NEXT:    s_lshr_b32 s4, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s4
-; SI-NEXT:    s_lshr_b32 s4, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s4
-; SI-NEXT:    s_lshr_b32 s4, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s4
-; SI-NEXT:    s_lshr_b32 s4, s12, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
-; SI-NEXT:    s_lshr_b32 s4, s13, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s4
-; SI-NEXT:    s_lshr_b32 s4, s14, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
-; SI-NEXT:    s_lshr_b32 s4, s15, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v1
+; SI-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v63
+; SI-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v63
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v62
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v17
+; SI-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v58
+; SI-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v62
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v12
+; SI-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v15
+; SI-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v5
+; SI-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v4
+; SI-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v3
+; SI-NEXT:    buffer_store_dword v19, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v18
 ; SI-NEXT:    s_cbranch_execnz .LBB33_3
 ; SI-NEXT:  .LBB33_2: ; %cmp.true
-; SI-NEXT:    v_add_f32_e64 v1, s16, 1.0
-; SI-NEXT:    v_add_f32_e64 v2, s17, 1.0
-; SI-NEXT:    v_add_f32_e64 v3, s18, 1.0
-; SI-NEXT:    v_add_f32_e64 v5, s19, 1.0
-; SI-NEXT:    v_add_f32_e64 v7, s20, 1.0
-; SI-NEXT:    v_add_f32_e64 v10, s21, 1.0
-; SI-NEXT:    v_add_f32_e64 v12, s22, 1.0
-; SI-NEXT:    v_add_f32_e64 v14, s23, 1.0
-; SI-NEXT:    v_add_f32_e64 v16, s24, 1.0
-; SI-NEXT:    v_add_f32_e64 v18, s25, 1.0
-; SI-NEXT:    v_add_f32_e64 v20, s26, 1.0
-; SI-NEXT:    v_add_f32_e64 v22, s27, 1.0
-; SI-NEXT:    v_add_f32_e64 v25, s28, 1.0
-; SI-NEXT:    v_add_f32_e64 v23, s29, 1.0
-; SI-NEXT:    v_add_f32_e64 v21, s15, 1.0
-; SI-NEXT:    v_add_f32_e64 v19, s14, 1.0
-; SI-NEXT:    v_add_f32_e64 v17, s13, 1.0
-; SI-NEXT:    v_add_f32_e64 v15, s12, 1.0
-; SI-NEXT:    v_add_f32_e64 v13, s11, 1.0
-; SI-NEXT:    v_add_f32_e64 v11, s10, 1.0
-; SI-NEXT:    v_add_f32_e64 v9, s8, 1.0
-; SI-NEXT:    v_add_f32_e64 v8, s7, 1.0
-; SI-NEXT:    v_add_f32_e64 v6, s6, 1.0
-; SI-NEXT:    v_add_f32_e64 v4, s9, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v3
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v5
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v7
-; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v10
-; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
-; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v25
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v23
-; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v21
-; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v19
-; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v17
-; SI-NEXT:    s_waitcnt expcnt(6)
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v15
-; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v13
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v11
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v9
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v8
-; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v6
-; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_add_f32_e32 v7, 1.0, v7
+; SI-NEXT:    v_add_f32_e32 v1, 1.0, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v7
+; SI-NEXT:    v_add_f32_e32 v24, 1.0, v57
+; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v21
+; SI-NEXT:    v_add_f32_e32 v18, 1.0, v18
+; SI-NEXT:    v_add_f32_e32 v15, 1.0, v15
+; SI-NEXT:    v_add_f32_e32 v13, 1.0, v13
+; SI-NEXT:    v_add_f32_e32 v12, 1.0, v12
+; SI-NEXT:    v_add_f32_e32 v19, 1.0, v62
+; SI-NEXT:    v_add_f32_e32 v20, 1.0, v59
+; SI-NEXT:    v_add_f32_e32 v22, 1.0, v58
+; SI-NEXT:    v_add_f32_e32 v16, 1.0, v16
+; SI-NEXT:    v_add_f32_e32 v17, 1.0, v17
+; SI-NEXT:    v_add_f32_e32 v14, 1.0, v14
+; SI-NEXT:    v_add_f32_e32 v11, 1.0, v11
+; SI-NEXT:    v_add_f32_e32 v26, 1.0, v63
+; SI-NEXT:    v_add_f32_e32 v28, 1.0, v60
+; SI-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; SI-NEXT:    v_add_f32_e32 v3, 1.0, v3
+; SI-NEXT:    v_add_f32_e32 v4, 1.0, v4
+; SI-NEXT:    v_add_f32_e32 v5, 1.0, v5
+; SI-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; SI-NEXT:    v_add_f32_e32 v8, 1.0, v8
+; SI-NEXT:    v_add_f32_e32 v9, 1.0, v9
+; SI-NEXT:    v_add_f32_e32 v10, 1.0, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v26
+; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v28
+; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v3
 ; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v62, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v10
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v13
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v21
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v60
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v59
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v58
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, v57
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v56
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v47
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v46
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v45
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v44
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v43
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v42
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v41
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v18
 ; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v63
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v62
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
 ; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v39
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
 ; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
 ; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
 ; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
 ; SI-NEXT:    v_cvt_f32_f16_e32 v40, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v47
+; SI-NEXT:    v_mov_b32_e32 v21, v10
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
 ; SI-NEXT:  .LBB33_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v40, v40
-; SI-NEXT:    v_cvt_f16_f32_e32 v55, v55
-; SI-NEXT:    v_cvt_f16_f32_e32 v54, v54
-; SI-NEXT:    v_cvt_f16_f32_e32 v53, v53
-; SI-NEXT:    v_cvt_f16_f32_e32 v52, v52
-; SI-NEXT:    v_cvt_f16_f32_e32 v51, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v50, v50
-; SI-NEXT:    v_lshlrev_b32_e32 v40, 16, v40
-; SI-NEXT:    v_cvt_f16_f32_e32 v49, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v39, v39
-; SI-NEXT:    v_or_b32_e32 v55, v55, v40
-; SI-NEXT:    v_lshlrev_b32_e32 v54, 16, v54
-; SI-NEXT:    v_cvt_f16_f32_e32 v48, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v37, v37
-; SI-NEXT:    buffer_store_dword v55, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v55, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v53, v53, v54
-; SI-NEXT:    v_lshlrev_b32_e32 v52, 16, v52
-; SI-NEXT:    v_cvt_f16_f32_e32 v38, v38
-; SI-NEXT:    v_cvt_f16_f32_e32 v35, v35
-; SI-NEXT:    buffer_store_dword v53, v55, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v47
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v19
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v45
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v61
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v53, vcc, 8, v0
-; SI-NEXT:    v_or_b32_e32 v51, v51, v52
-; SI-NEXT:    v_lshlrev_b32_e32 v50, 16, v50
-; SI-NEXT:    v_cvt_f16_f32_e32 v36, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v33, v33
-; SI-NEXT:    buffer_store_dword v51, v53, s[0:3], 0 offen
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
+; SI-NEXT:    v_or_b32_e32 v2, v4, v2
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v42
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v51, vcc, 12, v0
-; SI-NEXT:    v_or_b32_e32 v49, v49, v50
-; SI-NEXT:    v_lshlrev_b32_e32 v39, 16, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v34, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v31, v31
-; SI-NEXT:    buffer_store_dword v49, v51, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v56
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v49, vcc, 16, v0
-; SI-NEXT:    v_or_b32_e32 v39, v48, v39
-; SI-NEXT:    v_lshlrev_b32_e32 v37, 16, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v32, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v29, v29
-; SI-NEXT:    buffer_store_dword v39, v49, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v40
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v46
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v39, vcc, 20, v0
-; SI-NEXT:    v_or_b32_e32 v37, v38, v37
-; SI-NEXT:    v_lshlrev_b32_e32 v35, 16, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; SI-NEXT:    buffer_store_dword v37, v39, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v54
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v44
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v37, vcc, 24, v0
-; SI-NEXT:    v_or_b32_e32 v35, v36, v35
-; SI-NEXT:    v_lshlrev_b32_e32 v33, 16, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v28, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v24
-; SI-NEXT:    buffer_store_dword v35, v37, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v52
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v43
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 28, v0
-; SI-NEXT:    v_or_b32_e32 v33, v34, v33
-; SI-NEXT:    v_lshlrev_b32_e32 v31, 16, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; SI-NEXT:    buffer_store_dword v33, v35, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v50
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v41
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 32, v0
-; SI-NEXT:    v_or_b32_e32 v31, v32, v31
-; SI-NEXT:    v_lshlrev_b32_e32 v29, 16, v29
-; SI-NEXT:    buffer_store_dword v31, v33, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v55
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 36, v0
-; SI-NEXT:    v_or_b32_e32 v29, v30, v29
-; SI-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
-; SI-NEXT:    buffer_store_dword v29, v31, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v38
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v53
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v29, vcc, 40, v0
-; SI-NEXT:    v_or_b32_e32 v27, v28, v27
-; SI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
-; SI-NEXT:    buffer_store_dword v27, v29, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v37
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v51
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v27, vcc, 44, v0
-; SI-NEXT:    v_or_b32_e32 v24, v26, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v22
-; SI-NEXT:    buffer_store_dword v24, v27, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v36
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v49
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v25
-; SI-NEXT:    v_add_i32_e32 v25, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v22, 16, v22
-; SI-NEXT:    v_or_b32_e32 v22, v24, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v20
-; SI-NEXT:    buffer_store_dword v22, v25, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v34
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v39
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v23
-; SI-NEXT:    v_add_i32_e32 v23, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v20, 16, v20
-; SI-NEXT:    v_or_b32_e32 v20, v22, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v18
-; SI-NEXT:    buffer_store_dword v20, v23, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v32
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v35
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v21
-; SI-NEXT:    v_add_i32_e32 v21, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v18, 16, v18
-; SI-NEXT:    v_or_b32_e32 v18, v20, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v16
-; SI-NEXT:    buffer_store_dword v18, v21, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v30
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v33
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v19
-; SI-NEXT:    v_add_i32_e32 v19, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v16, 16, v16
-; SI-NEXT:    v_or_b32_e32 v16, v18, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; SI-NEXT:    buffer_store_dword v16, v19, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v28
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v31
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v17
-; SI-NEXT:    v_add_i32_e32 v17, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
-; SI-NEXT:    v_or_b32_e32 v14, v16, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; SI-NEXT:    buffer_store_dword v14, v17, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v26
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v15
-; SI-NEXT:    v_add_i32_e32 v15, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
-; SI-NEXT:    v_or_b32_e32 v12, v14, v12
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v10
-; SI-NEXT:    buffer_store_dword v12, v15, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v13
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v12, v10
-; SI-NEXT:    v_cvt_f16_f32_e32 v7, v7
-; SI-NEXT:    buffer_store_dword v10, v13, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v11
-; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x4c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v7, 16, v7
-; SI-NEXT:    v_or_b32_e32 v7, v10, v7
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v5
-; SI-NEXT:    buffer_store_dword v7, v11, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v7, v9
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 0x50, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v7, v5
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v8
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 0x54, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v5, v3
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v24
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v3, v7, s[0:3], 0 offen
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v6
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x58, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; SI-NEXT:    v_or_b32_e32 v2, v3, v2
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v22
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v20
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v5, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v4
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v23
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x54, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v25
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x58, v0
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x5c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v27
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v21
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    buffer_load_dword v60, off, s[0:3], s32 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB33_4:
-; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; kill: killed $vgpr21
+; SI-NEXT:    ; implicit-def: $vgpr20
+; SI-NEXT:    ; kill: killed $vgpr20
+; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; kill: killed $vgpr21
+; SI-NEXT:    ; implicit-def: $vgpr20
+; SI-NEXT:    ; kill: killed $vgpr20
+; SI-NEXT:    ; implicit-def: $vgpr19
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr61
+; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr46
 ; SI-NEXT:    ; implicit-def: $vgpr40
-; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr44
 ; SI-NEXT:    ; implicit-def: $vgpr54
-; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr43
 ; SI-NEXT:    ; implicit-def: $vgpr52
-; SI-NEXT:    ; implicit-def: $vgpr49
+; SI-NEXT:    ; implicit-def: $vgpr41
 ; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr55
 ; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr39
+; SI-NEXT:    ; implicit-def: $vgpr53
 ; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr51
 ; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr49
 ; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr39
 ; SI-NEXT:    ; implicit-def: $vgpr34
-; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; implicit-def: $vgpr35
 ; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr33
 ; SI-NEXT:    ; implicit-def: $vgpr30
-; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr26
 ; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr25
 ; SI-NEXT:    ; implicit-def: $vgpr22
 ; SI-NEXT:    ; implicit-def: $vgpr23
+; SI-NEXT:    ; implicit-def: $vgpr25
+; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; kill: killed $vgpr21
+; SI-NEXT:    ; implicit-def: $vgpr20
+; SI-NEXT:    ; kill: killed $vgpr20
+; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; kill: killed $vgpr21
 ; SI-NEXT:    ; implicit-def: $vgpr20
 ; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr14
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr13
-; SI-NEXT:    ; implicit-def: $vgpr10
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr8
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr6
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr1
+; SI-NEXT:    ; kill: killed $vgpr21
+; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; kill: killed $vgpr21
+; SI-NEXT:    ; implicit-def: $vgpr21
 ; SI-NEXT:    s_branch .LBB33_2
 ;
 ; VI-LABEL: bitcast_v24f32_to_v48f16_scalar:
@@ -22113,13 +22397,41 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_store_dword v12, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_writelane_b32 v12, s30, 0
-; SI-NEXT:    v_writelane_b32 v12, s31, 1
+; SI-NEXT:    v_writelane_b32 v20, s30, 0
+; SI-NEXT:    v_mov_b32_e32 v12, s16
+; SI-NEXT:    v_mov_b32_e32 v13, s17
+; SI-NEXT:    v_mov_b32_e32 v14, s18
+; SI-NEXT:    v_mov_b32_e32 v15, s19
+; SI-NEXT:    v_mov_b32_e32 v16, s20
+; SI-NEXT:    v_mov_b32_e32 v17, s21
+; SI-NEXT:    v_writelane_b32 v20, s31, 1
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s40, v12
+; SI-NEXT:    v_mov_b32_e32 v12, s24
+; SI-NEXT:    v_readfirstlane_b32 s41, v13
+; SI-NEXT:    v_mov_b32_e32 v13, s25
+; SI-NEXT:    v_readfirstlane_b32 s24, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; SI-NEXT:    v_writelane_b32 v12, s34, 2
+; SI-NEXT:    v_writelane_b32 v20, s34, 2
+; SI-NEXT:    v_readfirstlane_b32 s20, v18
+; SI-NEXT:    v_readfirstlane_b32 s21, v19
+; SI-NEXT:    v_readfirstlane_b32 s18, v12
+; SI-NEXT:    v_readfirstlane_b32 s19, v13
+; SI-NEXT:    v_readfirstlane_b32 s16, v14
+; SI-NEXT:    v_readfirstlane_b32 s17, v15
+; SI-NEXT:    v_readfirstlane_b32 s14, v16
+; SI-NEXT:    v_readfirstlane_b32 s15, v17
 ; SI-NEXT:    v_readfirstlane_b32 s12, v1
 ; SI-NEXT:    v_readfirstlane_b32 s13, v2
 ; SI-NEXT:    v_readfirstlane_b32 s10, v3
@@ -22129,9 +22441,9 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v7
 ; SI-NEXT:    v_readfirstlane_b32 s7, v8
 ; SI-NEXT:    v_readfirstlane_b32 s4, v9
-; SI-NEXT:    s_and_b64 s[14:15], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v10
-; SI-NEXT:    v_writelane_b32 v12, s35, 3
+; SI-NEXT:    v_writelane_b32 v20, s35, 3
 ; SI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s88, s5, 16
@@ -22139,25 +22451,25 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s90, s9, 16
 ; SI-NEXT:    s_lshr_b32 s91, s11, 16
 ; SI-NEXT:    s_lshr_b32 s92, s13, 16
-; SI-NEXT:    s_lshr_b32 s93, s29, 16
-; SI-NEXT:    s_lshr_b32 s94, s27, 16
-; SI-NEXT:    s_lshr_b32 s95, s25, 16
-; SI-NEXT:    s_lshr_b32 s30, s23, 16
-; SI-NEXT:    s_lshr_b32 s31, s21, 16
-; SI-NEXT:    s_lshr_b32 s34, s19, 16
-; SI-NEXT:    s_lshr_b32 s35, s17, 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s93, s15, 16
+; SI-NEXT:    s_lshr_b32 s94, s17, 16
+; SI-NEXT:    s_lshr_b32 s95, s19, 16
+; SI-NEXT:    s_lshr_b32 s30, s21, 16
+; SI-NEXT:    s_lshr_b32 s31, s23, 16
+; SI-NEXT:    s_lshr_b32 s34, s25, 16
+; SI-NEXT:    s_lshr_b32 s35, s41, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[42:43], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[44:45], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[12:13], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[40:41], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB41_3
 ; SI-NEXT:  .LBB41_2: ; %cmp.true
 ; SI-NEXT:    s_add_u32 s4, s4, 3
@@ -22170,142 +22482,142 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; SI-NEXT:    s_addc_u32 s11, s11, 0
 ; SI-NEXT:    s_add_u32 s12, s12, 3
 ; SI-NEXT:    s_addc_u32 s13, s13, 0
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_add_u32 s20, s20, 3
-; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s14, s14, 3
+; SI-NEXT:    s_addc_u32 s15, s15, 0
 ; SI-NEXT:    s_add_u32 s16, s16, 3
 ; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
+; SI-NEXT:    s_add_u32 s22, s22, 3
+; SI-NEXT:    s_addc_u32 s23, s23, 0
+; SI-NEXT:    s_add_u32 s24, s24, 3
+; SI-NEXT:    s_addc_u32 s25, s25, 0
+; SI-NEXT:    s_add_u32 s40, s40, 3
+; SI-NEXT:    s_addc_u32 s41, s41, 0
 ; SI-NEXT:    s_lshr_b32 s88, s5, 16
 ; SI-NEXT:    s_lshr_b32 s89, s7, 16
 ; SI-NEXT:    s_lshr_b32 s90, s9, 16
 ; SI-NEXT:    s_lshr_b32 s91, s11, 16
 ; SI-NEXT:    s_lshr_b32 s92, s13, 16
-; SI-NEXT:    s_lshr_b32 s93, s29, 16
-; SI-NEXT:    s_lshr_b32 s94, s27, 16
-; SI-NEXT:    s_lshr_b32 s95, s25, 16
-; SI-NEXT:    s_lshr_b32 s30, s23, 16
-; SI-NEXT:    s_lshr_b32 s31, s21, 16
-; SI-NEXT:    s_lshr_b32 s34, s19, 16
-; SI-NEXT:    s_lshr_b32 s35, s17, 16
-; SI-NEXT:    s_lshr_b64 s[14:15], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s93, s15, 16
+; SI-NEXT:    s_lshr_b32 s94, s17, 16
+; SI-NEXT:    s_lshr_b32 s95, s19, 16
+; SI-NEXT:    s_lshr_b32 s30, s21, 16
+; SI-NEXT:    s_lshr_b32 s31, s23, 16
+; SI-NEXT:    s_lshr_b32 s34, s25, 16
+; SI-NEXT:    s_lshr_b32 s35, s41, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[42:43], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[44:45], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[12:13], 16
-; SI-NEXT:    s_lshr_b64 s[56:57], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[58:59], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[56:57], s[14:15], 16
+; SI-NEXT:    s_lshr_b64 s[58:59], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[40:41], 16
 ; SI-NEXT:  .LBB41_3: ; %end
-; SI-NEXT:    s_lshl_b32 s15, s76, 16
-; SI-NEXT:    s_and_b32 s16, s16, 0xffff
-; SI-NEXT:    s_or_b32 s15, s16, s15
-; SI-NEXT:    v_mov_b32_e32 v1, s15
-; SI-NEXT:    s_and_b32 s15, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s35, 16
-; SI-NEXT:    s_or_b32 s15, s15, s16
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_lshl_b32 s15, s74, 16
-; SI-NEXT:    s_and_b32 s16, s18, 0xffff
-; SI-NEXT:    s_or_b32 s15, s16, s15
-; SI-NEXT:    v_mov_b32_e32 v3, s15
-; SI-NEXT:    s_and_b32 s15, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s34, 16
+; SI-NEXT:    s_lshl_b32 s27, s76, 16
+; SI-NEXT:    s_and_b32 s29, s40, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s27
+; SI-NEXT:    s_and_b32 s27, s41, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s35, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_lshl_b32 s27, s74, 16
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_or_b32 s24, s24, s27
+; SI-NEXT:    v_mov_b32_e32 v3, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
+; SI-NEXT:    s_lshl_b32 s25, s34, 16
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s24, s24, s25
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s20, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s24, s72, 16
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s22, s22, s24
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s31, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s31, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s22, s22, s23
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s62, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s22, s62, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s30, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s30, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s60, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s60, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s95, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s95, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s58, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s58, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s27, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s94, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
+; SI-NEXT:    s_lshl_b32 s17, s94, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s16, s16, s17
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s28, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v2, s16
+; SI-NEXT:    s_and_b32 s14, s14, 0xffff
 ; SI-NEXT:    s_lshl_b32 s16, s56, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s14, s14, s16
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
-; SI-NEXT:    s_and_b32 s15, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s16, s93, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s14
+; SI-NEXT:    s_and_b32 s14, s15, 0xffff
+; SI-NEXT:    s_lshl_b32 s15, s93, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s15, s15, s16
+; SI-NEXT:    s_or_b32 s14, s14, s15
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s15
+; SI-NEXT:    v_mov_b32_e32 v2, s14
 ; SI-NEXT:    s_and_b32 s12, s12, 0xffff
-; SI-NEXT:    s_lshl_b32 s15, s46, 16
+; SI-NEXT:    s_lshl_b32 s14, s46, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s12, s12, s15
+; SI-NEXT:    s_or_b32 s12, s12, s14
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s12
@@ -22345,7 +22657,7 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s40, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x4c, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -22359,7 +22671,7 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s14, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x54, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -22373,12 +22685,12 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x5c, v0
 ; SI-NEXT:    v_mov_b32_e32 v1, s4
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    v_readlane_b32 s35, v12, 3
-; SI-NEXT:    v_readlane_b32 s34, v12, 2
-; SI-NEXT:    v_readlane_b32 s31, v12, 1
-; SI-NEXT:    v_readlane_b32 s30, v12, 0
+; SI-NEXT:    v_readlane_b32 s35, v20, 3
+; SI-NEXT:    v_readlane_b32 s34, v20, 2
+; SI-NEXT:    v_readlane_b32 s31, v20, 1
+; SI-NEXT:    v_readlane_b32 s30, v20, 0
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_load_dword v12, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 ; 4-byte Folded Reload
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -22403,16 +22715,44 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr91
 ; SI-NEXT:    ; implicit-def: $sgpr42
 ; SI-NEXT:    ; implicit-def: $sgpr90
-; SI-NEXT:    ; implicit-def: $sgpr40
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr89
-; SI-NEXT:    ; implicit-def: $sgpr14
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr88
 ; SI-NEXT:    s_branch .LBB41_2
 ;
 ; VI-LABEL: bitcast_v12i64_to_v48i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v11, s16
+; VI-NEXT:    v_mov_b32_e32 v12, s17
+; VI-NEXT:    v_mov_b32_e32 v13, s18
+; VI-NEXT:    v_mov_b32_e32 v14, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s20
+; VI-NEXT:    v_mov_b32_e32 v16, s21
+; VI-NEXT:    v_mov_b32_e32 v17, s22
+; VI-NEXT:    v_mov_b32_e32 v18, s23
+; VI-NEXT:    v_mov_b32_e32 v19, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v11
+; VI-NEXT:    v_mov_b32_e32 v11, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v12
+; VI-NEXT:    v_mov_b32_e32 v12, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v13
+; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v14
+; VI-NEXT:    v_mov_b32_e32 v14, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; VI-NEXT:    v_readfirstlane_b32 s24, v16
+; VI-NEXT:    v_readfirstlane_b32 s23, v17
+; VI-NEXT:    v_readfirstlane_b32 s22, v18
+; VI-NEXT:    v_readfirstlane_b32 s21, v19
+; VI-NEXT:    v_readfirstlane_b32 s20, v11
+; VI-NEXT:    v_readfirstlane_b32 s19, v12
+; VI-NEXT:    v_readfirstlane_b32 s18, v13
+; VI-NEXT:    v_readfirstlane_b32 s17, v14
+; VI-NEXT:    v_readfirstlane_b32 s16, v15
 ; VI-NEXT:    v_readfirstlane_b32 s15, v0
 ; VI-NEXT:    v_readfirstlane_b32 s14, v1
 ; VI-NEXT:    v_readfirstlane_b32 s13, v2
@@ -22426,9 +22766,9 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; VI-NEXT:    v_readfirstlane_b32 s7, v9
 ; VI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s40, s7, 16
-; VI-NEXT:    s_lshr_b32 s41, s6, 16
-; VI-NEXT:    s_lshr_b32 s42, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s43, s9, 16
 ; VI-NEXT:    s_lshr_b32 s44, s10, 16
 ; VI-NEXT:    s_lshr_b32 s45, s11, 16
@@ -22436,20 +22776,20 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s47, s13, 16
 ; VI-NEXT:    s_lshr_b32 s56, s14, 16
 ; VI-NEXT:    s_lshr_b32 s57, s15, 16
-; VI-NEXT:    s_lshr_b32 s58, s29, 16
-; VI-NEXT:    s_lshr_b32 s59, s28, 16
-; VI-NEXT:    s_lshr_b32 s60, s27, 16
-; VI-NEXT:    s_lshr_b32 s61, s26, 16
-; VI-NEXT:    s_lshr_b32 s62, s25, 16
-; VI-NEXT:    s_lshr_b32 s63, s24, 16
-; VI-NEXT:    s_lshr_b32 s72, s23, 16
-; VI-NEXT:    s_lshr_b32 s73, s22, 16
-; VI-NEXT:    s_lshr_b32 s74, s21, 16
-; VI-NEXT:    s_lshr_b32 s75, s20, 16
-; VI-NEXT:    s_lshr_b32 s76, s19, 16
-; VI-NEXT:    s_lshr_b32 s77, s18, 16
-; VI-NEXT:    s_lshr_b32 s78, s17, 16
-; VI-NEXT:    s_lshr_b32 s79, s16, 16
+; VI-NEXT:    s_lshr_b32 s58, s16, 16
+; VI-NEXT:    s_lshr_b32 s59, s17, 16
+; VI-NEXT:    s_lshr_b32 s60, s18, 16
+; VI-NEXT:    s_lshr_b32 s61, s19, 16
+; VI-NEXT:    s_lshr_b32 s62, s20, 16
+; VI-NEXT:    s_lshr_b32 s63, s21, 16
+; VI-NEXT:    s_lshr_b32 s72, s22, 16
+; VI-NEXT:    s_lshr_b32 s73, s23, 16
+; VI-NEXT:    s_lshr_b32 s74, s24, 16
+; VI-NEXT:    s_lshr_b32 s75, s25, 16
+; VI-NEXT:    s_lshr_b32 s76, s26, 16
+; VI-NEXT:    s_lshr_b32 s77, s40, 16
+; VI-NEXT:    s_lshr_b32 s78, s41, 16
+; VI-NEXT:    s_lshr_b32 s79, s42, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB41_3
 ; VI-NEXT:  .LBB41_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -22462,23 +22802,23 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
 ; VI-NEXT:    s_add_u32 s15, s15, 3
 ; VI-NEXT:    s_addc_u32 s14, s14, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s40, s7, 16
-; VI-NEXT:    s_lshr_b32 s41, s6, 16
-; VI-NEXT:    s_lshr_b32 s42, s8, 16
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_add_u32 s42, s42, 3
+; VI-NEXT:    s_addc_u32 s41, s41, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s43, s9, 16
 ; VI-NEXT:    s_lshr_b32 s44, s10, 16
 ; VI-NEXT:    s_lshr_b32 s45, s11, 16
@@ -22486,107 +22826,107 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s47, s13, 16
 ; VI-NEXT:    s_lshr_b32 s56, s14, 16
 ; VI-NEXT:    s_lshr_b32 s57, s15, 16
-; VI-NEXT:    s_lshr_b32 s58, s29, 16
-; VI-NEXT:    s_lshr_b32 s59, s28, 16
-; VI-NEXT:    s_lshr_b32 s60, s27, 16
-; VI-NEXT:    s_lshr_b32 s61, s26, 16
-; VI-NEXT:    s_lshr_b32 s62, s25, 16
-; VI-NEXT:    s_lshr_b32 s63, s24, 16
-; VI-NEXT:    s_lshr_b32 s72, s23, 16
-; VI-NEXT:    s_lshr_b32 s73, s22, 16
-; VI-NEXT:    s_lshr_b32 s74, s21, 16
-; VI-NEXT:    s_lshr_b32 s75, s20, 16
-; VI-NEXT:    s_lshr_b32 s76, s19, 16
-; VI-NEXT:    s_lshr_b32 s77, s18, 16
-; VI-NEXT:    s_lshr_b32 s78, s17, 16
-; VI-NEXT:    s_lshr_b32 s79, s16, 16
+; VI-NEXT:    s_lshr_b32 s58, s16, 16
+; VI-NEXT:    s_lshr_b32 s59, s17, 16
+; VI-NEXT:    s_lshr_b32 s60, s18, 16
+; VI-NEXT:    s_lshr_b32 s61, s19, 16
+; VI-NEXT:    s_lshr_b32 s62, s20, 16
+; VI-NEXT:    s_lshr_b32 s63, s21, 16
+; VI-NEXT:    s_lshr_b32 s72, s22, 16
+; VI-NEXT:    s_lshr_b32 s73, s23, 16
+; VI-NEXT:    s_lshr_b32 s74, s24, 16
+; VI-NEXT:    s_lshr_b32 s75, s25, 16
+; VI-NEXT:    s_lshr_b32 s76, s26, 16
+; VI-NEXT:    s_lshr_b32 s77, s40, 16
+; VI-NEXT:    s_lshr_b32 s78, s41, 16
+; VI-NEXT:    s_lshr_b32 s79, s42, 16
 ; VI-NEXT:  .LBB41_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s42
 ; VI-NEXT:    s_lshl_b32 s5, s79, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s78, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s77, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s76, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s75, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s74, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s73, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s72, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s63, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s62, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s61, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s60, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s59, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s58, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s5, 0xffff, s41
+; VI-NEXT:    s_lshl_b32 s41, s78, 16
+; VI-NEXT:    s_or_b32 s5, s5, s41
+; VI-NEXT:    s_and_b32 s40, 0xffff, s40
+; VI-NEXT:    s_lshl_b32 s41, s77, 16
+; VI-NEXT:    s_or_b32 s40, s40, s41
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s41, s76, 16
+; VI-NEXT:    s_or_b32 s26, s26, s41
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s41, s75, 16
+; VI-NEXT:    s_or_b32 s25, s25, s41
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s41, s74, 16
+; VI-NEXT:    s_or_b32 s24, s24, s41
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s41, s73, 16
+; VI-NEXT:    s_or_b32 s23, s23, s41
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s41, s72, 16
+; VI-NEXT:    s_or_b32 s22, s22, s41
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s41, s63, 16
+; VI-NEXT:    s_or_b32 s21, s21, s41
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s41, s62, 16
+; VI-NEXT:    s_or_b32 s20, s20, s41
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s41, s61, 16
+; VI-NEXT:    s_or_b32 s19, s19, s41
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s41, s60, 16
+; VI-NEXT:    s_or_b32 s18, s18, s41
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s41, s59, 16
+; VI-NEXT:    s_or_b32 s17, s17, s41
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s41, s58, 16
+; VI-NEXT:    s_or_b32 s16, s16, s41
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s28, s57, 16
-; VI-NEXT:    s_or_b32 s15, s15, s28
+; VI-NEXT:    s_lshl_b32 s41, s57, 16
+; VI-NEXT:    s_or_b32 s15, s15, s41
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s28, s56, 16
-; VI-NEXT:    s_or_b32 s14, s14, s28
+; VI-NEXT:    s_lshl_b32 s41, s56, 16
+; VI-NEXT:    s_or_b32 s14, s14, s41
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s28, s47, 16
-; VI-NEXT:    s_or_b32 s13, s13, s28
+; VI-NEXT:    s_lshl_b32 s41, s47, 16
+; VI-NEXT:    s_or_b32 s13, s13, s41
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s28, s46, 16
-; VI-NEXT:    s_or_b32 s12, s12, s28
+; VI-NEXT:    s_lshl_b32 s41, s46, 16
+; VI-NEXT:    s_or_b32 s12, s12, s41
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s45, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s41, s45, 16
+; VI-NEXT:    s_or_b32 s11, s11, s41
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s44, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
+; VI-NEXT:    s_lshl_b32 s41, s44, 16
+; VI-NEXT:    s_or_b32 s10, s10, s41
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s28, s43, 16
-; VI-NEXT:    s_or_b32 s9, s9, s28
+; VI-NEXT:    s_lshl_b32 s41, s43, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s8, s8, s28
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
-; VI-NEXT:    s_or_b32 s7, s7, s28
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s41
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s40
+; VI-NEXT:    v_mov_b32_e32 v3, s26
+; VI-NEXT:    v_mov_b32_e32 v4, s25
+; VI-NEXT:    v_mov_b32_e32 v5, s24
+; VI-NEXT:    v_mov_b32_e32 v6, s23
+; VI-NEXT:    v_mov_b32_e32 v7, s22
+; VI-NEXT:    v_mov_b32_e32 v8, s21
+; VI-NEXT:    v_mov_b32_e32 v9, s20
+; VI-NEXT:    v_mov_b32_e32 v10, s19
+; VI-NEXT:    v_mov_b32_e32 v11, s18
+; VI-NEXT:    v_mov_b32_e32 v12, s17
+; VI-NEXT:    v_mov_b32_e32 v13, s16
 ; VI-NEXT:    v_mov_b32_e32 v14, s15
 ; VI-NEXT:    v_mov_b32_e32 v15, s14
 ; VI-NEXT:    v_mov_b32_e32 v16, s13
@@ -22620,64 +22960,82 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr45
 ; VI-NEXT:    ; implicit-def: $sgpr44
 ; VI-NEXT:    ; implicit-def: $sgpr43
-; VI-NEXT:    ; implicit-def: $sgpr42
-; VI-NEXT:    ; implicit-def: $sgpr41
-; VI-NEXT:    ; implicit-def: $sgpr40
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB41_2
 ;
 ; GFX9-LABEL: bitcast_v12i64_to_v48i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v11, s16
+; GFX9-NEXT:    v_mov_b32_e32 v12, s17
+; GFX9-NEXT:    v_mov_b32_e32 v13, s18
+; GFX9-NEXT:    v_mov_b32_e32 v14, s19
+; GFX9-NEXT:    v_mov_b32_e32 v15, s20
+; GFX9-NEXT:    v_mov_b32_e32 v16, s21
+; GFX9-NEXT:    v_mov_b32_e32 v17, s22
+; GFX9-NEXT:    v_mov_b32_e32 v18, s23
+; GFX9-NEXT:    v_mov_b32_e32 v19, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v11
+; GFX9-NEXT:    v_mov_b32_e32 v11, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v12
+; GFX9-NEXT:    v_mov_b32_e32 v12, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v13
+; GFX9-NEXT:    v_mov_b32_e32 v13, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v14
+; GFX9-NEXT:    v_mov_b32_e32 v14, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s40, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB41_3
 ; GFX9-NEXT:  .LBB41_2: ; %cmp.true
-; GFX9-NEXT:    s_add_u32 s14, s14, 3
-; GFX9-NEXT:    s_addc_u32 s15, s15, 0
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_add_u32 s28, s28, 3
 ; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
@@ -22692,79 +23050,89 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
-; GFX9-NEXT:    s_lshr_b32 s40, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s16, 16
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
+; GFX9-NEXT:    s_lshr_b32 s40, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s6, 16
 ; GFX9-NEXT:  .LBB41_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s40
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB41_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr79
@@ -22796,37 +23164,64 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; GFX11-LABEL: bitcast_v12i64_to_v48i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v7, s0 :: v_dual_mov_b32 v8, s1
+; GFX11-NEXT:    v_dual_mov_b32 v9, s2 :: v_dual_mov_b32 v10, s3
+; GFX11-NEXT:    v_dual_mov_b32 v11, s16 :: v_dual_mov_b32 v12, s17
+; GFX11-NEXT:    v_dual_mov_b32 v13, s18 :: v_dual_mov_b32 v14, s19
+; GFX11-NEXT:    v_dual_mov_b32 v15, s20 :: v_dual_mov_b32 v16, s21
+; GFX11-NEXT:    v_dual_mov_b32 v17, s22 :: v_dual_mov_b32 v18, s23
+; GFX11-NEXT:    v_dual_mov_b32 v19, s24 :: v_dual_mov_b32 v20, s25
+; GFX11-NEXT:    v_dual_mov_b32 v21, s26 :: v_dual_mov_b32 v22, s27
+; GFX11-NEXT:    v_dual_mov_b32 v23, s28 :: v_dual_mov_b32 v24, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v5
 ; GFX11-NEXT:    s_mov_b32 s74, 0
-; GFX11-NEXT:    s_and_b32 s10, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s24, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s10, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s62, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s63, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s72, s1, 16
@@ -22834,50 +23229,50 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s74
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB41_3
 ; GFX11-NEXT:  .LBB41_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s9, s9, 3
-; GFX11-NEXT:    s_addc_u32 s8, s8, 0
-; GFX11-NEXT:    s_add_u32 s6, s6, 3
-; GFX11-NEXT:    s_addc_u32 s7, s7, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
-; GFX11-NEXT:    s_add_u32 s24, s24, 3
-; GFX11-NEXT:    s_addc_u32 s25, s25, 0
-; GFX11-NEXT:    s_add_u32 s22, s22, 3
-; GFX11-NEXT:    s_addc_u32 s23, s23, 0
+; GFX11-NEXT:    s_add_u32 s23, s23, 3
+; GFX11-NEXT:    s_addc_u32 s22, s22, 0
 ; GFX11-NEXT:    s_add_u32 s20, s20, 3
 ; GFX11-NEXT:    s_addc_u32 s21, s21, 0
 ; GFX11-NEXT:    s_add_u32 s18, s18, 3
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s10, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s62, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s63, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s72, s1, 16
@@ -22888,38 +23283,38 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s72
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s63
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s10
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s24
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s9 :: v_dual_mov_b32 v23, s8
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s23 :: v_dual_mov_b32 v23, s22
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB41_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr73
@@ -22940,12 +23335,12 @@ define inreg <48 x i16> @bitcast_v12i64_to_v48i16_scalar(<12 x i64> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
 ; GFX11-NEXT:    s_branch .LBB41_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -23343,7 +23738,7 @@ define <12 x i64> @bitcast_v48i16_to_v12i64(<48 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v20, vcc, s6, v20
 ; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
 ; SI-NEXT:    v_add_i32_e32 v22, vcc, s6, v22
-; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
+; SI-NEXT:    v_add_i32_e32 v23, vcc, 0x30000, v23
 ; SI-NEXT:  .LBB42_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
@@ -26139,7 +26534,35 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; SI-LABEL: bitcast_v12i64_to_v48f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v12, s16
+; SI-NEXT:    v_mov_b32_e32 v13, s17
+; SI-NEXT:    v_mov_b32_e32 v14, s18
+; SI-NEXT:    v_mov_b32_e32 v15, s19
+; SI-NEXT:    v_mov_b32_e32 v16, s20
+; SI-NEXT:    v_mov_b32_e32 v17, s21
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s22, v12
+; SI-NEXT:    v_mov_b32_e32 v12, s24
+; SI-NEXT:    v_readfirstlane_b32 s40, v13
+; SI-NEXT:    v_mov_b32_e32 v13, s25
+; SI-NEXT:    v_readfirstlane_b32 s23, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s26
+; SI-NEXT:    v_readfirstlane_b32 s41, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s27
+; SI-NEXT:    v_readfirstlane_b32 s24, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s28
+; SI-NEXT:    v_readfirstlane_b32 s27, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
+; SI-NEXT:    v_readfirstlane_b32 s25, v18
+; SI-NEXT:    v_readfirstlane_b32 s26, v19
+; SI-NEXT:    v_readfirstlane_b32 s20, v12
+; SI-NEXT:    v_readfirstlane_b32 s21, v13
+; SI-NEXT:    v_readfirstlane_b32 s18, v14
+; SI-NEXT:    v_readfirstlane_b32 s19, v15
+; SI-NEXT:    v_readfirstlane_b32 s16, v16
+; SI-NEXT:    v_readfirstlane_b32 s17, v17
 ; SI-NEXT:    v_readfirstlane_b32 s14, v1
 ; SI-NEXT:    v_readfirstlane_b32 s15, v2
 ; SI-NEXT:    v_readfirstlane_b32 s12, v3
@@ -26174,33 +26597,33 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
 ; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s4
 ; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
 ; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
+; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
+; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
+; SI-NEXT:    s_lshr_b32 s4, s41, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s4
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v40, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s9
@@ -26213,50 +26636,50 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s15
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s41
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, s40
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, s22
 ; SI-NEXT:    s_cbranch_execnz .LBB45_3
 ; SI-NEXT:  .LBB45_2: ; %cmp.true
-; SI-NEXT:    s_add_u32 s4, s16, 3
-; SI-NEXT:    s_addc_u32 s5, s17, 0
-; SI-NEXT:    s_lshr_b32 s16, s4, 16
-; SI-NEXT:    s_lshr_b32 s17, s5, 16
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
-; SI-NEXT:    s_lshr_b32 s40, s18, 16
-; SI-NEXT:    s_lshr_b32 s41, s19, 16
+; SI-NEXT:    s_add_u32 s4, s22, 3
+; SI-NEXT:    s_addc_u32 s5, s40, 0
+; SI-NEXT:    s_lshr_b32 s22, s4, 16
+; SI-NEXT:    s_lshr_b32 s28, s5, 16
+; SI-NEXT:    s_add_u32 s23, s23, 3
+; SI-NEXT:    s_addc_u32 s29, s41, 0
+; SI-NEXT:    s_lshr_b32 s40, s23, 16
+; SI-NEXT:    s_lshr_b32 s41, s29, 16
+; SI-NEXT:    s_add_u32 s24, s24, 3
+; SI-NEXT:    s_addc_u32 s27, s27, 0
+; SI-NEXT:    s_lshr_b32 s42, s24, 16
+; SI-NEXT:    s_lshr_b32 s43, s27, 16
+; SI-NEXT:    s_add_u32 s25, s25, 3
+; SI-NEXT:    s_addc_u32 s26, s26, 0
+; SI-NEXT:    s_lshr_b32 s44, s25, 16
+; SI-NEXT:    s_lshr_b32 s45, s26, 16
 ; SI-NEXT:    s_add_u32 s20, s20, 3
 ; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_lshr_b32 s42, s20, 16
-; SI-NEXT:    s_lshr_b32 s43, s21, 16
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_lshr_b32 s44, s22, 16
-; SI-NEXT:    s_lshr_b32 s45, s23, 16
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_lshr_b32 s46, s24, 16
-; SI-NEXT:    s_lshr_b32 s47, s25, 16
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_lshr_b32 s56, s26, 16
-; SI-NEXT:    s_lshr_b32 s57, s27, 16
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_lshr_b32 s58, s28, 16
-; SI-NEXT:    s_lshr_b32 s59, s29, 16
+; SI-NEXT:    s_lshr_b32 s46, s20, 16
+; SI-NEXT:    s_lshr_b32 s47, s21, 16
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_lshr_b32 s56, s18, 16
+; SI-NEXT:    s_lshr_b32 s57, s19, 16
+; SI-NEXT:    s_add_u32 s16, s16, 3
+; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_lshr_b32 s58, s16, 16
+; SI-NEXT:    s_lshr_b32 s59, s17, 16
 ; SI-NEXT:    s_add_u32 s14, s14, 3
 ; SI-NEXT:    s_addc_u32 s15, s15, 0
 ; SI-NEXT:    s_lshr_b32 s60, s14, 16
@@ -26287,18 +26710,18 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s15
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s23
 ; SI-NEXT:    v_cvt_f32_f16_e32 v53, s5
 ; SI-NEXT:    v_cvt_f32_f16_e32 v55, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s77
@@ -26323,9 +26746,9 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v39, s42
 ; SI-NEXT:    v_cvt_f32_f16_e32 v50, s41
 ; SI-NEXT:    v_cvt_f32_f16_e32 v52, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s28
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, s22
 ; SI-NEXT:  .LBB45_3: ; %end
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v40, v40
@@ -26551,7 +26974,35 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; VI-LABEL: bitcast_v12i64_to_v48f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v11, s16
+; VI-NEXT:    v_mov_b32_e32 v12, s17
+; VI-NEXT:    v_mov_b32_e32 v13, s18
+; VI-NEXT:    v_mov_b32_e32 v14, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s20
+; VI-NEXT:    v_mov_b32_e32 v16, s21
+; VI-NEXT:    v_mov_b32_e32 v17, s22
+; VI-NEXT:    v_mov_b32_e32 v18, s23
+; VI-NEXT:    v_mov_b32_e32 v19, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v11
+; VI-NEXT:    v_mov_b32_e32 v11, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v12
+; VI-NEXT:    v_mov_b32_e32 v12, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v13
+; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v14
+; VI-NEXT:    v_mov_b32_e32 v14, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
+; VI-NEXT:    v_readfirstlane_b32 s24, v16
+; VI-NEXT:    v_readfirstlane_b32 s23, v17
+; VI-NEXT:    v_readfirstlane_b32 s22, v18
+; VI-NEXT:    v_readfirstlane_b32 s21, v19
+; VI-NEXT:    v_readfirstlane_b32 s20, v11
+; VI-NEXT:    v_readfirstlane_b32 s19, v12
+; VI-NEXT:    v_readfirstlane_b32 s18, v13
+; VI-NEXT:    v_readfirstlane_b32 s17, v14
+; VI-NEXT:    v_readfirstlane_b32 s16, v15
 ; VI-NEXT:    v_readfirstlane_b32 s15, v0
 ; VI-NEXT:    v_readfirstlane_b32 s14, v1
 ; VI-NEXT:    v_readfirstlane_b32 s13, v2
@@ -26565,9 +27016,9 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; VI-NEXT:    v_readfirstlane_b32 s7, v9
 ; VI-NEXT:    s_cbranch_scc0 .LBB45_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s40, s7, 16
-; VI-NEXT:    s_lshr_b32 s41, s6, 16
-; VI-NEXT:    s_lshr_b32 s42, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s43, s9, 16
 ; VI-NEXT:    s_lshr_b32 s44, s10, 16
 ; VI-NEXT:    s_lshr_b32 s45, s11, 16
@@ -26575,20 +27026,20 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s47, s13, 16
 ; VI-NEXT:    s_lshr_b32 s56, s14, 16
 ; VI-NEXT:    s_lshr_b32 s57, s15, 16
-; VI-NEXT:    s_lshr_b32 s58, s29, 16
-; VI-NEXT:    s_lshr_b32 s59, s28, 16
-; VI-NEXT:    s_lshr_b32 s60, s27, 16
-; VI-NEXT:    s_lshr_b32 s61, s26, 16
-; VI-NEXT:    s_lshr_b32 s62, s25, 16
-; VI-NEXT:    s_lshr_b32 s63, s24, 16
-; VI-NEXT:    s_lshr_b32 s72, s23, 16
-; VI-NEXT:    s_lshr_b32 s73, s22, 16
-; VI-NEXT:    s_lshr_b32 s74, s21, 16
-; VI-NEXT:    s_lshr_b32 s75, s20, 16
-; VI-NEXT:    s_lshr_b32 s76, s19, 16
-; VI-NEXT:    s_lshr_b32 s77, s18, 16
-; VI-NEXT:    s_lshr_b32 s78, s17, 16
-; VI-NEXT:    s_lshr_b32 s79, s16, 16
+; VI-NEXT:    s_lshr_b32 s58, s16, 16
+; VI-NEXT:    s_lshr_b32 s59, s17, 16
+; VI-NEXT:    s_lshr_b32 s60, s18, 16
+; VI-NEXT:    s_lshr_b32 s61, s19, 16
+; VI-NEXT:    s_lshr_b32 s62, s20, 16
+; VI-NEXT:    s_lshr_b32 s63, s21, 16
+; VI-NEXT:    s_lshr_b32 s72, s22, 16
+; VI-NEXT:    s_lshr_b32 s73, s23, 16
+; VI-NEXT:    s_lshr_b32 s74, s24, 16
+; VI-NEXT:    s_lshr_b32 s75, s25, 16
+; VI-NEXT:    s_lshr_b32 s76, s26, 16
+; VI-NEXT:    s_lshr_b32 s77, s40, 16
+; VI-NEXT:    s_lshr_b32 s78, s41, 16
+; VI-NEXT:    s_lshr_b32 s79, s42, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB45_3
 ; VI-NEXT:  .LBB45_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -26601,23 +27052,23 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
 ; VI-NEXT:    s_add_u32 s15, s15, 3
 ; VI-NEXT:    s_addc_u32 s14, s14, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s40, s7, 16
-; VI-NEXT:    s_lshr_b32 s41, s6, 16
-; VI-NEXT:    s_lshr_b32 s42, s8, 16
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_add_u32 s42, s42, 3
+; VI-NEXT:    s_addc_u32 s41, s41, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s43, s9, 16
 ; VI-NEXT:    s_lshr_b32 s44, s10, 16
 ; VI-NEXT:    s_lshr_b32 s45, s11, 16
@@ -26625,107 +27076,107 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s47, s13, 16
 ; VI-NEXT:    s_lshr_b32 s56, s14, 16
 ; VI-NEXT:    s_lshr_b32 s57, s15, 16
-; VI-NEXT:    s_lshr_b32 s58, s29, 16
-; VI-NEXT:    s_lshr_b32 s59, s28, 16
-; VI-NEXT:    s_lshr_b32 s60, s27, 16
-; VI-NEXT:    s_lshr_b32 s61, s26, 16
-; VI-NEXT:    s_lshr_b32 s62, s25, 16
-; VI-NEXT:    s_lshr_b32 s63, s24, 16
-; VI-NEXT:    s_lshr_b32 s72, s23, 16
-; VI-NEXT:    s_lshr_b32 s73, s22, 16
-; VI-NEXT:    s_lshr_b32 s74, s21, 16
-; VI-NEXT:    s_lshr_b32 s75, s20, 16
-; VI-NEXT:    s_lshr_b32 s76, s19, 16
-; VI-NEXT:    s_lshr_b32 s77, s18, 16
-; VI-NEXT:    s_lshr_b32 s78, s17, 16
-; VI-NEXT:    s_lshr_b32 s79, s16, 16
+; VI-NEXT:    s_lshr_b32 s58, s16, 16
+; VI-NEXT:    s_lshr_b32 s59, s17, 16
+; VI-NEXT:    s_lshr_b32 s60, s18, 16
+; VI-NEXT:    s_lshr_b32 s61, s19, 16
+; VI-NEXT:    s_lshr_b32 s62, s20, 16
+; VI-NEXT:    s_lshr_b32 s63, s21, 16
+; VI-NEXT:    s_lshr_b32 s72, s22, 16
+; VI-NEXT:    s_lshr_b32 s73, s23, 16
+; VI-NEXT:    s_lshr_b32 s74, s24, 16
+; VI-NEXT:    s_lshr_b32 s75, s25, 16
+; VI-NEXT:    s_lshr_b32 s76, s26, 16
+; VI-NEXT:    s_lshr_b32 s77, s40, 16
+; VI-NEXT:    s_lshr_b32 s78, s41, 16
+; VI-NEXT:    s_lshr_b32 s79, s42, 16
 ; VI-NEXT:  .LBB45_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s42
 ; VI-NEXT:    s_lshl_b32 s5, s79, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s78, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s77, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s76, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s75, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s74, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s73, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s72, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s63, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s62, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s61, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s60, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s59, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s58, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
+; VI-NEXT:    s_and_b32 s5, 0xffff, s41
+; VI-NEXT:    s_lshl_b32 s41, s78, 16
+; VI-NEXT:    s_or_b32 s5, s5, s41
+; VI-NEXT:    s_and_b32 s40, 0xffff, s40
+; VI-NEXT:    s_lshl_b32 s41, s77, 16
+; VI-NEXT:    s_or_b32 s40, s40, s41
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s41, s76, 16
+; VI-NEXT:    s_or_b32 s26, s26, s41
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s41, s75, 16
+; VI-NEXT:    s_or_b32 s25, s25, s41
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s41, s74, 16
+; VI-NEXT:    s_or_b32 s24, s24, s41
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s41, s73, 16
+; VI-NEXT:    s_or_b32 s23, s23, s41
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s41, s72, 16
+; VI-NEXT:    s_or_b32 s22, s22, s41
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s41, s63, 16
+; VI-NEXT:    s_or_b32 s21, s21, s41
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s41, s62, 16
+; VI-NEXT:    s_or_b32 s20, s20, s41
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s41, s61, 16
+; VI-NEXT:    s_or_b32 s19, s19, s41
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s41, s60, 16
+; VI-NEXT:    s_or_b32 s18, s18, s41
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s41, s59, 16
+; VI-NEXT:    s_or_b32 s17, s17, s41
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s41, s58, 16
+; VI-NEXT:    s_or_b32 s16, s16, s41
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s28, s57, 16
-; VI-NEXT:    s_or_b32 s15, s15, s28
+; VI-NEXT:    s_lshl_b32 s41, s57, 16
+; VI-NEXT:    s_or_b32 s15, s15, s41
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s28, s56, 16
-; VI-NEXT:    s_or_b32 s14, s14, s28
+; VI-NEXT:    s_lshl_b32 s41, s56, 16
+; VI-NEXT:    s_or_b32 s14, s14, s41
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s28, s47, 16
-; VI-NEXT:    s_or_b32 s13, s13, s28
+; VI-NEXT:    s_lshl_b32 s41, s47, 16
+; VI-NEXT:    s_or_b32 s13, s13, s41
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s28, s46, 16
-; VI-NEXT:    s_or_b32 s12, s12, s28
+; VI-NEXT:    s_lshl_b32 s41, s46, 16
+; VI-NEXT:    s_or_b32 s12, s12, s41
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s28, s45, 16
-; VI-NEXT:    s_or_b32 s11, s11, s28
+; VI-NEXT:    s_lshl_b32 s41, s45, 16
+; VI-NEXT:    s_or_b32 s11, s11, s41
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s28, s44, 16
-; VI-NEXT:    s_or_b32 s10, s10, s28
+; VI-NEXT:    s_lshl_b32 s41, s44, 16
+; VI-NEXT:    s_or_b32 s10, s10, s41
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s28, s43, 16
-; VI-NEXT:    s_or_b32 s9, s9, s28
+; VI-NEXT:    s_lshl_b32 s41, s43, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s28, s42, 16
-; VI-NEXT:    s_or_b32 s8, s8, s28
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s28, s41, 16
-; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s28, s40, 16
-; VI-NEXT:    s_or_b32 s7, s7, s28
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s41
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
+; VI-NEXT:    v_mov_b32_e32 v2, s40
+; VI-NEXT:    v_mov_b32_e32 v3, s26
+; VI-NEXT:    v_mov_b32_e32 v4, s25
+; VI-NEXT:    v_mov_b32_e32 v5, s24
+; VI-NEXT:    v_mov_b32_e32 v6, s23
+; VI-NEXT:    v_mov_b32_e32 v7, s22
+; VI-NEXT:    v_mov_b32_e32 v8, s21
+; VI-NEXT:    v_mov_b32_e32 v9, s20
+; VI-NEXT:    v_mov_b32_e32 v10, s19
+; VI-NEXT:    v_mov_b32_e32 v11, s18
+; VI-NEXT:    v_mov_b32_e32 v12, s17
+; VI-NEXT:    v_mov_b32_e32 v13, s16
 ; VI-NEXT:    v_mov_b32_e32 v14, s15
 ; VI-NEXT:    v_mov_b32_e32 v15, s14
 ; VI-NEXT:    v_mov_b32_e32 v16, s13
@@ -26759,64 +27210,82 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr45
 ; VI-NEXT:    ; implicit-def: $sgpr44
 ; VI-NEXT:    ; implicit-def: $sgpr43
-; VI-NEXT:    ; implicit-def: $sgpr42
-; VI-NEXT:    ; implicit-def: $sgpr41
-; VI-NEXT:    ; implicit-def: $sgpr40
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB45_2
 ;
 ; GFX9-LABEL: bitcast_v12i64_to_v48f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v11, s16
+; GFX9-NEXT:    v_mov_b32_e32 v12, s17
+; GFX9-NEXT:    v_mov_b32_e32 v13, s18
+; GFX9-NEXT:    v_mov_b32_e32 v14, s19
+; GFX9-NEXT:    v_mov_b32_e32 v15, s20
+; GFX9-NEXT:    v_mov_b32_e32 v16, s21
+; GFX9-NEXT:    v_mov_b32_e32 v17, s22
+; GFX9-NEXT:    v_mov_b32_e32 v18, s23
+; GFX9-NEXT:    v_mov_b32_e32 v19, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v11
+; GFX9-NEXT:    v_mov_b32_e32 v11, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v12
+; GFX9-NEXT:    v_mov_b32_e32 v12, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v13
+; GFX9-NEXT:    v_mov_b32_e32 v13, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v14
+; GFX9-NEXT:    v_mov_b32_e32 v14, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v10
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v11
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v12
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
-; GFX9-NEXT:    s_lshr_b32 s40, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s40, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB45_3
 ; GFX9-NEXT:  .LBB45_2: ; %cmp.true
-; GFX9-NEXT:    s_add_u32 s14, s14, 3
-; GFX9-NEXT:    s_addc_u32 s15, s15, 0
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_add_u32 s28, s28, 3
 ; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
@@ -26831,79 +27300,89 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
-; GFX9-NEXT:    s_lshr_b32 s40, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s41, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s16, 16
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
+; GFX9-NEXT:    s_lshr_b32 s40, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s41, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s6, 16
 ; GFX9-NEXT:  .LBB45_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s44
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s43
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s42
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s41
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s40
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s43
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s42
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s41
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s40
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; GFX9-NEXT:  .LBB45_4:
 ; GFX9-NEXT:    ; implicit-def: $sgpr79
@@ -26935,37 +27414,64 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; GFX11-LABEL: bitcast_v12i64_to_v48f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v7, s0 :: v_dual_mov_b32 v8, s1
+; GFX11-NEXT:    v_dual_mov_b32 v9, s2 :: v_dual_mov_b32 v10, s3
+; GFX11-NEXT:    v_dual_mov_b32 v11, s16 :: v_dual_mov_b32 v12, s17
+; GFX11-NEXT:    v_dual_mov_b32 v13, s18 :: v_dual_mov_b32 v14, s19
+; GFX11-NEXT:    v_dual_mov_b32 v15, s20 :: v_dual_mov_b32 v16, s21
+; GFX11-NEXT:    v_dual_mov_b32 v17, s22 :: v_dual_mov_b32 v18, s23
+; GFX11-NEXT:    v_dual_mov_b32 v19, s24 :: v_dual_mov_b32 v20, s25
+; GFX11-NEXT:    v_dual_mov_b32 v21, s26 :: v_dual_mov_b32 v22, s27
+; GFX11-NEXT:    v_dual_mov_b32 v23, s28 :: v_dual_mov_b32 v24, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v5
 ; GFX11-NEXT:    s_mov_b32 s74, 0
-; GFX11-NEXT:    s_and_b32 s10, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s24, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s10, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s62, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s63, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s72, s1, 16
@@ -26973,50 +27479,50 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s74
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB45_3
 ; GFX11-NEXT:  .LBB45_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s9, s9, 3
-; GFX11-NEXT:    s_addc_u32 s8, s8, 0
-; GFX11-NEXT:    s_add_u32 s6, s6, 3
-; GFX11-NEXT:    s_addc_u32 s7, s7, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
-; GFX11-NEXT:    s_add_u32 s24, s24, 3
-; GFX11-NEXT:    s_addc_u32 s25, s25, 0
-; GFX11-NEXT:    s_add_u32 s22, s22, 3
-; GFX11-NEXT:    s_addc_u32 s23, s23, 0
+; GFX11-NEXT:    s_add_u32 s23, s23, 3
+; GFX11-NEXT:    s_addc_u32 s22, s22, 0
 ; GFX11-NEXT:    s_add_u32 s20, s20, 3
 ; GFX11-NEXT:    s_addc_u32 s21, s21, 0
 ; GFX11-NEXT:    s_add_u32 s18, s18, 3
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s10, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s11, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s12, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s24, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s25, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s62, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s63, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s72, s1, 16
@@ -27027,38 +27533,38 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s72
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s63
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s12
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s11
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s10
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s26
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s25
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s24
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s9 :: v_dual_mov_b32 v23, s8
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s23 :: v_dual_mov_b32 v23, s22
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB45_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr73
@@ -27079,12 +27585,12 @@ define inreg <48 x half> @bitcast_v12i64_to_v48f16_scalar(<12 x i64> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
-; GFX11-NEXT:    ; implicit-def: $sgpr11
-; GFX11-NEXT:    ; implicit-def: $sgpr10
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
+; GFX11-NEXT:    ; implicit-def: $sgpr25
+; GFX11-NEXT:    ; implicit-def: $sgpr24
 ; GFX11-NEXT:    s_branch .LBB45_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -30514,8 +31020,8 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; VI-NEXT:    v_mov_b32_e32 v24, s17
 ; VI-NEXT:    v_mov_b32_e32 v19, s18
 ; VI-NEXT:    v_mov_b32_e32 v20, s19
-; VI-NEXT:    v_mov_b32_e32 v15, s20
-; VI-NEXT:    v_mov_b32_e32 v16, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s21
 ; VI-NEXT:    v_mov_b32_e32 v11, s22
 ; VI-NEXT:    v_mov_b32_e32 v12, s23
 ; VI-NEXT:    v_mov_b32_e32 v21, s24
@@ -30523,8 +31029,8 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; VI-NEXT:    v_mov_b32_e32 v17, s26
 ; VI-NEXT:    v_mov_b32_e32 v18, s27
 ; VI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; VI-NEXT:    v_mov_b32_e32 v13, s28
-; VI-NEXT:    v_mov_b32_e32 v14, s29
+; VI-NEXT:    v_mov_b32_e32 v15, s28
+; VI-NEXT:    v_mov_b32_e32 v16, s29
 ; VI-NEXT:    s_cbranch_scc0 .LBB49_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
 ; VI-NEXT:    v_lshrrev_b32_e32 v34, 16, v9
@@ -30537,16 +31043,16 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v52, 16, v14
-; VI-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
+; VI-NEXT:    v_lshrrev_b32_e32 v52, 16, v16
+; VI-NEXT:    v_lshrrev_b32_e32 v53, 16, v15
 ; VI-NEXT:    v_lshrrev_b32_e32 v54, 16, v18
 ; VI-NEXT:    v_lshrrev_b32_e32 v10, 16, v17
 ; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v21
 ; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
 ; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v11
-; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
+; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v33, 16, v20
 ; VI-NEXT:    v_lshrrev_b32_e32 v32, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v24
@@ -30558,11 +31064,11 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; VI-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; VI-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; VI-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; VI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; VI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; VI-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
-; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; VI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
 ; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; VI-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; VI-NEXT:    v_lshrrev_b32_e32 v34, 16, v9
@@ -30575,16 +31081,16 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v52, 16, v14
-; VI-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
+; VI-NEXT:    v_lshrrev_b32_e32 v52, 16, v16
+; VI-NEXT:    v_lshrrev_b32_e32 v53, 16, v15
 ; VI-NEXT:    v_lshrrev_b32_e32 v54, 16, v18
 ; VI-NEXT:    v_lshrrev_b32_e32 v10, 16, v17
 ; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v21
 ; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
 ; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v11
-; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
+; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v33, 16, v20
 ; VI-NEXT:    v_lshrrev_b32_e32 v32, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v24
@@ -30599,26 +31105,26 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v33
 ; VI-NEXT:    v_or_b32_sdwa v33, v20, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v55
-; VI-NEXT:    v_or_b32_sdwa v24, v15, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v25
-; VI-NEXT:    v_or_b32_sdwa v25, v16, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v26
-; VI-NEXT:    v_or_b32_sdwa v26, v11, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v24, v13, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v25
+; VI-NEXT:    v_or_b32_sdwa v25, v14, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v26
+; VI-NEXT:    v_or_b32_sdwa v26, v11, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v27
+; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v51
 ; VI-NEXT:    v_or_b32_sdwa v27, v12, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v12, 16, v53
-; VI-NEXT:    v_or_b32_sdwa v12, v13, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v52
-; VI-NEXT:    v_or_b32_sdwa v13, v14, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v51
 ; VI-NEXT:    v_or_b32_sdwa v14, v0, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v50
 ; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v28
+; VI-NEXT:    v_or_b32_sdwa v12, v15, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v52
 ; VI-NEXT:    v_or_b32_sdwa v15, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v49
 ; VI-NEXT:    v_or_b32_sdwa v28, v21, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v29
 ; VI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
+; VI-NEXT:    v_or_b32_sdwa v13, v16, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v16, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v48
 ; VI-NEXT:    v_or_b32_sdwa v29, v22, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -30684,8 +31190,8 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s17
 ; GFX9-NEXT:    v_mov_b32_e32 v19, s18
 ; GFX9-NEXT:    v_mov_b32_e32 v20, s19
-; GFX9-NEXT:    v_mov_b32_e32 v15, s20
-; GFX9-NEXT:    v_mov_b32_e32 v16, s21
+; GFX9-NEXT:    v_mov_b32_e32 v13, s20
+; GFX9-NEXT:    v_mov_b32_e32 v14, s21
 ; GFX9-NEXT:    v_mov_b32_e32 v11, s22
 ; GFX9-NEXT:    v_mov_b32_e32 v12, s23
 ; GFX9-NEXT:    v_mov_b32_e32 v21, s24
@@ -30693,8 +31199,8 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; GFX9-NEXT:    v_mov_b32_e32 v17, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v18, s27
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_mov_b32_e32 v13, s28
-; GFX9-NEXT:    v_mov_b32_e32 v14, s29
+; GFX9-NEXT:    v_mov_b32_e32 v15, s28
+; GFX9-NEXT:    v_mov_b32_e32 v16, s29
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB49_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v34, 16, v9
@@ -30707,16 +31213,16 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v52, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
+; GFX9-NEXT:    v_lshrrev_b32_e32 v52, 16, v16
+; GFX9-NEXT:    v_lshrrev_b32_e32 v53, 16, v15
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v54, 16, v18
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v17
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v21
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v11
-; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
+; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v33, 16, v20
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v32, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v24
@@ -30728,11 +31234,11 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; GFX9-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; GFX9-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; GFX9-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
-; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; GFX9-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
 ; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; GFX9-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v34, 16, v9
@@ -30745,42 +31251,42 @@ define inreg <48 x i16> @bitcast_v12f64_to_v48i16_scalar(<12 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v52, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
+; GFX9-NEXT:    v_lshrrev_b32_e32 v52, 16, v16
+; GFX9-NEXT:    v_lshrrev_b32_e32 v53, 16, v15
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v54, 16, v18
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v17
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v21
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v11
-; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
+; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v33, 16, v20
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v32, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v24
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v23
 ; GFX9-NEXT:  .LBB49_3: ; %end
 ; GFX9-NEXT:    v_and_b32_e32 v23, 0xffff, v23
-; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v15
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v13
 ; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v11
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    v_lshl_or_b32 v30, v30, 16, v23
 ; GFX9-NEXT:    v_and_b32_e32 v23, 0xffff, v24
-; GFX9-NEXT:    v_lshl_or_b32 v24, v55, 16, v15
-; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v16
+; GFX9-NEXT:    v_lshl_or_b32 v24, v55, 16, v13
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v14
 ; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v11
 ; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v12
-; GFX9-NEXT:    v_and_b32_e32 v12, 0xffff, v13
-; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v14
 ; GFX9-NEXT:    v_lshl_or_b32 v14, v51, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v1
-; GFX9-NEXT:    v_lshl_or_b32 v25, v25, 16, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v11
 ; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v21
+; GFX9-NEXT:    v_and_b32_e32 v12, 0xffff, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v15, v50, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
+; GFX9-NEXT:    v_lshl_or_b32 v25, v25, 16, v13
 ; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v11
 ; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v22
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v16
 ; GFX9-NEXT:    v_lshl_or_b32 v16, v49, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v3
 ; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v19
@@ -31553,7 +32059,7 @@ define <12 x double> @bitcast_v48i16_to_v12f64(<48 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v20, vcc, s6, v20
 ; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
 ; SI-NEXT:    v_add_i32_e32 v22, vcc, s6, v22
-; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
+; SI-NEXT:    v_add_i32_e32 v23, vcc, 0x30000, v23
 ; SI-NEXT:  .LBB50_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
@@ -34266,430 +34772,489 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v11
-; SI-NEXT:    v_readfirstlane_b32 s12, v1
-; SI-NEXT:    v_readfirstlane_b32 s13, v2
-; SI-NEXT:    v_readfirstlane_b32 s10, v3
-; SI-NEXT:    v_readfirstlane_b32 s11, v4
-; SI-NEXT:    v_readfirstlane_b32 s8, v5
-; SI-NEXT:    v_readfirstlane_b32 s9, v6
-; SI-NEXT:    v_readfirstlane_b32 s6, v7
-; SI-NEXT:    v_readfirstlane_b32 s7, v8
-; SI-NEXT:    v_readfirstlane_b32 s4, v9
-; SI-NEXT:    s_and_b64 s[14:15], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s5, v10
-; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v60, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v61, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    v_mov_b32_e32 v23, s16
+; SI-NEXT:    v_mov_b32_e32 v24, s17
+; SI-NEXT:    v_mov_b32_e32 v21, s18
+; SI-NEXT:    v_mov_b32_e32 v22, s19
+; SI-NEXT:    v_mov_b32_e32 v19, s20
+; SI-NEXT:    v_mov_b32_e32 v20, s21
+; SI-NEXT:    v_mov_b32_e32 v15, s22
+; SI-NEXT:    v_mov_b32_e32 v16, s23
+; SI-NEXT:    v_mov_b32_e32 v17, s24
+; SI-NEXT:    v_mov_b32_e32 v18, s25
+; SI-NEXT:    v_mov_b32_e32 v13, s26
+; SI-NEXT:    v_mov_b32_e32 v14, s27
+; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
+; SI-NEXT:    v_mov_b32_e32 v11, s28
+; SI-NEXT:    v_mov_b32_e32 v12, s29
+; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_cbranch_scc0 .LBB53_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s14, s5, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s14
-; SI-NEXT:    s_lshr_b32 s14, s4, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s14
-; SI-NEXT:    s_lshr_b32 s14, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s14
-; SI-NEXT:    s_lshr_b32 s14, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s14
-; SI-NEXT:    s_lshr_b32 s14, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s14
-; SI-NEXT:    s_lshr_b32 s14, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s14
-; SI-NEXT:    s_lshr_b32 s14, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s14
-; SI-NEXT:    s_lshr_b32 s14, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s14
-; SI-NEXT:    s_lshr_b32 s14, s13, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s14
-; SI-NEXT:    s_lshr_b32 s14, s12, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s14
-; SI-NEXT:    s_lshr_b32 s14, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s14
-; SI-NEXT:    s_lshr_b32 s14, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s14
-; SI-NEXT:    s_lshr_b32 s14, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s14
-; SI-NEXT:    s_lshr_b32 s14, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s14
-; SI-NEXT:    s_lshr_b32 s14, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s14
-; SI-NEXT:    s_lshr_b32 s14, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s14
-; SI-NEXT:    s_lshr_b32 s14, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s14
-; SI-NEXT:    s_lshr_b32 s14, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s14
-; SI-NEXT:    s_lshr_b32 s14, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s14
-; SI-NEXT:    s_lshr_b32 s14, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s14
-; SI-NEXT:    s_lshr_b32 s14, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s14
-; SI-NEXT:    s_lshr_b32 s14, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s14
-; SI-NEXT:    s_lshr_b32 s14, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s14
-; SI-NEXT:    s_lshr_b32 s14, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s5
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v26
+; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v9
+; SI-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v25
+; SI-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
+; SI-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v10
+; SI-NEXT:    buffer_store_dword v25, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v4
+; SI-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v12
+; SI-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v18
+; SI-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v20
+; SI-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
+; SI-NEXT:    buffer_store_dword v26, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v15
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v23
 ; SI-NEXT:    s_cbranch_execnz .LBB53_3
 ; SI-NEXT:  .LBB53_2: ; %cmp.true
-; SI-NEXT:    v_add_f64 v[1:2], s[16:17], 1.0
-; SI-NEXT:    v_add_f64 v[50:51], s[18:19], 1.0
-; SI-NEXT:    v_add_f64 v[37:38], s[20:21], 1.0
-; SI-NEXT:    v_add_f64 v[33:34], s[22:23], 1.0
-; SI-NEXT:    v_add_f64 v[29:30], s[24:25], 1.0
-; SI-NEXT:    v_add_f64 v[27:28], s[26:27], 1.0
-; SI-NEXT:    v_add_f64 v[22:23], s[28:29], 1.0
-; SI-NEXT:    v_add_f64 v[18:19], s[12:13], 1.0
-; SI-NEXT:    v_add_f64 v[14:15], s[10:11], 1.0
-; SI-NEXT:    v_add_f64 v[10:11], s[8:9], 1.0
-; SI-NEXT:    v_add_f64 v[7:8], s[6:7], 1.0
-; SI-NEXT:    v_add_f64 v[3:4], s[4:5], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v50
-; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v51
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v37
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v38
-; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v33
-; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v34
-; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v29
-; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v30
-; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v27
-; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v28
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v23
-; SI-NEXT:    s_waitcnt expcnt(6)
-; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v16, 16, v19
-; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v10
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v11
-; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v7
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v8
+; SI-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
+; SI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
+; SI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; SI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; SI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; SI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; SI-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
+; SI-NEXT:    v_add_f64 v[1:2], v[1:2], 1.0
+; SI-NEXT:    v_add_f64 v[3:4], v[3:4], 1.0
+; SI-NEXT:    v_add_f64 v[5:6], v[5:6], 1.0
+; SI-NEXT:    v_add_f64 v[7:8], v[7:8], 1.0
+; SI-NEXT:    v_add_f64 v[9:10], v[9:10], 1.0
+; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v21
 ; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v3
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v62, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
 ; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v28
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v61
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v60
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v58
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v57
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v56
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v47
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v46
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v24
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v45
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v44
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v43
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v16
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v49
 ; SI-NEXT:    v_cvt_f32_f16_e32 v39, v39
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
 ; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
 ; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
 ; SI-NEXT:    v_cvt_f32_f16_e32 v40, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v62
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
+; SI-NEXT:    v_mov_b32_e32 v35, v10
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; SI-NEXT:  .LBB53_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v40, v40
-; SI-NEXT:    v_cvt_f16_f32_e32 v55, v55
-; SI-NEXT:    v_cvt_f16_f32_e32 v54, v54
-; SI-NEXT:    v_cvt_f16_f32_e32 v53, v53
-; SI-NEXT:    v_cvt_f16_f32_e32 v52, v52
-; SI-NEXT:    v_cvt_f16_f32_e32 v51, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v50, v50
-; SI-NEXT:    v_lshlrev_b32_e32 v40, 16, v40
-; SI-NEXT:    v_cvt_f16_f32_e32 v49, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v39, v39
-; SI-NEXT:    v_or_b32_e32 v55, v55, v40
-; SI-NEXT:    v_lshlrev_b32_e32 v54, 16, v54
-; SI-NEXT:    v_cvt_f16_f32_e32 v48, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v37, v37
-; SI-NEXT:    buffer_store_dword v55, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v55, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v53, v53, v54
-; SI-NEXT:    v_lshlrev_b32_e32 v52, 16, v52
-; SI-NEXT:    v_cvt_f16_f32_e32 v38, v38
-; SI-NEXT:    v_cvt_f16_f32_e32 v35, v35
-; SI-NEXT:    buffer_store_dword v53, v55, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v30
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v33
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v28
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v32
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v53, vcc, 8, v0
-; SI-NEXT:    v_or_b32_e32 v51, v51, v52
-; SI-NEXT:    v_lshlrev_b32_e32 v50, 16, v50
-; SI-NEXT:    v_cvt_f16_f32_e32 v36, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v33, v33
-; SI-NEXT:    buffer_store_dword v51, v53, s[0:3], 0 offen
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
+; SI-NEXT:    v_or_b32_e32 v2, v4, v2
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v25
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v51, vcc, 12, v0
-; SI-NEXT:    v_or_b32_e32 v49, v49, v50
-; SI-NEXT:    v_lshlrev_b32_e32 v39, 16, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v34, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v31, v31
-; SI-NEXT:    buffer_store_dword v49, v51, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v31
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v49, vcc, 16, v0
-; SI-NEXT:    v_or_b32_e32 v39, v48, v39
-; SI-NEXT:    v_lshlrev_b32_e32 v37, 16, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v32, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v29, v29
-; SI-NEXT:    buffer_store_dword v39, v49, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v62
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v39, vcc, 20, v0
-; SI-NEXT:    v_or_b32_e32 v37, v38, v37
-; SI-NEXT:    v_lshlrev_b32_e32 v35, 16, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v27, v27
-; SI-NEXT:    buffer_store_dword v37, v39, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v60
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v27
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v37, vcc, 24, v0
-; SI-NEXT:    v_or_b32_e32 v35, v36, v35
-; SI-NEXT:    v_lshlrev_b32_e32 v33, 16, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v28, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v24
-; SI-NEXT:    buffer_store_dword v35, v37, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v58
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v26
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 28, v0
-; SI-NEXT:    v_or_b32_e32 v33, v34, v33
-; SI-NEXT:    v_lshlrev_b32_e32 v31, 16, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v26, v26
-; SI-NEXT:    buffer_store_dword v33, v35, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v56
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v63
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 32, v0
-; SI-NEXT:    v_or_b32_e32 v31, v32, v31
-; SI-NEXT:    v_lshlrev_b32_e32 v29, 16, v29
-; SI-NEXT:    buffer_store_dword v31, v33, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v46
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v61
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 36, v0
-; SI-NEXT:    v_or_b32_e32 v29, v30, v29
-; SI-NEXT:    v_lshlrev_b32_e32 v27, 16, v27
-; SI-NEXT:    buffer_store_dword v29, v31, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v44
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v59
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v29, vcc, 40, v0
-; SI-NEXT:    v_or_b32_e32 v27, v28, v27
-; SI-NEXT:    v_lshlrev_b32_e32 v24, 16, v24
-; SI-NEXT:    buffer_store_dword v27, v29, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v43
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v57
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v27, vcc, 44, v0
-; SI-NEXT:    v_or_b32_e32 v24, v26, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v22
-; SI-NEXT:    buffer_store_dword v24, v27, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v42
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v47
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v24, v25
-; SI-NEXT:    v_add_i32_e32 v25, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v22, 16, v22
-; SI-NEXT:    v_or_b32_e32 v22, v24, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v20
-; SI-NEXT:    buffer_store_dword v22, v25, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v40
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v45
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v22, v23
-; SI-NEXT:    v_add_i32_e32 v23, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v20, 16, v20
-; SI-NEXT:    v_or_b32_e32 v20, v22, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v18
-; SI-NEXT:    buffer_store_dword v20, v23, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v54
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v41
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v20, v21
-; SI-NEXT:    v_add_i32_e32 v21, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v18, 16, v18
-; SI-NEXT:    v_or_b32_e32 v18, v20, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v16
-; SI-NEXT:    buffer_store_dword v18, v21, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v52
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v55
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v18, v19
-; SI-NEXT:    v_add_i32_e32 v19, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v16, 16, v16
-; SI-NEXT:    v_or_b32_e32 v16, v18, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; SI-NEXT:    buffer_store_dword v16, v19, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v50
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v53
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v16, v17
-; SI-NEXT:    v_add_i32_e32 v17, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
-; SI-NEXT:    v_or_b32_e32 v14, v16, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; SI-NEXT:    buffer_store_dword v14, v17, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v15
-; SI-NEXT:    v_add_i32_e32 v15, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
-; SI-NEXT:    v_or_b32_e32 v12, v14, v12
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v10
-; SI-NEXT:    buffer_store_dword v12, v15, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v12, v13
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v12, v10
-; SI-NEXT:    v_cvt_f16_f32_e32 v7, v7
-; SI-NEXT:    buffer_store_dword v10, v13, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v11
-; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x4c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v7, 16, v7
-; SI-NEXT:    v_or_b32_e32 v7, v10, v7
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v5
-; SI-NEXT:    buffer_store_dword v7, v11, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v7, v9
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 0x50, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v7, v5
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v8
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 0x54, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v5, v3
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v3, v7, s[0:3], 0 offen
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v6
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x58, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; SI-NEXT:    v_or_b32_e32 v2, v3, v2
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v38
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v36
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v34
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v5, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v4
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v37
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v39
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x54, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v49
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x58, v0
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x5c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v51
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v35
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    buffer_load_dword v61, off, s[0:3], s32 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v60, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v59, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v58, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v57, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v56, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB53_4:
-; SI-NEXT:    ; implicit-def: $vgpr55
-; SI-NEXT:    ; implicit-def: $vgpr40
-; SI-NEXT:    ; implicit-def: $vgpr53
-; SI-NEXT:    ; implicit-def: $vgpr54
-; SI-NEXT:    ; implicit-def: $vgpr51
-; SI-NEXT:    ; implicit-def: $vgpr52
-; SI-NEXT:    ; implicit-def: $vgpr49
-; SI-NEXT:    ; implicit-def: $vgpr50
-; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr39
-; SI-NEXT:    ; implicit-def: $vgpr38
-; SI-NEXT:    ; implicit-def: $vgpr37
-; SI-NEXT:    ; implicit-def: $vgpr36
 ; SI-NEXT:    ; implicit-def: $vgpr35
 ; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; kill: killed $vgpr35
+; SI-NEXT:    ; kill: killed $vgpr34
+; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; kill: killed $vgpr35
+; SI-NEXT:    ; kill: killed $vgpr34
 ; SI-NEXT:    ; implicit-def: $vgpr33
-; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    ; implicit-def: $vgpr30
-; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr32
 ; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr27
-; SI-NEXT:    ; implicit-def: $vgpr26
-; SI-NEXT:    ; implicit-def: $vgpr24
+; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    ; implicit-def: $vgpr25
-; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr23
-; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr14
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr13
-; SI-NEXT:    ; implicit-def: $vgpr10
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr8
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr6
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr1
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr62
+; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr60
+; SI-NEXT:    ; implicit-def: $vgpr26
+; SI-NEXT:    ; implicit-def: $vgpr58
+; SI-NEXT:    ; implicit-def: $vgpr63
+; SI-NEXT:    ; implicit-def: $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr61
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr59
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr57
+; SI-NEXT:    ; implicit-def: $vgpr43
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr48
+; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr36
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr39
+; SI-NEXT:    ; implicit-def: $vgpr49
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; kill: killed $vgpr35
+; SI-NEXT:    ; kill: killed $vgpr34
+; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; kill: killed $vgpr35
+; SI-NEXT:    ; kill: killed $vgpr34
+; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; kill: killed $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr35
 ; SI-NEXT:    s_branch .LBB53_2
 ;
 ; VI-LABEL: bitcast_v12f64_to_v48f16_scalar:
@@ -34700,8 +35265,8 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; VI-NEXT:    v_mov_b32_e32 v24, s17
 ; VI-NEXT:    v_mov_b32_e32 v19, s18
 ; VI-NEXT:    v_mov_b32_e32 v20, s19
-; VI-NEXT:    v_mov_b32_e32 v15, s20
-; VI-NEXT:    v_mov_b32_e32 v16, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s21
 ; VI-NEXT:    v_mov_b32_e32 v11, s22
 ; VI-NEXT:    v_mov_b32_e32 v12, s23
 ; VI-NEXT:    v_mov_b32_e32 v21, s24
@@ -34709,8 +35274,8 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; VI-NEXT:    v_mov_b32_e32 v17, s26
 ; VI-NEXT:    v_mov_b32_e32 v18, s27
 ; VI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; VI-NEXT:    v_mov_b32_e32 v13, s28
-; VI-NEXT:    v_mov_b32_e32 v14, s29
+; VI-NEXT:    v_mov_b32_e32 v15, s28
+; VI-NEXT:    v_mov_b32_e32 v16, s29
 ; VI-NEXT:    s_cbranch_scc0 .LBB53_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
 ; VI-NEXT:    v_lshrrev_b32_e32 v34, 16, v9
@@ -34723,16 +35288,16 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v52, 16, v14
-; VI-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
+; VI-NEXT:    v_lshrrev_b32_e32 v52, 16, v16
+; VI-NEXT:    v_lshrrev_b32_e32 v53, 16, v15
 ; VI-NEXT:    v_lshrrev_b32_e32 v54, 16, v18
 ; VI-NEXT:    v_lshrrev_b32_e32 v10, 16, v17
 ; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v21
 ; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
 ; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v11
-; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
+; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v33, 16, v20
 ; VI-NEXT:    v_lshrrev_b32_e32 v32, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v24
@@ -34744,11 +35309,11 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; VI-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; VI-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; VI-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; VI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; VI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; VI-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
-; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; VI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
 ; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; VI-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; VI-NEXT:    v_lshrrev_b32_e32 v34, 16, v9
@@ -34761,16 +35326,16 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v52, 16, v14
-; VI-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
+; VI-NEXT:    v_lshrrev_b32_e32 v52, 16, v16
+; VI-NEXT:    v_lshrrev_b32_e32 v53, 16, v15
 ; VI-NEXT:    v_lshrrev_b32_e32 v54, 16, v18
 ; VI-NEXT:    v_lshrrev_b32_e32 v10, 16, v17
 ; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v21
 ; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
 ; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v11
-; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
+; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v33, 16, v20
 ; VI-NEXT:    v_lshrrev_b32_e32 v32, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v24
@@ -34785,26 +35350,26 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v33
 ; VI-NEXT:    v_or_b32_sdwa v33, v20, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v55
-; VI-NEXT:    v_or_b32_sdwa v24, v15, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v25
-; VI-NEXT:    v_or_b32_sdwa v25, v16, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v26
-; VI-NEXT:    v_or_b32_sdwa v26, v11, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v24, v13, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v25
+; VI-NEXT:    v_or_b32_sdwa v25, v14, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v26
+; VI-NEXT:    v_or_b32_sdwa v26, v11, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v27
+; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v51
 ; VI-NEXT:    v_or_b32_sdwa v27, v12, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v12, 16, v53
-; VI-NEXT:    v_or_b32_sdwa v12, v13, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v52
-; VI-NEXT:    v_or_b32_sdwa v13, v14, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v51
 ; VI-NEXT:    v_or_b32_sdwa v14, v0, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v50
 ; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v28
+; VI-NEXT:    v_or_b32_sdwa v12, v15, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v52
 ; VI-NEXT:    v_or_b32_sdwa v15, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v49
 ; VI-NEXT:    v_or_b32_sdwa v28, v21, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v11, 16, v29
 ; VI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
+; VI-NEXT:    v_or_b32_sdwa v13, v16, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v16, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v48
 ; VI-NEXT:    v_or_b32_sdwa v29, v22, v11 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -34870,8 +35435,8 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s17
 ; GFX9-NEXT:    v_mov_b32_e32 v19, s18
 ; GFX9-NEXT:    v_mov_b32_e32 v20, s19
-; GFX9-NEXT:    v_mov_b32_e32 v15, s20
-; GFX9-NEXT:    v_mov_b32_e32 v16, s21
+; GFX9-NEXT:    v_mov_b32_e32 v13, s20
+; GFX9-NEXT:    v_mov_b32_e32 v14, s21
 ; GFX9-NEXT:    v_mov_b32_e32 v11, s22
 ; GFX9-NEXT:    v_mov_b32_e32 v12, s23
 ; GFX9-NEXT:    v_mov_b32_e32 v21, s24
@@ -34879,8 +35444,8 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; GFX9-NEXT:    v_mov_b32_e32 v17, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v18, s27
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_mov_b32_e32 v13, s28
-; GFX9-NEXT:    v_mov_b32_e32 v14, s29
+; GFX9-NEXT:    v_mov_b32_e32 v15, s28
+; GFX9-NEXT:    v_mov_b32_e32 v16, s29
 ; GFX9-NEXT:    s_cbranch_scc0 .LBB53_4
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v34, 16, v9
@@ -34893,16 +35458,16 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v52, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
+; GFX9-NEXT:    v_lshrrev_b32_e32 v52, 16, v16
+; GFX9-NEXT:    v_lshrrev_b32_e32 v53, 16, v15
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v54, 16, v18
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v17
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v21
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v11
-; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
+; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v33, 16, v20
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v32, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v24
@@ -34914,11 +35479,11 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; GFX9-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; GFX9-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; GFX9-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
-; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; GFX9-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
 ; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; GFX9-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v34, 16, v9
@@ -34931,42 +35496,42 @@ define inreg <48 x half> @bitcast_v12f64_to_v48f16_scalar(<12 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v52, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v53, 16, v13
+; GFX9-NEXT:    v_lshrrev_b32_e32 v52, 16, v16
+; GFX9-NEXT:    v_lshrrev_b32_e32 v53, 16, v15
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v54, 16, v18
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v17
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v21
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v11
-; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v14
+; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v33, 16, v20
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v32, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v24
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v23
 ; GFX9-NEXT:  .LBB53_3: ; %end
 ; GFX9-NEXT:    v_and_b32_e32 v23, 0xffff, v23
-; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v15
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v13
 ; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v11
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    v_lshl_or_b32 v30, v30, 16, v23
 ; GFX9-NEXT:    v_and_b32_e32 v23, 0xffff, v24
-; GFX9-NEXT:    v_lshl_or_b32 v24, v55, 16, v15
-; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v16
+; GFX9-NEXT:    v_lshl_or_b32 v24, v55, 16, v13
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v14
 ; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v11
 ; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v12
-; GFX9-NEXT:    v_and_b32_e32 v12, 0xffff, v13
-; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v14
 ; GFX9-NEXT:    v_lshl_or_b32 v14, v51, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v1
-; GFX9-NEXT:    v_lshl_or_b32 v25, v25, 16, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v11
 ; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v21
+; GFX9-NEXT:    v_and_b32_e32 v12, 0xffff, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v15, v50, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
+; GFX9-NEXT:    v_lshl_or_b32 v25, v25, 16, v13
 ; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v11
 ; GFX9-NEXT:    v_and_b32_e32 v11, 0xffff, v22
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v16
 ; GFX9-NEXT:    v_lshl_or_b32 v16, v49, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v3
 ; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v19

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.832bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.832bit.ll
@@ -3409,18 +3409,46 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_store_dword v14, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_writelane_b32 v14, s30, 0
-; SI-NEXT:    v_writelane_b32 v14, s31, 1
-; SI-NEXT:    v_writelane_b32 v14, s34, 2
-; SI-NEXT:    v_writelane_b32 v14, s35, 3
-; SI-NEXT:    v_writelane_b32 v14, s36, 4
-; SI-NEXT:    v_writelane_b32 v14, s37, 5
-; SI-NEXT:    v_writelane_b32 v14, s38, 6
+; SI-NEXT:    v_writelane_b32 v20, s30, 0
+; SI-NEXT:    v_writelane_b32 v20, s31, 1
+; SI-NEXT:    v_writelane_b32 v20, s34, 2
+; SI-NEXT:    v_writelane_b32 v20, s35, 3
+; SI-NEXT:    v_writelane_b32 v20, s36, 4
+; SI-NEXT:    v_mov_b32_e32 v14, s16
+; SI-NEXT:    v_mov_b32_e32 v15, s17
+; SI-NEXT:    v_writelane_b32 v20, s37, 5
+; SI-NEXT:    v_mov_b32_e32 v16, s18
+; SI-NEXT:    v_mov_b32_e32 v17, s19
+; SI-NEXT:    v_mov_b32_e32 v18, s20
+; SI-NEXT:    v_mov_b32_e32 v19, s21
+; SI-NEXT:    v_readfirstlane_b32 s42, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s22
+; SI-NEXT:    v_readfirstlane_b32 s43, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s23
+; SI-NEXT:    v_writelane_b32 v20, s38, 6
+; SI-NEXT:    v_readfirstlane_b32 s40, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_readfirstlane_b32 s41, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_readfirstlane_b32 s24, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; SI-NEXT:    v_writelane_b32 v14, s39, 7
+; SI-NEXT:    v_writelane_b32 v20, s39, 7
+; SI-NEXT:    v_readfirstlane_b32 s20, v16
+; SI-NEXT:    v_readfirstlane_b32 s21, v17
+; SI-NEXT:    v_readfirstlane_b32 s18, v18
+; SI-NEXT:    v_readfirstlane_b32 s19, v19
+; SI-NEXT:    v_readfirstlane_b32 s16, v14
+; SI-NEXT:    v_readfirstlane_b32 s17, v15
 ; SI-NEXT:    v_readfirstlane_b32 s14, v1
 ; SI-NEXT:    v_readfirstlane_b32 s15, v2
 ; SI-NEXT:    v_readfirstlane_b32 s12, v3
@@ -3432,9 +3460,9 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v9
 ; SI-NEXT:    v_readfirstlane_b32 s7, v10
 ; SI-NEXT:    v_readfirstlane_b32 s4, v11
-; SI-NEXT:    s_and_b64 s[40:41], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v12
-; SI-NEXT:    v_writelane_b32 v14, s48, 8
+; SI-NEXT:    v_writelane_b32 v20, s48, 8
 ; SI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s92, s5, 16
@@ -3443,42 +3471,42 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s95, s11, 16
 ; SI-NEXT:    s_lshr_b32 s30, s13, 16
 ; SI-NEXT:    s_lshr_b32 s31, s15, 16
-; SI-NEXT:    s_lshr_b32 s34, s29, 16
-; SI-NEXT:    s_lshr_b32 s35, s27, 16
-; SI-NEXT:    s_lshr_b32 s36, s25, 16
+; SI-NEXT:    s_lshr_b32 s34, s17, 16
+; SI-NEXT:    s_lshr_b32 s35, s19, 16
+; SI-NEXT:    s_lshr_b32 s36, s21, 16
 ; SI-NEXT:    s_lshr_b32 s37, s23, 16
-; SI-NEXT:    s_lshr_b32 s38, s21, 16
-; SI-NEXT:    s_lshr_b32 s39, s19, 16
-; SI-NEXT:    s_lshr_b32 s48, s17, 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s38, s25, 16
+; SI-NEXT:    s_lshr_b32 s39, s41, 16
+; SI-NEXT:    s_lshr_b32 s48, s43, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[44:45], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[20:21], 16
 ; SI-NEXT:    s_lshr_b64 s[74:75], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[88:89], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[88:89], s[42:43], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB13_3
 ; SI-NEXT:  .LBB13_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s23, s23, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s43, s43, 3
+; SI-NEXT:    s_add_i32 s42, s42, 3
+; SI-NEXT:    s_add_i32 s41, s41, 3
+; SI-NEXT:    s_add_i32 s40, s40, 3
 ; SI-NEXT:    s_add_i32 s25, s25, 3
 ; SI-NEXT:    s_add_i32 s24, s24, 3
-; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s26, s26, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
+; SI-NEXT:    s_add_i32 s23, s23, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
 ; SI-NEXT:    s_add_i32 s15, s15, 3
 ; SI-NEXT:    s_add_i32 s14, s14, 3
 ; SI-NEXT:    s_add_i32 s13, s13, 3
@@ -3491,118 +3519,118 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s5, s5, 3
 ; SI-NEXT:    s_add_i32 s4, s4, 3
-; SI-NEXT:    s_lshr_b64 s[40:41], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[44:45], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[28:29], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[16:17], 16
 ; SI-NEXT:    s_lshr_b32 s92, s5, 16
 ; SI-NEXT:    s_lshr_b32 s93, s7, 16
 ; SI-NEXT:    s_lshr_b32 s94, s9, 16
 ; SI-NEXT:    s_lshr_b32 s95, s11, 16
 ; SI-NEXT:    s_lshr_b32 s30, s13, 16
 ; SI-NEXT:    s_lshr_b32 s31, s15, 16
-; SI-NEXT:    s_lshr_b32 s34, s29, 16
-; SI-NEXT:    s_lshr_b32 s35, s27, 16
-; SI-NEXT:    s_lshr_b32 s36, s25, 16
+; SI-NEXT:    s_lshr_b32 s34, s17, 16
+; SI-NEXT:    s_lshr_b32 s35, s19, 16
+; SI-NEXT:    s_lshr_b32 s36, s21, 16
 ; SI-NEXT:    s_lshr_b32 s37, s23, 16
-; SI-NEXT:    s_lshr_b32 s38, s21, 16
-; SI-NEXT:    s_lshr_b32 s39, s19, 16
-; SI-NEXT:    s_lshr_b32 s48, s17, 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[24:25], 16
+; SI-NEXT:    s_lshr_b32 s38, s25, 16
+; SI-NEXT:    s_lshr_b32 s39, s41, 16
+; SI-NEXT:    s_lshr_b32 s48, s43, 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[20:21], 16
 ; SI-NEXT:    s_lshr_b64 s[74:75], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[88:89], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[88:89], s[42:43], 16
 ; SI-NEXT:  .LBB13_3: ; %end
-; SI-NEXT:    s_lshl_b32 s41, s88, 16
-; SI-NEXT:    s_and_b32 s16, s16, 0xffff
-; SI-NEXT:    s_or_b32 s16, s16, s41
-; SI-NEXT:    v_mov_b32_e32 v1, s16
-; SI-NEXT:    s_and_b32 s16, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s48, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_lshl_b32 s16, s78, 16
-; SI-NEXT:    s_and_b32 s17, s18, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
-; SI-NEXT:    v_mov_b32_e32 v3, s16
-; SI-NEXT:    s_and_b32 s16, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s39, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v4, s16
-; SI-NEXT:    s_lshl_b32 s16, s76, 16
-; SI-NEXT:    s_and_b32 s17, s20, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
+; SI-NEXT:    s_lshl_b32 s27, s88, 16
+; SI-NEXT:    s_and_b32 s29, s42, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s27
+; SI-NEXT:    s_and_b32 s27, s43, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s48, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_lshl_b32 s27, s78, 16
+; SI-NEXT:    s_and_b32 s29, s40, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v3, s27
+; SI-NEXT:    s_and_b32 s27, s41, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s39, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v4, s27
+; SI-NEXT:    s_lshl_b32 s27, s76, 16
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_or_b32 s24, s24, s27
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    v_mov_b32_e32 v5, s16
-; SI-NEXT:    s_and_b32 s16, s21, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v5, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    s_lshl_b32 s17, s38, 16
+; SI-NEXT:    s_lshl_b32 s25, s38, 16
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s25
 ; SI-NEXT:    buffer_store_dword v4, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
 ; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s74, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s24, s74, 16
 ; SI-NEXT:    buffer_store_dword v5, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s24
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s37, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s37, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s23
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s22, s72, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s36, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s36, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s62, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s62, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s27, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s35, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s35, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s60, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s60, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s29, 0xffff
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
 ; SI-NEXT:    s_lshl_b32 s17, s34, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
 ; SI-NEXT:    s_or_b32 s16, s16, s17
@@ -3666,7 +3694,7 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s42, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x54, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3680,7 +3708,7 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s40, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x5c, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3694,17 +3722,17 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x64, v0
 ; SI-NEXT:    v_mov_b32_e32 v1, s4
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    v_readlane_b32 s48, v14, 8
-; SI-NEXT:    v_readlane_b32 s39, v14, 7
-; SI-NEXT:    v_readlane_b32 s38, v14, 6
-; SI-NEXT:    v_readlane_b32 s37, v14, 5
-; SI-NEXT:    v_readlane_b32 s36, v14, 4
-; SI-NEXT:    v_readlane_b32 s35, v14, 3
-; SI-NEXT:    v_readlane_b32 s34, v14, 2
-; SI-NEXT:    v_readlane_b32 s31, v14, 1
-; SI-NEXT:    v_readlane_b32 s30, v14, 0
+; SI-NEXT:    v_readlane_b32 s48, v20, 8
+; SI-NEXT:    v_readlane_b32 s39, v20, 7
+; SI-NEXT:    v_readlane_b32 s38, v20, 6
+; SI-NEXT:    v_readlane_b32 s37, v20, 5
+; SI-NEXT:    v_readlane_b32 s36, v20, 4
+; SI-NEXT:    v_readlane_b32 s35, v20, 3
+; SI-NEXT:    v_readlane_b32 s34, v20, 2
+; SI-NEXT:    v_readlane_b32 s31, v20, 1
+; SI-NEXT:    v_readlane_b32 s30, v20, 0
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 ; 4-byte Folded Reload
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -3733,16 +3761,44 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr94
 ; SI-NEXT:    ; implicit-def: $sgpr93
 ; SI-NEXT:    ; implicit-def: $sgpr92
-; SI-NEXT:    ; implicit-def: $sgpr42
-; SI-NEXT:    ; implicit-def: $sgpr40
+; SI-NEXT:    ; implicit-def: $sgpr28
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    s_branch .LBB13_2
 ;
 ; VI-LABEL: bitcast_v26i32_to_v52i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v13, s16
+; VI-NEXT:    v_mov_b32_e32 v14, s17
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s20
+; VI-NEXT:    v_mov_b32_e32 v18, s21
+; VI-NEXT:    v_mov_b32_e32 v19, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v13
+; VI-NEXT:    v_mov_b32_e32 v13, s23
+; VI-NEXT:    v_readfirstlane_b32 s43, v14
+; VI-NEXT:    v_mov_b32_e32 v14, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
-; VI-NEXT:    v_readfirstlane_b32 s41, v0
-; VI-NEXT:    v_readfirstlane_b32 s40, v1
+; VI-NEXT:    v_readfirstlane_b32 s24, v13
+; VI-NEXT:    v_readfirstlane_b32 s23, v14
+; VI-NEXT:    v_readfirstlane_b32 s22, v15
+; VI-NEXT:    v_readfirstlane_b32 s21, v16
+; VI-NEXT:    v_readfirstlane_b32 s20, v17
+; VI-NEXT:    v_readfirstlane_b32 s19, v18
+; VI-NEXT:    v_readfirstlane_b32 s18, v19
+; VI-NEXT:    v_readfirstlane_b32 s17, v0
+; VI-NEXT:    v_readfirstlane_b32 s16, v1
 ; VI-NEXT:    v_readfirstlane_b32 s15, v2
 ; VI-NEXT:    v_readfirstlane_b32 s14, v3
 ; VI-NEXT:    v_readfirstlane_b32 s13, v4
@@ -3756,9 +3812,9 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; VI-NEXT:    v_readfirstlane_b32 s7, v11
 ; VI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s42, s7, 16
-; VI-NEXT:    s_lshr_b32 s43, s6, 16
-; VI-NEXT:    s_lshr_b32 s44, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s45, s9, 16
 ; VI-NEXT:    s_lshr_b32 s46, s10, 16
 ; VI-NEXT:    s_lshr_b32 s47, s11, 16
@@ -3766,22 +3822,22 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s57, s13, 16
 ; VI-NEXT:    s_lshr_b32 s58, s14, 16
 ; VI-NEXT:    s_lshr_b32 s59, s15, 16
-; VI-NEXT:    s_lshr_b32 s60, s40, 16
-; VI-NEXT:    s_lshr_b32 s61, s41, 16
-; VI-NEXT:    s_lshr_b32 s62, s29, 16
-; VI-NEXT:    s_lshr_b32 s63, s28, 16
-; VI-NEXT:    s_lshr_b32 s72, s27, 16
-; VI-NEXT:    s_lshr_b32 s73, s26, 16
-; VI-NEXT:    s_lshr_b32 s74, s25, 16
-; VI-NEXT:    s_lshr_b32 s75, s24, 16
-; VI-NEXT:    s_lshr_b32 s76, s23, 16
-; VI-NEXT:    s_lshr_b32 s77, s22, 16
-; VI-NEXT:    s_lshr_b32 s78, s21, 16
-; VI-NEXT:    s_lshr_b32 s79, s20, 16
-; VI-NEXT:    s_lshr_b32 s88, s19, 16
-; VI-NEXT:    s_lshr_b32 s89, s18, 16
-; VI-NEXT:    s_lshr_b32 s90, s17, 16
-; VI-NEXT:    s_lshr_b32 s91, s16, 16
+; VI-NEXT:    s_lshr_b32 s60, s16, 16
+; VI-NEXT:    s_lshr_b32 s61, s17, 16
+; VI-NEXT:    s_lshr_b32 s62, s18, 16
+; VI-NEXT:    s_lshr_b32 s63, s19, 16
+; VI-NEXT:    s_lshr_b32 s72, s20, 16
+; VI-NEXT:    s_lshr_b32 s73, s21, 16
+; VI-NEXT:    s_lshr_b32 s74, s22, 16
+; VI-NEXT:    s_lshr_b32 s75, s23, 16
+; VI-NEXT:    s_lshr_b32 s76, s24, 16
+; VI-NEXT:    s_lshr_b32 s77, s25, 16
+; VI-NEXT:    s_lshr_b32 s78, s26, 16
+; VI-NEXT:    s_lshr_b32 s79, s40, 16
+; VI-NEXT:    s_lshr_b32 s88, s41, 16
+; VI-NEXT:    s_lshr_b32 s89, s42, 16
+; VI-NEXT:    s_lshr_b32 s90, s43, 16
+; VI-NEXT:    s_lshr_b32 s91, s44, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB13_3
 ; VI-NEXT:  .LBB13_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -3794,25 +3850,25 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; VI-NEXT:    s_add_i32 s13, s13, 3
 ; VI-NEXT:    s_add_i32 s14, s14, 3
 ; VI-NEXT:    s_add_i32 s15, s15, 3
+; VI-NEXT:    s_add_i32 s16, s16, 3
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
 ; VI-NEXT:    s_add_i32 s40, s40, 3
 ; VI-NEXT:    s_add_i32 s41, s41, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
-; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s42, s7, 16
-; VI-NEXT:    s_lshr_b32 s43, s6, 16
-; VI-NEXT:    s_lshr_b32 s44, s8, 16
+; VI-NEXT:    s_add_i32 s42, s42, 3
+; VI-NEXT:    s_add_i32 s43, s43, 3
+; VI-NEXT:    s_add_i32 s44, s44, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s45, s9, 16
 ; VI-NEXT:    s_lshr_b32 s46, s10, 16
 ; VI-NEXT:    s_lshr_b32 s47, s11, 16
@@ -3820,117 +3876,117 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s57, s13, 16
 ; VI-NEXT:    s_lshr_b32 s58, s14, 16
 ; VI-NEXT:    s_lshr_b32 s59, s15, 16
-; VI-NEXT:    s_lshr_b32 s60, s40, 16
-; VI-NEXT:    s_lshr_b32 s61, s41, 16
-; VI-NEXT:    s_lshr_b32 s62, s29, 16
-; VI-NEXT:    s_lshr_b32 s63, s28, 16
-; VI-NEXT:    s_lshr_b32 s72, s27, 16
-; VI-NEXT:    s_lshr_b32 s73, s26, 16
-; VI-NEXT:    s_lshr_b32 s74, s25, 16
-; VI-NEXT:    s_lshr_b32 s75, s24, 16
-; VI-NEXT:    s_lshr_b32 s76, s23, 16
-; VI-NEXT:    s_lshr_b32 s77, s22, 16
-; VI-NEXT:    s_lshr_b32 s78, s21, 16
-; VI-NEXT:    s_lshr_b32 s79, s20, 16
-; VI-NEXT:    s_lshr_b32 s88, s19, 16
-; VI-NEXT:    s_lshr_b32 s89, s18, 16
-; VI-NEXT:    s_lshr_b32 s90, s17, 16
-; VI-NEXT:    s_lshr_b32 s91, s16, 16
+; VI-NEXT:    s_lshr_b32 s60, s16, 16
+; VI-NEXT:    s_lshr_b32 s61, s17, 16
+; VI-NEXT:    s_lshr_b32 s62, s18, 16
+; VI-NEXT:    s_lshr_b32 s63, s19, 16
+; VI-NEXT:    s_lshr_b32 s72, s20, 16
+; VI-NEXT:    s_lshr_b32 s73, s21, 16
+; VI-NEXT:    s_lshr_b32 s74, s22, 16
+; VI-NEXT:    s_lshr_b32 s75, s23, 16
+; VI-NEXT:    s_lshr_b32 s76, s24, 16
+; VI-NEXT:    s_lshr_b32 s77, s25, 16
+; VI-NEXT:    s_lshr_b32 s78, s26, 16
+; VI-NEXT:    s_lshr_b32 s79, s40, 16
+; VI-NEXT:    s_lshr_b32 s88, s41, 16
+; VI-NEXT:    s_lshr_b32 s89, s42, 16
+; VI-NEXT:    s_lshr_b32 s90, s43, 16
+; VI-NEXT:    s_lshr_b32 s91, s44, 16
 ; VI-NEXT:  .LBB13_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s44
 ; VI-NEXT:    s_lshl_b32 s5, s91, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s90, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s89, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s88, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s79, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s78, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s77, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s76, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s75, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s74, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s73, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s72, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s63, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s62, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s29, s61, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s40, s60, 16
-; VI-NEXT:    s_or_b32 s29, s29, s40
+; VI-NEXT:    s_and_b32 s5, 0xffff, s43
+; VI-NEXT:    s_lshl_b32 s43, s90, 16
+; VI-NEXT:    s_or_b32 s5, s5, s43
+; VI-NEXT:    s_and_b32 s42, 0xffff, s42
+; VI-NEXT:    s_lshl_b32 s43, s89, 16
+; VI-NEXT:    s_or_b32 s42, s42, s43
+; VI-NEXT:    s_and_b32 s41, 0xffff, s41
+; VI-NEXT:    s_lshl_b32 s43, s88, 16
+; VI-NEXT:    s_or_b32 s41, s41, s43
+; VI-NEXT:    s_and_b32 s40, 0xffff, s40
+; VI-NEXT:    s_lshl_b32 s43, s79, 16
+; VI-NEXT:    s_or_b32 s40, s40, s43
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s43, s78, 16
+; VI-NEXT:    s_or_b32 s26, s26, s43
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s43, s77, 16
+; VI-NEXT:    s_or_b32 s25, s25, s43
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s43, s76, 16
+; VI-NEXT:    s_or_b32 s24, s24, s43
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s43, s75, 16
+; VI-NEXT:    s_or_b32 s23, s23, s43
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s43, s74, 16
+; VI-NEXT:    s_or_b32 s22, s22, s43
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s43, s73, 16
+; VI-NEXT:    s_or_b32 s21, s21, s43
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s43, s72, 16
+; VI-NEXT:    s_or_b32 s20, s20, s43
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s43, s63, 16
+; VI-NEXT:    s_or_b32 s19, s19, s43
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s43, s62, 16
+; VI-NEXT:    s_or_b32 s18, s18, s43
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s43, s61, 16
+; VI-NEXT:    s_or_b32 s17, s17, s43
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s43, s60, 16
+; VI-NEXT:    s_or_b32 s16, s16, s43
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s40, s59, 16
-; VI-NEXT:    s_or_b32 s15, s15, s40
+; VI-NEXT:    s_lshl_b32 s43, s59, 16
+; VI-NEXT:    s_or_b32 s15, s15, s43
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s40, s58, 16
-; VI-NEXT:    s_or_b32 s14, s14, s40
+; VI-NEXT:    s_lshl_b32 s43, s58, 16
+; VI-NEXT:    s_or_b32 s14, s14, s43
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s40, s57, 16
-; VI-NEXT:    s_or_b32 s13, s13, s40
+; VI-NEXT:    s_lshl_b32 s43, s57, 16
+; VI-NEXT:    s_or_b32 s13, s13, s43
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s40, s56, 16
-; VI-NEXT:    s_or_b32 s12, s12, s40
+; VI-NEXT:    s_lshl_b32 s43, s56, 16
+; VI-NEXT:    s_or_b32 s12, s12, s43
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s40, s47, 16
-; VI-NEXT:    s_or_b32 s11, s11, s40
+; VI-NEXT:    s_lshl_b32 s43, s47, 16
+; VI-NEXT:    s_or_b32 s11, s11, s43
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s40, s46, 16
-; VI-NEXT:    s_or_b32 s10, s10, s40
+; VI-NEXT:    s_lshl_b32 s43, s46, 16
+; VI-NEXT:    s_or_b32 s10, s10, s43
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s40, s45, 16
-; VI-NEXT:    s_or_b32 s9, s9, s40
+; VI-NEXT:    s_lshl_b32 s43, s45, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s40, s44, 16
-; VI-NEXT:    s_or_b32 s8, s8, s40
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s40, s43, 16
-; VI-NEXT:    s_or_b32 s6, s6, s40
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s40, s42, 16
-; VI-NEXT:    s_or_b32 s7, s7, s40
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s43
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
+; VI-NEXT:    v_mov_b32_e32 v2, s42
+; VI-NEXT:    v_mov_b32_e32 v3, s41
+; VI-NEXT:    v_mov_b32_e32 v4, s40
+; VI-NEXT:    v_mov_b32_e32 v5, s26
+; VI-NEXT:    v_mov_b32_e32 v6, s25
+; VI-NEXT:    v_mov_b32_e32 v7, s24
+; VI-NEXT:    v_mov_b32_e32 v8, s23
+; VI-NEXT:    v_mov_b32_e32 v9, s22
+; VI-NEXT:    v_mov_b32_e32 v10, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s20
+; VI-NEXT:    v_mov_b32_e32 v12, s19
+; VI-NEXT:    v_mov_b32_e32 v13, s18
+; VI-NEXT:    v_mov_b32_e32 v14, s17
+; VI-NEXT:    v_mov_b32_e32 v15, s16
 ; VI-NEXT:    v_mov_b32_e32 v16, s15
 ; VI-NEXT:    v_mov_b32_e32 v17, s14
 ; VI-NEXT:    v_mov_b32_e32 v18, s13
@@ -3966,25 +4022,53 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr47
 ; VI-NEXT:    ; implicit-def: $sgpr46
 ; VI-NEXT:    ; implicit-def: $sgpr45
-; VI-NEXT:    ; implicit-def: $sgpr44
-; VI-NEXT:    ; implicit-def: $sgpr43
-; VI-NEXT:    ; implicit-def: $sgpr42
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB13_2
 ;
 ; GFX9-LABEL: bitcast_v26i32_to_v52i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v13, s16
+; GFX9-NEXT:    v_mov_b32_e32 v14, s17
+; GFX9-NEXT:    v_mov_b32_e32 v15, s18
+; GFX9-NEXT:    v_mov_b32_e32 v16, s19
+; GFX9-NEXT:    v_mov_b32_e32 v17, s20
+; GFX9-NEXT:    v_mov_b32_e32 v18, s21
+; GFX9-NEXT:    v_mov_b32_e32 v19, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v13
+; GFX9-NEXT:    v_mov_b32_e32 v13, s23
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX9-NEXT:    v_mov_b32_e32 v14, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
@@ -3992,44 +4076,34 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
 ; GFX9-NEXT:    s_lshr_b32 s42, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s43, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB13_3
 ; GFX9-NEXT:  .LBB13_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_i32 s41, s41, 3
 ; GFX9-NEXT:    s_add_i32 s40, s40, 3
-; GFX9-NEXT:    s_add_i32 s15, s15, 3
-; GFX9-NEXT:    s_add_i32 s14, s14, 3
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_add_i32 s29, s29, 3
 ; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
@@ -4044,83 +4118,93 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_lshr_b32 s42, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s43, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s6, 16
 ; GFX9-NEXT:  .LBB13_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s44
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s43
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s42
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -4156,41 +4240,68 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; GFX11-LABEL: bitcast_v26i32_to_v52i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v9, s0 :: v_dual_mov_b32 v10, s1
+; GFX11-NEXT:    v_dual_mov_b32 v11, s2 :: v_dual_mov_b32 v12, s3
+; GFX11-NEXT:    v_dual_mov_b32 v13, s16 :: v_dual_mov_b32 v14, s17
+; GFX11-NEXT:    v_dual_mov_b32 v15, s18 :: v_dual_mov_b32 v16, s19
+; GFX11-NEXT:    v_dual_mov_b32 v17, s20 :: v_dual_mov_b32 v18, s21
+; GFX11-NEXT:    v_dual_mov_b32 v19, s22 :: v_dual_mov_b32 v20, s23
+; GFX11-NEXT:    v_dual_mov_b32 v21, s24 :: v_dual_mov_b32 v22, s25
+; GFX11-NEXT:    v_dual_mov_b32 v23, s26 :: v_dual_mov_b32 v24, s27
+; GFX11-NEXT:    v_dual_mov_b32 v25, s28 :: v_dual_mov_b32 v26, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v7
 ; GFX11-NEXT:    s_mov_b32 s78, 0
-; GFX11-NEXT:    s_and_b32 s12, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s26, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s12, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s74, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s75, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s76, s1, 16
@@ -4198,20 +4309,8 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s78
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB13_3
 ; GFX11-NEXT:  .LBB13_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s10, s10, 3
-; GFX11-NEXT:    s_add_i32 s11, s11, 3
-; GFX11-NEXT:    s_add_i32 s9, s9, 3
-; GFX11-NEXT:    s_add_i32 s8, s8, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
-; GFX11-NEXT:    s_add_i32 s26, s26, 3
-; GFX11-NEXT:    s_add_i32 s25, s25, 3
 ; GFX11-NEXT:    s_add_i32 s24, s24, 3
+; GFX11-NEXT:    s_add_i32 s25, s25, 3
 ; GFX11-NEXT:    s_add_i32 s23, s23, 3
 ; GFX11-NEXT:    s_add_i32 s22, s22, 3
 ; GFX11-NEXT:    s_add_i32 s21, s21, 3
@@ -4220,32 +4319,44 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s12, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s74, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s75, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s76, s1, 16
@@ -4256,41 +4367,41 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s76
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s75
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s12
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s26
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s11 :: v_dual_mov_b32 v25, s10
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s25 :: v_dual_mov_b32 v25, s24
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB13_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr77
@@ -4315,10 +4426,10 @@ define inreg <52 x i16> @bitcast_v26i32_to_v52i16_scalar(<26 x i32> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
 ; GFX11-NEXT:    s_branch .LBB13_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -4761,7 +4872,7 @@ define <26 x i32> @bitcast_v52i16_to_v26i32(<52 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
 ; SI-NEXT:    v_add_i32_e32 v22, vcc, s6, v22
 ; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
-; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
+; SI-NEXT:    v_add_i32_e32 v24, vcc, 0x30000, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, 0x30000, v25
 ; SI-NEXT:  .LBB14_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -7827,9 +7938,37 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; SI-LABEL: bitcast_v26i32_to_v52f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v14, s16
+; SI-NEXT:    v_mov_b32_e32 v15, s17
+; SI-NEXT:    v_mov_b32_e32 v16, s18
+; SI-NEXT:    v_mov_b32_e32 v17, s19
+; SI-NEXT:    v_mov_b32_e32 v18, s20
+; SI-NEXT:    v_mov_b32_e32 v19, s21
+; SI-NEXT:    v_readfirstlane_b32 s40, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s22
+; SI-NEXT:    v_readfirstlane_b32 s41, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s23
+; SI-NEXT:    v_readfirstlane_b32 s23, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_readfirstlane_b32 s24, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_readfirstlane_b32 s25, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s26, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s27, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s28
+; SI-NEXT:    v_readfirstlane_b32 s28, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; SI-NEXT:    v_readfirstlane_b32 s41, v1
-; SI-NEXT:    v_readfirstlane_b32 s40, v2
+; SI-NEXT:    v_readfirstlane_b32 s29, v16
+; SI-NEXT:    v_readfirstlane_b32 s22, v17
+; SI-NEXT:    v_readfirstlane_b32 s21, v18
+; SI-NEXT:    v_readfirstlane_b32 s20, v19
+; SI-NEXT:    v_readfirstlane_b32 s19, v14
+; SI-NEXT:    v_readfirstlane_b32 s18, v15
+; SI-NEXT:    v_readfirstlane_b32 s17, v1
+; SI-NEXT:    v_readfirstlane_b32 s16, v2
 ; SI-NEXT:    v_readfirstlane_b32 s15, v3
 ; SI-NEXT:    v_readfirstlane_b32 s14, v4
 ; SI-NEXT:    v_readfirstlane_b32 s13, v5
@@ -7868,39 +8007,39 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
 ; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    s_lshr_b32 s4, s16, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s41, 16
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
 ; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
+; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
+; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
+; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
+; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
 ; SI-NEXT:    s_waitcnt expcnt(4)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v40, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    s_lshr_b32 s4, s41, 16
 ; SI-NEXT:    s_waitcnt expcnt(2)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v42, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v44, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s9
@@ -7913,31 +8052,26 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, s41
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, s40
 ; SI-NEXT:    s_cbranch_execnz .LBB17_3
 ; SI-NEXT:  .LBB17_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s40, s40, 3
+; SI-NEXT:    s_add_i32 s41, s41, 3
 ; SI-NEXT:    s_add_i32 s23, s23, 3
 ; SI-NEXT:    s_add_i32 s24, s24, 3
 ; SI-NEXT:    s_add_i32 s25, s25, 3
@@ -7945,8 +8079,13 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; SI-NEXT:    s_add_i32 s27, s27, 3
 ; SI-NEXT:    s_add_i32 s28, s28, 3
 ; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s41, s41, 3
-; SI-NEXT:    s_add_i32 s40, s40, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
 ; SI-NEXT:    s_add_i32 s15, s15, 3
 ; SI-NEXT:    s_add_i32 s14, s14, 3
 ; SI-NEXT:    s_add_i32 s13, s13, 3
@@ -7957,22 +8096,22 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; SI-NEXT:    s_add_i32 s7, s7, 3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s9, s9, 3
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    s_lshr_b32 s5, s17, 16
-; SI-NEXT:    s_lshr_b32 s42, s18, 16
-; SI-NEXT:    s_lshr_b32 s43, s19, 16
-; SI-NEXT:    s_lshr_b32 s44, s20, 16
-; SI-NEXT:    s_lshr_b32 s45, s21, 16
-; SI-NEXT:    s_lshr_b32 s46, s22, 16
-; SI-NEXT:    s_lshr_b32 s47, s23, 16
-; SI-NEXT:    s_lshr_b32 s56, s24, 16
-; SI-NEXT:    s_lshr_b32 s57, s25, 16
-; SI-NEXT:    s_lshr_b32 s58, s26, 16
-; SI-NEXT:    s_lshr_b32 s59, s27, 16
-; SI-NEXT:    s_lshr_b32 s60, s28, 16
-; SI-NEXT:    s_lshr_b32 s61, s29, 16
-; SI-NEXT:    s_lshr_b32 s62, s41, 16
-; SI-NEXT:    s_lshr_b32 s63, s40, 16
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    s_lshr_b32 s5, s41, 16
+; SI-NEXT:    s_lshr_b32 s42, s23, 16
+; SI-NEXT:    s_lshr_b32 s43, s24, 16
+; SI-NEXT:    s_lshr_b32 s44, s25, 16
+; SI-NEXT:    s_lshr_b32 s45, s26, 16
+; SI-NEXT:    s_lshr_b32 s46, s27, 16
+; SI-NEXT:    s_lshr_b32 s47, s28, 16
+; SI-NEXT:    s_lshr_b32 s56, s29, 16
+; SI-NEXT:    s_lshr_b32 s57, s22, 16
+; SI-NEXT:    s_lshr_b32 s58, s21, 16
+; SI-NEXT:    s_lshr_b32 s59, s20, 16
+; SI-NEXT:    s_lshr_b32 s60, s19, 16
+; SI-NEXT:    s_lshr_b32 s61, s18, 16
+; SI-NEXT:    s_lshr_b32 s62, s17, 16
+; SI-NEXT:    s_lshr_b32 s63, s16, 16
 ; SI-NEXT:    s_lshr_b32 s72, s15, 16
 ; SI-NEXT:    s_lshr_b32 s73, s14, 16
 ; SI-NEXT:    s_lshr_b32 s74, s13, 16
@@ -7993,24 +8132,24 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, s23
 ; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, s41
 ; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, s40
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s89
 ; SI-NEXT:    v_cvt_f32_f16_e32 v2, s88
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s79
@@ -8285,9 +8424,37 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; VI-LABEL: bitcast_v26i32_to_v52f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v13, s16
+; VI-NEXT:    v_mov_b32_e32 v14, s17
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s20
+; VI-NEXT:    v_mov_b32_e32 v18, s21
+; VI-NEXT:    v_mov_b32_e32 v19, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v13
+; VI-NEXT:    v_mov_b32_e32 v13, s23
+; VI-NEXT:    v_readfirstlane_b32 s43, v14
+; VI-NEXT:    v_mov_b32_e32 v14, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
-; VI-NEXT:    v_readfirstlane_b32 s41, v0
-; VI-NEXT:    v_readfirstlane_b32 s40, v1
+; VI-NEXT:    v_readfirstlane_b32 s24, v13
+; VI-NEXT:    v_readfirstlane_b32 s23, v14
+; VI-NEXT:    v_readfirstlane_b32 s22, v15
+; VI-NEXT:    v_readfirstlane_b32 s21, v16
+; VI-NEXT:    v_readfirstlane_b32 s20, v17
+; VI-NEXT:    v_readfirstlane_b32 s19, v18
+; VI-NEXT:    v_readfirstlane_b32 s18, v19
+; VI-NEXT:    v_readfirstlane_b32 s17, v0
+; VI-NEXT:    v_readfirstlane_b32 s16, v1
 ; VI-NEXT:    v_readfirstlane_b32 s15, v2
 ; VI-NEXT:    v_readfirstlane_b32 s14, v3
 ; VI-NEXT:    v_readfirstlane_b32 s13, v4
@@ -8301,9 +8468,9 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; VI-NEXT:    v_readfirstlane_b32 s7, v11
 ; VI-NEXT:    s_cbranch_scc0 .LBB17_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s42, s7, 16
-; VI-NEXT:    s_lshr_b32 s43, s6, 16
-; VI-NEXT:    s_lshr_b32 s44, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s45, s9, 16
 ; VI-NEXT:    s_lshr_b32 s46, s10, 16
 ; VI-NEXT:    s_lshr_b32 s47, s11, 16
@@ -8311,22 +8478,22 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s57, s13, 16
 ; VI-NEXT:    s_lshr_b32 s58, s14, 16
 ; VI-NEXT:    s_lshr_b32 s59, s15, 16
-; VI-NEXT:    s_lshr_b32 s60, s40, 16
-; VI-NEXT:    s_lshr_b32 s61, s41, 16
-; VI-NEXT:    s_lshr_b32 s62, s29, 16
-; VI-NEXT:    s_lshr_b32 s63, s28, 16
-; VI-NEXT:    s_lshr_b32 s72, s27, 16
-; VI-NEXT:    s_lshr_b32 s73, s26, 16
-; VI-NEXT:    s_lshr_b32 s74, s25, 16
-; VI-NEXT:    s_lshr_b32 s75, s24, 16
-; VI-NEXT:    s_lshr_b32 s76, s23, 16
-; VI-NEXT:    s_lshr_b32 s77, s22, 16
-; VI-NEXT:    s_lshr_b32 s78, s21, 16
-; VI-NEXT:    s_lshr_b32 s79, s20, 16
-; VI-NEXT:    s_lshr_b32 s88, s19, 16
-; VI-NEXT:    s_lshr_b32 s89, s18, 16
-; VI-NEXT:    s_lshr_b32 s90, s17, 16
-; VI-NEXT:    s_lshr_b32 s91, s16, 16
+; VI-NEXT:    s_lshr_b32 s60, s16, 16
+; VI-NEXT:    s_lshr_b32 s61, s17, 16
+; VI-NEXT:    s_lshr_b32 s62, s18, 16
+; VI-NEXT:    s_lshr_b32 s63, s19, 16
+; VI-NEXT:    s_lshr_b32 s72, s20, 16
+; VI-NEXT:    s_lshr_b32 s73, s21, 16
+; VI-NEXT:    s_lshr_b32 s74, s22, 16
+; VI-NEXT:    s_lshr_b32 s75, s23, 16
+; VI-NEXT:    s_lshr_b32 s76, s24, 16
+; VI-NEXT:    s_lshr_b32 s77, s25, 16
+; VI-NEXT:    s_lshr_b32 s78, s26, 16
+; VI-NEXT:    s_lshr_b32 s79, s40, 16
+; VI-NEXT:    s_lshr_b32 s88, s41, 16
+; VI-NEXT:    s_lshr_b32 s89, s42, 16
+; VI-NEXT:    s_lshr_b32 s90, s43, 16
+; VI-NEXT:    s_lshr_b32 s91, s44, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB17_3
 ; VI-NEXT:  .LBB17_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -8339,25 +8506,25 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; VI-NEXT:    s_add_i32 s13, s13, 3
 ; VI-NEXT:    s_add_i32 s14, s14, 3
 ; VI-NEXT:    s_add_i32 s15, s15, 3
+; VI-NEXT:    s_add_i32 s16, s16, 3
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
 ; VI-NEXT:    s_add_i32 s40, s40, 3
 ; VI-NEXT:    s_add_i32 s41, s41, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
-; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s42, s7, 16
-; VI-NEXT:    s_lshr_b32 s43, s6, 16
-; VI-NEXT:    s_lshr_b32 s44, s8, 16
+; VI-NEXT:    s_add_i32 s42, s42, 3
+; VI-NEXT:    s_add_i32 s43, s43, 3
+; VI-NEXT:    s_add_i32 s44, s44, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s45, s9, 16
 ; VI-NEXT:    s_lshr_b32 s46, s10, 16
 ; VI-NEXT:    s_lshr_b32 s47, s11, 16
@@ -8365,117 +8532,117 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s57, s13, 16
 ; VI-NEXT:    s_lshr_b32 s58, s14, 16
 ; VI-NEXT:    s_lshr_b32 s59, s15, 16
-; VI-NEXT:    s_lshr_b32 s60, s40, 16
-; VI-NEXT:    s_lshr_b32 s61, s41, 16
-; VI-NEXT:    s_lshr_b32 s62, s29, 16
-; VI-NEXT:    s_lshr_b32 s63, s28, 16
-; VI-NEXT:    s_lshr_b32 s72, s27, 16
-; VI-NEXT:    s_lshr_b32 s73, s26, 16
-; VI-NEXT:    s_lshr_b32 s74, s25, 16
-; VI-NEXT:    s_lshr_b32 s75, s24, 16
-; VI-NEXT:    s_lshr_b32 s76, s23, 16
-; VI-NEXT:    s_lshr_b32 s77, s22, 16
-; VI-NEXT:    s_lshr_b32 s78, s21, 16
-; VI-NEXT:    s_lshr_b32 s79, s20, 16
-; VI-NEXT:    s_lshr_b32 s88, s19, 16
-; VI-NEXT:    s_lshr_b32 s89, s18, 16
-; VI-NEXT:    s_lshr_b32 s90, s17, 16
-; VI-NEXT:    s_lshr_b32 s91, s16, 16
+; VI-NEXT:    s_lshr_b32 s60, s16, 16
+; VI-NEXT:    s_lshr_b32 s61, s17, 16
+; VI-NEXT:    s_lshr_b32 s62, s18, 16
+; VI-NEXT:    s_lshr_b32 s63, s19, 16
+; VI-NEXT:    s_lshr_b32 s72, s20, 16
+; VI-NEXT:    s_lshr_b32 s73, s21, 16
+; VI-NEXT:    s_lshr_b32 s74, s22, 16
+; VI-NEXT:    s_lshr_b32 s75, s23, 16
+; VI-NEXT:    s_lshr_b32 s76, s24, 16
+; VI-NEXT:    s_lshr_b32 s77, s25, 16
+; VI-NEXT:    s_lshr_b32 s78, s26, 16
+; VI-NEXT:    s_lshr_b32 s79, s40, 16
+; VI-NEXT:    s_lshr_b32 s88, s41, 16
+; VI-NEXT:    s_lshr_b32 s89, s42, 16
+; VI-NEXT:    s_lshr_b32 s90, s43, 16
+; VI-NEXT:    s_lshr_b32 s91, s44, 16
 ; VI-NEXT:  .LBB17_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s44
 ; VI-NEXT:    s_lshl_b32 s5, s91, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s90, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s89, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s88, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s79, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s78, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s77, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s76, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s75, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s74, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s73, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s72, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s63, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s62, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s29, s61, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s40, s60, 16
-; VI-NEXT:    s_or_b32 s29, s29, s40
+; VI-NEXT:    s_and_b32 s5, 0xffff, s43
+; VI-NEXT:    s_lshl_b32 s43, s90, 16
+; VI-NEXT:    s_or_b32 s5, s5, s43
+; VI-NEXT:    s_and_b32 s42, 0xffff, s42
+; VI-NEXT:    s_lshl_b32 s43, s89, 16
+; VI-NEXT:    s_or_b32 s42, s42, s43
+; VI-NEXT:    s_and_b32 s41, 0xffff, s41
+; VI-NEXT:    s_lshl_b32 s43, s88, 16
+; VI-NEXT:    s_or_b32 s41, s41, s43
+; VI-NEXT:    s_and_b32 s40, 0xffff, s40
+; VI-NEXT:    s_lshl_b32 s43, s79, 16
+; VI-NEXT:    s_or_b32 s40, s40, s43
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s43, s78, 16
+; VI-NEXT:    s_or_b32 s26, s26, s43
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s43, s77, 16
+; VI-NEXT:    s_or_b32 s25, s25, s43
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s43, s76, 16
+; VI-NEXT:    s_or_b32 s24, s24, s43
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s43, s75, 16
+; VI-NEXT:    s_or_b32 s23, s23, s43
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s43, s74, 16
+; VI-NEXT:    s_or_b32 s22, s22, s43
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s43, s73, 16
+; VI-NEXT:    s_or_b32 s21, s21, s43
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s43, s72, 16
+; VI-NEXT:    s_or_b32 s20, s20, s43
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s43, s63, 16
+; VI-NEXT:    s_or_b32 s19, s19, s43
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s43, s62, 16
+; VI-NEXT:    s_or_b32 s18, s18, s43
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s43, s61, 16
+; VI-NEXT:    s_or_b32 s17, s17, s43
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s43, s60, 16
+; VI-NEXT:    s_or_b32 s16, s16, s43
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s40, s59, 16
-; VI-NEXT:    s_or_b32 s15, s15, s40
+; VI-NEXT:    s_lshl_b32 s43, s59, 16
+; VI-NEXT:    s_or_b32 s15, s15, s43
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s40, s58, 16
-; VI-NEXT:    s_or_b32 s14, s14, s40
+; VI-NEXT:    s_lshl_b32 s43, s58, 16
+; VI-NEXT:    s_or_b32 s14, s14, s43
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s40, s57, 16
-; VI-NEXT:    s_or_b32 s13, s13, s40
+; VI-NEXT:    s_lshl_b32 s43, s57, 16
+; VI-NEXT:    s_or_b32 s13, s13, s43
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s40, s56, 16
-; VI-NEXT:    s_or_b32 s12, s12, s40
+; VI-NEXT:    s_lshl_b32 s43, s56, 16
+; VI-NEXT:    s_or_b32 s12, s12, s43
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s40, s47, 16
-; VI-NEXT:    s_or_b32 s11, s11, s40
+; VI-NEXT:    s_lshl_b32 s43, s47, 16
+; VI-NEXT:    s_or_b32 s11, s11, s43
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s40, s46, 16
-; VI-NEXT:    s_or_b32 s10, s10, s40
+; VI-NEXT:    s_lshl_b32 s43, s46, 16
+; VI-NEXT:    s_or_b32 s10, s10, s43
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s40, s45, 16
-; VI-NEXT:    s_or_b32 s9, s9, s40
+; VI-NEXT:    s_lshl_b32 s43, s45, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s40, s44, 16
-; VI-NEXT:    s_or_b32 s8, s8, s40
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s40, s43, 16
-; VI-NEXT:    s_or_b32 s6, s6, s40
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s40, s42, 16
-; VI-NEXT:    s_or_b32 s7, s7, s40
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s43
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
+; VI-NEXT:    v_mov_b32_e32 v2, s42
+; VI-NEXT:    v_mov_b32_e32 v3, s41
+; VI-NEXT:    v_mov_b32_e32 v4, s40
+; VI-NEXT:    v_mov_b32_e32 v5, s26
+; VI-NEXT:    v_mov_b32_e32 v6, s25
+; VI-NEXT:    v_mov_b32_e32 v7, s24
+; VI-NEXT:    v_mov_b32_e32 v8, s23
+; VI-NEXT:    v_mov_b32_e32 v9, s22
+; VI-NEXT:    v_mov_b32_e32 v10, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s20
+; VI-NEXT:    v_mov_b32_e32 v12, s19
+; VI-NEXT:    v_mov_b32_e32 v13, s18
+; VI-NEXT:    v_mov_b32_e32 v14, s17
+; VI-NEXT:    v_mov_b32_e32 v15, s16
 ; VI-NEXT:    v_mov_b32_e32 v16, s15
 ; VI-NEXT:    v_mov_b32_e32 v17, s14
 ; VI-NEXT:    v_mov_b32_e32 v18, s13
@@ -8511,25 +8678,53 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr47
 ; VI-NEXT:    ; implicit-def: $sgpr46
 ; VI-NEXT:    ; implicit-def: $sgpr45
-; VI-NEXT:    ; implicit-def: $sgpr44
-; VI-NEXT:    ; implicit-def: $sgpr43
-; VI-NEXT:    ; implicit-def: $sgpr42
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB17_2
 ;
 ; GFX9-LABEL: bitcast_v26i32_to_v52f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v13, s16
+; GFX9-NEXT:    v_mov_b32_e32 v14, s17
+; GFX9-NEXT:    v_mov_b32_e32 v15, s18
+; GFX9-NEXT:    v_mov_b32_e32 v16, s19
+; GFX9-NEXT:    v_mov_b32_e32 v17, s20
+; GFX9-NEXT:    v_mov_b32_e32 v18, s21
+; GFX9-NEXT:    v_mov_b32_e32 v19, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v13
+; GFX9-NEXT:    v_mov_b32_e32 v13, s23
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX9-NEXT:    v_mov_b32_e32 v14, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
@@ -8537,44 +8732,34 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
 ; GFX9-NEXT:    s_lshr_b32 s42, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s43, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB17_3
 ; GFX9-NEXT:  .LBB17_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_i32 s41, s41, 3
 ; GFX9-NEXT:    s_add_i32 s40, s40, 3
-; GFX9-NEXT:    s_add_i32 s15, s15, 3
-; GFX9-NEXT:    s_add_i32 s14, s14, 3
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_add_i32 s29, s29, 3
 ; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
@@ -8589,83 +8774,93 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_lshr_b32 s42, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s43, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s6, 16
 ; GFX9-NEXT:  .LBB17_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s44
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s43
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s42
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -8701,41 +8896,68 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; GFX11-LABEL: bitcast_v26i32_to_v52f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v9, s0 :: v_dual_mov_b32 v10, s1
+; GFX11-NEXT:    v_dual_mov_b32 v11, s2 :: v_dual_mov_b32 v12, s3
+; GFX11-NEXT:    v_dual_mov_b32 v13, s16 :: v_dual_mov_b32 v14, s17
+; GFX11-NEXT:    v_dual_mov_b32 v15, s18 :: v_dual_mov_b32 v16, s19
+; GFX11-NEXT:    v_dual_mov_b32 v17, s20 :: v_dual_mov_b32 v18, s21
+; GFX11-NEXT:    v_dual_mov_b32 v19, s22 :: v_dual_mov_b32 v20, s23
+; GFX11-NEXT:    v_dual_mov_b32 v21, s24 :: v_dual_mov_b32 v22, s25
+; GFX11-NEXT:    v_dual_mov_b32 v23, s26 :: v_dual_mov_b32 v24, s27
+; GFX11-NEXT:    v_dual_mov_b32 v25, s28 :: v_dual_mov_b32 v26, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v7
 ; GFX11-NEXT:    s_mov_b32 s78, 0
-; GFX11-NEXT:    s_and_b32 s12, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s26, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s12, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s74, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s75, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s76, s1, 16
@@ -8743,20 +8965,8 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s78
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB17_3
 ; GFX11-NEXT:  .LBB17_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s10, s10, 3
-; GFX11-NEXT:    s_add_i32 s11, s11, 3
-; GFX11-NEXT:    s_add_i32 s9, s9, 3
-; GFX11-NEXT:    s_add_i32 s8, s8, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
-; GFX11-NEXT:    s_add_i32 s26, s26, 3
-; GFX11-NEXT:    s_add_i32 s25, s25, 3
 ; GFX11-NEXT:    s_add_i32 s24, s24, 3
+; GFX11-NEXT:    s_add_i32 s25, s25, 3
 ; GFX11-NEXT:    s_add_i32 s23, s23, 3
 ; GFX11-NEXT:    s_add_i32 s22, s22, 3
 ; GFX11-NEXT:    s_add_i32 s21, s21, 3
@@ -8765,32 +8975,44 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s12, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s74, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s75, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s76, s1, 16
@@ -8801,41 +9023,41 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s76
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s75
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s12
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s26
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s11 :: v_dual_mov_b32 v25, s10
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s25 :: v_dual_mov_b32 v25, s24
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB17_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr77
@@ -8860,10 +9082,10 @@ define inreg <52 x half> @bitcast_v26i32_to_v52f16_scalar(<26 x i32> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
 ; GFX11-NEXT:    s_branch .LBB17_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -15485,7 +15707,7 @@ define <26 x float> @bitcast_v52i16_to_v26f32(<52 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
 ; SI-NEXT:    v_add_i32_e32 v22, vcc, s6, v22
 ; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
-; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
+; SI-NEXT:    v_add_i32_e32 v24, vcc, 0x30000, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, 0x30000, v25
 ; SI-NEXT:  .LBB30_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -18526,19 +18748,6 @@ define inreg <52 x half> @bitcast_v26f32_to_v52f16_scalar(<26 x float> inreg %a,
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; SI-NEXT:    v_readfirstlane_b32 s41, v1
-; SI-NEXT:    v_readfirstlane_b32 s40, v2
-; SI-NEXT:    v_readfirstlane_b32 s15, v3
-; SI-NEXT:    v_readfirstlane_b32 s14, v4
-; SI-NEXT:    v_readfirstlane_b32 s13, v5
-; SI-NEXT:    v_readfirstlane_b32 s12, v6
-; SI-NEXT:    v_readfirstlane_b32 s11, v7
-; SI-NEXT:    v_readfirstlane_b32 s10, v8
-; SI-NEXT:    v_readfirstlane_b32 s8, v9
-; SI-NEXT:    v_readfirstlane_b32 s7, v10
-; SI-NEXT:    v_readfirstlane_b32 s6, v11
-; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s9, v12
 ; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
@@ -18555,377 +18764,468 @@ define inreg <52 x half> @bitcast_v26f32_to_v52f16_scalar(<26 x float> inreg %a,
 ; SI-NEXT:    buffer_store_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    v_mov_b32_e32 v21, s16
+; SI-NEXT:    v_mov_b32_e32 v18, s17
+; SI-NEXT:    v_mov_b32_e32 v16, s18
+; SI-NEXT:    v_mov_b32_e32 v15, s19
+; SI-NEXT:    v_mov_b32_e32 v14, s20
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v63, s21
+; SI-NEXT:    v_mov_b32_e32 v25, s22
+; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
+; SI-NEXT:    v_mov_b32_e32 v26, s23
+; SI-NEXT:    v_mov_b32_e32 v24, s24
+; SI-NEXT:    v_mov_b32_e32 v23, s25
+; SI-NEXT:    v_mov_b32_e32 v22, s26
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_mov_b32_e32 v17, s28
+; SI-NEXT:    v_mov_b32_e32 v13, s29
 ; SI-NEXT:    s_cbranch_scc0 .LBB33_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s4, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s4
-; SI-NEXT:    s_lshr_b32 s4, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s4
-; SI-NEXT:    s_lshr_b32 s4, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s4
-; SI-NEXT:    s_lshr_b32 s4, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s4
-; SI-NEXT:    s_lshr_b32 s4, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s4
-; SI-NEXT:    s_lshr_b32 s4, s11, 16
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, s4
-; SI-NEXT:    s_lshr_b32 s4, s12, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, s4
-; SI-NEXT:    s_lshr_b32 s4, s13, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s4
-; SI-NEXT:    s_lshr_b32 s4, s14, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
-; SI-NEXT:    s_lshr_b32 s4, s15, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s40, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s41, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v11
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v23
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v25
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v63
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v63
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v15
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v21
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v8
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v7
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v6
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v5
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v4
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v3
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v2
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v1
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v13
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v17
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v18
 ; SI-NEXT:    s_cbranch_execnz .LBB33_3
 ; SI-NEXT:  .LBB33_2: ; %cmp.true
-; SI-NEXT:    v_add_f32_e64 v1, s16, 1.0
-; SI-NEXT:    v_add_f32_e64 v2, s17, 1.0
-; SI-NEXT:    v_add_f32_e64 v3, s18, 1.0
-; SI-NEXT:    v_add_f32_e64 v5, s19, 1.0
-; SI-NEXT:    v_add_f32_e64 v7, s20, 1.0
-; SI-NEXT:    v_add_f32_e64 v9, s21, 1.0
-; SI-NEXT:    v_add_f32_e64 v11, s22, 1.0
-; SI-NEXT:    v_add_f32_e64 v14, s23, 1.0
-; SI-NEXT:    v_add_f32_e64 v16, s24, 1.0
-; SI-NEXT:    v_add_f32_e64 v18, s25, 1.0
-; SI-NEXT:    v_add_f32_e64 v20, s26, 1.0
-; SI-NEXT:    v_add_f32_e64 v22, s27, 1.0
-; SI-NEXT:    v_add_f32_e64 v24, s28, 1.0
-; SI-NEXT:    v_add_f32_e64 v27, s29, 1.0
-; SI-NEXT:    v_add_f32_e64 v25, s41, 1.0
-; SI-NEXT:    v_add_f32_e64 v23, s40, 1.0
-; SI-NEXT:    v_add_f32_e64 v21, s15, 1.0
-; SI-NEXT:    v_add_f32_e64 v19, s14, 1.0
-; SI-NEXT:    v_add_f32_e64 v17, s13, 1.0
-; SI-NEXT:    v_add_f32_e64 v15, s12, 1.0
-; SI-NEXT:    v_add_f32_e64 v13, s11, 1.0
-; SI-NEXT:    v_add_f32_e64 v12, s10, 1.0
-; SI-NEXT:    v_add_f32_e64 v10, s8, 1.0
-; SI-NEXT:    v_add_f32_e64 v8, s7, 1.0
-; SI-NEXT:    v_add_f32_e64 v6, s6, 1.0
-; SI-NEXT:    v_add_f32_e64 v29, s9, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v3
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v5
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v7
-; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v9
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v11
-; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v20
-; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v24
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v27
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v25
-; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v23
-; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v21
-; SI-NEXT:    s_waitcnt expcnt(6)
-; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v19
-; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v17
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v15
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v13
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v12
-; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v62, 16, v10
+; SI-NEXT:    v_add_f32_e32 v1, 1.0, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SI-NEXT:    v_add_f32_e32 v13, 1.0, v13
+; SI-NEXT:    v_add_f32_e32 v17, 1.0, v17
+; SI-NEXT:    v_add_f32_e32 v7, 1.0, v7
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v8
-; SI-NEXT:    v_lshrrev_b32_e32 v4, 16, v6
-; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v13
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v21
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v24
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v7
+; SI-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v6
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v17
+; SI-NEXT:    v_add_f32_e32 v21, 1.0, v21
+; SI-NEXT:    v_add_f32_e32 v18, 1.0, v18
+; SI-NEXT:    v_add_f32_e32 v16, 1.0, v16
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v35
+; SI-NEXT:    v_add_f32_e32 v15, 1.0, v15
+; SI-NEXT:    v_add_f32_e32 v14, 1.0, v14
+; SI-NEXT:    v_add_f32_e32 v20, 1.0, v63
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v29
+; SI-NEXT:    v_add_f32_e32 v25, 1.0, v25
+; SI-NEXT:    v_add_f32_e32 v26, 1.0, v26
+; SI-NEXT:    v_add_f32_e32 v24, 1.0, v24
+; SI-NEXT:    v_add_f32_e32 v23, 1.0, v23
+; SI-NEXT:    v_add_f32_e32 v22, 1.0, v22
+; SI-NEXT:    v_add_f32_e32 v19, 1.0, v19
+; SI-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; SI-NEXT:    v_add_f32_e32 v3, 1.0, v3
+; SI-NEXT:    v_add_f32_e32 v4, 1.0, v4
+; SI-NEXT:    v_add_f32_e32 v5, 1.0, v5
+; SI-NEXT:    v_add_f32_e32 v8, 1.0, v8
+; SI-NEXT:    v_add_f32_e32 v9, 1.0, v9
+; SI-NEXT:    v_add_f32_e32 v10, 1.0, v10
+; SI-NEXT:    v_add_f32_e32 v11, 1.0, v11
+; SI-NEXT:    v_add_f32_e32 v12, 1.0, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v26
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v10
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v63
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, v62
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v61
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, v60
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, v59
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v58
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v57
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v56
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v47
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v46
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
 ; SI-NEXT:    v_cvt_f32_f16_e32 v39, v39
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v63
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v33
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
 ; SI-NEXT:    v_cvt_f32_f16_e32 v49, v49
 ; SI-NEXT:    v_cvt_f32_f16_e32 v51, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, v40
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v47
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v60
+; SI-NEXT:    v_mov_b32_e32 v35, v11
+; SI-NEXT:    v_mov_b32_e32 v29, v12
+; SI-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
 ; SI-NEXT:  .LBB33_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v44
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v43
-; SI-NEXT:    v_cvt_f16_f32_e32 v42, v42
-; SI-NEXT:    v_cvt_f16_f32_e32 v41, v41
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    v_lshlrev_b32_e32 v30, 16, v42
-; SI-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v30, v41, v30
-; SI-NEXT:    buffer_store_dword v30, v4, s[0:3], 0 offen
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v40
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v55
-; SI-NEXT:    v_add_i32_e32 v55, vcc, 8, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    buffer_store_dword v4, v55, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v54
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v53
-; SI-NEXT:    v_add_i32_e32 v53, vcc, 12, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    buffer_store_dword v4, v53, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v52
-; SI-NEXT:    v_add_i32_e32 v51, vcc, 16, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    buffer_store_dword v4, v51, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v9
-; SI-NEXT:    v_add_i32_e32 v49, vcc, 20, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    buffer_store_dword v4, v49, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v11
-; SI-NEXT:    v_add_i32_e32 v39, vcc, 24, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    buffer_store_dword v4, v39, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v13
-; SI-NEXT:    v_add_i32_e32 v37, vcc, 28, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    buffer_store_dword v4, v37, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v12
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 32, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    buffer_store_dword v4, v35, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v10
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 36, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    buffer_store_dword v4, v33, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v30, v8
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 40, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v30, v4
-; SI-NEXT:    buffer_store_dword v4, v31, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v6
-; SI-NEXT:    v_add_i32_e32 v28, vcc, 44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v28, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v29
-; SI-NEXT:    v_add_i32_e32 v26, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v26, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v27
-; SI-NEXT:    v_add_i32_e32 v24, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v24, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v25
-; SI-NEXT:    v_add_i32_e32 v22, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v22, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v60
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v27
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v58
 ; SI-NEXT:    v_cvt_f16_f32_e32 v4, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v23
-; SI-NEXT:    v_add_i32_e32 v20, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v20, s[0:3], 0 offen
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v21
-; SI-NEXT:    v_add_i32_e32 v18, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v18, s[0:3], 0 offen
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
+; SI-NEXT:    v_or_b32_e32 v2, v4, v2
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v47
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v19
-; SI-NEXT:    v_add_i32_e32 v16, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v16, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v62
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v17
-; SI-NEXT:    v_add_i32_e32 v14, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v14, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v45
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v61
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v59
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v15
-; SI-NEXT:    v_add_i32_e32 v11, vcc, 0x4c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v11, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v43
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v59
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v60
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v48
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 0x50, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v9, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v41
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v57
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v7
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v38
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 0x54, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v7, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v55
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v56
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v5
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v36
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x58, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v46
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v34
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x5c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v4, v3
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v51
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v44
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v49
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v42
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v38
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v40
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v36
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v54
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v34
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v3, v5, s[0:3], 0 offen
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:116 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v32
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 0x60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; SI-NEXT:    v_or_b32_e32 v2, v3, v2
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v33
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v32
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v31
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v30
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v28
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v45
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v37
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x54, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v39
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x58, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x5c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v50
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v35
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v52
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x64, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
@@ -18949,58 +19249,73 @@ define inreg <52 x half> @bitcast_v26f32_to_v52f16_scalar(<26 x float> inreg %a,
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB33_4:
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr28
+; SI-NEXT:    ; kill: killed $vgpr28
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr28
+; SI-NEXT:    ; kill: killed $vgpr28
+; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr60
+; SI-NEXT:    ; implicit-def: $vgpr20
+; SI-NEXT:    ; implicit-def: $vgpr58
+; SI-NEXT:    ; implicit-def: $vgpr62
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr61
+; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr59
 ; SI-NEXT:    ; implicit-def: $vgpr43
-; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr57
 ; SI-NEXT:    ; implicit-def: $vgpr41
-; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr56
 ; SI-NEXT:    ; implicit-def: $vgpr55
-; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr46
 ; SI-NEXT:    ; implicit-def: $vgpr53
-; SI-NEXT:    ; implicit-def: $vgpr54
-; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr44
 ; SI-NEXT:    ; implicit-def: $vgpr51
-; SI-NEXT:    ; implicit-def: $vgpr9
+; SI-NEXT:    ; implicit-def: $vgpr42
 ; SI-NEXT:    ; implicit-def: $vgpr49
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr39
-; SI-NEXT:    ; implicit-def: $vgpr13
-; SI-NEXT:    ; implicit-def: $vgpr37
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr35
-; SI-NEXT:    ; implicit-def: $vgpr10
+; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr36
+; SI-NEXT:    ; implicit-def: $vgpr34
 ; SI-NEXT:    ; implicit-def: $vgpr33
-; SI-NEXT:    ; implicit-def: $vgpr8
+; SI-NEXT:    ; implicit-def: $vgpr32
 ; SI-NEXT:    ; implicit-def: $vgpr31
-; SI-NEXT:    ; implicit-def: $vgpr6
+; SI-NEXT:    ; implicit-def: $vgpr30
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr39
+; SI-NEXT:    ; implicit-def: $vgpr48
+; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr28
+; SI-NEXT:    ; kill: killed $vgpr28
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr28
+; SI-NEXT:    ; kill: killed $vgpr28
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr28
+; SI-NEXT:    ; kill: killed $vgpr28
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr28
+; SI-NEXT:    ; kill: killed $vgpr28
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr28
 ; SI-NEXT:    ; implicit-def: $vgpr29
-; SI-NEXT:    ; implicit-def: $vgpr26
-; SI-NEXT:    ; implicit-def: $vgpr27
-; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr25
-; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr23
-; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr14
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr59
-; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr60
-; SI-NEXT:    ; implicit-def: $vgpr38
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr34
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr45
-; SI-NEXT:    ; implicit-def: $vgpr1
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    s_branch .LBB33_2
 ;
 ; VI-LABEL: bitcast_v26f32_to_v52f16_scalar:
@@ -24069,18 +24384,46 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_store_dword v14, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_writelane_b32 v14, s30, 0
-; SI-NEXT:    v_writelane_b32 v14, s31, 1
-; SI-NEXT:    v_writelane_b32 v14, s34, 2
-; SI-NEXT:    v_writelane_b32 v14, s35, 3
-; SI-NEXT:    v_writelane_b32 v14, s36, 4
-; SI-NEXT:    v_writelane_b32 v14, s37, 5
-; SI-NEXT:    v_writelane_b32 v14, s38, 6
+; SI-NEXT:    v_writelane_b32 v20, s30, 0
+; SI-NEXT:    v_writelane_b32 v20, s31, 1
+; SI-NEXT:    v_writelane_b32 v20, s34, 2
+; SI-NEXT:    v_writelane_b32 v20, s35, 3
+; SI-NEXT:    v_writelane_b32 v20, s36, 4
+; SI-NEXT:    v_mov_b32_e32 v14, s16
+; SI-NEXT:    v_mov_b32_e32 v15, s17
+; SI-NEXT:    v_writelane_b32 v20, s37, 5
+; SI-NEXT:    v_mov_b32_e32 v16, s18
+; SI-NEXT:    v_mov_b32_e32 v17, s19
+; SI-NEXT:    v_mov_b32_e32 v18, s20
+; SI-NEXT:    v_mov_b32_e32 v19, s21
+; SI-NEXT:    v_readfirstlane_b32 s42, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s22
+; SI-NEXT:    v_readfirstlane_b32 s43, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s23
+; SI-NEXT:    v_writelane_b32 v20, s38, 6
+; SI-NEXT:    v_readfirstlane_b32 s40, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_readfirstlane_b32 s41, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_readfirstlane_b32 s24, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; SI-NEXT:    v_writelane_b32 v14, s39, 7
+; SI-NEXT:    v_writelane_b32 v20, s39, 7
+; SI-NEXT:    v_readfirstlane_b32 s20, v16
+; SI-NEXT:    v_readfirstlane_b32 s21, v17
+; SI-NEXT:    v_readfirstlane_b32 s18, v18
+; SI-NEXT:    v_readfirstlane_b32 s19, v19
+; SI-NEXT:    v_readfirstlane_b32 s16, v14
+; SI-NEXT:    v_readfirstlane_b32 s17, v15
 ; SI-NEXT:    v_readfirstlane_b32 s14, v1
 ; SI-NEXT:    v_readfirstlane_b32 s15, v2
 ; SI-NEXT:    v_readfirstlane_b32 s12, v3
@@ -24092,9 +24435,9 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v9
 ; SI-NEXT:    v_readfirstlane_b32 s7, v10
 ; SI-NEXT:    v_readfirstlane_b32 s4, v11
-; SI-NEXT:    s_and_b64 s[40:41], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v12
-; SI-NEXT:    v_writelane_b32 v14, s48, 8
+; SI-NEXT:    v_writelane_b32 v20, s48, 8
 ; SI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s92, s5, 16
@@ -24103,26 +24446,26 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s95, s11, 16
 ; SI-NEXT:    s_lshr_b32 s30, s13, 16
 ; SI-NEXT:    s_lshr_b32 s31, s15, 16
-; SI-NEXT:    s_lshr_b32 s34, s29, 16
-; SI-NEXT:    s_lshr_b32 s35, s27, 16
-; SI-NEXT:    s_lshr_b32 s36, s25, 16
+; SI-NEXT:    s_lshr_b32 s34, s17, 16
+; SI-NEXT:    s_lshr_b32 s35, s19, 16
+; SI-NEXT:    s_lshr_b32 s36, s21, 16
 ; SI-NEXT:    s_lshr_b32 s37, s23, 16
-; SI-NEXT:    s_lshr_b32 s38, s21, 16
-; SI-NEXT:    s_lshr_b32 s39, s19, 16
-; SI-NEXT:    s_lshr_b32 s48, s17, 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s38, s25, 16
+; SI-NEXT:    s_lshr_b32 s39, s41, 16
+; SI-NEXT:    s_lshr_b32 s48, s43, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[44:45], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[20:21], 16
 ; SI-NEXT:    s_lshr_b64 s[74:75], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[88:89], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[88:89], s[42:43], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB41_3
 ; SI-NEXT:  .LBB41_2: ; %cmp.true
 ; SI-NEXT:    s_add_u32 s4, s4, 3
@@ -24137,132 +24480,132 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; SI-NEXT:    s_addc_u32 s13, s13, 0
 ; SI-NEXT:    s_add_u32 s14, s14, 3
 ; SI-NEXT:    s_addc_u32 s15, s15, 0
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_add_u32 s20, s20, 3
-; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
 ; SI-NEXT:    s_add_u32 s16, s16, 3
 ; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
+; SI-NEXT:    s_add_u32 s22, s22, 3
+; SI-NEXT:    s_addc_u32 s23, s23, 0
+; SI-NEXT:    s_add_u32 s24, s24, 3
+; SI-NEXT:    s_addc_u32 s25, s25, 0
+; SI-NEXT:    s_add_u32 s40, s40, 3
+; SI-NEXT:    s_addc_u32 s41, s41, 0
+; SI-NEXT:    s_add_u32 s42, s42, 3
+; SI-NEXT:    s_addc_u32 s43, s43, 0
 ; SI-NEXT:    s_lshr_b32 s92, s5, 16
 ; SI-NEXT:    s_lshr_b32 s93, s7, 16
 ; SI-NEXT:    s_lshr_b32 s94, s9, 16
 ; SI-NEXT:    s_lshr_b32 s95, s11, 16
 ; SI-NEXT:    s_lshr_b32 s30, s13, 16
 ; SI-NEXT:    s_lshr_b32 s31, s15, 16
-; SI-NEXT:    s_lshr_b32 s34, s29, 16
-; SI-NEXT:    s_lshr_b32 s35, s27, 16
-; SI-NEXT:    s_lshr_b32 s36, s25, 16
+; SI-NEXT:    s_lshr_b32 s34, s17, 16
+; SI-NEXT:    s_lshr_b32 s35, s19, 16
+; SI-NEXT:    s_lshr_b32 s36, s21, 16
 ; SI-NEXT:    s_lshr_b32 s37, s23, 16
-; SI-NEXT:    s_lshr_b32 s38, s21, 16
-; SI-NEXT:    s_lshr_b32 s39, s19, 16
-; SI-NEXT:    s_lshr_b32 s48, s17, 16
-; SI-NEXT:    s_lshr_b64 s[40:41], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s38, s25, 16
+; SI-NEXT:    s_lshr_b32 s39, s41, 16
+; SI-NEXT:    s_lshr_b32 s48, s43, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[44:45], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[60:61], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[60:61], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[20:21], 16
 ; SI-NEXT:    s_lshr_b64 s[74:75], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[88:89], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[88:89], s[42:43], 16
 ; SI-NEXT:  .LBB41_3: ; %end
-; SI-NEXT:    s_lshl_b32 s41, s88, 16
-; SI-NEXT:    s_and_b32 s16, s16, 0xffff
-; SI-NEXT:    s_or_b32 s16, s16, s41
-; SI-NEXT:    v_mov_b32_e32 v1, s16
-; SI-NEXT:    s_and_b32 s16, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s48, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_lshl_b32 s16, s78, 16
-; SI-NEXT:    s_and_b32 s17, s18, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
-; SI-NEXT:    v_mov_b32_e32 v3, s16
-; SI-NEXT:    s_and_b32 s16, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s39, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v4, s16
-; SI-NEXT:    s_lshl_b32 s16, s76, 16
-; SI-NEXT:    s_and_b32 s17, s20, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
+; SI-NEXT:    s_lshl_b32 s27, s88, 16
+; SI-NEXT:    s_and_b32 s29, s42, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s27
+; SI-NEXT:    s_and_b32 s27, s43, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s48, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_lshl_b32 s27, s78, 16
+; SI-NEXT:    s_and_b32 s29, s40, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v3, s27
+; SI-NEXT:    s_and_b32 s27, s41, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s39, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v4, s27
+; SI-NEXT:    s_lshl_b32 s27, s76, 16
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_or_b32 s24, s24, s27
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    v_mov_b32_e32 v5, s16
-; SI-NEXT:    s_and_b32 s16, s21, 0xffff
+; SI-NEXT:    v_mov_b32_e32 v5, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    s_lshl_b32 s17, s38, 16
+; SI-NEXT:    s_lshl_b32 s25, s38, 16
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s25
 ; SI-NEXT:    buffer_store_dword v4, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
 ; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s74, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s24, s74, 16
 ; SI-NEXT:    buffer_store_dword v5, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s24
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s37, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s37, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s23
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s22, s72, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s36, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s36, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s62, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s62, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s27, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s35, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s35, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s60, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s60, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s29, 0xffff
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
 ; SI-NEXT:    s_lshl_b32 s17, s34, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
 ; SI-NEXT:    s_or_b32 s16, s16, s17
@@ -24326,7 +24669,7 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s42, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x54, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -24340,7 +24683,7 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s40, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x5c, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -24354,17 +24697,17 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x64, v0
 ; SI-NEXT:    v_mov_b32_e32 v1, s4
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    v_readlane_b32 s48, v14, 8
-; SI-NEXT:    v_readlane_b32 s39, v14, 7
-; SI-NEXT:    v_readlane_b32 s38, v14, 6
-; SI-NEXT:    v_readlane_b32 s37, v14, 5
-; SI-NEXT:    v_readlane_b32 s36, v14, 4
-; SI-NEXT:    v_readlane_b32 s35, v14, 3
-; SI-NEXT:    v_readlane_b32 s34, v14, 2
-; SI-NEXT:    v_readlane_b32 s31, v14, 1
-; SI-NEXT:    v_readlane_b32 s30, v14, 0
+; SI-NEXT:    v_readlane_b32 s48, v20, 8
+; SI-NEXT:    v_readlane_b32 s39, v20, 7
+; SI-NEXT:    v_readlane_b32 s38, v20, 6
+; SI-NEXT:    v_readlane_b32 s37, v20, 5
+; SI-NEXT:    v_readlane_b32 s36, v20, 4
+; SI-NEXT:    v_readlane_b32 s35, v20, 3
+; SI-NEXT:    v_readlane_b32 s34, v20, 2
+; SI-NEXT:    v_readlane_b32 s31, v20, 1
+; SI-NEXT:    v_readlane_b32 s30, v20, 0
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_load_dword v14, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 ; 4-byte Folded Reload
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -24393,16 +24736,44 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr94
 ; SI-NEXT:    ; implicit-def: $sgpr93
 ; SI-NEXT:    ; implicit-def: $sgpr92
-; SI-NEXT:    ; implicit-def: $sgpr42
-; SI-NEXT:    ; implicit-def: $sgpr40
+; SI-NEXT:    ; implicit-def: $sgpr28
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    s_branch .LBB41_2
 ;
 ; VI-LABEL: bitcast_v13i64_to_v52i16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v13, s16
+; VI-NEXT:    v_mov_b32_e32 v14, s17
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s20
+; VI-NEXT:    v_mov_b32_e32 v18, s21
+; VI-NEXT:    v_mov_b32_e32 v19, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v13
+; VI-NEXT:    v_mov_b32_e32 v13, s23
+; VI-NEXT:    v_readfirstlane_b32 s43, v14
+; VI-NEXT:    v_mov_b32_e32 v14, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
-; VI-NEXT:    v_readfirstlane_b32 s41, v0
-; VI-NEXT:    v_readfirstlane_b32 s40, v1
+; VI-NEXT:    v_readfirstlane_b32 s24, v13
+; VI-NEXT:    v_readfirstlane_b32 s23, v14
+; VI-NEXT:    v_readfirstlane_b32 s22, v15
+; VI-NEXT:    v_readfirstlane_b32 s21, v16
+; VI-NEXT:    v_readfirstlane_b32 s20, v17
+; VI-NEXT:    v_readfirstlane_b32 s19, v18
+; VI-NEXT:    v_readfirstlane_b32 s18, v19
+; VI-NEXT:    v_readfirstlane_b32 s17, v0
+; VI-NEXT:    v_readfirstlane_b32 s16, v1
 ; VI-NEXT:    v_readfirstlane_b32 s15, v2
 ; VI-NEXT:    v_readfirstlane_b32 s14, v3
 ; VI-NEXT:    v_readfirstlane_b32 s13, v4
@@ -24416,9 +24787,9 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; VI-NEXT:    v_readfirstlane_b32 s7, v11
 ; VI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s42, s7, 16
-; VI-NEXT:    s_lshr_b32 s43, s6, 16
-; VI-NEXT:    s_lshr_b32 s44, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s45, s9, 16
 ; VI-NEXT:    s_lshr_b32 s46, s10, 16
 ; VI-NEXT:    s_lshr_b32 s47, s11, 16
@@ -24426,22 +24797,22 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s57, s13, 16
 ; VI-NEXT:    s_lshr_b32 s58, s14, 16
 ; VI-NEXT:    s_lshr_b32 s59, s15, 16
-; VI-NEXT:    s_lshr_b32 s60, s40, 16
-; VI-NEXT:    s_lshr_b32 s61, s41, 16
-; VI-NEXT:    s_lshr_b32 s62, s29, 16
-; VI-NEXT:    s_lshr_b32 s63, s28, 16
-; VI-NEXT:    s_lshr_b32 s72, s27, 16
-; VI-NEXT:    s_lshr_b32 s73, s26, 16
-; VI-NEXT:    s_lshr_b32 s74, s25, 16
-; VI-NEXT:    s_lshr_b32 s75, s24, 16
-; VI-NEXT:    s_lshr_b32 s76, s23, 16
-; VI-NEXT:    s_lshr_b32 s77, s22, 16
-; VI-NEXT:    s_lshr_b32 s78, s21, 16
-; VI-NEXT:    s_lshr_b32 s79, s20, 16
-; VI-NEXT:    s_lshr_b32 s88, s19, 16
-; VI-NEXT:    s_lshr_b32 s89, s18, 16
-; VI-NEXT:    s_lshr_b32 s90, s17, 16
-; VI-NEXT:    s_lshr_b32 s91, s16, 16
+; VI-NEXT:    s_lshr_b32 s60, s16, 16
+; VI-NEXT:    s_lshr_b32 s61, s17, 16
+; VI-NEXT:    s_lshr_b32 s62, s18, 16
+; VI-NEXT:    s_lshr_b32 s63, s19, 16
+; VI-NEXT:    s_lshr_b32 s72, s20, 16
+; VI-NEXT:    s_lshr_b32 s73, s21, 16
+; VI-NEXT:    s_lshr_b32 s74, s22, 16
+; VI-NEXT:    s_lshr_b32 s75, s23, 16
+; VI-NEXT:    s_lshr_b32 s76, s24, 16
+; VI-NEXT:    s_lshr_b32 s77, s25, 16
+; VI-NEXT:    s_lshr_b32 s78, s26, 16
+; VI-NEXT:    s_lshr_b32 s79, s40, 16
+; VI-NEXT:    s_lshr_b32 s88, s41, 16
+; VI-NEXT:    s_lshr_b32 s89, s42, 16
+; VI-NEXT:    s_lshr_b32 s90, s43, 16
+; VI-NEXT:    s_lshr_b32 s91, s44, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB41_3
 ; VI-NEXT:  .LBB41_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -24454,25 +24825,25 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
 ; VI-NEXT:    s_add_u32 s15, s15, 3
 ; VI-NEXT:    s_addc_u32 s14, s14, 0
-; VI-NEXT:    s_add_u32 s41, s41, 3
-; VI-NEXT:    s_addc_u32 s40, s40, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s42, s7, 16
-; VI-NEXT:    s_lshr_b32 s43, s6, 16
-; VI-NEXT:    s_lshr_b32 s44, s8, 16
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_add_u32 s42, s42, 3
+; VI-NEXT:    s_addc_u32 s41, s41, 0
+; VI-NEXT:    s_add_u32 s44, s44, 3
+; VI-NEXT:    s_addc_u32 s43, s43, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s45, s9, 16
 ; VI-NEXT:    s_lshr_b32 s46, s10, 16
 ; VI-NEXT:    s_lshr_b32 s47, s11, 16
@@ -24480,117 +24851,117 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s57, s13, 16
 ; VI-NEXT:    s_lshr_b32 s58, s14, 16
 ; VI-NEXT:    s_lshr_b32 s59, s15, 16
-; VI-NEXT:    s_lshr_b32 s60, s40, 16
-; VI-NEXT:    s_lshr_b32 s61, s41, 16
-; VI-NEXT:    s_lshr_b32 s62, s29, 16
-; VI-NEXT:    s_lshr_b32 s63, s28, 16
-; VI-NEXT:    s_lshr_b32 s72, s27, 16
-; VI-NEXT:    s_lshr_b32 s73, s26, 16
-; VI-NEXT:    s_lshr_b32 s74, s25, 16
-; VI-NEXT:    s_lshr_b32 s75, s24, 16
-; VI-NEXT:    s_lshr_b32 s76, s23, 16
-; VI-NEXT:    s_lshr_b32 s77, s22, 16
-; VI-NEXT:    s_lshr_b32 s78, s21, 16
-; VI-NEXT:    s_lshr_b32 s79, s20, 16
-; VI-NEXT:    s_lshr_b32 s88, s19, 16
-; VI-NEXT:    s_lshr_b32 s89, s18, 16
-; VI-NEXT:    s_lshr_b32 s90, s17, 16
-; VI-NEXT:    s_lshr_b32 s91, s16, 16
+; VI-NEXT:    s_lshr_b32 s60, s16, 16
+; VI-NEXT:    s_lshr_b32 s61, s17, 16
+; VI-NEXT:    s_lshr_b32 s62, s18, 16
+; VI-NEXT:    s_lshr_b32 s63, s19, 16
+; VI-NEXT:    s_lshr_b32 s72, s20, 16
+; VI-NEXT:    s_lshr_b32 s73, s21, 16
+; VI-NEXT:    s_lshr_b32 s74, s22, 16
+; VI-NEXT:    s_lshr_b32 s75, s23, 16
+; VI-NEXT:    s_lshr_b32 s76, s24, 16
+; VI-NEXT:    s_lshr_b32 s77, s25, 16
+; VI-NEXT:    s_lshr_b32 s78, s26, 16
+; VI-NEXT:    s_lshr_b32 s79, s40, 16
+; VI-NEXT:    s_lshr_b32 s88, s41, 16
+; VI-NEXT:    s_lshr_b32 s89, s42, 16
+; VI-NEXT:    s_lshr_b32 s90, s43, 16
+; VI-NEXT:    s_lshr_b32 s91, s44, 16
 ; VI-NEXT:  .LBB41_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s44
 ; VI-NEXT:    s_lshl_b32 s5, s91, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s90, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s89, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s88, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s79, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s78, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s77, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s76, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s75, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s74, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s73, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s72, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s63, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s62, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s29, s61, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s40, s60, 16
-; VI-NEXT:    s_or_b32 s29, s29, s40
+; VI-NEXT:    s_and_b32 s5, 0xffff, s43
+; VI-NEXT:    s_lshl_b32 s43, s90, 16
+; VI-NEXT:    s_or_b32 s5, s5, s43
+; VI-NEXT:    s_and_b32 s42, 0xffff, s42
+; VI-NEXT:    s_lshl_b32 s43, s89, 16
+; VI-NEXT:    s_or_b32 s42, s42, s43
+; VI-NEXT:    s_and_b32 s41, 0xffff, s41
+; VI-NEXT:    s_lshl_b32 s43, s88, 16
+; VI-NEXT:    s_or_b32 s41, s41, s43
+; VI-NEXT:    s_and_b32 s40, 0xffff, s40
+; VI-NEXT:    s_lshl_b32 s43, s79, 16
+; VI-NEXT:    s_or_b32 s40, s40, s43
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s43, s78, 16
+; VI-NEXT:    s_or_b32 s26, s26, s43
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s43, s77, 16
+; VI-NEXT:    s_or_b32 s25, s25, s43
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s43, s76, 16
+; VI-NEXT:    s_or_b32 s24, s24, s43
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s43, s75, 16
+; VI-NEXT:    s_or_b32 s23, s23, s43
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s43, s74, 16
+; VI-NEXT:    s_or_b32 s22, s22, s43
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s43, s73, 16
+; VI-NEXT:    s_or_b32 s21, s21, s43
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s43, s72, 16
+; VI-NEXT:    s_or_b32 s20, s20, s43
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s43, s63, 16
+; VI-NEXT:    s_or_b32 s19, s19, s43
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s43, s62, 16
+; VI-NEXT:    s_or_b32 s18, s18, s43
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s43, s61, 16
+; VI-NEXT:    s_or_b32 s17, s17, s43
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s43, s60, 16
+; VI-NEXT:    s_or_b32 s16, s16, s43
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s40, s59, 16
-; VI-NEXT:    s_or_b32 s15, s15, s40
+; VI-NEXT:    s_lshl_b32 s43, s59, 16
+; VI-NEXT:    s_or_b32 s15, s15, s43
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s40, s58, 16
-; VI-NEXT:    s_or_b32 s14, s14, s40
+; VI-NEXT:    s_lshl_b32 s43, s58, 16
+; VI-NEXT:    s_or_b32 s14, s14, s43
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s40, s57, 16
-; VI-NEXT:    s_or_b32 s13, s13, s40
+; VI-NEXT:    s_lshl_b32 s43, s57, 16
+; VI-NEXT:    s_or_b32 s13, s13, s43
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s40, s56, 16
-; VI-NEXT:    s_or_b32 s12, s12, s40
+; VI-NEXT:    s_lshl_b32 s43, s56, 16
+; VI-NEXT:    s_or_b32 s12, s12, s43
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s40, s47, 16
-; VI-NEXT:    s_or_b32 s11, s11, s40
+; VI-NEXT:    s_lshl_b32 s43, s47, 16
+; VI-NEXT:    s_or_b32 s11, s11, s43
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s40, s46, 16
-; VI-NEXT:    s_or_b32 s10, s10, s40
+; VI-NEXT:    s_lshl_b32 s43, s46, 16
+; VI-NEXT:    s_or_b32 s10, s10, s43
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s40, s45, 16
-; VI-NEXT:    s_or_b32 s9, s9, s40
+; VI-NEXT:    s_lshl_b32 s43, s45, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s40, s44, 16
-; VI-NEXT:    s_or_b32 s8, s8, s40
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s40, s43, 16
-; VI-NEXT:    s_or_b32 s6, s6, s40
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s40, s42, 16
-; VI-NEXT:    s_or_b32 s7, s7, s40
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s43
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
+; VI-NEXT:    v_mov_b32_e32 v2, s42
+; VI-NEXT:    v_mov_b32_e32 v3, s41
+; VI-NEXT:    v_mov_b32_e32 v4, s40
+; VI-NEXT:    v_mov_b32_e32 v5, s26
+; VI-NEXT:    v_mov_b32_e32 v6, s25
+; VI-NEXT:    v_mov_b32_e32 v7, s24
+; VI-NEXT:    v_mov_b32_e32 v8, s23
+; VI-NEXT:    v_mov_b32_e32 v9, s22
+; VI-NEXT:    v_mov_b32_e32 v10, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s20
+; VI-NEXT:    v_mov_b32_e32 v12, s19
+; VI-NEXT:    v_mov_b32_e32 v13, s18
+; VI-NEXT:    v_mov_b32_e32 v14, s17
+; VI-NEXT:    v_mov_b32_e32 v15, s16
 ; VI-NEXT:    v_mov_b32_e32 v16, s15
 ; VI-NEXT:    v_mov_b32_e32 v17, s14
 ; VI-NEXT:    v_mov_b32_e32 v18, s13
@@ -24626,25 +24997,53 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr47
 ; VI-NEXT:    ; implicit-def: $sgpr46
 ; VI-NEXT:    ; implicit-def: $sgpr45
-; VI-NEXT:    ; implicit-def: $sgpr44
-; VI-NEXT:    ; implicit-def: $sgpr43
-; VI-NEXT:    ; implicit-def: $sgpr42
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB41_2
 ;
 ; GFX9-LABEL: bitcast_v13i64_to_v52i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v13, s16
+; GFX9-NEXT:    v_mov_b32_e32 v14, s17
+; GFX9-NEXT:    v_mov_b32_e32 v15, s18
+; GFX9-NEXT:    v_mov_b32_e32 v16, s19
+; GFX9-NEXT:    v_mov_b32_e32 v17, s20
+; GFX9-NEXT:    v_mov_b32_e32 v18, s21
+; GFX9-NEXT:    v_mov_b32_e32 v19, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v13
+; GFX9-NEXT:    v_mov_b32_e32 v13, s23
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX9-NEXT:    v_mov_b32_e32 v14, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
@@ -24652,44 +25051,34 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
 ; GFX9-NEXT:    s_lshr_b32 s42, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s43, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB41_3
 ; GFX9-NEXT:  .LBB41_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_u32 s40, s40, 3
 ; GFX9-NEXT:    s_addc_u32 s41, s41, 0
-; GFX9-NEXT:    s_add_u32 s14, s14, 3
-; GFX9-NEXT:    s_addc_u32 s15, s15, 0
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_add_u32 s28, s28, 3
 ; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
@@ -24704,83 +25093,93 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_lshr_b32 s42, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s43, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s6, 16
 ; GFX9-NEXT:  .LBB41_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s44
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s43
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s42
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -24816,41 +25215,68 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; GFX11-LABEL: bitcast_v13i64_to_v52i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v9, s0 :: v_dual_mov_b32 v10, s1
+; GFX11-NEXT:    v_dual_mov_b32 v11, s2 :: v_dual_mov_b32 v12, s3
+; GFX11-NEXT:    v_dual_mov_b32 v13, s16 :: v_dual_mov_b32 v14, s17
+; GFX11-NEXT:    v_dual_mov_b32 v15, s18 :: v_dual_mov_b32 v16, s19
+; GFX11-NEXT:    v_dual_mov_b32 v17, s20 :: v_dual_mov_b32 v18, s21
+; GFX11-NEXT:    v_dual_mov_b32 v19, s22 :: v_dual_mov_b32 v20, s23
+; GFX11-NEXT:    v_dual_mov_b32 v21, s24 :: v_dual_mov_b32 v22, s25
+; GFX11-NEXT:    v_dual_mov_b32 v23, s26 :: v_dual_mov_b32 v24, s27
+; GFX11-NEXT:    v_dual_mov_b32 v25, s28 :: v_dual_mov_b32 v26, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v7
 ; GFX11-NEXT:    s_mov_b32 s78, 0
-; GFX11-NEXT:    s_and_b32 s12, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s26, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s12, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s74, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s75, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s76, s1, 16
@@ -24858,20 +25284,8 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s78
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB41_3
 ; GFX11-NEXT:  .LBB41_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s11, s11, 3
-; GFX11-NEXT:    s_addc_u32 s10, s10, 0
-; GFX11-NEXT:    s_add_u32 s8, s8, 3
-; GFX11-NEXT:    s_addc_u32 s9, s9, 0
-; GFX11-NEXT:    s_add_u32 s6, s6, 3
-; GFX11-NEXT:    s_addc_u32 s7, s7, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
-; GFX11-NEXT:    s_add_u32 s24, s24, 3
-; GFX11-NEXT:    s_addc_u32 s25, s25, 0
+; GFX11-NEXT:    s_add_u32 s25, s25, 3
+; GFX11-NEXT:    s_addc_u32 s24, s24, 0
 ; GFX11-NEXT:    s_add_u32 s22, s22, 3
 ; GFX11-NEXT:    s_addc_u32 s23, s23, 0
 ; GFX11-NEXT:    s_add_u32 s20, s20, 3
@@ -24880,32 +25294,44 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s12, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s74, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s75, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s76, s1, 16
@@ -24916,41 +25342,41 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s76
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s75
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s12
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s26
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s11 :: v_dual_mov_b32 v25, s10
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s25 :: v_dual_mov_b32 v25, s24
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB41_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr77
@@ -24975,10 +25401,10 @@ define inreg <52 x i16> @bitcast_v13i64_to_v52i16_scalar(<13 x i64> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
 ; GFX11-NEXT:    s_branch .LBB41_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -25421,7 +25847,7 @@ define <13 x i64> @bitcast_v52i16_to_v13i64(<52 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
 ; SI-NEXT:    v_add_i32_e32 v22, vcc, s6, v22
 ; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
-; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
+; SI-NEXT:    v_add_i32_e32 v24, vcc, 0x30000, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, 0x30000, v25
 ; SI-NEXT:  .LBB42_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -28502,9 +28928,37 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; SI-LABEL: bitcast_v13i64_to_v52f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v14, s16
+; SI-NEXT:    v_mov_b32_e32 v15, s17
+; SI-NEXT:    v_mov_b32_e32 v16, s18
+; SI-NEXT:    v_mov_b32_e32 v17, s19
+; SI-NEXT:    v_mov_b32_e32 v18, s20
+; SI-NEXT:    v_mov_b32_e32 v19, s21
+; SI-NEXT:    v_readfirstlane_b32 s40, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s22
+; SI-NEXT:    v_readfirstlane_b32 s41, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s23
+; SI-NEXT:    v_readfirstlane_b32 s22, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_readfirstlane_b32 s42, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_readfirstlane_b32 s23, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s43, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s24, v14
+; SI-NEXT:    v_mov_b32_e32 v14, s28
+; SI-NEXT:    v_readfirstlane_b32 s27, v15
+; SI-NEXT:    v_mov_b32_e32 v15, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; SI-NEXT:    v_readfirstlane_b32 s40, v1
-; SI-NEXT:    v_readfirstlane_b32 s41, v2
+; SI-NEXT:    v_readfirstlane_b32 s25, v16
+; SI-NEXT:    v_readfirstlane_b32 s26, v17
+; SI-NEXT:    v_readfirstlane_b32 s20, v18
+; SI-NEXT:    v_readfirstlane_b32 s21, v19
+; SI-NEXT:    v_readfirstlane_b32 s18, v14
+; SI-NEXT:    v_readfirstlane_b32 s19, v15
+; SI-NEXT:    v_readfirstlane_b32 s16, v1
+; SI-NEXT:    v_readfirstlane_b32 s17, v2
 ; SI-NEXT:    v_readfirstlane_b32 s14, v3
 ; SI-NEXT:    v_readfirstlane_b32 s15, v4
 ; SI-NEXT:    v_readfirstlane_b32 s12, v5
@@ -28543,39 +28997,39 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v16, s4
 ; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s41, 16
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    s_lshr_b32 s4, s16, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
 ; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
 ; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s4
+; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s4
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
+; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
+; SI-NEXT:    s_lshr_b32 s4, s43, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
+; SI-NEXT:    s_lshr_b32 s4, s42, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
 ; SI-NEXT:    s_waitcnt expcnt(4)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v40, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    s_lshr_b32 s4, s41, 16
 ; SI-NEXT:    s_waitcnt expcnt(2)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v42, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v44, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s9
@@ -28588,56 +29042,56 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s15
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s43
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, s42
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, s41
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, s40
 ; SI-NEXT:    s_cbranch_execnz .LBB45_3
 ; SI-NEXT:  .LBB45_2: ; %cmp.true
-; SI-NEXT:    s_add_u32 s4, s16, 3
-; SI-NEXT:    s_addc_u32 s5, s17, 0
-; SI-NEXT:    s_lshr_b32 s16, s4, 16
-; SI-NEXT:    s_lshr_b32 s17, s5, 16
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
-; SI-NEXT:    s_lshr_b32 s42, s18, 16
-; SI-NEXT:    s_lshr_b32 s43, s19, 16
+; SI-NEXT:    s_add_u32 s4, s40, 3
+; SI-NEXT:    s_addc_u32 s5, s41, 0
+; SI-NEXT:    s_lshr_b32 s28, s4, 16
+; SI-NEXT:    s_lshr_b32 s29, s5, 16
+; SI-NEXT:    s_add_u32 s22, s22, 3
+; SI-NEXT:    s_addc_u32 s40, s42, 0
+; SI-NEXT:    s_lshr_b32 s41, s22, 16
+; SI-NEXT:    s_lshr_b32 s42, s40, 16
+; SI-NEXT:    s_add_u32 s23, s23, 3
+; SI-NEXT:    s_addc_u32 s43, s43, 0
+; SI-NEXT:    s_lshr_b32 s44, s23, 16
+; SI-NEXT:    s_lshr_b32 s45, s43, 16
+; SI-NEXT:    s_add_u32 s24, s24, 3
+; SI-NEXT:    s_addc_u32 s27, s27, 0
+; SI-NEXT:    s_lshr_b32 s46, s24, 16
+; SI-NEXT:    s_lshr_b32 s47, s27, 16
+; SI-NEXT:    s_add_u32 s25, s25, 3
+; SI-NEXT:    s_addc_u32 s26, s26, 0
+; SI-NEXT:    s_lshr_b32 s56, s25, 16
+; SI-NEXT:    s_lshr_b32 s57, s26, 16
 ; SI-NEXT:    s_add_u32 s20, s20, 3
 ; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_lshr_b32 s44, s20, 16
-; SI-NEXT:    s_lshr_b32 s45, s21, 16
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_lshr_b32 s46, s22, 16
-; SI-NEXT:    s_lshr_b32 s47, s23, 16
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_lshr_b32 s56, s24, 16
-; SI-NEXT:    s_lshr_b32 s57, s25, 16
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_lshr_b32 s58, s26, 16
-; SI-NEXT:    s_lshr_b32 s59, s27, 16
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_lshr_b32 s60, s28, 16
-; SI-NEXT:    s_lshr_b32 s61, s29, 16
-; SI-NEXT:    s_add_u32 s40, s40, 3
-; SI-NEXT:    s_addc_u32 s41, s41, 0
-; SI-NEXT:    s_lshr_b32 s62, s40, 16
-; SI-NEXT:    s_lshr_b32 s63, s41, 16
+; SI-NEXT:    s_lshr_b32 s58, s20, 16
+; SI-NEXT:    s_lshr_b32 s59, s21, 16
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_lshr_b32 s60, s18, 16
+; SI-NEXT:    s_lshr_b32 s61, s19, 16
+; SI-NEXT:    s_add_u32 s16, s16, 3
+; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_lshr_b32 s62, s16, 16
+; SI-NEXT:    s_lshr_b32 s63, s17, 16
 ; SI-NEXT:    s_add_u32 s14, s14, 3
 ; SI-NEXT:    s_addc_u32 s15, s15, 0
 ; SI-NEXT:    s_lshr_b32 s72, s14, 16
@@ -28668,20 +29122,20 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s15
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s43
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, s40
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, s22
 ; SI-NEXT:    s_waitcnt expcnt(3)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v41, s5
 ; SI-NEXT:    s_waitcnt expcnt(1)
@@ -28708,11 +29162,11 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v39, s46
 ; SI-NEXT:    v_cvt_f32_f16_e32 v49, s45
 ; SI-NEXT:    v_cvt_f32_f16_e32 v51, s44
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s42
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, s41
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, s29
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, s28
 ; SI-NEXT:  .LBB45_3: ; %end
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v44, v44
@@ -28960,9 +29414,37 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; VI-LABEL: bitcast_v13i64_to_v52f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v13, s16
+; VI-NEXT:    v_mov_b32_e32 v14, s17
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s20
+; VI-NEXT:    v_mov_b32_e32 v18, s21
+; VI-NEXT:    v_mov_b32_e32 v19, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v13
+; VI-NEXT:    v_mov_b32_e32 v13, s23
+; VI-NEXT:    v_readfirstlane_b32 s43, v14
+; VI-NEXT:    v_mov_b32_e32 v14, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
-; VI-NEXT:    v_readfirstlane_b32 s41, v0
-; VI-NEXT:    v_readfirstlane_b32 s40, v1
+; VI-NEXT:    v_readfirstlane_b32 s24, v13
+; VI-NEXT:    v_readfirstlane_b32 s23, v14
+; VI-NEXT:    v_readfirstlane_b32 s22, v15
+; VI-NEXT:    v_readfirstlane_b32 s21, v16
+; VI-NEXT:    v_readfirstlane_b32 s20, v17
+; VI-NEXT:    v_readfirstlane_b32 s19, v18
+; VI-NEXT:    v_readfirstlane_b32 s18, v19
+; VI-NEXT:    v_readfirstlane_b32 s17, v0
+; VI-NEXT:    v_readfirstlane_b32 s16, v1
 ; VI-NEXT:    v_readfirstlane_b32 s15, v2
 ; VI-NEXT:    v_readfirstlane_b32 s14, v3
 ; VI-NEXT:    v_readfirstlane_b32 s13, v4
@@ -28976,9 +29458,9 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; VI-NEXT:    v_readfirstlane_b32 s7, v11
 ; VI-NEXT:    s_cbranch_scc0 .LBB45_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s42, s7, 16
-; VI-NEXT:    s_lshr_b32 s43, s6, 16
-; VI-NEXT:    s_lshr_b32 s44, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s45, s9, 16
 ; VI-NEXT:    s_lshr_b32 s46, s10, 16
 ; VI-NEXT:    s_lshr_b32 s47, s11, 16
@@ -28986,22 +29468,22 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s57, s13, 16
 ; VI-NEXT:    s_lshr_b32 s58, s14, 16
 ; VI-NEXT:    s_lshr_b32 s59, s15, 16
-; VI-NEXT:    s_lshr_b32 s60, s40, 16
-; VI-NEXT:    s_lshr_b32 s61, s41, 16
-; VI-NEXT:    s_lshr_b32 s62, s29, 16
-; VI-NEXT:    s_lshr_b32 s63, s28, 16
-; VI-NEXT:    s_lshr_b32 s72, s27, 16
-; VI-NEXT:    s_lshr_b32 s73, s26, 16
-; VI-NEXT:    s_lshr_b32 s74, s25, 16
-; VI-NEXT:    s_lshr_b32 s75, s24, 16
-; VI-NEXT:    s_lshr_b32 s76, s23, 16
-; VI-NEXT:    s_lshr_b32 s77, s22, 16
-; VI-NEXT:    s_lshr_b32 s78, s21, 16
-; VI-NEXT:    s_lshr_b32 s79, s20, 16
-; VI-NEXT:    s_lshr_b32 s88, s19, 16
-; VI-NEXT:    s_lshr_b32 s89, s18, 16
-; VI-NEXT:    s_lshr_b32 s90, s17, 16
-; VI-NEXT:    s_lshr_b32 s91, s16, 16
+; VI-NEXT:    s_lshr_b32 s60, s16, 16
+; VI-NEXT:    s_lshr_b32 s61, s17, 16
+; VI-NEXT:    s_lshr_b32 s62, s18, 16
+; VI-NEXT:    s_lshr_b32 s63, s19, 16
+; VI-NEXT:    s_lshr_b32 s72, s20, 16
+; VI-NEXT:    s_lshr_b32 s73, s21, 16
+; VI-NEXT:    s_lshr_b32 s74, s22, 16
+; VI-NEXT:    s_lshr_b32 s75, s23, 16
+; VI-NEXT:    s_lshr_b32 s76, s24, 16
+; VI-NEXT:    s_lshr_b32 s77, s25, 16
+; VI-NEXT:    s_lshr_b32 s78, s26, 16
+; VI-NEXT:    s_lshr_b32 s79, s40, 16
+; VI-NEXT:    s_lshr_b32 s88, s41, 16
+; VI-NEXT:    s_lshr_b32 s89, s42, 16
+; VI-NEXT:    s_lshr_b32 s90, s43, 16
+; VI-NEXT:    s_lshr_b32 s91, s44, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB45_3
 ; VI-NEXT:  .LBB45_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -29014,25 +29496,25 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
 ; VI-NEXT:    s_add_u32 s15, s15, 3
 ; VI-NEXT:    s_addc_u32 s14, s14, 0
-; VI-NEXT:    s_add_u32 s41, s41, 3
-; VI-NEXT:    s_addc_u32 s40, s40, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s42, s7, 16
-; VI-NEXT:    s_lshr_b32 s43, s6, 16
-; VI-NEXT:    s_lshr_b32 s44, s8, 16
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_add_u32 s42, s42, 3
+; VI-NEXT:    s_addc_u32 s41, s41, 0
+; VI-NEXT:    s_add_u32 s44, s44, 3
+; VI-NEXT:    s_addc_u32 s43, s43, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s45, s9, 16
 ; VI-NEXT:    s_lshr_b32 s46, s10, 16
 ; VI-NEXT:    s_lshr_b32 s47, s11, 16
@@ -29040,117 +29522,117 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s57, s13, 16
 ; VI-NEXT:    s_lshr_b32 s58, s14, 16
 ; VI-NEXT:    s_lshr_b32 s59, s15, 16
-; VI-NEXT:    s_lshr_b32 s60, s40, 16
-; VI-NEXT:    s_lshr_b32 s61, s41, 16
-; VI-NEXT:    s_lshr_b32 s62, s29, 16
-; VI-NEXT:    s_lshr_b32 s63, s28, 16
-; VI-NEXT:    s_lshr_b32 s72, s27, 16
-; VI-NEXT:    s_lshr_b32 s73, s26, 16
-; VI-NEXT:    s_lshr_b32 s74, s25, 16
-; VI-NEXT:    s_lshr_b32 s75, s24, 16
-; VI-NEXT:    s_lshr_b32 s76, s23, 16
-; VI-NEXT:    s_lshr_b32 s77, s22, 16
-; VI-NEXT:    s_lshr_b32 s78, s21, 16
-; VI-NEXT:    s_lshr_b32 s79, s20, 16
-; VI-NEXT:    s_lshr_b32 s88, s19, 16
-; VI-NEXT:    s_lshr_b32 s89, s18, 16
-; VI-NEXT:    s_lshr_b32 s90, s17, 16
-; VI-NEXT:    s_lshr_b32 s91, s16, 16
+; VI-NEXT:    s_lshr_b32 s60, s16, 16
+; VI-NEXT:    s_lshr_b32 s61, s17, 16
+; VI-NEXT:    s_lshr_b32 s62, s18, 16
+; VI-NEXT:    s_lshr_b32 s63, s19, 16
+; VI-NEXT:    s_lshr_b32 s72, s20, 16
+; VI-NEXT:    s_lshr_b32 s73, s21, 16
+; VI-NEXT:    s_lshr_b32 s74, s22, 16
+; VI-NEXT:    s_lshr_b32 s75, s23, 16
+; VI-NEXT:    s_lshr_b32 s76, s24, 16
+; VI-NEXT:    s_lshr_b32 s77, s25, 16
+; VI-NEXT:    s_lshr_b32 s78, s26, 16
+; VI-NEXT:    s_lshr_b32 s79, s40, 16
+; VI-NEXT:    s_lshr_b32 s88, s41, 16
+; VI-NEXT:    s_lshr_b32 s89, s42, 16
+; VI-NEXT:    s_lshr_b32 s90, s43, 16
+; VI-NEXT:    s_lshr_b32 s91, s44, 16
 ; VI-NEXT:  .LBB45_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s44
 ; VI-NEXT:    s_lshl_b32 s5, s91, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s90, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s89, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s88, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s79, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s78, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s77, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s76, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s75, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s74, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s73, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s72, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s63, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s62, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s29, s61, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s40, s60, 16
-; VI-NEXT:    s_or_b32 s29, s29, s40
+; VI-NEXT:    s_and_b32 s5, 0xffff, s43
+; VI-NEXT:    s_lshl_b32 s43, s90, 16
+; VI-NEXT:    s_or_b32 s5, s5, s43
+; VI-NEXT:    s_and_b32 s42, 0xffff, s42
+; VI-NEXT:    s_lshl_b32 s43, s89, 16
+; VI-NEXT:    s_or_b32 s42, s42, s43
+; VI-NEXT:    s_and_b32 s41, 0xffff, s41
+; VI-NEXT:    s_lshl_b32 s43, s88, 16
+; VI-NEXT:    s_or_b32 s41, s41, s43
+; VI-NEXT:    s_and_b32 s40, 0xffff, s40
+; VI-NEXT:    s_lshl_b32 s43, s79, 16
+; VI-NEXT:    s_or_b32 s40, s40, s43
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s43, s78, 16
+; VI-NEXT:    s_or_b32 s26, s26, s43
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s43, s77, 16
+; VI-NEXT:    s_or_b32 s25, s25, s43
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s43, s76, 16
+; VI-NEXT:    s_or_b32 s24, s24, s43
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s43, s75, 16
+; VI-NEXT:    s_or_b32 s23, s23, s43
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s43, s74, 16
+; VI-NEXT:    s_or_b32 s22, s22, s43
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s43, s73, 16
+; VI-NEXT:    s_or_b32 s21, s21, s43
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s43, s72, 16
+; VI-NEXT:    s_or_b32 s20, s20, s43
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s43, s63, 16
+; VI-NEXT:    s_or_b32 s19, s19, s43
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s43, s62, 16
+; VI-NEXT:    s_or_b32 s18, s18, s43
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s43, s61, 16
+; VI-NEXT:    s_or_b32 s17, s17, s43
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s43, s60, 16
+; VI-NEXT:    s_or_b32 s16, s16, s43
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s40, s59, 16
-; VI-NEXT:    s_or_b32 s15, s15, s40
+; VI-NEXT:    s_lshl_b32 s43, s59, 16
+; VI-NEXT:    s_or_b32 s15, s15, s43
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s40, s58, 16
-; VI-NEXT:    s_or_b32 s14, s14, s40
+; VI-NEXT:    s_lshl_b32 s43, s58, 16
+; VI-NEXT:    s_or_b32 s14, s14, s43
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s40, s57, 16
-; VI-NEXT:    s_or_b32 s13, s13, s40
+; VI-NEXT:    s_lshl_b32 s43, s57, 16
+; VI-NEXT:    s_or_b32 s13, s13, s43
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s40, s56, 16
-; VI-NEXT:    s_or_b32 s12, s12, s40
+; VI-NEXT:    s_lshl_b32 s43, s56, 16
+; VI-NEXT:    s_or_b32 s12, s12, s43
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s40, s47, 16
-; VI-NEXT:    s_or_b32 s11, s11, s40
+; VI-NEXT:    s_lshl_b32 s43, s47, 16
+; VI-NEXT:    s_or_b32 s11, s11, s43
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s40, s46, 16
-; VI-NEXT:    s_or_b32 s10, s10, s40
+; VI-NEXT:    s_lshl_b32 s43, s46, 16
+; VI-NEXT:    s_or_b32 s10, s10, s43
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s40, s45, 16
-; VI-NEXT:    s_or_b32 s9, s9, s40
+; VI-NEXT:    s_lshl_b32 s43, s45, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s40, s44, 16
-; VI-NEXT:    s_or_b32 s8, s8, s40
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s40, s43, 16
-; VI-NEXT:    s_or_b32 s6, s6, s40
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s40, s42, 16
-; VI-NEXT:    s_or_b32 s7, s7, s40
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s43
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
+; VI-NEXT:    v_mov_b32_e32 v2, s42
+; VI-NEXT:    v_mov_b32_e32 v3, s41
+; VI-NEXT:    v_mov_b32_e32 v4, s40
+; VI-NEXT:    v_mov_b32_e32 v5, s26
+; VI-NEXT:    v_mov_b32_e32 v6, s25
+; VI-NEXT:    v_mov_b32_e32 v7, s24
+; VI-NEXT:    v_mov_b32_e32 v8, s23
+; VI-NEXT:    v_mov_b32_e32 v9, s22
+; VI-NEXT:    v_mov_b32_e32 v10, s21
+; VI-NEXT:    v_mov_b32_e32 v11, s20
+; VI-NEXT:    v_mov_b32_e32 v12, s19
+; VI-NEXT:    v_mov_b32_e32 v13, s18
+; VI-NEXT:    v_mov_b32_e32 v14, s17
+; VI-NEXT:    v_mov_b32_e32 v15, s16
 ; VI-NEXT:    v_mov_b32_e32 v16, s15
 ; VI-NEXT:    v_mov_b32_e32 v17, s14
 ; VI-NEXT:    v_mov_b32_e32 v18, s13
@@ -29186,25 +29668,53 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr47
 ; VI-NEXT:    ; implicit-def: $sgpr46
 ; VI-NEXT:    ; implicit-def: $sgpr45
-; VI-NEXT:    ; implicit-def: $sgpr44
-; VI-NEXT:    ; implicit-def: $sgpr43
-; VI-NEXT:    ; implicit-def: $sgpr42
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB45_2
 ;
 ; GFX9-LABEL: bitcast_v13i64_to_v52f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v13, s16
+; GFX9-NEXT:    v_mov_b32_e32 v14, s17
+; GFX9-NEXT:    v_mov_b32_e32 v15, s18
+; GFX9-NEXT:    v_mov_b32_e32 v16, s19
+; GFX9-NEXT:    v_mov_b32_e32 v17, s20
+; GFX9-NEXT:    v_mov_b32_e32 v18, s21
+; GFX9-NEXT:    v_mov_b32_e32 v19, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v13
+; GFX9-NEXT:    v_mov_b32_e32 v13, s23
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v14
+; GFX9-NEXT:    v_mov_b32_e32 v14, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v13
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v14
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
@@ -29212,44 +29722,34 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; GFX9-NEXT:  ; %bb.1: ; %cmp.false
 ; GFX9-NEXT:    s_lshr_b32 s42, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s43, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB45_3
 ; GFX9-NEXT:  .LBB45_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_u32 s40, s40, 3
 ; GFX9-NEXT:    s_addc_u32 s41, s41, 0
-; GFX9-NEXT:    s_add_u32 s14, s14, 3
-; GFX9-NEXT:    s_addc_u32 s15, s15, 0
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_add_u32 s28, s28, 3
 ; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
@@ -29264,83 +29764,93 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_lshr_b32 s42, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s43, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s44, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s45, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s46, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s47, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s44, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s45, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s46, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s47, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s6, 16
 ; GFX9-NEXT:  .LBB45_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s56
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s47
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s46
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s45
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s44
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s47
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s46
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s45
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s44
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s43
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s42
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -29376,41 +29886,68 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; GFX11-LABEL: bitcast_v13i64_to_v52f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v9, s0 :: v_dual_mov_b32 v10, s1
+; GFX11-NEXT:    v_dual_mov_b32 v11, s2 :: v_dual_mov_b32 v12, s3
+; GFX11-NEXT:    v_dual_mov_b32 v13, s16 :: v_dual_mov_b32 v14, s17
+; GFX11-NEXT:    v_dual_mov_b32 v15, s18 :: v_dual_mov_b32 v16, s19
+; GFX11-NEXT:    v_dual_mov_b32 v17, s20 :: v_dual_mov_b32 v18, s21
+; GFX11-NEXT:    v_dual_mov_b32 v19, s22 :: v_dual_mov_b32 v20, s23
+; GFX11-NEXT:    v_dual_mov_b32 v21, s24 :: v_dual_mov_b32 v22, s25
+; GFX11-NEXT:    v_dual_mov_b32 v23, s26 :: v_dual_mov_b32 v24, s27
+; GFX11-NEXT:    v_dual_mov_b32 v25, s28 :: v_dual_mov_b32 v26, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v7
 ; GFX11-NEXT:    s_mov_b32 s78, 0
-; GFX11-NEXT:    s_and_b32 s12, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s26, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s12, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s74, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s75, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s76, s1, 16
@@ -29418,20 +29955,8 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s78
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB45_3
 ; GFX11-NEXT:  .LBB45_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s11, s11, 3
-; GFX11-NEXT:    s_addc_u32 s10, s10, 0
-; GFX11-NEXT:    s_add_u32 s8, s8, 3
-; GFX11-NEXT:    s_addc_u32 s9, s9, 0
-; GFX11-NEXT:    s_add_u32 s6, s6, 3
-; GFX11-NEXT:    s_addc_u32 s7, s7, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
-; GFX11-NEXT:    s_add_u32 s24, s24, 3
-; GFX11-NEXT:    s_addc_u32 s25, s25, 0
+; GFX11-NEXT:    s_add_u32 s25, s25, 3
+; GFX11-NEXT:    s_addc_u32 s24, s24, 0
 ; GFX11-NEXT:    s_add_u32 s22, s22, 3
 ; GFX11-NEXT:    s_addc_u32 s23, s23, 0
 ; GFX11-NEXT:    s_add_u32 s20, s20, 3
@@ -29440,32 +29965,44 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s12, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s13, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s14, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s26, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s27, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s74, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s75, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s76, s1, 16
@@ -29476,41 +30013,41 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s76
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s75
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s14
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s13
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s12
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s28
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s27
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s26
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s11 :: v_dual_mov_b32 v25, s10
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s25 :: v_dual_mov_b32 v25, s24
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB45_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr77
@@ -29535,10 +30072,10 @@ define inreg <52 x half> @bitcast_v13i64_to_v52f16_scalar(<13 x i64> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
-; GFX11-NEXT:    ; implicit-def: $sgpr13
-; GFX11-NEXT:    ; implicit-def: $sgpr12
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
+; GFX11-NEXT:    ; implicit-def: $sgpr27
+; GFX11-NEXT:    ; implicit-def: $sgpr26
 ; GFX11-NEXT:    s_branch .LBB45_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -33287,8 +33824,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
 ; VI-NEXT:    v_mov_b32_e32 v21, s16
 ; VI-NEXT:    v_mov_b32_e32 v22, s17
-; VI-NEXT:    v_mov_b32_e32 v17, s18
-; VI-NEXT:    v_mov_b32_e32 v18, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s19
 ; VI-NEXT:    v_mov_b32_e32 v13, s20
 ; VI-NEXT:    v_mov_b32_e32 v14, s21
 ; VI-NEXT:    v_mov_b32_e32 v30, s22
@@ -33298,8 +33835,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; VI-NEXT:    v_mov_b32_e32 v19, s26
 ; VI-NEXT:    v_mov_b32_e32 v20, s27
 ; VI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; VI-NEXT:    v_mov_b32_e32 v15, s28
-; VI-NEXT:    v_mov_b32_e32 v16, s29
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; VI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; VI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
@@ -33318,8 +33855,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v40, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v41, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v41, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v12, 16, v17
 ; VI-NEXT:    v_lshrrev_b32_e32 v35, 16, v20
 ; VI-NEXT:    v_lshrrev_b32_e32 v34, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
@@ -33328,8 +33865,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v43, 16, v30
 ; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
 ; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v13
-; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v15
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v36, 16, v21
 ; VI-NEXT:    s_cbranch_execnz .LBB49_3
@@ -33340,12 +33877,12 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; VI-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; VI-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; VI-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; VI-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; VI-NEXT:    v_add_f64 v[30:31], v[30:31], 1.0
 ; VI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
-; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; VI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v11
 ; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v10
@@ -33359,8 +33896,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v40, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v41, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v41, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v12, 16, v17
 ; VI-NEXT:    v_lshrrev_b32_e32 v35, 16, v20
 ; VI-NEXT:    v_lshrrev_b32_e32 v34, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
@@ -33369,8 +33906,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v43, 16, v30
 ; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
 ; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v13
-; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v15
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v36, 16, v21
 ; VI-NEXT:  .LBB49_3: ; %end
@@ -33379,11 +33916,11 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; VI-NEXT:    v_lshlrev_b32_e32 v21, 16, v37
 ; VI-NEXT:    v_or_b32_sdwa v37, v22, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v21, 16, v26
-; VI-NEXT:    v_or_b32_sdwa v26, v17, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v27
-; VI-NEXT:    v_or_b32_sdwa v27, v18, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v28
-; VI-NEXT:    v_or_b32_sdwa v28, v13, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v26, v15, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v27
+; VI-NEXT:    v_or_b32_sdwa v27, v16, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v28
+; VI-NEXT:    v_or_b32_sdwa v28, v13, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v29
 ; VI-NEXT:    v_or_b32_sdwa v29, v14, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v43
@@ -33404,17 +33941,17 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; VI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; VI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; VI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
-; VI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
 ; VI-NEXT:    v_or_b32_sdwa v14, v0, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v55
-; VI-NEXT:    v_or_b32_sdwa v12, v15, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v15, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v54
-; VI-NEXT:    v_or_b32_sdwa v13, v16, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
 ; VI-NEXT:    v_or_b32_sdwa v16, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v53
+; VI-NEXT:    v_or_b32_sdwa v12, v17, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v17, v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v52
+; VI-NEXT:    v_or_b32_sdwa v13, v18, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v18, v4, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v51
 ; VI-NEXT:    v_or_b32_sdwa v19, v5, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -33479,8 +34016,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
 ; GFX9-NEXT:    v_mov_b32_e32 v21, s16
 ; GFX9-NEXT:    v_mov_b32_e32 v22, s17
-; GFX9-NEXT:    v_mov_b32_e32 v17, s18
-; GFX9-NEXT:    v_mov_b32_e32 v18, s19
+; GFX9-NEXT:    v_mov_b32_e32 v15, s18
+; GFX9-NEXT:    v_mov_b32_e32 v16, s19
 ; GFX9-NEXT:    v_mov_b32_e32 v13, s20
 ; GFX9-NEXT:    v_mov_b32_e32 v14, s21
 ; GFX9-NEXT:    v_mov_b32_e32 v30, s22
@@ -33490,8 +34027,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; GFX9-NEXT:    v_mov_b32_e32 v19, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v20, s27
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_mov_b32_e32 v15, s28
-; GFX9-NEXT:    v_mov_b32_e32 v16, s29
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; GFX9-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GFX9-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
@@ -33510,8 +34047,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v40, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v41, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v41, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v17
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v35, 16, v20
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v34, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
@@ -33520,8 +34057,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v43, 16, v30
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v15
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v36, 16, v21
 ; GFX9-NEXT:    s_cbranch_execnz .LBB49_3
@@ -33532,12 +34069,12 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; GFX9-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; GFX9-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; GFX9-NEXT:    v_add_f64 v[30:31], v[30:31], 1.0
 ; GFX9-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
-; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; GFX9-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v11
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v10
@@ -33551,8 +34088,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v40, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v41, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v41, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v17
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v35, 16, v20
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v34, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
@@ -33561,8 +34098,8 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v43, 16, v30
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v15
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v36, 16, v21
 ; GFX9-NEXT:  .LBB49_3: ; %end
@@ -33582,9 +34119,9 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; GFX9-NEXT:    v_lshl_or_b32 v34, v34, 16, v13
 ; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v20
 ; GFX9-NEXT:    v_lshl_or_b32 v35, v35, 16, v13
-; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v15
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v12, v12, 16, v13
-; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v16
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v18
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    v_lshl_or_b32 v13, v41, 16, v13
 ; GFX9-NEXT:    v_lshl_or_b32 v14, v40, 16, v0
@@ -33592,15 +34129,15 @@ define inreg <52 x i16> @bitcast_v13f64_to_v52i16_scalar(<13 x double> inreg %a,
 ; GFX9-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GFX9-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GFX9-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v15
+; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v15
+; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v16
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v1
-; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v17
+; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v15, v55, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
-; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v17
-; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v18
 ; GFX9-NEXT:    v_lshl_or_b32 v16, v54, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v3
-; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v17, v53, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v4
 ; GFX9-NEXT:    v_lshl_or_b32 v18, v52, 16, v0
@@ -34440,7 +34977,7 @@ define <13 x double> @bitcast_v52i16_to_v13f64(<52 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v21, vcc, s6, v21
 ; SI-NEXT:    v_add_i32_e32 v22, vcc, s6, v22
 ; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
-; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
+; SI-NEXT:    v_add_i32_e32 v24, vcc, 0x30000, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, 0x30000, v25
 ; SI-NEXT:  .LBB50_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -37429,19 +37966,21 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; SI-NEXT:    v_readfirstlane_b32 s14, v1
-; SI-NEXT:    v_readfirstlane_b32 s15, v2
-; SI-NEXT:    v_readfirstlane_b32 s12, v3
-; SI-NEXT:    v_readfirstlane_b32 s13, v4
-; SI-NEXT:    v_readfirstlane_b32 s10, v5
-; SI-NEXT:    v_readfirstlane_b32 s11, v6
-; SI-NEXT:    v_readfirstlane_b32 s8, v7
-; SI-NEXT:    v_readfirstlane_b32 s9, v8
-; SI-NEXT:    v_readfirstlane_b32 s6, v9
-; SI-NEXT:    v_readfirstlane_b32 s7, v10
-; SI-NEXT:    v_readfirstlane_b32 s4, v11
-; SI-NEXT:    s_and_b64 s[40:41], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s5, v12
+; SI-NEXT:    v_mov_b32_e32 v25, s16
+; SI-NEXT:    v_mov_b32_e32 v26, s17
+; SI-NEXT:    v_mov_b32_e32 v21, s18
+; SI-NEXT:    v_mov_b32_e32 v22, s19
+; SI-NEXT:    v_mov_b32_e32 v17, s20
+; SI-NEXT:    v_mov_b32_e32 v18, s21
+; SI-NEXT:    v_mov_b32_e32 v23, s22
+; SI-NEXT:    v_mov_b32_e32 v24, s23
+; SI-NEXT:    v_mov_b32_e32 v19, s24
+; SI-NEXT:    v_mov_b32_e32 v20, s25
+; SI-NEXT:    v_mov_b32_e32 v15, s26
+; SI-NEXT:    v_mov_b32_e32 v16, s27
+; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
+; SI-NEXT:    v_mov_b32_e32 v13, s28
+; SI-NEXT:    v_mov_b32_e32 v14, s29
 ; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
@@ -37460,362 +37999,440 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_cbranch_scc0 .LBB53_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s40, s5, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s40
-; SI-NEXT:    s_lshr_b32 s40, s4, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s40
-; SI-NEXT:    s_lshr_b32 s40, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v6, s40
-; SI-NEXT:    s_lshr_b32 s40, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s40
-; SI-NEXT:    s_lshr_b32 s40, s9, 16
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v12
+; SI-NEXT:    s_waitcnt expcnt(3)
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v10
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v63, s40
-; SI-NEXT:    s_lshr_b32 s40, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s40
-; SI-NEXT:    s_lshr_b32 s40, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v62, s40
-; SI-NEXT:    s_lshr_b32 s40, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s40
-; SI-NEXT:    s_lshr_b32 s40, s13, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s40
-; SI-NEXT:    s_lshr_b32 s40, s12, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s40
-; SI-NEXT:    s_lshr_b32 s40, s15, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s40
-; SI-NEXT:    s_lshr_b32 s40, s14, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s40
-; SI-NEXT:    s_lshr_b32 s40, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s40
-; SI-NEXT:    s_lshr_b32 s40, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s40
-; SI-NEXT:    s_lshr_b32 s40, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s40
-; SI-NEXT:    s_lshr_b32 s40, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s40
-; SI-NEXT:    s_lshr_b32 s40, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s40
-; SI-NEXT:    s_lshr_b32 s40, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s40
-; SI-NEXT:    s_lshr_b32 s40, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s40
-; SI-NEXT:    s_lshr_b32 s40, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s40
-; SI-NEXT:    s_lshr_b32 s40, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s40
-; SI-NEXT:    s_lshr_b32 s40, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s40
-; SI-NEXT:    s_lshr_b32 s40, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s40
-; SI-NEXT:    s_lshr_b32 s40, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s40
-; SI-NEXT:    s_lshr_b32 s40, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s40
-; SI-NEXT:    s_lshr_b32 s40, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s5
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v19
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v18
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v21
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v25
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v7
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v6
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v5
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v4
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v3
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v2
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v1
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v14
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v13
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v16
+; SI-NEXT:    buffer_store_dword v27, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v20
 ; SI-NEXT:    s_cbranch_execnz .LBB53_3
 ; SI-NEXT:  .LBB53_2: ; %cmp.true
-; SI-NEXT:    v_add_f64 v[1:2], s[16:17], 1.0
-; SI-NEXT:    v_add_f64 v[54:55], s[18:19], 1.0
-; SI-NEXT:    v_add_f64 v[49:50], s[20:21], 1.0
-; SI-NEXT:    v_add_f64 v[37:38], s[22:23], 1.0
-; SI-NEXT:    v_add_f64 v[33:34], s[24:25], 1.0
-; SI-NEXT:    v_add_f64 v[31:32], s[26:27], 1.0
-; SI-NEXT:    v_add_f64 v[26:27], s[28:29], 1.0
-; SI-NEXT:    v_add_f64 v[22:23], s[14:15], 1.0
-; SI-NEXT:    v_add_f64 v[18:19], s[12:13], 1.0
-; SI-NEXT:    v_add_f64 v[14:15], s[10:11], 1.0
-; SI-NEXT:    v_add_f64 v[11:12], s[8:9], 1.0
-; SI-NEXT:    v_add_f64 v[7:8], s[6:7], 1.0
-; SI-NEXT:    v_add_f64 v[3:4], s[4:5], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v54
-; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v55
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v49
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v50
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v37
-; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v38
-; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v33
-; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v34
-; SI-NEXT:    s_waitcnt expcnt(6)
-; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v31
-; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v32
-; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v26
-; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v27
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v23
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v16, 16, v19
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v14
-; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v62, 16, v15
-; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v11
+; SI-NEXT:    v_add_f64 v[1:2], v[1:2], 1.0
+; SI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; SI-NEXT:    v_add_f64 v[7:8], v[7:8], 1.0
+; SI-NEXT:    v_add_f64 v[5:6], v[5:6], 1.0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v7
-; SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v8
-; SI-NEXT:    v_lshrrev_b32_e32 v10, 16, v3
-; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v32
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, v49
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, v55
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v6
+; SI-NEXT:    v_add_f64 v[25:26], v[25:26], 1.0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, v13
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v10
+; SI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
+; SI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; SI-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v16
+; SI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; SI-NEXT:    v_add_f64 v[3:4], v[3:4], 1.0
+; SI-NEXT:    v_add_f64 v[9:10], v[9:10], 1.0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v43
+; SI-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v26
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v41
+; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
 ; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; SI-NEXT:    v_cvt_f32_f16_e32 v63, v63
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
-; SI-NEXT:    v_cvt_f32_f16_e32 v62, v62
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v61
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v60
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v59
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v24
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v58
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v57
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v56
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v47
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v39
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, v46
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v45
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v55
 ; SI-NEXT:    v_cvt_f32_f16_e32 v40, v40
 ; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
 ; SI-NEXT:    v_cvt_f32_f16_e32 v44, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v47
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v57
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v61
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v63
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
+; SI-NEXT:    v_mov_b32_e32 v43, v10
+; SI-NEXT:    v_mov_b32_e32 v41, v11
+; SI-NEXT:    v_mov_b32_e32 v51, v12
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
 ; SI-NEXT:  .LBB53_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v44
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v43
-; SI-NEXT:    v_cvt_f16_f32_e32 v42, v42
-; SI-NEXT:    v_cvt_f16_f32_e32 v41, v41
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    v_lshlrev_b32_e32 v13, 16, v42
-; SI-NEXT:    buffer_store_dword v10, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v13, v41, v13
-; SI-NEXT:    buffer_store_dword v13, v10, s[0:3], 0 offen
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v40
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v37
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v49
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v35
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v48
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v55
-; SI-NEXT:    v_add_i32_e32 v55, vcc, 8, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v55, s[0:3], 0 offen
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
+; SI-NEXT:    v_or_b32_e32 v2, v4, v2
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v32
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v54
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v53
-; SI-NEXT:    v_add_i32_e32 v53, vcc, 12, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v53, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v39
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v52
-; SI-NEXT:    v_add_i32_e32 v51, vcc, 16, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v51, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v30
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v38
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v50
-; SI-NEXT:    v_add_i32_e32 v49, vcc, 20, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v49, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v28
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v36
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v48
-; SI-NEXT:    v_add_i32_e32 v39, vcc, 24, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v39, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v63
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v34
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v38
-; SI-NEXT:    v_add_i32_e32 v37, vcc, 28, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v37, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v61
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v33
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v36
-; SI-NEXT:    v_add_i32_e32 v35, vcc, 32, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v35, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v59
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v31
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v34
-; SI-NEXT:    v_add_i32_e32 v33, vcc, 36, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v33, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v57
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v31
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v32
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 40, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v31, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v47
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v27
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v30
-; SI-NEXT:    v_add_i32_e32 v28, vcc, 44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v28, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v44
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v62
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v11
-; SI-NEXT:    v_add_i32_e32 v26, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v26, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v27
-; SI-NEXT:    v_add_i32_e32 v24, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v24, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v4
-; SI-NEXT:    v_add_i32_e32 v22, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v22, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v23
-; SI-NEXT:    v_add_i32_e32 v20, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v20, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v8
-; SI-NEXT:    v_add_i32_e32 v18, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v18, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v16
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v19
-; SI-NEXT:    v_add_i32_e32 v16, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v16, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v13, v7
-; SI-NEXT:    v_add_i32_e32 v14, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_or_b32_e32 v10, v13, v10
-; SI-NEXT:    buffer_store_dword v10, v14, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v62
-; SI-NEXT:    v_cvt_f16_f32_e32 v11, v15
-; SI-NEXT:    v_cvt_f16_f32_e32 v9, v9
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; SI-NEXT:    v_lshlrev_b32_e32 v10, 16, v10
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 0x4c, v0
-; SI-NEXT:    v_or_b32_e32 v10, v11, v10
-; SI-NEXT:    v_lshlrev_b32_e32 v9, 16, v9
-; SI-NEXT:    buffer_store_dword v10, v13, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 0x50, v0
-; SI-NEXT:    v_or_b32_e32 v3, v3, v9
-; SI-NEXT:    buffer_store_dword v3, v10, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v63
-; SI-NEXT:    v_cvt_f16_f32_e32 v7, v12
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 0x54, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v7, v3
-; SI-NEXT:    buffer_store_dword v3, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v5
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v25
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x58, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v4, v3
-; SI-NEXT:    buffer_store_dword v3, v5, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v6
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v21
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x5c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v4, v3
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v42
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    buffer_store_dword v3, v5, s[0:3], 0 offen
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:116 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v17
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 0x60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; SI-NEXT:    v_or_b32_e32 v2, v3, v2
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v40
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v55
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v54
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v52
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v50
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v45
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v45
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x54, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v46
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x58, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v56
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v43
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x5c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v58
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v41
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v60
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v51
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x64, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
@@ -37839,58 +38456,73 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB53_4:
-; SI-NEXT:    ; implicit-def: $vgpr43
-; SI-NEXT:    ; implicit-def: $vgpr44
-; SI-NEXT:    ; implicit-def: $vgpr41
-; SI-NEXT:    ; implicit-def: $vgpr42
-; SI-NEXT:    ; implicit-def: $vgpr55
-; SI-NEXT:    ; implicit-def: $vgpr40
-; SI-NEXT:    ; implicit-def: $vgpr53
-; SI-NEXT:    ; implicit-def: $vgpr54
-; SI-NEXT:    ; implicit-def: $vgpr52
 ; SI-NEXT:    ; implicit-def: $vgpr51
 ; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; kill: killed $vgpr51
+; SI-NEXT:    ; kill: killed $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; kill: killed $vgpr51
+; SI-NEXT:    ; kill: killed $vgpr50
 ; SI-NEXT:    ; implicit-def: $vgpr49
-; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr39
-; SI-NEXT:    ; implicit-def: $vgpr38
 ; SI-NEXT:    ; implicit-def: $vgpr37
-; SI-NEXT:    ; implicit-def: $vgpr36
+; SI-NEXT:    ; implicit-def: $vgpr48
 ; SI-NEXT:    ; implicit-def: $vgpr35
-; SI-NEXT:    ; implicit-def: $vgpr34
-; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; implicit-def: $vgpr39
 ; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr38
 ; SI-NEXT:    ; implicit-def: $vgpr30
+; SI-NEXT:    ; implicit-def: $vgpr36
 ; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr26
-; SI-NEXT:    ; implicit-def: $vgpr27
-; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr23
-; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr8
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr14
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr62
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr12
+; SI-NEXT:    ; implicit-def: $vgpr34
 ; SI-NEXT:    ; implicit-def: $vgpr63
-; SI-NEXT:    ; implicit-def: $vgpr25
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr6
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr2
+; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; implicit-def: $vgpr61
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr59
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr57
+; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr62
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr52
 ; SI-NEXT:    ; implicit-def: $vgpr45
-; SI-NEXT:    ; implicit-def: $vgpr1
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr43
+; SI-NEXT:    ; implicit-def: $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr58
+; SI-NEXT:    ; implicit-def: $vgpr60
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; kill: killed $vgpr51
+; SI-NEXT:    ; kill: killed $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; kill: killed $vgpr51
+; SI-NEXT:    ; kill: killed $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; kill: killed $vgpr51
+; SI-NEXT:    ; kill: killed $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; kill: killed $vgpr51
+; SI-NEXT:    ; kill: killed $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; kill: killed $vgpr51
+; SI-NEXT:    ; kill: killed $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; kill: killed $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr51
 ; SI-NEXT:    s_branch .LBB53_2
 ;
 ; VI-LABEL: bitcast_v13f64_to_v52f16_scalar:
@@ -37899,8 +38531,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
 ; VI-NEXT:    v_mov_b32_e32 v21, s16
 ; VI-NEXT:    v_mov_b32_e32 v22, s17
-; VI-NEXT:    v_mov_b32_e32 v17, s18
-; VI-NEXT:    v_mov_b32_e32 v18, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s19
 ; VI-NEXT:    v_mov_b32_e32 v13, s20
 ; VI-NEXT:    v_mov_b32_e32 v14, s21
 ; VI-NEXT:    v_mov_b32_e32 v30, s22
@@ -37910,8 +38542,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; VI-NEXT:    v_mov_b32_e32 v19, s26
 ; VI-NEXT:    v_mov_b32_e32 v20, s27
 ; VI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; VI-NEXT:    v_mov_b32_e32 v15, s28
-; VI-NEXT:    v_mov_b32_e32 v16, s29
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; VI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; VI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
@@ -37930,8 +38562,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v40, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v41, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v41, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v12, 16, v17
 ; VI-NEXT:    v_lshrrev_b32_e32 v35, 16, v20
 ; VI-NEXT:    v_lshrrev_b32_e32 v34, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
@@ -37940,8 +38572,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v43, 16, v30
 ; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
 ; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v13
-; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v15
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v36, 16, v21
 ; VI-NEXT:    s_cbranch_execnz .LBB53_3
@@ -37952,12 +38584,12 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; VI-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; VI-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; VI-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; VI-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; VI-NEXT:    v_add_f64 v[30:31], v[30:31], 1.0
 ; VI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
-; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; VI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; VI-NEXT:    v_lshrrev_b32_e32 v25, 16, v11
 ; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v10
@@ -37971,8 +38603,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v55, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v40, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v41, 16, v16
-; VI-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
+; VI-NEXT:    v_lshrrev_b32_e32 v41, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v12, 16, v17
 ; VI-NEXT:    v_lshrrev_b32_e32 v35, 16, v20
 ; VI-NEXT:    v_lshrrev_b32_e32 v34, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
@@ -37981,8 +38613,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v43, 16, v30
 ; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
 ; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v13
-; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; VI-NEXT:    v_lshrrev_b32_e32 v26, 16, v15
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v36, 16, v21
 ; VI-NEXT:  .LBB53_3: ; %end
@@ -37991,11 +38623,11 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; VI-NEXT:    v_lshlrev_b32_e32 v21, 16, v37
 ; VI-NEXT:    v_or_b32_sdwa v37, v22, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v21, 16, v26
-; VI-NEXT:    v_or_b32_sdwa v26, v17, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v27
-; VI-NEXT:    v_or_b32_sdwa v27, v18, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v28
-; VI-NEXT:    v_or_b32_sdwa v28, v13, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v26, v15, v21 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v27
+; VI-NEXT:    v_or_b32_sdwa v27, v16, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v28
+; VI-NEXT:    v_or_b32_sdwa v28, v13, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v29
 ; VI-NEXT:    v_or_b32_sdwa v29, v14, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v13, 16, v43
@@ -38016,17 +38648,17 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; VI-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; VI-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; VI-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
-; VI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
 ; VI-NEXT:    v_or_b32_sdwa v14, v0, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v55
-; VI-NEXT:    v_or_b32_sdwa v12, v15, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v15, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v54
-; VI-NEXT:    v_or_b32_sdwa v13, v16, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v12, 16, v12
 ; VI-NEXT:    v_or_b32_sdwa v16, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v53
+; VI-NEXT:    v_or_b32_sdwa v12, v17, v12 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v17, v3, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v52
+; VI-NEXT:    v_or_b32_sdwa v13, v18, v13 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v18, v4, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v51
 ; VI-NEXT:    v_or_b32_sdwa v19, v5, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -38091,8 +38723,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
 ; GFX9-NEXT:    v_mov_b32_e32 v21, s16
 ; GFX9-NEXT:    v_mov_b32_e32 v22, s17
-; GFX9-NEXT:    v_mov_b32_e32 v17, s18
-; GFX9-NEXT:    v_mov_b32_e32 v18, s19
+; GFX9-NEXT:    v_mov_b32_e32 v15, s18
+; GFX9-NEXT:    v_mov_b32_e32 v16, s19
 ; GFX9-NEXT:    v_mov_b32_e32 v13, s20
 ; GFX9-NEXT:    v_mov_b32_e32 v14, s21
 ; GFX9-NEXT:    v_mov_b32_e32 v30, s22
@@ -38102,8 +38734,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; GFX9-NEXT:    v_mov_b32_e32 v19, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v20, s27
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_mov_b32_e32 v15, s28
-; GFX9-NEXT:    v_mov_b32_e32 v16, s29
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; GFX9-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; GFX9-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
@@ -38122,8 +38754,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v40, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v41, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v41, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v17
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v35, 16, v20
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v34, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
@@ -38132,8 +38764,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v43, 16, v30
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v15
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v36, 16, v21
 ; GFX9-NEXT:    s_cbranch_execnz .LBB53_3
@@ -38144,12 +38776,12 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; GFX9-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; GFX9-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; GFX9-NEXT:    v_add_f64 v[30:31], v[30:31], 1.0
 ; GFX9-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
-; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; GFX9-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v25, 16, v11
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v10
@@ -38163,8 +38795,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v54, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v55, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v40, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v41, 16, v16
-; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v15
+; GFX9-NEXT:    v_lshrrev_b32_e32 v41, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v17
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v35, 16, v20
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v34, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
@@ -38173,8 +38805,8 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v43, 16, v30
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v16
+; GFX9-NEXT:    v_lshrrev_b32_e32 v26, 16, v15
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v36, 16, v21
 ; GFX9-NEXT:  .LBB53_3: ; %end
@@ -38194,9 +38826,9 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; GFX9-NEXT:    v_lshl_or_b32 v34, v34, 16, v13
 ; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v20
 ; GFX9-NEXT:    v_lshl_or_b32 v35, v35, 16, v13
-; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v15
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v12, v12, 16, v13
-; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v16
+; GFX9-NEXT:    v_and_b32_e32 v13, 0xffff, v18
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    v_lshl_or_b32 v13, v41, 16, v13
 ; GFX9-NEXT:    v_lshl_or_b32 v14, v40, 16, v0
@@ -38204,15 +38836,15 @@ define inreg <52 x half> @bitcast_v13f64_to_v52f16_scalar(<13 x double> inreg %a
 ; GFX9-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GFX9-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; GFX9-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
+; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v15
+; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v15
+; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v16
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v1
-; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v17
+; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v15, v55, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
-; GFX9-NEXT:    v_lshl_or_b32 v26, v26, 16, v17
-; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v18
 ; GFX9-NEXT:    v_lshl_or_b32 v16, v54, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v3
-; GFX9-NEXT:    v_lshl_or_b32 v27, v27, 16, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v17, v53, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v4
 ; GFX9-NEXT:    v_lshl_or_b32 v18, v52, 16, v0

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.896bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.896bit.ll
@@ -3638,25 +3638,53 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_writelane_b32 v16, s30, 0
-; SI-NEXT:    v_writelane_b32 v16, s31, 1
-; SI-NEXT:    v_writelane_b32 v16, s34, 2
-; SI-NEXT:    v_writelane_b32 v16, s35, 3
-; SI-NEXT:    v_writelane_b32 v16, s36, 4
-; SI-NEXT:    v_writelane_b32 v16, s37, 5
-; SI-NEXT:    v_writelane_b32 v16, s38, 6
-; SI-NEXT:    v_writelane_b32 v16, s39, 7
-; SI-NEXT:    v_writelane_b32 v16, s48, 8
-; SI-NEXT:    v_writelane_b32 v16, s49, 9
-; SI-NEXT:    v_writelane_b32 v16, s50, 10
-; SI-NEXT:    v_writelane_b32 v16, s51, 11
+; SI-NEXT:    v_writelane_b32 v20, s30, 0
+; SI-NEXT:    v_writelane_b32 v20, s31, 1
+; SI-NEXT:    v_writelane_b32 v20, s34, 2
+; SI-NEXT:    v_writelane_b32 v20, s35, 3
+; SI-NEXT:    v_writelane_b32 v20, s36, 4
+; SI-NEXT:    v_writelane_b32 v20, s37, 5
+; SI-NEXT:    v_writelane_b32 v20, s38, 6
+; SI-NEXT:    v_writelane_b32 v20, s39, 7
+; SI-NEXT:    v_writelane_b32 v20, s48, 8
+; SI-NEXT:    v_mov_b32_e32 v16, s16
+; SI-NEXT:    v_mov_b32_e32 v17, s17
+; SI-NEXT:    v_writelane_b32 v20, s49, 9
+; SI-NEXT:    v_mov_b32_e32 v18, s18
+; SI-NEXT:    v_mov_b32_e32 v19, s19
+; SI-NEXT:    v_readfirstlane_b32 s44, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s20
+; SI-NEXT:    v_readfirstlane_b32 s45, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s21
+; SI-NEXT:    v_writelane_b32 v20, s50, 10
+; SI-NEXT:    v_readfirstlane_b32 s42, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_readfirstlane_b32 s43, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s40, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_readfirstlane_b32 s41, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_writelane_b32 v20, s51, 11
+; SI-NEXT:    v_readfirstlane_b32 s24, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; SI-NEXT:    v_writelane_b32 v16, s52, 12
-; SI-NEXT:    v_readfirstlane_b32 s40, v1
-; SI-NEXT:    v_readfirstlane_b32 s41, v2
+; SI-NEXT:    v_writelane_b32 v20, s52, 12
+; SI-NEXT:    v_readfirstlane_b32 s20, v18
+; SI-NEXT:    v_readfirstlane_b32 s21, v19
+; SI-NEXT:    v_readfirstlane_b32 s18, v16
+; SI-NEXT:    v_readfirstlane_b32 s19, v17
+; SI-NEXT:    v_readfirstlane_b32 s16, v1
+; SI-NEXT:    v_readfirstlane_b32 s17, v2
 ; SI-NEXT:    v_readfirstlane_b32 s14, v3
 ; SI-NEXT:    v_readfirstlane_b32 s15, v4
 ; SI-NEXT:    v_readfirstlane_b32 s12, v5
@@ -3668,9 +3696,9 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v11
 ; SI-NEXT:    v_readfirstlane_b32 s7, v12
 ; SI-NEXT:    v_readfirstlane_b32 s4, v13
-; SI-NEXT:    s_and_b64 s[42:43], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v14
-; SI-NEXT:    v_writelane_b32 v16, s53, 13
+; SI-NEXT:    v_writelane_b32 v20, s53, 13
 ; SI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s30, s5, 16
@@ -3679,46 +3707,46 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s35, s11, 16
 ; SI-NEXT:    s_lshr_b32 s36, s13, 16
 ; SI-NEXT:    s_lshr_b32 s37, s15, 16
-; SI-NEXT:    s_lshr_b32 s38, s41, 16
-; SI-NEXT:    s_lshr_b32 s39, s29, 16
-; SI-NEXT:    s_lshr_b32 s48, s27, 16
-; SI-NEXT:    s_lshr_b32 s49, s25, 16
-; SI-NEXT:    s_lshr_b32 s50, s23, 16
-; SI-NEXT:    s_lshr_b32 s51, s21, 16
-; SI-NEXT:    s_lshr_b32 s52, s19, 16
-; SI-NEXT:    s_lshr_b32 s53, s17, 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s38, s17, 16
+; SI-NEXT:    s_lshr_b32 s39, s19, 16
+; SI-NEXT:    s_lshr_b32 s48, s21, 16
+; SI-NEXT:    s_lshr_b32 s49, s23, 16
+; SI-NEXT:    s_lshr_b32 s50, s25, 16
+; SI-NEXT:    s_lshr_b32 s51, s41, 16
+; SI-NEXT:    s_lshr_b32 s52, s43, 16
+; SI-NEXT:    s_lshr_b32 s53, s45, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[40:41], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[88:89], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[90:91], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[92:93], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[88:89], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[90:91], s[42:43], 16
+; SI-NEXT:    s_lshr_b64 s[92:93], s[44:45], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB13_3
 ; SI-NEXT:  .LBB13_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s23, s23, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
-; SI-NEXT:    s_add_i32 s25, s25, 3
-; SI-NEXT:    s_add_i32 s24, s24, 3
-; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s26, s26, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
+; SI-NEXT:    s_add_i32 s45, s45, 3
+; SI-NEXT:    s_add_i32 s44, s44, 3
+; SI-NEXT:    s_add_i32 s43, s43, 3
+; SI-NEXT:    s_add_i32 s42, s42, 3
 ; SI-NEXT:    s_add_i32 s41, s41, 3
 ; SI-NEXT:    s_add_i32 s40, s40, 3
+; SI-NEXT:    s_add_i32 s25, s25, 3
+; SI-NEXT:    s_add_i32 s24, s24, 3
+; SI-NEXT:    s_add_i32 s23, s23, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
 ; SI-NEXT:    s_add_i32 s15, s15, 3
 ; SI-NEXT:    s_add_i32 s14, s14, 3
 ; SI-NEXT:    s_add_i32 s13, s13, 3
@@ -3731,135 +3759,135 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s5, s5, 3
 ; SI-NEXT:    s_add_i32 s4, s4, 3
-; SI-NEXT:    s_lshr_b64 s[42:43], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[40:41], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[26:27], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[20:21], 16
 ; SI-NEXT:    s_lshr_b32 s30, s5, 16
 ; SI-NEXT:    s_lshr_b32 s31, s7, 16
 ; SI-NEXT:    s_lshr_b32 s34, s9, 16
 ; SI-NEXT:    s_lshr_b32 s35, s11, 16
 ; SI-NEXT:    s_lshr_b32 s36, s13, 16
 ; SI-NEXT:    s_lshr_b32 s37, s15, 16
-; SI-NEXT:    s_lshr_b32 s38, s41, 16
-; SI-NEXT:    s_lshr_b32 s39, s29, 16
-; SI-NEXT:    s_lshr_b32 s48, s27, 16
-; SI-NEXT:    s_lshr_b32 s49, s25, 16
-; SI-NEXT:    s_lshr_b32 s50, s23, 16
-; SI-NEXT:    s_lshr_b32 s51, s21, 16
-; SI-NEXT:    s_lshr_b32 s52, s19, 16
-; SI-NEXT:    s_lshr_b32 s53, s17, 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[88:89], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[90:91], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[92:93], s[16:17], 16
+; SI-NEXT:    s_lshr_b32 s38, s17, 16
+; SI-NEXT:    s_lshr_b32 s39, s19, 16
+; SI-NEXT:    s_lshr_b32 s48, s21, 16
+; SI-NEXT:    s_lshr_b32 s49, s23, 16
+; SI-NEXT:    s_lshr_b32 s50, s25, 16
+; SI-NEXT:    s_lshr_b32 s51, s41, 16
+; SI-NEXT:    s_lshr_b32 s52, s43, 16
+; SI-NEXT:    s_lshr_b32 s53, s45, 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[88:89], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[90:91], s[42:43], 16
+; SI-NEXT:    s_lshr_b64 s[92:93], s[44:45], 16
 ; SI-NEXT:  .LBB13_3: ; %end
-; SI-NEXT:    s_lshl_b32 s43, s92, 16
-; SI-NEXT:    s_and_b32 s16, s16, 0xffff
-; SI-NEXT:    s_or_b32 s16, s16, s43
-; SI-NEXT:    v_mov_b32_e32 v1, s16
-; SI-NEXT:    s_and_b32 s16, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s53, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_lshl_b32 s16, s90, 16
-; SI-NEXT:    s_and_b32 s17, s18, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
-; SI-NEXT:    v_mov_b32_e32 v3, s16
-; SI-NEXT:    s_and_b32 s16, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s52, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v4, s16
+; SI-NEXT:    s_lshl_b32 s27, s92, 16
+; SI-NEXT:    s_and_b32 s29, s44, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s27
+; SI-NEXT:    s_and_b32 s27, s45, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s53, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_lshl_b32 s27, s90, 16
+; SI-NEXT:    s_and_b32 s29, s42, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v3, s27
+; SI-NEXT:    s_and_b32 s27, s43, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s52, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v4, s27
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_lshl_b32 s16, s88, 16
-; SI-NEXT:    s_and_b32 s17, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s88, 16
+; SI-NEXT:    s_and_b32 s29, s40, 0xffff
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    s_or_b32 s16, s17, s16
+; SI-NEXT:    s_or_b32 s27, s29, s27
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
 ; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s51, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_and_b32 s27, s41, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s51, 16
 ; SI-NEXT:    buffer_store_dword v4, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s27, s27, s29
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s78, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s78, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s27
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s50, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
+; SI-NEXT:    s_lshl_b32 s25, s50, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s25
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s76, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s24, s76, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s24
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s49, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s49, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s23
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s74, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s22, s74, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s27, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s48, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s48, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s72, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s39, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s39, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s40, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s62, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s62, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s41, 0xffff
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
 ; SI-NEXT:    s_lshl_b32 s17, s38, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 56, v0
 ; SI-NEXT:    s_or_b32 s16, s16, s17
@@ -3923,7 +3951,7 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s44, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x5c, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3937,7 +3965,7 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s42, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x64, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -3951,22 +3979,22 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x6c, v0
 ; SI-NEXT:    v_mov_b32_e32 v1, s4
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    v_readlane_b32 s53, v16, 13
-; SI-NEXT:    v_readlane_b32 s52, v16, 12
-; SI-NEXT:    v_readlane_b32 s51, v16, 11
-; SI-NEXT:    v_readlane_b32 s50, v16, 10
-; SI-NEXT:    v_readlane_b32 s49, v16, 9
-; SI-NEXT:    v_readlane_b32 s48, v16, 8
-; SI-NEXT:    v_readlane_b32 s39, v16, 7
-; SI-NEXT:    v_readlane_b32 s38, v16, 6
-; SI-NEXT:    v_readlane_b32 s37, v16, 5
-; SI-NEXT:    v_readlane_b32 s36, v16, 4
-; SI-NEXT:    v_readlane_b32 s35, v16, 3
-; SI-NEXT:    v_readlane_b32 s34, v16, 2
-; SI-NEXT:    v_readlane_b32 s31, v16, 1
-; SI-NEXT:    v_readlane_b32 s30, v16, 0
+; SI-NEXT:    v_readlane_b32 s53, v20, 13
+; SI-NEXT:    v_readlane_b32 s52, v20, 12
+; SI-NEXT:    v_readlane_b32 s51, v20, 11
+; SI-NEXT:    v_readlane_b32 s50, v20, 10
+; SI-NEXT:    v_readlane_b32 s49, v20, 9
+; SI-NEXT:    v_readlane_b32 s48, v20, 8
+; SI-NEXT:    v_readlane_b32 s39, v20, 7
+; SI-NEXT:    v_readlane_b32 s38, v20, 6
+; SI-NEXT:    v_readlane_b32 s37, v20, 5
+; SI-NEXT:    v_readlane_b32 s36, v20, 4
+; SI-NEXT:    v_readlane_b32 s35, v20, 3
+; SI-NEXT:    v_readlane_b32 s34, v20, 2
+; SI-NEXT:    v_readlane_b32 s31, v20, 1
+; SI-NEXT:    v_readlane_b32 s30, v20, 0
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 ; 4-byte Folded Reload
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -3995,9 +4023,9 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr35
 ; SI-NEXT:    ; implicit-def: $sgpr46
 ; SI-NEXT:    ; implicit-def: $sgpr34
-; SI-NEXT:    ; implicit-def: $sgpr44
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr31
-; SI-NEXT:    ; implicit-def: $sgpr42
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr30
 ; SI-NEXT:    s_branch .LBB13_2
 ;
@@ -4007,14 +4035,42 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; VI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
 ; VI-NEXT:    buffer_store_dword v28, off, s[0:3], s32 ; 4-byte Folded Spill
 ; VI-NEXT:    s_mov_b64 exec, s[4:5]
+; VI-NEXT:    v_mov_b32_e32 v15, s16
+; VI-NEXT:    v_mov_b32_e32 v16, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s18
+; VI-NEXT:    v_mov_b32_e32 v18, s19
 ; VI-NEXT:    v_writelane_b32 v28, s30, 0
+; VI-NEXT:    v_mov_b32_e32 v19, s20
+; VI-NEXT:    v_readfirstlane_b32 s46, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s21
+; VI-NEXT:    v_readfirstlane_b32 s45, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s23
+; VI-NEXT:    v_readfirstlane_b32 s43, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s24
 ; VI-NEXT:    v_writelane_b32 v28, s31, 1
+; VI-NEXT:    v_readfirstlane_b32 s42, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
 ; VI-NEXT:    v_writelane_b32 v28, s34, 2
-; VI-NEXT:    v_readfirstlane_b32 s43, v0
-; VI-NEXT:    v_readfirstlane_b32 s42, v1
-; VI-NEXT:    v_readfirstlane_b32 s41, v2
-; VI-NEXT:    v_readfirstlane_b32 s40, v3
+; VI-NEXT:    v_readfirstlane_b32 s24, v19
+; VI-NEXT:    v_readfirstlane_b32 s23, v15
+; VI-NEXT:    v_readfirstlane_b32 s22, v16
+; VI-NEXT:    v_readfirstlane_b32 s21, v17
+; VI-NEXT:    v_readfirstlane_b32 s20, v18
+; VI-NEXT:    v_readfirstlane_b32 s19, v0
+; VI-NEXT:    v_readfirstlane_b32 s18, v1
+; VI-NEXT:    v_readfirstlane_b32 s17, v2
+; VI-NEXT:    v_readfirstlane_b32 s16, v3
 ; VI-NEXT:    v_readfirstlane_b32 s15, v4
 ; VI-NEXT:    v_readfirstlane_b32 s14, v5
 ; VI-NEXT:    v_readfirstlane_b32 s13, v6
@@ -4029,9 +4085,9 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; VI-NEXT:    v_writelane_b32 v28, s35, 3
 ; VI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s44, s7, 16
-; VI-NEXT:    s_lshr_b32 s45, s6, 16
-; VI-NEXT:    s_lshr_b32 s46, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s47, s9, 16
 ; VI-NEXT:    s_lshr_b32 s56, s10, 16
 ; VI-NEXT:    s_lshr_b32 s57, s11, 16
@@ -4039,24 +4095,24 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s59, s13, 16
 ; VI-NEXT:    s_lshr_b32 s60, s14, 16
 ; VI-NEXT:    s_lshr_b32 s61, s15, 16
-; VI-NEXT:    s_lshr_b32 s62, s40, 16
-; VI-NEXT:    s_lshr_b32 s63, s41, 16
-; VI-NEXT:    s_lshr_b32 s72, s42, 16
-; VI-NEXT:    s_lshr_b32 s73, s43, 16
-; VI-NEXT:    s_lshr_b32 s74, s29, 16
-; VI-NEXT:    s_lshr_b32 s75, s28, 16
-; VI-NEXT:    s_lshr_b32 s76, s27, 16
-; VI-NEXT:    s_lshr_b32 s77, s26, 16
-; VI-NEXT:    s_lshr_b32 s78, s25, 16
-; VI-NEXT:    s_lshr_b32 s79, s24, 16
-; VI-NEXT:    s_lshr_b32 s88, s23, 16
-; VI-NEXT:    s_lshr_b32 s89, s22, 16
-; VI-NEXT:    s_lshr_b32 s90, s21, 16
-; VI-NEXT:    s_lshr_b32 s91, s20, 16
-; VI-NEXT:    s_lshr_b32 s30, s19, 16
-; VI-NEXT:    s_lshr_b32 s31, s18, 16
-; VI-NEXT:    s_lshr_b32 s34, s17, 16
-; VI-NEXT:    s_lshr_b32 s35, s16, 16
+; VI-NEXT:    s_lshr_b32 s62, s16, 16
+; VI-NEXT:    s_lshr_b32 s63, s17, 16
+; VI-NEXT:    s_lshr_b32 s72, s18, 16
+; VI-NEXT:    s_lshr_b32 s73, s19, 16
+; VI-NEXT:    s_lshr_b32 s74, s20, 16
+; VI-NEXT:    s_lshr_b32 s75, s21, 16
+; VI-NEXT:    s_lshr_b32 s76, s22, 16
+; VI-NEXT:    s_lshr_b32 s77, s23, 16
+; VI-NEXT:    s_lshr_b32 s78, s24, 16
+; VI-NEXT:    s_lshr_b32 s79, s25, 16
+; VI-NEXT:    s_lshr_b32 s88, s26, 16
+; VI-NEXT:    s_lshr_b32 s89, s40, 16
+; VI-NEXT:    s_lshr_b32 s90, s41, 16
+; VI-NEXT:    s_lshr_b32 s91, s42, 16
+; VI-NEXT:    s_lshr_b32 s30, s43, 16
+; VI-NEXT:    s_lshr_b32 s31, s44, 16
+; VI-NEXT:    s_lshr_b32 s34, s45, 16
+; VI-NEXT:    s_lshr_b32 s35, s46, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB13_3
 ; VI-NEXT:  .LBB13_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -4069,27 +4125,27 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; VI-NEXT:    s_add_i32 s13, s13, 3
 ; VI-NEXT:    s_add_i32 s14, s14, 3
 ; VI-NEXT:    s_add_i32 s15, s15, 3
+; VI-NEXT:    s_add_i32 s16, s16, 3
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
 ; VI-NEXT:    s_add_i32 s40, s40, 3
 ; VI-NEXT:    s_add_i32 s41, s41, 3
 ; VI-NEXT:    s_add_i32 s42, s42, 3
 ; VI-NEXT:    s_add_i32 s43, s43, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
-; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s44, s7, 16
-; VI-NEXT:    s_lshr_b32 s45, s6, 16
-; VI-NEXT:    s_lshr_b32 s46, s8, 16
+; VI-NEXT:    s_add_i32 s44, s44, 3
+; VI-NEXT:    s_add_i32 s45, s45, 3
+; VI-NEXT:    s_add_i32 s46, s46, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s47, s9, 16
 ; VI-NEXT:    s_lshr_b32 s56, s10, 16
 ; VI-NEXT:    s_lshr_b32 s57, s11, 16
@@ -4097,127 +4153,127 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s59, s13, 16
 ; VI-NEXT:    s_lshr_b32 s60, s14, 16
 ; VI-NEXT:    s_lshr_b32 s61, s15, 16
-; VI-NEXT:    s_lshr_b32 s62, s40, 16
-; VI-NEXT:    s_lshr_b32 s63, s41, 16
-; VI-NEXT:    s_lshr_b32 s72, s42, 16
-; VI-NEXT:    s_lshr_b32 s73, s43, 16
-; VI-NEXT:    s_lshr_b32 s74, s29, 16
-; VI-NEXT:    s_lshr_b32 s75, s28, 16
-; VI-NEXT:    s_lshr_b32 s76, s27, 16
-; VI-NEXT:    s_lshr_b32 s77, s26, 16
-; VI-NEXT:    s_lshr_b32 s78, s25, 16
-; VI-NEXT:    s_lshr_b32 s79, s24, 16
-; VI-NEXT:    s_lshr_b32 s88, s23, 16
-; VI-NEXT:    s_lshr_b32 s89, s22, 16
-; VI-NEXT:    s_lshr_b32 s90, s21, 16
-; VI-NEXT:    s_lshr_b32 s91, s20, 16
-; VI-NEXT:    s_lshr_b32 s30, s19, 16
-; VI-NEXT:    s_lshr_b32 s31, s18, 16
-; VI-NEXT:    s_lshr_b32 s34, s17, 16
-; VI-NEXT:    s_lshr_b32 s35, s16, 16
+; VI-NEXT:    s_lshr_b32 s62, s16, 16
+; VI-NEXT:    s_lshr_b32 s63, s17, 16
+; VI-NEXT:    s_lshr_b32 s72, s18, 16
+; VI-NEXT:    s_lshr_b32 s73, s19, 16
+; VI-NEXT:    s_lshr_b32 s74, s20, 16
+; VI-NEXT:    s_lshr_b32 s75, s21, 16
+; VI-NEXT:    s_lshr_b32 s76, s22, 16
+; VI-NEXT:    s_lshr_b32 s77, s23, 16
+; VI-NEXT:    s_lshr_b32 s78, s24, 16
+; VI-NEXT:    s_lshr_b32 s79, s25, 16
+; VI-NEXT:    s_lshr_b32 s88, s26, 16
+; VI-NEXT:    s_lshr_b32 s89, s40, 16
+; VI-NEXT:    s_lshr_b32 s90, s41, 16
+; VI-NEXT:    s_lshr_b32 s91, s42, 16
+; VI-NEXT:    s_lshr_b32 s30, s43, 16
+; VI-NEXT:    s_lshr_b32 s31, s44, 16
+; VI-NEXT:    s_lshr_b32 s34, s45, 16
+; VI-NEXT:    s_lshr_b32 s35, s46, 16
 ; VI-NEXT:  .LBB13_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s46
 ; VI-NEXT:    s_lshl_b32 s5, s35, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s34, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s31, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s30, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s91, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s90, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s89, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s88, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s79, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s78, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s77, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s76, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s75, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s74, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s43
-; VI-NEXT:    s_lshl_b32 s29, s73, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s42
-; VI-NEXT:    s_lshl_b32 s42, s72, 16
-; VI-NEXT:    s_or_b32 s29, s29, s42
+; VI-NEXT:    s_and_b32 s5, 0xffff, s45
+; VI-NEXT:    s_lshl_b32 s45, s34, 16
+; VI-NEXT:    s_or_b32 s5, s5, s45
+; VI-NEXT:    s_and_b32 s44, 0xffff, s44
+; VI-NEXT:    s_lshl_b32 s45, s31, 16
+; VI-NEXT:    s_or_b32 s44, s44, s45
+; VI-NEXT:    s_and_b32 s43, 0xffff, s43
+; VI-NEXT:    s_lshl_b32 s45, s30, 16
+; VI-NEXT:    s_or_b32 s43, s43, s45
+; VI-NEXT:    s_and_b32 s42, 0xffff, s42
+; VI-NEXT:    s_lshl_b32 s45, s91, 16
+; VI-NEXT:    s_or_b32 s42, s42, s45
 ; VI-NEXT:    s_and_b32 s41, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s42, s63, 16
-; VI-NEXT:    s_or_b32 s41, s41, s42
+; VI-NEXT:    s_lshl_b32 s45, s90, 16
+; VI-NEXT:    s_or_b32 s41, s41, s45
 ; VI-NEXT:    s_and_b32 s40, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s42, s62, 16
-; VI-NEXT:    s_or_b32 s40, s40, s42
+; VI-NEXT:    s_lshl_b32 s45, s89, 16
+; VI-NEXT:    s_or_b32 s40, s40, s45
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s45, s88, 16
+; VI-NEXT:    s_or_b32 s26, s26, s45
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s45, s79, 16
+; VI-NEXT:    s_or_b32 s25, s25, s45
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s45, s78, 16
+; VI-NEXT:    s_or_b32 s24, s24, s45
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s45, s77, 16
+; VI-NEXT:    s_or_b32 s23, s23, s45
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s45, s76, 16
+; VI-NEXT:    s_or_b32 s22, s22, s45
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s45, s75, 16
+; VI-NEXT:    s_or_b32 s21, s21, s45
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s45, s74, 16
+; VI-NEXT:    s_or_b32 s20, s20, s45
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s45, s73, 16
+; VI-NEXT:    s_or_b32 s19, s19, s45
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s45, s72, 16
+; VI-NEXT:    s_or_b32 s18, s18, s45
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s45, s63, 16
+; VI-NEXT:    s_or_b32 s17, s17, s45
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s45, s62, 16
+; VI-NEXT:    s_or_b32 s16, s16, s45
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s42, s61, 16
-; VI-NEXT:    s_or_b32 s15, s15, s42
+; VI-NEXT:    s_lshl_b32 s45, s61, 16
+; VI-NEXT:    s_or_b32 s15, s15, s45
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s42, s60, 16
-; VI-NEXT:    s_or_b32 s14, s14, s42
+; VI-NEXT:    s_lshl_b32 s45, s60, 16
+; VI-NEXT:    s_or_b32 s14, s14, s45
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s42, s59, 16
-; VI-NEXT:    s_or_b32 s13, s13, s42
+; VI-NEXT:    s_lshl_b32 s45, s59, 16
+; VI-NEXT:    s_or_b32 s13, s13, s45
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s42, s58, 16
-; VI-NEXT:    s_or_b32 s12, s12, s42
+; VI-NEXT:    s_lshl_b32 s45, s58, 16
+; VI-NEXT:    s_or_b32 s12, s12, s45
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s42, s57, 16
-; VI-NEXT:    s_or_b32 s11, s11, s42
+; VI-NEXT:    s_lshl_b32 s45, s57, 16
+; VI-NEXT:    s_or_b32 s11, s11, s45
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s42, s56, 16
-; VI-NEXT:    s_or_b32 s10, s10, s42
+; VI-NEXT:    s_lshl_b32 s45, s56, 16
+; VI-NEXT:    s_or_b32 s10, s10, s45
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s42, s47, 16
-; VI-NEXT:    s_or_b32 s9, s9, s42
+; VI-NEXT:    s_lshl_b32 s45, s47, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s42, s46, 16
-; VI-NEXT:    s_or_b32 s8, s8, s42
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s42, s45, 16
-; VI-NEXT:    s_or_b32 s6, s6, s42
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s42, s44, 16
-; VI-NEXT:    s_or_b32 s7, s7, s42
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s45
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
-; VI-NEXT:    v_mov_b32_e32 v16, s41
-; VI-NEXT:    v_mov_b32_e32 v17, s40
+; VI-NEXT:    v_mov_b32_e32 v2, s44
+; VI-NEXT:    v_mov_b32_e32 v3, s43
+; VI-NEXT:    v_mov_b32_e32 v4, s42
+; VI-NEXT:    v_mov_b32_e32 v5, s41
+; VI-NEXT:    v_mov_b32_e32 v6, s40
+; VI-NEXT:    v_mov_b32_e32 v7, s26
+; VI-NEXT:    v_mov_b32_e32 v8, s25
+; VI-NEXT:    v_mov_b32_e32 v9, s24
+; VI-NEXT:    v_mov_b32_e32 v10, s23
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s16
 ; VI-NEXT:    v_mov_b32_e32 v18, s15
 ; VI-NEXT:    v_mov_b32_e32 v19, s14
 ; VI-NEXT:    v_mov_b32_e32 v20, s13
@@ -4263,25 +4319,53 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr57
 ; VI-NEXT:    ; implicit-def: $sgpr56
 ; VI-NEXT:    ; implicit-def: $sgpr47
-; VI-NEXT:    ; implicit-def: $sgpr46
-; VI-NEXT:    ; implicit-def: $sgpr45
-; VI-NEXT:    ; implicit-def: $sgpr44
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB13_2
 ;
 ; GFX9-LABEL: bitcast_v28i32_to_v56i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v15, s16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s20
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s21
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s23
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
 ; GFX9-NEXT:    v_readfirstlane_b32 s42, v12
@@ -4293,46 +4377,36 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_lshr_b32 s45, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s46, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB13_3
 ; GFX9-NEXT:  .LBB13_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_i32 s43, s43, 3
 ; GFX9-NEXT:    s_add_i32 s42, s42, 3
 ; GFX9-NEXT:    s_add_i32 s41, s41, 3
 ; GFX9-NEXT:    s_add_i32 s40, s40, 3
-; GFX9-NEXT:    s_add_i32 s15, s15, 3
-; GFX9-NEXT:    s_add_i32 s14, s14, 3
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_add_i32 s29, s29, 3
 ; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
@@ -4347,87 +4421,97 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_lshr_b32 s44, s43, 16
 ; GFX9-NEXT:    s_lshr_b32 s45, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s46, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s6, 16
 ; GFX9-NEXT:  .LBB13_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s95
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s94
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s93
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s92
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s95
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s94
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s93
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s92
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s56
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s47
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s46
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s40, s42, s45
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s41, s43, s44
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    v_mov_b32_e32 v26, s40
@@ -4467,45 +4551,72 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; GFX11-LABEL: bitcast_v28i32_to_v56i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v11, s0 :: v_dual_mov_b32 v12, s1
+; GFX11-NEXT:    v_dual_mov_b32 v13, s2 :: v_dual_mov_b32 v14, s3
+; GFX11-NEXT:    v_dual_mov_b32 v15, s16 :: v_dual_mov_b32 v16, s17
+; GFX11-NEXT:    v_dual_mov_b32 v17, s18 :: v_dual_mov_b32 v18, s19
+; GFX11-NEXT:    v_dual_mov_b32 v19, s20 :: v_dual_mov_b32 v20, s21
+; GFX11-NEXT:    v_dual_mov_b32 v21, s22 :: v_dual_mov_b32 v22, s23
+; GFX11-NEXT:    v_dual_mov_b32 v23, s24 :: v_dual_mov_b32 v24, s25
+; GFX11-NEXT:    v_dual_mov_b32 v25, s26 :: v_dual_mov_b32 v26, s27
+; GFX11-NEXT:    v_dual_mov_b32 v27, s28 :: v_dual_mov_b32 v28, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v10
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v7
-; GFX11-NEXT:    v_readfirstlane_b32 s13, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s12, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v27
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v28
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s27, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s26, v9
 ; GFX11-NEXT:    s_mov_b32 s90, 0
-; GFX11-NEXT:    s_and_b32 s14, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s28, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s14, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s78, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s79, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s88, s1, 16
@@ -4513,20 +4624,8 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s90
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB13_3
 ; GFX11-NEXT:  .LBB13_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s12, s12, 3
-; GFX11-NEXT:    s_add_i32 s13, s13, 3
-; GFX11-NEXT:    s_add_i32 s11, s11, 3
-; GFX11-NEXT:    s_add_i32 s10, s10, 3
-; GFX11-NEXT:    s_add_i32 s9, s9, 3
-; GFX11-NEXT:    s_add_i32 s8, s8, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
 ; GFX11-NEXT:    s_add_i32 s26, s26, 3
+; GFX11-NEXT:    s_add_i32 s27, s27, 3
 ; GFX11-NEXT:    s_add_i32 s25, s25, 3
 ; GFX11-NEXT:    s_add_i32 s24, s24, 3
 ; GFX11-NEXT:    s_add_i32 s23, s23, 3
@@ -4537,34 +4636,46 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s14, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s78, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s79, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s88, s1, 16
@@ -4575,44 +4686,44 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s88
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s79
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s78
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s77
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s76
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s75
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s14
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s77
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s76
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s75
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s74
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s28
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s10 :: v_dual_mov_b32 v25, s11
-; GFX11-NEXT:    v_dual_mov_b32 v26, s13 :: v_dual_mov_b32 v27, s12
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s24 :: v_dual_mov_b32 v25, s25
+; GFX11-NEXT:    v_dual_mov_b32 v26, s27 :: v_dual_mov_b32 v27, s26
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB13_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr89
@@ -4641,8 +4752,8 @@ define inreg <56 x i16> @bitcast_v28i32_to_v56i16_scalar(<28 x i32> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
 ; GFX11-NEXT:    s_branch .LBB13_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -5128,7 +5239,7 @@ define <28 x i32> @bitcast_v56i16_to_v28i32(<56 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
 ; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, s6, v25
-; SI-NEXT:    v_add_i32_e32 v26, vcc, s6, v26
+; SI-NEXT:    v_add_i32_e32 v26, vcc, 0x30000, v26
 ; SI-NEXT:    v_add_i32_e32 v27, vcc, 0x30000, v27
 ; SI-NEXT:  .LBB14_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -8458,11 +8569,39 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; SI-LABEL: bitcast_v28i32_to_v56f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v16, s16
+; SI-NEXT:    v_mov_b32_e32 v17, s17
+; SI-NEXT:    v_mov_b32_e32 v18, s18
+; SI-NEXT:    v_mov_b32_e32 v19, s19
+; SI-NEXT:    v_readfirstlane_b32 s40, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s20
+; SI-NEXT:    v_readfirstlane_b32 s41, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s21
+; SI-NEXT:    v_readfirstlane_b32 s42, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_readfirstlane_b32 s43, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s23, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_readfirstlane_b32 s24, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_readfirstlane_b32 s25, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s26, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s27, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s28
+; SI-NEXT:    v_readfirstlane_b32 s28, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; SI-NEXT:    v_readfirstlane_b32 s43, v1
-; SI-NEXT:    v_readfirstlane_b32 s42, v2
-; SI-NEXT:    v_readfirstlane_b32 s41, v3
-; SI-NEXT:    v_readfirstlane_b32 s40, v4
+; SI-NEXT:    v_readfirstlane_b32 s29, v18
+; SI-NEXT:    v_readfirstlane_b32 s22, v19
+; SI-NEXT:    v_readfirstlane_b32 s21, v16
+; SI-NEXT:    v_readfirstlane_b32 s20, v17
+; SI-NEXT:    v_readfirstlane_b32 s19, v1
+; SI-NEXT:    v_readfirstlane_b32 s18, v2
+; SI-NEXT:    v_readfirstlane_b32 s17, v3
+; SI-NEXT:    v_readfirstlane_b32 s16, v4
 ; SI-NEXT:    v_readfirstlane_b32 s15, v5
 ; SI-NEXT:    v_readfirstlane_b32 s14, v6
 ; SI-NEXT:    v_readfirstlane_b32 s13, v7
@@ -8505,44 +8644,44 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s4
 ; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    s_lshr_b32 s4, s16, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s41, 16
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s42, 16
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s43, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s4
 ; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
+; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
+; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
+; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
+; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, s4
+; SI-NEXT:    s_lshr_b32 s4, s43, 16
 ; SI-NEXT:    s_waitcnt expcnt(6)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v42, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    s_lshr_b32 s4, s42, 16
 ; SI-NEXT:    s_waitcnt expcnt(4)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v44, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    s_lshr_b32 s4, s41, 16
 ; SI-NEXT:    s_waitcnt expcnt(2)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v46, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v56, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s9
@@ -8555,33 +8694,30 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, s43
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, s42
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, s41
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, s40
 ; SI-NEXT:    s_cbranch_execnz .LBB17_3
 ; SI-NEXT:  .LBB17_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s40, s40, 3
+; SI-NEXT:    s_add_i32 s41, s41, 3
+; SI-NEXT:    s_add_i32 s42, s42, 3
+; SI-NEXT:    s_add_i32 s43, s43, 3
 ; SI-NEXT:    s_add_i32 s23, s23, 3
 ; SI-NEXT:    s_add_i32 s24, s24, 3
 ; SI-NEXT:    s_add_i32 s25, s25, 3
@@ -8589,10 +8725,13 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; SI-NEXT:    s_add_i32 s27, s27, 3
 ; SI-NEXT:    s_add_i32 s28, s28, 3
 ; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s43, s43, 3
-; SI-NEXT:    s_add_i32 s42, s42, 3
-; SI-NEXT:    s_add_i32 s41, s41, 3
-; SI-NEXT:    s_add_i32 s40, s40, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
 ; SI-NEXT:    s_add_i32 s15, s15, 3
 ; SI-NEXT:    s_add_i32 s14, s14, 3
 ; SI-NEXT:    s_add_i32 s13, s13, 3
@@ -8603,24 +8742,24 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; SI-NEXT:    s_add_i32 s7, s7, 3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s9, s9, 3
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    s_lshr_b32 s5, s17, 16
-; SI-NEXT:    s_lshr_b32 s44, s18, 16
-; SI-NEXT:    s_lshr_b32 s45, s19, 16
-; SI-NEXT:    s_lshr_b32 s46, s20, 16
-; SI-NEXT:    s_lshr_b32 s47, s21, 16
-; SI-NEXT:    s_lshr_b32 s56, s22, 16
-; SI-NEXT:    s_lshr_b32 s57, s23, 16
-; SI-NEXT:    s_lshr_b32 s58, s24, 16
-; SI-NEXT:    s_lshr_b32 s59, s25, 16
-; SI-NEXT:    s_lshr_b32 s60, s26, 16
-; SI-NEXT:    s_lshr_b32 s61, s27, 16
-; SI-NEXT:    s_lshr_b32 s62, s28, 16
-; SI-NEXT:    s_lshr_b32 s63, s29, 16
-; SI-NEXT:    s_lshr_b32 s72, s43, 16
-; SI-NEXT:    s_lshr_b32 s73, s42, 16
-; SI-NEXT:    s_lshr_b32 s74, s41, 16
-; SI-NEXT:    s_lshr_b32 s75, s40, 16
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    s_lshr_b32 s5, s41, 16
+; SI-NEXT:    s_lshr_b32 s44, s42, 16
+; SI-NEXT:    s_lshr_b32 s45, s43, 16
+; SI-NEXT:    s_lshr_b32 s46, s23, 16
+; SI-NEXT:    s_lshr_b32 s47, s24, 16
+; SI-NEXT:    s_lshr_b32 s56, s25, 16
+; SI-NEXT:    s_lshr_b32 s57, s26, 16
+; SI-NEXT:    s_lshr_b32 s58, s27, 16
+; SI-NEXT:    s_lshr_b32 s59, s28, 16
+; SI-NEXT:    s_lshr_b32 s60, s29, 16
+; SI-NEXT:    s_lshr_b32 s61, s22, 16
+; SI-NEXT:    s_lshr_b32 s62, s21, 16
+; SI-NEXT:    s_lshr_b32 s63, s20, 16
+; SI-NEXT:    s_lshr_b32 s72, s19, 16
+; SI-NEXT:    s_lshr_b32 s73, s18, 16
+; SI-NEXT:    s_lshr_b32 s74, s17, 16
+; SI-NEXT:    s_lshr_b32 s75, s16, 16
 ; SI-NEXT:    s_lshr_b32 s76, s15, 16
 ; SI-NEXT:    s_lshr_b32 s77, s14, 16
 ; SI-NEXT:    s_lshr_b32 s78, s13, 16
@@ -8641,27 +8780,27 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, s43
 ; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, s42
 ; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, s41
 ; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, s40
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, s93
 ; SI-NEXT:    v_cvt_f32_f16_e32 v2, s92
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s91
@@ -8963,14 +9102,42 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; VI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
 ; VI-NEXT:    buffer_store_dword v28, off, s[0:3], s32 ; 4-byte Folded Spill
 ; VI-NEXT:    s_mov_b64 exec, s[4:5]
+; VI-NEXT:    v_mov_b32_e32 v15, s16
+; VI-NEXT:    v_mov_b32_e32 v16, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s18
+; VI-NEXT:    v_mov_b32_e32 v18, s19
 ; VI-NEXT:    v_writelane_b32 v28, s30, 0
+; VI-NEXT:    v_mov_b32_e32 v19, s20
+; VI-NEXT:    v_readfirstlane_b32 s46, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s21
+; VI-NEXT:    v_readfirstlane_b32 s45, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s23
+; VI-NEXT:    v_readfirstlane_b32 s43, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s24
 ; VI-NEXT:    v_writelane_b32 v28, s31, 1
+; VI-NEXT:    v_readfirstlane_b32 s42, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
 ; VI-NEXT:    v_writelane_b32 v28, s34, 2
-; VI-NEXT:    v_readfirstlane_b32 s43, v0
-; VI-NEXT:    v_readfirstlane_b32 s42, v1
-; VI-NEXT:    v_readfirstlane_b32 s41, v2
-; VI-NEXT:    v_readfirstlane_b32 s40, v3
+; VI-NEXT:    v_readfirstlane_b32 s24, v19
+; VI-NEXT:    v_readfirstlane_b32 s23, v15
+; VI-NEXT:    v_readfirstlane_b32 s22, v16
+; VI-NEXT:    v_readfirstlane_b32 s21, v17
+; VI-NEXT:    v_readfirstlane_b32 s20, v18
+; VI-NEXT:    v_readfirstlane_b32 s19, v0
+; VI-NEXT:    v_readfirstlane_b32 s18, v1
+; VI-NEXT:    v_readfirstlane_b32 s17, v2
+; VI-NEXT:    v_readfirstlane_b32 s16, v3
 ; VI-NEXT:    v_readfirstlane_b32 s15, v4
 ; VI-NEXT:    v_readfirstlane_b32 s14, v5
 ; VI-NEXT:    v_readfirstlane_b32 s13, v6
@@ -8985,9 +9152,9 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; VI-NEXT:    v_writelane_b32 v28, s35, 3
 ; VI-NEXT:    s_cbranch_scc0 .LBB17_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s44, s7, 16
-; VI-NEXT:    s_lshr_b32 s45, s6, 16
-; VI-NEXT:    s_lshr_b32 s46, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s47, s9, 16
 ; VI-NEXT:    s_lshr_b32 s56, s10, 16
 ; VI-NEXT:    s_lshr_b32 s57, s11, 16
@@ -8995,24 +9162,24 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s59, s13, 16
 ; VI-NEXT:    s_lshr_b32 s60, s14, 16
 ; VI-NEXT:    s_lshr_b32 s61, s15, 16
-; VI-NEXT:    s_lshr_b32 s62, s40, 16
-; VI-NEXT:    s_lshr_b32 s63, s41, 16
-; VI-NEXT:    s_lshr_b32 s72, s42, 16
-; VI-NEXT:    s_lshr_b32 s73, s43, 16
-; VI-NEXT:    s_lshr_b32 s74, s29, 16
-; VI-NEXT:    s_lshr_b32 s75, s28, 16
-; VI-NEXT:    s_lshr_b32 s76, s27, 16
-; VI-NEXT:    s_lshr_b32 s77, s26, 16
-; VI-NEXT:    s_lshr_b32 s78, s25, 16
-; VI-NEXT:    s_lshr_b32 s79, s24, 16
-; VI-NEXT:    s_lshr_b32 s88, s23, 16
-; VI-NEXT:    s_lshr_b32 s89, s22, 16
-; VI-NEXT:    s_lshr_b32 s90, s21, 16
-; VI-NEXT:    s_lshr_b32 s91, s20, 16
-; VI-NEXT:    s_lshr_b32 s30, s19, 16
-; VI-NEXT:    s_lshr_b32 s31, s18, 16
-; VI-NEXT:    s_lshr_b32 s34, s17, 16
-; VI-NEXT:    s_lshr_b32 s35, s16, 16
+; VI-NEXT:    s_lshr_b32 s62, s16, 16
+; VI-NEXT:    s_lshr_b32 s63, s17, 16
+; VI-NEXT:    s_lshr_b32 s72, s18, 16
+; VI-NEXT:    s_lshr_b32 s73, s19, 16
+; VI-NEXT:    s_lshr_b32 s74, s20, 16
+; VI-NEXT:    s_lshr_b32 s75, s21, 16
+; VI-NEXT:    s_lshr_b32 s76, s22, 16
+; VI-NEXT:    s_lshr_b32 s77, s23, 16
+; VI-NEXT:    s_lshr_b32 s78, s24, 16
+; VI-NEXT:    s_lshr_b32 s79, s25, 16
+; VI-NEXT:    s_lshr_b32 s88, s26, 16
+; VI-NEXT:    s_lshr_b32 s89, s40, 16
+; VI-NEXT:    s_lshr_b32 s90, s41, 16
+; VI-NEXT:    s_lshr_b32 s91, s42, 16
+; VI-NEXT:    s_lshr_b32 s30, s43, 16
+; VI-NEXT:    s_lshr_b32 s31, s44, 16
+; VI-NEXT:    s_lshr_b32 s34, s45, 16
+; VI-NEXT:    s_lshr_b32 s35, s46, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB17_3
 ; VI-NEXT:  .LBB17_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -9025,27 +9192,27 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; VI-NEXT:    s_add_i32 s13, s13, 3
 ; VI-NEXT:    s_add_i32 s14, s14, 3
 ; VI-NEXT:    s_add_i32 s15, s15, 3
+; VI-NEXT:    s_add_i32 s16, s16, 3
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
 ; VI-NEXT:    s_add_i32 s40, s40, 3
 ; VI-NEXT:    s_add_i32 s41, s41, 3
 ; VI-NEXT:    s_add_i32 s42, s42, 3
 ; VI-NEXT:    s_add_i32 s43, s43, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
-; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s44, s7, 16
-; VI-NEXT:    s_lshr_b32 s45, s6, 16
-; VI-NEXT:    s_lshr_b32 s46, s8, 16
+; VI-NEXT:    s_add_i32 s44, s44, 3
+; VI-NEXT:    s_add_i32 s45, s45, 3
+; VI-NEXT:    s_add_i32 s46, s46, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s47, s9, 16
 ; VI-NEXT:    s_lshr_b32 s56, s10, 16
 ; VI-NEXT:    s_lshr_b32 s57, s11, 16
@@ -9053,127 +9220,127 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s59, s13, 16
 ; VI-NEXT:    s_lshr_b32 s60, s14, 16
 ; VI-NEXT:    s_lshr_b32 s61, s15, 16
-; VI-NEXT:    s_lshr_b32 s62, s40, 16
-; VI-NEXT:    s_lshr_b32 s63, s41, 16
-; VI-NEXT:    s_lshr_b32 s72, s42, 16
-; VI-NEXT:    s_lshr_b32 s73, s43, 16
-; VI-NEXT:    s_lshr_b32 s74, s29, 16
-; VI-NEXT:    s_lshr_b32 s75, s28, 16
-; VI-NEXT:    s_lshr_b32 s76, s27, 16
-; VI-NEXT:    s_lshr_b32 s77, s26, 16
-; VI-NEXT:    s_lshr_b32 s78, s25, 16
-; VI-NEXT:    s_lshr_b32 s79, s24, 16
-; VI-NEXT:    s_lshr_b32 s88, s23, 16
-; VI-NEXT:    s_lshr_b32 s89, s22, 16
-; VI-NEXT:    s_lshr_b32 s90, s21, 16
-; VI-NEXT:    s_lshr_b32 s91, s20, 16
-; VI-NEXT:    s_lshr_b32 s30, s19, 16
-; VI-NEXT:    s_lshr_b32 s31, s18, 16
-; VI-NEXT:    s_lshr_b32 s34, s17, 16
-; VI-NEXT:    s_lshr_b32 s35, s16, 16
+; VI-NEXT:    s_lshr_b32 s62, s16, 16
+; VI-NEXT:    s_lshr_b32 s63, s17, 16
+; VI-NEXT:    s_lshr_b32 s72, s18, 16
+; VI-NEXT:    s_lshr_b32 s73, s19, 16
+; VI-NEXT:    s_lshr_b32 s74, s20, 16
+; VI-NEXT:    s_lshr_b32 s75, s21, 16
+; VI-NEXT:    s_lshr_b32 s76, s22, 16
+; VI-NEXT:    s_lshr_b32 s77, s23, 16
+; VI-NEXT:    s_lshr_b32 s78, s24, 16
+; VI-NEXT:    s_lshr_b32 s79, s25, 16
+; VI-NEXT:    s_lshr_b32 s88, s26, 16
+; VI-NEXT:    s_lshr_b32 s89, s40, 16
+; VI-NEXT:    s_lshr_b32 s90, s41, 16
+; VI-NEXT:    s_lshr_b32 s91, s42, 16
+; VI-NEXT:    s_lshr_b32 s30, s43, 16
+; VI-NEXT:    s_lshr_b32 s31, s44, 16
+; VI-NEXT:    s_lshr_b32 s34, s45, 16
+; VI-NEXT:    s_lshr_b32 s35, s46, 16
 ; VI-NEXT:  .LBB17_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s46
 ; VI-NEXT:    s_lshl_b32 s5, s35, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s34, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s31, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s30, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s91, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s90, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s89, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s88, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s79, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s78, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s77, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s76, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s75, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s74, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s43
-; VI-NEXT:    s_lshl_b32 s29, s73, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s42
-; VI-NEXT:    s_lshl_b32 s42, s72, 16
-; VI-NEXT:    s_or_b32 s29, s29, s42
+; VI-NEXT:    s_and_b32 s5, 0xffff, s45
+; VI-NEXT:    s_lshl_b32 s45, s34, 16
+; VI-NEXT:    s_or_b32 s5, s5, s45
+; VI-NEXT:    s_and_b32 s44, 0xffff, s44
+; VI-NEXT:    s_lshl_b32 s45, s31, 16
+; VI-NEXT:    s_or_b32 s44, s44, s45
+; VI-NEXT:    s_and_b32 s43, 0xffff, s43
+; VI-NEXT:    s_lshl_b32 s45, s30, 16
+; VI-NEXT:    s_or_b32 s43, s43, s45
+; VI-NEXT:    s_and_b32 s42, 0xffff, s42
+; VI-NEXT:    s_lshl_b32 s45, s91, 16
+; VI-NEXT:    s_or_b32 s42, s42, s45
 ; VI-NEXT:    s_and_b32 s41, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s42, s63, 16
-; VI-NEXT:    s_or_b32 s41, s41, s42
+; VI-NEXT:    s_lshl_b32 s45, s90, 16
+; VI-NEXT:    s_or_b32 s41, s41, s45
 ; VI-NEXT:    s_and_b32 s40, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s42, s62, 16
-; VI-NEXT:    s_or_b32 s40, s40, s42
+; VI-NEXT:    s_lshl_b32 s45, s89, 16
+; VI-NEXT:    s_or_b32 s40, s40, s45
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s45, s88, 16
+; VI-NEXT:    s_or_b32 s26, s26, s45
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s45, s79, 16
+; VI-NEXT:    s_or_b32 s25, s25, s45
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s45, s78, 16
+; VI-NEXT:    s_or_b32 s24, s24, s45
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s45, s77, 16
+; VI-NEXT:    s_or_b32 s23, s23, s45
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s45, s76, 16
+; VI-NEXT:    s_or_b32 s22, s22, s45
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s45, s75, 16
+; VI-NEXT:    s_or_b32 s21, s21, s45
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s45, s74, 16
+; VI-NEXT:    s_or_b32 s20, s20, s45
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s45, s73, 16
+; VI-NEXT:    s_or_b32 s19, s19, s45
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s45, s72, 16
+; VI-NEXT:    s_or_b32 s18, s18, s45
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s45, s63, 16
+; VI-NEXT:    s_or_b32 s17, s17, s45
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s45, s62, 16
+; VI-NEXT:    s_or_b32 s16, s16, s45
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s42, s61, 16
-; VI-NEXT:    s_or_b32 s15, s15, s42
+; VI-NEXT:    s_lshl_b32 s45, s61, 16
+; VI-NEXT:    s_or_b32 s15, s15, s45
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s42, s60, 16
-; VI-NEXT:    s_or_b32 s14, s14, s42
+; VI-NEXT:    s_lshl_b32 s45, s60, 16
+; VI-NEXT:    s_or_b32 s14, s14, s45
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s42, s59, 16
-; VI-NEXT:    s_or_b32 s13, s13, s42
+; VI-NEXT:    s_lshl_b32 s45, s59, 16
+; VI-NEXT:    s_or_b32 s13, s13, s45
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s42, s58, 16
-; VI-NEXT:    s_or_b32 s12, s12, s42
+; VI-NEXT:    s_lshl_b32 s45, s58, 16
+; VI-NEXT:    s_or_b32 s12, s12, s45
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s42, s57, 16
-; VI-NEXT:    s_or_b32 s11, s11, s42
+; VI-NEXT:    s_lshl_b32 s45, s57, 16
+; VI-NEXT:    s_or_b32 s11, s11, s45
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s42, s56, 16
-; VI-NEXT:    s_or_b32 s10, s10, s42
+; VI-NEXT:    s_lshl_b32 s45, s56, 16
+; VI-NEXT:    s_or_b32 s10, s10, s45
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s42, s47, 16
-; VI-NEXT:    s_or_b32 s9, s9, s42
+; VI-NEXT:    s_lshl_b32 s45, s47, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s42, s46, 16
-; VI-NEXT:    s_or_b32 s8, s8, s42
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s42, s45, 16
-; VI-NEXT:    s_or_b32 s6, s6, s42
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s42, s44, 16
-; VI-NEXT:    s_or_b32 s7, s7, s42
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s45
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
-; VI-NEXT:    v_mov_b32_e32 v16, s41
-; VI-NEXT:    v_mov_b32_e32 v17, s40
+; VI-NEXT:    v_mov_b32_e32 v2, s44
+; VI-NEXT:    v_mov_b32_e32 v3, s43
+; VI-NEXT:    v_mov_b32_e32 v4, s42
+; VI-NEXT:    v_mov_b32_e32 v5, s41
+; VI-NEXT:    v_mov_b32_e32 v6, s40
+; VI-NEXT:    v_mov_b32_e32 v7, s26
+; VI-NEXT:    v_mov_b32_e32 v8, s25
+; VI-NEXT:    v_mov_b32_e32 v9, s24
+; VI-NEXT:    v_mov_b32_e32 v10, s23
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s16
 ; VI-NEXT:    v_mov_b32_e32 v18, s15
 ; VI-NEXT:    v_mov_b32_e32 v19, s14
 ; VI-NEXT:    v_mov_b32_e32 v20, s13
@@ -9219,25 +9386,53 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr57
 ; VI-NEXT:    ; implicit-def: $sgpr56
 ; VI-NEXT:    ; implicit-def: $sgpr47
-; VI-NEXT:    ; implicit-def: $sgpr46
-; VI-NEXT:    ; implicit-def: $sgpr45
-; VI-NEXT:    ; implicit-def: $sgpr44
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB17_2
 ;
 ; GFX9-LABEL: bitcast_v28i32_to_v56f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v15, s16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s20
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s21
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s23
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
 ; GFX9-NEXT:    v_readfirstlane_b32 s42, v12
@@ -9249,46 +9444,36 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; GFX9-NEXT:    s_lshr_b32 s45, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s46, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB17_3
 ; GFX9-NEXT:  .LBB17_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_i32 s43, s43, 3
 ; GFX9-NEXT:    s_add_i32 s42, s42, 3
 ; GFX9-NEXT:    s_add_i32 s41, s41, 3
 ; GFX9-NEXT:    s_add_i32 s40, s40, 3
-; GFX9-NEXT:    s_add_i32 s15, s15, 3
-; GFX9-NEXT:    s_add_i32 s14, s14, 3
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_add_i32 s29, s29, 3
 ; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
@@ -9303,87 +9488,97 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_lshr_b32 s44, s43, 16
 ; GFX9-NEXT:    s_lshr_b32 s45, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s46, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s6, 16
 ; GFX9-NEXT:  .LBB17_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s95
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s94
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s93
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s92
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s95
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s94
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s93
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s92
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s56
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s47
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s46
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s40, s42, s45
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s41, s43, s44
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    v_mov_b32_e32 v26, s40
@@ -9423,45 +9618,72 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; GFX11-LABEL: bitcast_v28i32_to_v56f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v11, s0 :: v_dual_mov_b32 v12, s1
+; GFX11-NEXT:    v_dual_mov_b32 v13, s2 :: v_dual_mov_b32 v14, s3
+; GFX11-NEXT:    v_dual_mov_b32 v15, s16 :: v_dual_mov_b32 v16, s17
+; GFX11-NEXT:    v_dual_mov_b32 v17, s18 :: v_dual_mov_b32 v18, s19
+; GFX11-NEXT:    v_dual_mov_b32 v19, s20 :: v_dual_mov_b32 v20, s21
+; GFX11-NEXT:    v_dual_mov_b32 v21, s22 :: v_dual_mov_b32 v22, s23
+; GFX11-NEXT:    v_dual_mov_b32 v23, s24 :: v_dual_mov_b32 v24, s25
+; GFX11-NEXT:    v_dual_mov_b32 v25, s26 :: v_dual_mov_b32 v26, s27
+; GFX11-NEXT:    v_dual_mov_b32 v27, s28 :: v_dual_mov_b32 v28, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v10
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v7
-; GFX11-NEXT:    v_readfirstlane_b32 s13, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s12, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v27
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v28
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s27, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s26, v9
 ; GFX11-NEXT:    s_mov_b32 s90, 0
-; GFX11-NEXT:    s_and_b32 s14, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s28, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s14, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s78, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s79, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s88, s1, 16
@@ -9469,20 +9691,8 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s90
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB17_3
 ; GFX11-NEXT:  .LBB17_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s12, s12, 3
-; GFX11-NEXT:    s_add_i32 s13, s13, 3
-; GFX11-NEXT:    s_add_i32 s11, s11, 3
-; GFX11-NEXT:    s_add_i32 s10, s10, 3
-; GFX11-NEXT:    s_add_i32 s9, s9, 3
-; GFX11-NEXT:    s_add_i32 s8, s8, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
-; GFX11-NEXT:    s_add_i32 s28, s28, 3
-; GFX11-NEXT:    s_add_i32 s27, s27, 3
 ; GFX11-NEXT:    s_add_i32 s26, s26, 3
+; GFX11-NEXT:    s_add_i32 s27, s27, 3
 ; GFX11-NEXT:    s_add_i32 s25, s25, 3
 ; GFX11-NEXT:    s_add_i32 s24, s24, 3
 ; GFX11-NEXT:    s_add_i32 s23, s23, 3
@@ -9493,34 +9703,46 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s14, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s78, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s79, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s88, s1, 16
@@ -9531,44 +9753,44 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s88
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s79
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s78
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s77
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s76
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s75
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s14
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s77
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s76
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s75
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s74
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s28
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s10 :: v_dual_mov_b32 v25, s11
-; GFX11-NEXT:    v_dual_mov_b32 v26, s13 :: v_dual_mov_b32 v27, s12
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s24 :: v_dual_mov_b32 v25, s25
+; GFX11-NEXT:    v_dual_mov_b32 v26, s27 :: v_dual_mov_b32 v27, s26
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB17_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr89
@@ -9597,8 +9819,8 @@ define inreg <56 x half> @bitcast_v28i32_to_v56f16_scalar(<28 x i32> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
 ; GFX11-NEXT:    s_branch .LBB17_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -16750,7 +16972,7 @@ define <28 x float> @bitcast_v56i16_to_v28f32(<56 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
 ; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, s6, v25
-; SI-NEXT:    v_add_i32_e32 v26, vcc, s6, v26
+; SI-NEXT:    v_add_i32_e32 v26, vcc, 0x30000, v26
 ; SI-NEXT:    v_add_i32_e32 v27, vcc, 0x30000, v27
 ; SI-NEXT:  .LBB30_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -20053,21 +20275,21 @@ define inreg <56 x half> @bitcast_v28f32_to_v56f16_scalar(<28 x float> inreg %a,
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; SI-NEXT:    v_readfirstlane_b32 s43, v1
-; SI-NEXT:    v_readfirstlane_b32 s42, v2
-; SI-NEXT:    v_readfirstlane_b32 s41, v3
-; SI-NEXT:    v_readfirstlane_b32 s40, v4
-; SI-NEXT:    v_readfirstlane_b32 s15, v5
-; SI-NEXT:    v_readfirstlane_b32 s14, v6
-; SI-NEXT:    v_readfirstlane_b32 s13, v7
-; SI-NEXT:    v_readfirstlane_b32 s12, v8
-; SI-NEXT:    v_readfirstlane_b32 s11, v9
-; SI-NEXT:    v_readfirstlane_b32 s10, v10
-; SI-NEXT:    v_readfirstlane_b32 s8, v11
-; SI-NEXT:    v_readfirstlane_b32 s7, v12
-; SI-NEXT:    v_readfirstlane_b32 s6, v13
+; SI-NEXT:    v_mov_b32_e32 v25, s16
+; SI-NEXT:    v_mov_b32_e32 v23, s17
+; SI-NEXT:    v_mov_b32_e32 v22, s18
+; SI-NEXT:    v_mov_b32_e32 v20, s19
+; SI-NEXT:    v_mov_b32_e32 v34, s20
 ; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s9, v14
+; SI-NEXT:    v_mov_b32_e32 v35, s21
+; SI-NEXT:    v_mov_b32_e32 v33, s22
+; SI-NEXT:    v_mov_b32_e32 v32, s23
+; SI-NEXT:    v_mov_b32_e32 v31, s24
+; SI-NEXT:    v_mov_b32_e32 v29, s25
+; SI-NEXT:    v_mov_b32_e32 v28, s26
+; SI-NEXT:    v_mov_b32_e32 v27, s27
+; SI-NEXT:    v_mov_b32_e32 v26, s28
+; SI-NEXT:    v_mov_b32_e32 v24, s29
 ; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
@@ -20086,407 +20308,514 @@ define inreg <56 x half> @bitcast_v28f32_to_v56f16_scalar(<28 x float> inreg %a,
 ; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_cbranch_scc0 .LBB33_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s4, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s4
-; SI-NEXT:    s_lshr_b32 s4, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s4
-; SI-NEXT:    s_lshr_b32 s4, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s4
-; SI-NEXT:    s_lshr_b32 s4, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s4
-; SI-NEXT:    s_lshr_b32 s4, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s4
-; SI-NEXT:    s_lshr_b32 s4, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
-; SI-NEXT:    s_lshr_b32 s4, s12, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
-; SI-NEXT:    s_lshr_b32 s4, s13, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s4
-; SI-NEXT:    s_lshr_b32 s4, s14, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s4
-; SI-NEXT:    s_lshr_b32 s4, s15, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s40, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s41, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s42, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s43, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s6
-; SI-NEXT:    s_waitcnt expcnt(6)
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, s7
-; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_cvt_f32_f16_e32 v58, s8
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, s10
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, s11
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v16, 16, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v11
+; SI-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v14
+; SI-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v7
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v12
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v8
+; SI-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v7
+; SI-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v27
+; SI-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v28
+; SI-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v3
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v31
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v3
+; SI-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v32
+; SI-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v26
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:132 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v31
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v33
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v34
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v33
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v35
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v25
 ; SI-NEXT:    s_cbranch_execnz .LBB33_3
 ; SI-NEXT:  .LBB33_2: ; %cmp.true
-; SI-NEXT:    v_add_f32_e64 v1, s16, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; SI-NEXT:    v_add_f32_e64 v14, s11, 1.0
-; SI-NEXT:    v_add_f32_e64 v36, s6, 1.0
-; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
-; SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v36
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, v6
-; SI-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; SI-NEXT:    v_add_f32_e64 v10, s8, 1.0
-; SI-NEXT:    v_add_f32_e64 v26, s29, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v10
-; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v26
-; SI-NEXT:    s_waitcnt expcnt(6)
-; SI-NEXT:    v_cvt_f32_f16_e32 v58, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v31
-; SI-NEXT:    v_add_f32_e64 v12, s10, 1.0
-; SI-NEXT:    v_add_f32_e64 v33, s7, 1.0
+; SI-NEXT:    v_add_f32_e32 v1, 1.0, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SI-NEXT:    v_add_f32_e32 v24, 1.0, v24
+; SI-NEXT:    v_add_f32_e32 v26, 1.0, v26
+; SI-NEXT:    v_add_f32_e32 v9, 1.0, v9
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_f32_e64 v2, s17, 1.0
-; SI-NEXT:    v_add_f32_e64 v3, s18, 1.0
-; SI-NEXT:    v_add_f32_e64 v5, s19, 1.0
-; SI-NEXT:    v_add_f32_e64 v7, s20, 1.0
-; SI-NEXT:    v_add_f32_e64 v9, s21, 1.0
-; SI-NEXT:    v_add_f32_e64 v11, s22, 1.0
-; SI-NEXT:    v_add_f32_e64 v13, s23, 1.0
-; SI-NEXT:    v_add_f32_e64 v15, s24, 1.0
-; SI-NEXT:    v_add_f32_e64 v18, s25, 1.0
-; SI-NEXT:    v_add_f32_e64 v20, s26, 1.0
-; SI-NEXT:    v_add_f32_e64 v22, s27, 1.0
-; SI-NEXT:    v_add_f32_e64 v24, s28, 1.0
-; SI-NEXT:    v_add_f32_e64 v29, s43, 1.0
-; SI-NEXT:    v_add_f32_e64 v27, s42, 1.0
-; SI-NEXT:    v_add_f32_e64 v25, s41, 1.0
-; SI-NEXT:    v_add_f32_e64 v23, s40, 1.0
-; SI-NEXT:    v_add_f32_e64 v21, s15, 1.0
-; SI-NEXT:    v_add_f32_e64 v19, s14, 1.0
-; SI-NEXT:    v_add_f32_e64 v17, s13, 1.0
-; SI-NEXT:    v_add_f32_e64 v16, s12, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v8, 16, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v33
-; SI-NEXT:    v_add_f32_e64 v48, s9, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v3
-; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v5
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v7
-; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v9
+; SI-NEXT:    v_add_f32_e32 v8, 1.0, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v8
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v26
+; SI-NEXT:    v_add_f32_e32 v7, 1.0, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v7
+; SI-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v49
+; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v6
+; SI-NEXT:    v_add_f32_e32 v5, 1.0, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v5
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v39
+; SI-NEXT:    v_add_f32_e32 v4, 1.0, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v4
+; SI-NEXT:    v_add_f32_e32 v3, 1.0, v3
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v37
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v3
+; SI-NEXT:    v_add_f32_e32 v15, 1.0, v25
+; SI-NEXT:    v_add_f32_e32 v21, 1.0, v23
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v61
+; SI-NEXT:    v_add_f32_e32 v19, 1.0, v22
+; SI-NEXT:    v_add_f32_e32 v18, 1.0, v20
+; SI-NEXT:    v_add_f32_e32 v16, 1.0, v34
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v59
+; SI-NEXT:    v_add_f32_e32 v30, 1.0, v35
+; SI-NEXT:    v_add_f32_e32 v33, 1.0, v33
+; SI-NEXT:    v_add_f32_e32 v32, 1.0, v32
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v57
+; SI-NEXT:    v_add_f32_e32 v31, 1.0, v31
+; SI-NEXT:    v_add_f32_e32 v29, 1.0, v29
+; SI-NEXT:    v_add_f32_e32 v28, 1.0, v28
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v47
+; SI-NEXT:    v_add_f32_e32 v27, 1.0, v27
+; SI-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; SI-NEXT:    v_add_f32_e32 v10, 1.0, v10
+; SI-NEXT:    v_add_f32_e32 v11, 1.0, v11
+; SI-NEXT:    v_add_f32_e32 v12, 1.0, v12
+; SI-NEXT:    v_add_f32_e32 v13, 1.0, v13
+; SI-NEXT:    v_add_f32_e32 v14, 1.0, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v22, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v30
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v33
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v32
+; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v28
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v26
+; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v10
 ; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v11
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v13
-; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v15
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v20
-; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v24
-; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v29
-; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v27
-; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v25
-; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v23
-; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v21
-; SI-NEXT:    v_lshrrev_b32_e32 v62, 16, v19
-; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v17
-; SI-NEXT:    v_lshrrev_b32_e32 v4, 16, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, v36
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v21
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v24
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, v14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v10
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
 ; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
 ; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v63
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v62
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v61
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v28
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v47
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v45
-; SI-NEXT:    v_mov_b32_e32 v45, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v43
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v32
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v35
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v39
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v49
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, v55
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, v42
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, v44
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, v46
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, v56
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, v6
-; SI-NEXT:    v_mov_b32_e32 v47, v8
-; SI-NEXT:    v_mov_b32_e32 v43, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v33
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v51
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    v_mov_b32_e32 v49, v12
+; SI-NEXT:    v_mov_b32_e32 v39, v13
+; SI-NEXT:    v_mov_b32_e32 v37, v14
+; SI-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:132 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
 ; SI-NEXT:  .LBB33_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v56
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v1
-; SI-NEXT:    v_cvt_f16_f32_e32 v31, v46
-; SI-NEXT:    v_cvt_f16_f32_e32 v34, v2
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    v_lshlrev_b32_e32 v8, 16, v31
-; SI-NEXT:    buffer_store_dword v6, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v8, v34, v8
-; SI-NEXT:    buffer_store_dword v8, v6, s[0:3], 0 offen
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v44
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v17
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v30
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v15
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v21
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v3
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 8, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v31, s[0:3], 0 offen
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
+; SI-NEXT:    v_or_b32_e32 v2, v4, v2
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v61
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v42
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v5
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 12, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v31, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v19
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v55
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v7
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 16, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v31, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v59
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v18
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v53
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v9
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 20, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v31, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v57
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v16
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v11
-; SI-NEXT:    v_add_i32_e32 v31, vcc, 24, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v31, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v47
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v63
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v13
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 28, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v13, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v45
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v62
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v48
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 32, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v13, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v43
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v60
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v14
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 36, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v13, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v41
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v58
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v36
-; SI-NEXT:    v_add_i32_e32 v13, vcc, 40, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v13, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v55
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v56
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v12
-; SI-NEXT:    v_add_i32_e32 v12, vcc, 44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v12, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v52
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v46
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v33
-; SI-NEXT:    v_add_i32_e32 v12, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v12, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v50
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v44
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:144 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v10
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v10, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:140 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v29
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v10, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v38
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:136 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v27
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v10, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v36
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v25
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v10, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:132 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v23
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v10, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:128 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v21
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    buffer_store_dword v6, v10, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:124 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v15
-; SI-NEXT:    v_cvt_f16_f32_e32 v8, v19
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 0x4c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v8, v6
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; SI-NEXT:    buffer_store_dword v6, v10, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v17
-; SI-NEXT:    v_add_i32_e32 v8, vcc, 0x50, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v8, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:116 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v50
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v16
-; SI-NEXT:    v_add_i32_e32 v8, vcc, 0x54, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v8, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v54
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v60
-; SI-NEXT:    v_add_i32_e32 v8, vcc, 0x58, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v8, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x54, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v47
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v59
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 0x5c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v7, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x58, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v45
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v58
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v43
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v51
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x5c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v57
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v4, v3
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v41
-; SI-NEXT:    buffer_store_dword v3, v5, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v52
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 0x68, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; SI-NEXT:    v_or_b32_e32 v2, v3, v2
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v54
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v49
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v1, v40
-; SI-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v39
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x68, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v38
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v42
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v37
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x6c, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
@@ -20510,62 +20839,83 @@ define inreg <56 x half> @bitcast_v28f32_to_v56f16_scalar(<28 x float> inreg %a,
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB33_4:
-; SI-NEXT:    ; implicit-def: $vgpr1
-; SI-NEXT:    ; implicit-def: $vgpr56
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr46
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr44
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr42
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr55
-; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr53
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr51
-; SI-NEXT:    ; implicit-def: $vgpr13
-; SI-NEXT:    ; implicit-def: $vgpr49
-; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr39
-; SI-NEXT:    ; implicit-def: $vgpr14
 ; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
 ; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr35
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; kill: killed $vgpr36
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr36
+; SI-NEXT:    ; kill: killed $vgpr36
 ; SI-NEXT:    ; implicit-def: $vgpr30
-; SI-NEXT:    ; implicit-def: $vgpr10
-; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr29
-; SI-NEXT:    ; implicit-def: $vgpr26
-; SI-NEXT:    ; implicit-def: $vgpr27
-; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr25
-; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr23
-; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr15
 ; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr50
-; SI-NEXT:    ; implicit-def: $vgpr60
-; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; implicit-def: $vgpr15
+; SI-NEXT:    ; implicit-def: $vgpr19
+; SI-NEXT:    ; implicit-def: $vgpr61
+; SI-NEXT:    ; implicit-def: $vgpr18
 ; SI-NEXT:    ; implicit-def: $vgpr59
-; SI-NEXT:    ; implicit-def: $vgpr47
-; SI-NEXT:    ; implicit-def: $vgpr58
-; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr16
 ; SI-NEXT:    ; implicit-def: $vgpr57
+; SI-NEXT:    ; implicit-def: $vgpr63
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr62
+; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr60
 ; SI-NEXT:    ; implicit-def: $vgpr43
-; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr58
 ; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr48
 ; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr49
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr39
 ; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr36
+; SI-NEXT:    ; kill: killed $vgpr36
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr36
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; kill: killed $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr37
 ; SI-NEXT:    s_branch .LBB33_2
 ;
 ; VI-LABEL: bitcast_v28f32_to_v56f16_scalar:
@@ -26047,25 +26397,53 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_writelane_b32 v16, s30, 0
-; SI-NEXT:    v_writelane_b32 v16, s31, 1
-; SI-NEXT:    v_writelane_b32 v16, s34, 2
-; SI-NEXT:    v_writelane_b32 v16, s35, 3
-; SI-NEXT:    v_writelane_b32 v16, s36, 4
-; SI-NEXT:    v_writelane_b32 v16, s37, 5
-; SI-NEXT:    v_writelane_b32 v16, s38, 6
-; SI-NEXT:    v_writelane_b32 v16, s39, 7
-; SI-NEXT:    v_writelane_b32 v16, s48, 8
-; SI-NEXT:    v_writelane_b32 v16, s49, 9
-; SI-NEXT:    v_writelane_b32 v16, s50, 10
-; SI-NEXT:    v_writelane_b32 v16, s51, 11
+; SI-NEXT:    v_writelane_b32 v20, s30, 0
+; SI-NEXT:    v_writelane_b32 v20, s31, 1
+; SI-NEXT:    v_writelane_b32 v20, s34, 2
+; SI-NEXT:    v_writelane_b32 v20, s35, 3
+; SI-NEXT:    v_writelane_b32 v20, s36, 4
+; SI-NEXT:    v_writelane_b32 v20, s37, 5
+; SI-NEXT:    v_writelane_b32 v20, s38, 6
+; SI-NEXT:    v_writelane_b32 v20, s39, 7
+; SI-NEXT:    v_writelane_b32 v20, s48, 8
+; SI-NEXT:    v_mov_b32_e32 v16, s16
+; SI-NEXT:    v_mov_b32_e32 v17, s17
+; SI-NEXT:    v_writelane_b32 v20, s49, 9
+; SI-NEXT:    v_mov_b32_e32 v18, s18
+; SI-NEXT:    v_mov_b32_e32 v19, s19
+; SI-NEXT:    v_readfirstlane_b32 s44, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s20
+; SI-NEXT:    v_readfirstlane_b32 s45, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s21
+; SI-NEXT:    v_writelane_b32 v20, s50, 10
+; SI-NEXT:    v_readfirstlane_b32 s42, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_readfirstlane_b32 s43, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s40, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_readfirstlane_b32 s41, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_writelane_b32 v20, s51, 11
+; SI-NEXT:    v_readfirstlane_b32 s24, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s22, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; SI-NEXT:    v_writelane_b32 v16, s52, 12
-; SI-NEXT:    v_readfirstlane_b32 s40, v1
-; SI-NEXT:    v_readfirstlane_b32 s41, v2
+; SI-NEXT:    v_writelane_b32 v20, s52, 12
+; SI-NEXT:    v_readfirstlane_b32 s20, v18
+; SI-NEXT:    v_readfirstlane_b32 s21, v19
+; SI-NEXT:    v_readfirstlane_b32 s18, v16
+; SI-NEXT:    v_readfirstlane_b32 s19, v17
+; SI-NEXT:    v_readfirstlane_b32 s16, v1
+; SI-NEXT:    v_readfirstlane_b32 s17, v2
 ; SI-NEXT:    v_readfirstlane_b32 s14, v3
 ; SI-NEXT:    v_readfirstlane_b32 s15, v4
 ; SI-NEXT:    v_readfirstlane_b32 s12, v5
@@ -26077,9 +26455,9 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v11
 ; SI-NEXT:    v_readfirstlane_b32 s7, v12
 ; SI-NEXT:    v_readfirstlane_b32 s4, v13
-; SI-NEXT:    s_and_b64 s[42:43], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v14
-; SI-NEXT:    v_writelane_b32 v16, s53, 13
+; SI-NEXT:    v_writelane_b32 v20, s53, 13
 ; SI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s30, s5, 16
@@ -26088,28 +26466,28 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s35, s11, 16
 ; SI-NEXT:    s_lshr_b32 s36, s13, 16
 ; SI-NEXT:    s_lshr_b32 s37, s15, 16
-; SI-NEXT:    s_lshr_b32 s38, s41, 16
-; SI-NEXT:    s_lshr_b32 s39, s29, 16
-; SI-NEXT:    s_lshr_b32 s48, s27, 16
-; SI-NEXT:    s_lshr_b32 s49, s25, 16
-; SI-NEXT:    s_lshr_b32 s50, s23, 16
-; SI-NEXT:    s_lshr_b32 s51, s21, 16
-; SI-NEXT:    s_lshr_b32 s52, s19, 16
-; SI-NEXT:    s_lshr_b32 s53, s17, 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s38, s17, 16
+; SI-NEXT:    s_lshr_b32 s39, s19, 16
+; SI-NEXT:    s_lshr_b32 s48, s21, 16
+; SI-NEXT:    s_lshr_b32 s49, s23, 16
+; SI-NEXT:    s_lshr_b32 s50, s25, 16
+; SI-NEXT:    s_lshr_b32 s51, s41, 16
+; SI-NEXT:    s_lshr_b32 s52, s43, 16
+; SI-NEXT:    s_lshr_b32 s53, s45, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[40:41], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[88:89], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[90:91], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[92:93], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[88:89], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[90:91], s[42:43], 16
+; SI-NEXT:    s_lshr_b64 s[92:93], s[44:45], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB41_3
 ; SI-NEXT:  .LBB41_2: ; %cmp.true
 ; SI-NEXT:    s_add_u32 s4, s4, 3
@@ -26124,151 +26502,151 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; SI-NEXT:    s_addc_u32 s13, s13, 0
 ; SI-NEXT:    s_add_u32 s14, s14, 3
 ; SI-NEXT:    s_addc_u32 s15, s15, 0
-; SI-NEXT:    s_add_u32 s40, s40, 3
-; SI-NEXT:    s_addc_u32 s41, s41, 0
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_add_u32 s20, s20, 3
-; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
 ; SI-NEXT:    s_add_u32 s16, s16, 3
 ; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
+; SI-NEXT:    s_add_u32 s22, s22, 3
+; SI-NEXT:    s_addc_u32 s23, s23, 0
+; SI-NEXT:    s_add_u32 s24, s24, 3
+; SI-NEXT:    s_addc_u32 s25, s25, 0
+; SI-NEXT:    s_add_u32 s40, s40, 3
+; SI-NEXT:    s_addc_u32 s41, s41, 0
+; SI-NEXT:    s_add_u32 s42, s42, 3
+; SI-NEXT:    s_addc_u32 s43, s43, 0
+; SI-NEXT:    s_add_u32 s44, s44, 3
+; SI-NEXT:    s_addc_u32 s45, s45, 0
 ; SI-NEXT:    s_lshr_b32 s30, s5, 16
 ; SI-NEXT:    s_lshr_b32 s31, s7, 16
 ; SI-NEXT:    s_lshr_b32 s34, s9, 16
 ; SI-NEXT:    s_lshr_b32 s35, s11, 16
 ; SI-NEXT:    s_lshr_b32 s36, s13, 16
 ; SI-NEXT:    s_lshr_b32 s37, s15, 16
-; SI-NEXT:    s_lshr_b32 s38, s41, 16
-; SI-NEXT:    s_lshr_b32 s39, s29, 16
-; SI-NEXT:    s_lshr_b32 s48, s27, 16
-; SI-NEXT:    s_lshr_b32 s49, s25, 16
-; SI-NEXT:    s_lshr_b32 s50, s23, 16
-; SI-NEXT:    s_lshr_b32 s51, s21, 16
-; SI-NEXT:    s_lshr_b32 s52, s19, 16
-; SI-NEXT:    s_lshr_b32 s53, s17, 16
-; SI-NEXT:    s_lshr_b64 s[42:43], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s38, s17, 16
+; SI-NEXT:    s_lshr_b32 s39, s19, 16
+; SI-NEXT:    s_lshr_b32 s48, s21, 16
+; SI-NEXT:    s_lshr_b32 s49, s23, 16
+; SI-NEXT:    s_lshr_b32 s50, s25, 16
+; SI-NEXT:    s_lshr_b32 s51, s41, 16
+; SI-NEXT:    s_lshr_b32 s52, s43, 16
+; SI-NEXT:    s_lshr_b32 s53, s45, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[46:47], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[62:63], s[40:41], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[26:27], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[88:89], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[90:91], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[92:93], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[62:63], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[22:23], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[24:25], 16
+; SI-NEXT:    s_lshr_b64 s[88:89], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[90:91], s[42:43], 16
+; SI-NEXT:    s_lshr_b64 s[92:93], s[44:45], 16
 ; SI-NEXT:  .LBB41_3: ; %end
-; SI-NEXT:    s_lshl_b32 s43, s92, 16
-; SI-NEXT:    s_and_b32 s16, s16, 0xffff
-; SI-NEXT:    s_or_b32 s16, s16, s43
-; SI-NEXT:    v_mov_b32_e32 v1, s16
-; SI-NEXT:    s_and_b32 s16, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s53, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_lshl_b32 s16, s90, 16
-; SI-NEXT:    s_and_b32 s17, s18, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
-; SI-NEXT:    v_mov_b32_e32 v3, s16
-; SI-NEXT:    s_and_b32 s16, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s52, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v4, s16
+; SI-NEXT:    s_lshl_b32 s27, s92, 16
+; SI-NEXT:    s_and_b32 s29, s44, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s27
+; SI-NEXT:    s_and_b32 s27, s45, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s53, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_lshl_b32 s27, s90, 16
+; SI-NEXT:    s_and_b32 s29, s42, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v3, s27
+; SI-NEXT:    s_and_b32 s27, s43, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s52, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v4, s27
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_lshl_b32 s16, s88, 16
-; SI-NEXT:    s_and_b32 s17, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s88, 16
+; SI-NEXT:    s_and_b32 s29, s40, 0xffff
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    s_or_b32 s16, s17, s16
+; SI-NEXT:    s_or_b32 s27, s29, s27
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
 ; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s51, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_and_b32 s27, s41, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s51, 16
 ; SI-NEXT:    buffer_store_dword v4, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s27, s27, s29
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s22, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s78, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s78, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s27
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s50, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
+; SI-NEXT:    s_lshl_b32 s25, s50, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s25
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s76, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s24, s76, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s24
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s49, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s49, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s23
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s74, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s22, s74, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s27, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s48, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s48, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s72, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s39, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s39, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s40, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s62, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s62, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s41, 0xffff
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
 ; SI-NEXT:    s_lshl_b32 s17, s38, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 56, v0
 ; SI-NEXT:    s_or_b32 s16, s16, s17
@@ -26332,7 +26710,7 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s44, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x5c, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -26346,7 +26724,7 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s42, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x64, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -26360,22 +26738,22 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x6c, v0
 ; SI-NEXT:    v_mov_b32_e32 v1, s4
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    v_readlane_b32 s53, v16, 13
-; SI-NEXT:    v_readlane_b32 s52, v16, 12
-; SI-NEXT:    v_readlane_b32 s51, v16, 11
-; SI-NEXT:    v_readlane_b32 s50, v16, 10
-; SI-NEXT:    v_readlane_b32 s49, v16, 9
-; SI-NEXT:    v_readlane_b32 s48, v16, 8
-; SI-NEXT:    v_readlane_b32 s39, v16, 7
-; SI-NEXT:    v_readlane_b32 s38, v16, 6
-; SI-NEXT:    v_readlane_b32 s37, v16, 5
-; SI-NEXT:    v_readlane_b32 s36, v16, 4
-; SI-NEXT:    v_readlane_b32 s35, v16, 3
-; SI-NEXT:    v_readlane_b32 s34, v16, 2
-; SI-NEXT:    v_readlane_b32 s31, v16, 1
-; SI-NEXT:    v_readlane_b32 s30, v16, 0
+; SI-NEXT:    v_readlane_b32 s53, v20, 13
+; SI-NEXT:    v_readlane_b32 s52, v20, 12
+; SI-NEXT:    v_readlane_b32 s51, v20, 11
+; SI-NEXT:    v_readlane_b32 s50, v20, 10
+; SI-NEXT:    v_readlane_b32 s49, v20, 9
+; SI-NEXT:    v_readlane_b32 s48, v20, 8
+; SI-NEXT:    v_readlane_b32 s39, v20, 7
+; SI-NEXT:    v_readlane_b32 s38, v20, 6
+; SI-NEXT:    v_readlane_b32 s37, v20, 5
+; SI-NEXT:    v_readlane_b32 s36, v20, 4
+; SI-NEXT:    v_readlane_b32 s35, v20, 3
+; SI-NEXT:    v_readlane_b32 s34, v20, 2
+; SI-NEXT:    v_readlane_b32 s31, v20, 1
+; SI-NEXT:    v_readlane_b32 s30, v20, 0
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_load_dword v16, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 ; 4-byte Folded Reload
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -26404,9 +26782,9 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr35
 ; SI-NEXT:    ; implicit-def: $sgpr46
 ; SI-NEXT:    ; implicit-def: $sgpr34
-; SI-NEXT:    ; implicit-def: $sgpr44
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr31
-; SI-NEXT:    ; implicit-def: $sgpr42
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    ; implicit-def: $sgpr30
 ; SI-NEXT:    s_branch .LBB41_2
 ;
@@ -26416,14 +26794,42 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; VI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
 ; VI-NEXT:    buffer_store_dword v28, off, s[0:3], s32 ; 4-byte Folded Spill
 ; VI-NEXT:    s_mov_b64 exec, s[4:5]
+; VI-NEXT:    v_mov_b32_e32 v15, s16
+; VI-NEXT:    v_mov_b32_e32 v16, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s18
+; VI-NEXT:    v_mov_b32_e32 v18, s19
 ; VI-NEXT:    v_writelane_b32 v28, s30, 0
+; VI-NEXT:    v_mov_b32_e32 v19, s20
+; VI-NEXT:    v_readfirstlane_b32 s46, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s21
+; VI-NEXT:    v_readfirstlane_b32 s45, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s23
+; VI-NEXT:    v_readfirstlane_b32 s43, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s24
 ; VI-NEXT:    v_writelane_b32 v28, s31, 1
+; VI-NEXT:    v_readfirstlane_b32 s42, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
 ; VI-NEXT:    v_writelane_b32 v28, s34, 2
-; VI-NEXT:    v_readfirstlane_b32 s43, v0
-; VI-NEXT:    v_readfirstlane_b32 s42, v1
-; VI-NEXT:    v_readfirstlane_b32 s41, v2
-; VI-NEXT:    v_readfirstlane_b32 s40, v3
+; VI-NEXT:    v_readfirstlane_b32 s24, v19
+; VI-NEXT:    v_readfirstlane_b32 s23, v15
+; VI-NEXT:    v_readfirstlane_b32 s22, v16
+; VI-NEXT:    v_readfirstlane_b32 s21, v17
+; VI-NEXT:    v_readfirstlane_b32 s20, v18
+; VI-NEXT:    v_readfirstlane_b32 s19, v0
+; VI-NEXT:    v_readfirstlane_b32 s18, v1
+; VI-NEXT:    v_readfirstlane_b32 s17, v2
+; VI-NEXT:    v_readfirstlane_b32 s16, v3
 ; VI-NEXT:    v_readfirstlane_b32 s15, v4
 ; VI-NEXT:    v_readfirstlane_b32 s14, v5
 ; VI-NEXT:    v_readfirstlane_b32 s13, v6
@@ -26438,9 +26844,9 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; VI-NEXT:    v_writelane_b32 v28, s35, 3
 ; VI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s44, s7, 16
-; VI-NEXT:    s_lshr_b32 s45, s6, 16
-; VI-NEXT:    s_lshr_b32 s46, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s47, s9, 16
 ; VI-NEXT:    s_lshr_b32 s56, s10, 16
 ; VI-NEXT:    s_lshr_b32 s57, s11, 16
@@ -26448,24 +26854,24 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s59, s13, 16
 ; VI-NEXT:    s_lshr_b32 s60, s14, 16
 ; VI-NEXT:    s_lshr_b32 s61, s15, 16
-; VI-NEXT:    s_lshr_b32 s62, s40, 16
-; VI-NEXT:    s_lshr_b32 s63, s41, 16
-; VI-NEXT:    s_lshr_b32 s72, s42, 16
-; VI-NEXT:    s_lshr_b32 s73, s43, 16
-; VI-NEXT:    s_lshr_b32 s74, s29, 16
-; VI-NEXT:    s_lshr_b32 s75, s28, 16
-; VI-NEXT:    s_lshr_b32 s76, s27, 16
-; VI-NEXT:    s_lshr_b32 s77, s26, 16
-; VI-NEXT:    s_lshr_b32 s78, s25, 16
-; VI-NEXT:    s_lshr_b32 s79, s24, 16
-; VI-NEXT:    s_lshr_b32 s88, s23, 16
-; VI-NEXT:    s_lshr_b32 s89, s22, 16
-; VI-NEXT:    s_lshr_b32 s90, s21, 16
-; VI-NEXT:    s_lshr_b32 s91, s20, 16
-; VI-NEXT:    s_lshr_b32 s30, s19, 16
-; VI-NEXT:    s_lshr_b32 s31, s18, 16
-; VI-NEXT:    s_lshr_b32 s34, s17, 16
-; VI-NEXT:    s_lshr_b32 s35, s16, 16
+; VI-NEXT:    s_lshr_b32 s62, s16, 16
+; VI-NEXT:    s_lshr_b32 s63, s17, 16
+; VI-NEXT:    s_lshr_b32 s72, s18, 16
+; VI-NEXT:    s_lshr_b32 s73, s19, 16
+; VI-NEXT:    s_lshr_b32 s74, s20, 16
+; VI-NEXT:    s_lshr_b32 s75, s21, 16
+; VI-NEXT:    s_lshr_b32 s76, s22, 16
+; VI-NEXT:    s_lshr_b32 s77, s23, 16
+; VI-NEXT:    s_lshr_b32 s78, s24, 16
+; VI-NEXT:    s_lshr_b32 s79, s25, 16
+; VI-NEXT:    s_lshr_b32 s88, s26, 16
+; VI-NEXT:    s_lshr_b32 s89, s40, 16
+; VI-NEXT:    s_lshr_b32 s90, s41, 16
+; VI-NEXT:    s_lshr_b32 s91, s42, 16
+; VI-NEXT:    s_lshr_b32 s30, s43, 16
+; VI-NEXT:    s_lshr_b32 s31, s44, 16
+; VI-NEXT:    s_lshr_b32 s34, s45, 16
+; VI-NEXT:    s_lshr_b32 s35, s46, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB41_3
 ; VI-NEXT:  .LBB41_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -26478,27 +26884,27 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
 ; VI-NEXT:    s_add_u32 s15, s15, 3
 ; VI-NEXT:    s_addc_u32 s14, s14, 0
-; VI-NEXT:    s_add_u32 s41, s41, 3
-; VI-NEXT:    s_addc_u32 s40, s40, 0
-; VI-NEXT:    s_add_u32 s43, s43, 3
-; VI-NEXT:    s_addc_u32 s42, s42, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s44, s7, 16
-; VI-NEXT:    s_lshr_b32 s45, s6, 16
-; VI-NEXT:    s_lshr_b32 s46, s8, 16
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_add_u32 s42, s42, 3
+; VI-NEXT:    s_addc_u32 s41, s41, 0
+; VI-NEXT:    s_add_u32 s44, s44, 3
+; VI-NEXT:    s_addc_u32 s43, s43, 0
+; VI-NEXT:    s_add_u32 s46, s46, 3
+; VI-NEXT:    s_addc_u32 s45, s45, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s47, s9, 16
 ; VI-NEXT:    s_lshr_b32 s56, s10, 16
 ; VI-NEXT:    s_lshr_b32 s57, s11, 16
@@ -26506,127 +26912,127 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s59, s13, 16
 ; VI-NEXT:    s_lshr_b32 s60, s14, 16
 ; VI-NEXT:    s_lshr_b32 s61, s15, 16
-; VI-NEXT:    s_lshr_b32 s62, s40, 16
-; VI-NEXT:    s_lshr_b32 s63, s41, 16
-; VI-NEXT:    s_lshr_b32 s72, s42, 16
-; VI-NEXT:    s_lshr_b32 s73, s43, 16
-; VI-NEXT:    s_lshr_b32 s74, s29, 16
-; VI-NEXT:    s_lshr_b32 s75, s28, 16
-; VI-NEXT:    s_lshr_b32 s76, s27, 16
-; VI-NEXT:    s_lshr_b32 s77, s26, 16
-; VI-NEXT:    s_lshr_b32 s78, s25, 16
-; VI-NEXT:    s_lshr_b32 s79, s24, 16
-; VI-NEXT:    s_lshr_b32 s88, s23, 16
-; VI-NEXT:    s_lshr_b32 s89, s22, 16
-; VI-NEXT:    s_lshr_b32 s90, s21, 16
-; VI-NEXT:    s_lshr_b32 s91, s20, 16
-; VI-NEXT:    s_lshr_b32 s30, s19, 16
-; VI-NEXT:    s_lshr_b32 s31, s18, 16
-; VI-NEXT:    s_lshr_b32 s34, s17, 16
-; VI-NEXT:    s_lshr_b32 s35, s16, 16
+; VI-NEXT:    s_lshr_b32 s62, s16, 16
+; VI-NEXT:    s_lshr_b32 s63, s17, 16
+; VI-NEXT:    s_lshr_b32 s72, s18, 16
+; VI-NEXT:    s_lshr_b32 s73, s19, 16
+; VI-NEXT:    s_lshr_b32 s74, s20, 16
+; VI-NEXT:    s_lshr_b32 s75, s21, 16
+; VI-NEXT:    s_lshr_b32 s76, s22, 16
+; VI-NEXT:    s_lshr_b32 s77, s23, 16
+; VI-NEXT:    s_lshr_b32 s78, s24, 16
+; VI-NEXT:    s_lshr_b32 s79, s25, 16
+; VI-NEXT:    s_lshr_b32 s88, s26, 16
+; VI-NEXT:    s_lshr_b32 s89, s40, 16
+; VI-NEXT:    s_lshr_b32 s90, s41, 16
+; VI-NEXT:    s_lshr_b32 s91, s42, 16
+; VI-NEXT:    s_lshr_b32 s30, s43, 16
+; VI-NEXT:    s_lshr_b32 s31, s44, 16
+; VI-NEXT:    s_lshr_b32 s34, s45, 16
+; VI-NEXT:    s_lshr_b32 s35, s46, 16
 ; VI-NEXT:  .LBB41_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s46
 ; VI-NEXT:    s_lshl_b32 s5, s35, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s34, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s31, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s30, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s91, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s90, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s89, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s88, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s79, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s78, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s77, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s76, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s75, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s74, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s43
-; VI-NEXT:    s_lshl_b32 s29, s73, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s42
-; VI-NEXT:    s_lshl_b32 s42, s72, 16
-; VI-NEXT:    s_or_b32 s29, s29, s42
+; VI-NEXT:    s_and_b32 s5, 0xffff, s45
+; VI-NEXT:    s_lshl_b32 s45, s34, 16
+; VI-NEXT:    s_or_b32 s5, s5, s45
+; VI-NEXT:    s_and_b32 s44, 0xffff, s44
+; VI-NEXT:    s_lshl_b32 s45, s31, 16
+; VI-NEXT:    s_or_b32 s44, s44, s45
+; VI-NEXT:    s_and_b32 s43, 0xffff, s43
+; VI-NEXT:    s_lshl_b32 s45, s30, 16
+; VI-NEXT:    s_or_b32 s43, s43, s45
+; VI-NEXT:    s_and_b32 s42, 0xffff, s42
+; VI-NEXT:    s_lshl_b32 s45, s91, 16
+; VI-NEXT:    s_or_b32 s42, s42, s45
 ; VI-NEXT:    s_and_b32 s41, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s42, s63, 16
-; VI-NEXT:    s_or_b32 s41, s41, s42
+; VI-NEXT:    s_lshl_b32 s45, s90, 16
+; VI-NEXT:    s_or_b32 s41, s41, s45
 ; VI-NEXT:    s_and_b32 s40, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s42, s62, 16
-; VI-NEXT:    s_or_b32 s40, s40, s42
+; VI-NEXT:    s_lshl_b32 s45, s89, 16
+; VI-NEXT:    s_or_b32 s40, s40, s45
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s45, s88, 16
+; VI-NEXT:    s_or_b32 s26, s26, s45
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s45, s79, 16
+; VI-NEXT:    s_or_b32 s25, s25, s45
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s45, s78, 16
+; VI-NEXT:    s_or_b32 s24, s24, s45
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s45, s77, 16
+; VI-NEXT:    s_or_b32 s23, s23, s45
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s45, s76, 16
+; VI-NEXT:    s_or_b32 s22, s22, s45
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s45, s75, 16
+; VI-NEXT:    s_or_b32 s21, s21, s45
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s45, s74, 16
+; VI-NEXT:    s_or_b32 s20, s20, s45
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s45, s73, 16
+; VI-NEXT:    s_or_b32 s19, s19, s45
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s45, s72, 16
+; VI-NEXT:    s_or_b32 s18, s18, s45
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s45, s63, 16
+; VI-NEXT:    s_or_b32 s17, s17, s45
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s45, s62, 16
+; VI-NEXT:    s_or_b32 s16, s16, s45
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s42, s61, 16
-; VI-NEXT:    s_or_b32 s15, s15, s42
+; VI-NEXT:    s_lshl_b32 s45, s61, 16
+; VI-NEXT:    s_or_b32 s15, s15, s45
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s42, s60, 16
-; VI-NEXT:    s_or_b32 s14, s14, s42
+; VI-NEXT:    s_lshl_b32 s45, s60, 16
+; VI-NEXT:    s_or_b32 s14, s14, s45
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s42, s59, 16
-; VI-NEXT:    s_or_b32 s13, s13, s42
+; VI-NEXT:    s_lshl_b32 s45, s59, 16
+; VI-NEXT:    s_or_b32 s13, s13, s45
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s42, s58, 16
-; VI-NEXT:    s_or_b32 s12, s12, s42
+; VI-NEXT:    s_lshl_b32 s45, s58, 16
+; VI-NEXT:    s_or_b32 s12, s12, s45
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s42, s57, 16
-; VI-NEXT:    s_or_b32 s11, s11, s42
+; VI-NEXT:    s_lshl_b32 s45, s57, 16
+; VI-NEXT:    s_or_b32 s11, s11, s45
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s42, s56, 16
-; VI-NEXT:    s_or_b32 s10, s10, s42
+; VI-NEXT:    s_lshl_b32 s45, s56, 16
+; VI-NEXT:    s_or_b32 s10, s10, s45
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s42, s47, 16
-; VI-NEXT:    s_or_b32 s9, s9, s42
+; VI-NEXT:    s_lshl_b32 s45, s47, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s42, s46, 16
-; VI-NEXT:    s_or_b32 s8, s8, s42
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s42, s45, 16
-; VI-NEXT:    s_or_b32 s6, s6, s42
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s42, s44, 16
-; VI-NEXT:    s_or_b32 s7, s7, s42
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s45
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
-; VI-NEXT:    v_mov_b32_e32 v16, s41
-; VI-NEXT:    v_mov_b32_e32 v17, s40
+; VI-NEXT:    v_mov_b32_e32 v2, s44
+; VI-NEXT:    v_mov_b32_e32 v3, s43
+; VI-NEXT:    v_mov_b32_e32 v4, s42
+; VI-NEXT:    v_mov_b32_e32 v5, s41
+; VI-NEXT:    v_mov_b32_e32 v6, s40
+; VI-NEXT:    v_mov_b32_e32 v7, s26
+; VI-NEXT:    v_mov_b32_e32 v8, s25
+; VI-NEXT:    v_mov_b32_e32 v9, s24
+; VI-NEXT:    v_mov_b32_e32 v10, s23
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s16
 ; VI-NEXT:    v_mov_b32_e32 v18, s15
 ; VI-NEXT:    v_mov_b32_e32 v19, s14
 ; VI-NEXT:    v_mov_b32_e32 v20, s13
@@ -26672,25 +27078,53 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr57
 ; VI-NEXT:    ; implicit-def: $sgpr56
 ; VI-NEXT:    ; implicit-def: $sgpr47
-; VI-NEXT:    ; implicit-def: $sgpr46
-; VI-NEXT:    ; implicit-def: $sgpr45
-; VI-NEXT:    ; implicit-def: $sgpr44
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB41_2
 ;
 ; GFX9-LABEL: bitcast_v14i64_to_v56i16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v15, s16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s20
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s21
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s23
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
 ; GFX9-NEXT:    v_readfirstlane_b32 s42, v12
@@ -26702,46 +27136,36 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_lshr_b32 s45, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s46, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB41_3
 ; GFX9-NEXT:  .LBB41_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_u32 s42, s42, 3
 ; GFX9-NEXT:    s_addc_u32 s43, s43, 0
 ; GFX9-NEXT:    s_add_u32 s40, s40, 3
 ; GFX9-NEXT:    s_addc_u32 s41, s41, 0
-; GFX9-NEXT:    s_add_u32 s14, s14, 3
-; GFX9-NEXT:    s_addc_u32 s15, s15, 0
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_add_u32 s28, s28, 3
 ; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
@@ -26756,87 +27180,97 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_lshr_b32 s44, s43, 16
 ; GFX9-NEXT:    s_lshr_b32 s45, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s46, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s6, 16
 ; GFX9-NEXT:  .LBB41_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s95
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s94
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s93
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s92
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s95
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s94
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s93
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s92
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s56
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s47
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s46
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s40, s42, s45
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s41, s43, s44
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    v_mov_b32_e32 v26, s40
@@ -26876,45 +27310,72 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; GFX11-LABEL: bitcast_v14i64_to_v56i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v11, s0 :: v_dual_mov_b32 v12, s1
+; GFX11-NEXT:    v_dual_mov_b32 v13, s2 :: v_dual_mov_b32 v14, s3
+; GFX11-NEXT:    v_dual_mov_b32 v15, s16 :: v_dual_mov_b32 v16, s17
+; GFX11-NEXT:    v_dual_mov_b32 v17, s18 :: v_dual_mov_b32 v18, s19
+; GFX11-NEXT:    v_dual_mov_b32 v19, s20 :: v_dual_mov_b32 v20, s21
+; GFX11-NEXT:    v_dual_mov_b32 v21, s22 :: v_dual_mov_b32 v22, s23
+; GFX11-NEXT:    v_dual_mov_b32 v23, s24 :: v_dual_mov_b32 v24, s25
+; GFX11-NEXT:    v_dual_mov_b32 v25, s26 :: v_dual_mov_b32 v26, s27
+; GFX11-NEXT:    v_dual_mov_b32 v27, s28 :: v_dual_mov_b32 v28, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v10
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v7
-; GFX11-NEXT:    v_readfirstlane_b32 s13, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s12, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v27
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v28
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s27, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s26, v9
 ; GFX11-NEXT:    s_mov_b32 s90, 0
-; GFX11-NEXT:    s_and_b32 s14, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s28, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s14, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s78, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s79, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s88, s1, 16
@@ -26922,20 +27383,8 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s90
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB41_3
 ; GFX11-NEXT:  .LBB41_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s13, s13, 3
-; GFX11-NEXT:    s_addc_u32 s12, s12, 0
-; GFX11-NEXT:    s_add_u32 s10, s10, 3
-; GFX11-NEXT:    s_addc_u32 s11, s11, 0
-; GFX11-NEXT:    s_add_u32 s8, s8, 3
-; GFX11-NEXT:    s_addc_u32 s9, s9, 0
-; GFX11-NEXT:    s_add_u32 s6, s6, 3
-; GFX11-NEXT:    s_addc_u32 s7, s7, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
+; GFX11-NEXT:    s_add_u32 s27, s27, 3
+; GFX11-NEXT:    s_addc_u32 s26, s26, 0
 ; GFX11-NEXT:    s_add_u32 s24, s24, 3
 ; GFX11-NEXT:    s_addc_u32 s25, s25, 0
 ; GFX11-NEXT:    s_add_u32 s22, s22, 3
@@ -26946,34 +27395,46 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s14, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s78, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s79, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s88, s1, 16
@@ -26984,44 +27445,44 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s88
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s79
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s78
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s77
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s76
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s75
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s14
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s77
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s76
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s75
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s74
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s28
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s10 :: v_dual_mov_b32 v25, s11
-; GFX11-NEXT:    v_dual_mov_b32 v26, s13 :: v_dual_mov_b32 v27, s12
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s24 :: v_dual_mov_b32 v25, s25
+; GFX11-NEXT:    v_dual_mov_b32 v26, s27 :: v_dual_mov_b32 v27, s26
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB41_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr89
@@ -27050,8 +27511,8 @@ define inreg <56 x i16> @bitcast_v14i64_to_v56i16_scalar(<14 x i64> inreg %a, i3
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
 ; GFX11-NEXT:    s_branch .LBB41_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -27537,7 +27998,7 @@ define <14 x i64> @bitcast_v56i16_to_v14i64(<56 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
 ; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, s6, v25
-; SI-NEXT:    v_add_i32_e32 v26, vcc, s6, v26
+; SI-NEXT:    v_add_i32_e32 v26, vcc, 0x30000, v26
 ; SI-NEXT:    v_add_i32_e32 v27, vcc, 0x30000, v27
 ; SI-NEXT:  .LBB42_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -30881,11 +31342,39 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; SI-LABEL: bitcast_v14i64_to_v56f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v16, s16
+; SI-NEXT:    v_mov_b32_e32 v17, s17
+; SI-NEXT:    v_mov_b32_e32 v18, s18
+; SI-NEXT:    v_mov_b32_e32 v19, s19
+; SI-NEXT:    v_readfirstlane_b32 s40, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s20
+; SI-NEXT:    v_readfirstlane_b32 s42, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s21
+; SI-NEXT:    v_readfirstlane_b32 s41, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_readfirstlane_b32 s43, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s22, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s24
+; SI-NEXT:    v_readfirstlane_b32 s44, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s25
+; SI-NEXT:    v_readfirstlane_b32 s23, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s45, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s24, v16
+; SI-NEXT:    v_mov_b32_e32 v16, s28
+; SI-NEXT:    v_readfirstlane_b32 s27, v17
+; SI-NEXT:    v_mov_b32_e32 v17, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; SI-NEXT:    v_readfirstlane_b32 s42, v1
-; SI-NEXT:    v_readfirstlane_b32 s43, v2
-; SI-NEXT:    v_readfirstlane_b32 s40, v3
-; SI-NEXT:    v_readfirstlane_b32 s41, v4
+; SI-NEXT:    v_readfirstlane_b32 s25, v18
+; SI-NEXT:    v_readfirstlane_b32 s26, v19
+; SI-NEXT:    v_readfirstlane_b32 s20, v16
+; SI-NEXT:    v_readfirstlane_b32 s21, v17
+; SI-NEXT:    v_readfirstlane_b32 s18, v1
+; SI-NEXT:    v_readfirstlane_b32 s19, v2
+; SI-NEXT:    v_readfirstlane_b32 s16, v3
+; SI-NEXT:    v_readfirstlane_b32 s17, v4
 ; SI-NEXT:    v_readfirstlane_b32 s14, v5
 ; SI-NEXT:    v_readfirstlane_b32 s15, v6
 ; SI-NEXT:    v_readfirstlane_b32 s12, v7
@@ -30928,44 +31417,44 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s4
 ; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s4
-; SI-NEXT:    s_lshr_b32 s4, s41, 16
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v20, s4
-; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    s_lshr_b32 s4, s16, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s43, 16
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s42, 16
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
 ; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
 ; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
+; SI-NEXT:    s_lshr_b32 s4, s27, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v37, s4
 ; SI-NEXT:    s_lshr_b32 s4, s24, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    s_lshr_b32 s4, s45, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    s_lshr_b32 s4, s44, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v53, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v55, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    s_lshr_b32 s4, s43, 16
 ; SI-NEXT:    s_waitcnt expcnt(6)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v42, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    s_lshr_b32 s4, s41, 16
 ; SI-NEXT:    s_waitcnt expcnt(4)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v44, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    s_lshr_b32 s4, s42, 16
 ; SI-NEXT:    s_waitcnt expcnt(2)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v46, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v56, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s9
@@ -30978,62 +31467,62 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s15
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
 ; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s45
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s44
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, s43
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, s41
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, s42
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, s40
 ; SI-NEXT:    s_cbranch_execnz .LBB45_3
 ; SI-NEXT:  .LBB45_2: ; %cmp.true
-; SI-NEXT:    s_add_u32 s4, s16, 3
-; SI-NEXT:    s_addc_u32 s5, s17, 0
-; SI-NEXT:    s_lshr_b32 s16, s4, 16
-; SI-NEXT:    s_lshr_b32 s17, s5, 16
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
-; SI-NEXT:    s_lshr_b32 s44, s18, 16
-; SI-NEXT:    s_lshr_b32 s45, s19, 16
+; SI-NEXT:    s_add_u32 s4, s40, 3
+; SI-NEXT:    s_addc_u32 s5, s42, 0
+; SI-NEXT:    s_lshr_b32 s28, s4, 16
+; SI-NEXT:    s_lshr_b32 s29, s5, 16
+; SI-NEXT:    s_add_u32 s40, s41, 3
+; SI-NEXT:    s_addc_u32 s41, s43, 0
+; SI-NEXT:    s_lshr_b32 s42, s40, 16
+; SI-NEXT:    s_lshr_b32 s43, s41, 16
+; SI-NEXT:    s_add_u32 s22, s22, 3
+; SI-NEXT:    s_addc_u32 s44, s44, 0
+; SI-NEXT:    s_lshr_b32 s46, s22, 16
+; SI-NEXT:    s_lshr_b32 s47, s44, 16
+; SI-NEXT:    s_add_u32 s23, s23, 3
+; SI-NEXT:    s_addc_u32 s45, s45, 0
+; SI-NEXT:    s_lshr_b32 s56, s23, 16
+; SI-NEXT:    s_lshr_b32 s57, s45, 16
+; SI-NEXT:    s_add_u32 s24, s24, 3
+; SI-NEXT:    s_addc_u32 s27, s27, 0
+; SI-NEXT:    s_lshr_b32 s58, s24, 16
+; SI-NEXT:    s_lshr_b32 s59, s27, 16
+; SI-NEXT:    s_add_u32 s25, s25, 3
+; SI-NEXT:    s_addc_u32 s26, s26, 0
+; SI-NEXT:    s_lshr_b32 s60, s25, 16
+; SI-NEXT:    s_lshr_b32 s61, s26, 16
 ; SI-NEXT:    s_add_u32 s20, s20, 3
 ; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_lshr_b32 s46, s20, 16
-; SI-NEXT:    s_lshr_b32 s47, s21, 16
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_lshr_b32 s56, s22, 16
-; SI-NEXT:    s_lshr_b32 s57, s23, 16
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_lshr_b32 s58, s24, 16
-; SI-NEXT:    s_lshr_b32 s59, s25, 16
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_lshr_b32 s60, s26, 16
-; SI-NEXT:    s_lshr_b32 s61, s27, 16
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_lshr_b32 s62, s28, 16
-; SI-NEXT:    s_lshr_b32 s63, s29, 16
-; SI-NEXT:    s_add_u32 s42, s42, 3
-; SI-NEXT:    s_addc_u32 s43, s43, 0
-; SI-NEXT:    s_lshr_b32 s72, s42, 16
-; SI-NEXT:    s_lshr_b32 s73, s43, 16
-; SI-NEXT:    s_add_u32 s40, s40, 3
-; SI-NEXT:    s_addc_u32 s41, s41, 0
-; SI-NEXT:    s_lshr_b32 s74, s40, 16
-; SI-NEXT:    s_lshr_b32 s75, s41, 16
+; SI-NEXT:    s_lshr_b32 s62, s20, 16
+; SI-NEXT:    s_lshr_b32 s63, s21, 16
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_lshr_b32 s72, s18, 16
+; SI-NEXT:    s_lshr_b32 s73, s19, 16
+; SI-NEXT:    s_add_u32 s16, s16, 3
+; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_lshr_b32 s74, s16, 16
+; SI-NEXT:    s_lshr_b32 s75, s17, 16
 ; SI-NEXT:    s_add_u32 s14, s14, 3
 ; SI-NEXT:    s_addc_u32 s15, s15, 0
 ; SI-NEXT:    s_lshr_b32 s76, s14, 16
@@ -31064,23 +31553,23 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s15
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
 ; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s45
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s44
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, s41
 ; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, s40
 ; SI-NEXT:    s_waitcnt expcnt(3)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v45, s5
 ; SI-NEXT:    s_waitcnt expcnt(1)
@@ -31109,11 +31598,11 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v51, s56
 ; SI-NEXT:    v_cvt_f32_f16_e32 v53, s47
 ; SI-NEXT:    v_cvt_f32_f16_e32 v55, s46
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s45
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s44
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, s43
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, s42
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, s29
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, s28
 ; SI-NEXT:  .LBB45_3: ; %end
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v56, v56
@@ -31386,14 +31875,42 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; VI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
 ; VI-NEXT:    buffer_store_dword v28, off, s[0:3], s32 ; 4-byte Folded Spill
 ; VI-NEXT:    s_mov_b64 exec, s[4:5]
+; VI-NEXT:    v_mov_b32_e32 v15, s16
+; VI-NEXT:    v_mov_b32_e32 v16, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s18
+; VI-NEXT:    v_mov_b32_e32 v18, s19
 ; VI-NEXT:    v_writelane_b32 v28, s30, 0
+; VI-NEXT:    v_mov_b32_e32 v19, s20
+; VI-NEXT:    v_readfirstlane_b32 s46, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s21
+; VI-NEXT:    v_readfirstlane_b32 s45, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s23
+; VI-NEXT:    v_readfirstlane_b32 s43, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s24
 ; VI-NEXT:    v_writelane_b32 v28, s31, 1
+; VI-NEXT:    v_readfirstlane_b32 s42, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v15
+; VI-NEXT:    v_mov_b32_e32 v15, s26
+; VI-NEXT:    v_readfirstlane_b32 s40, v16
+; VI-NEXT:    v_mov_b32_e32 v16, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
 ; VI-NEXT:    v_writelane_b32 v28, s34, 2
-; VI-NEXT:    v_readfirstlane_b32 s43, v0
-; VI-NEXT:    v_readfirstlane_b32 s42, v1
-; VI-NEXT:    v_readfirstlane_b32 s41, v2
-; VI-NEXT:    v_readfirstlane_b32 s40, v3
+; VI-NEXT:    v_readfirstlane_b32 s24, v19
+; VI-NEXT:    v_readfirstlane_b32 s23, v15
+; VI-NEXT:    v_readfirstlane_b32 s22, v16
+; VI-NEXT:    v_readfirstlane_b32 s21, v17
+; VI-NEXT:    v_readfirstlane_b32 s20, v18
+; VI-NEXT:    v_readfirstlane_b32 s19, v0
+; VI-NEXT:    v_readfirstlane_b32 s18, v1
+; VI-NEXT:    v_readfirstlane_b32 s17, v2
+; VI-NEXT:    v_readfirstlane_b32 s16, v3
 ; VI-NEXT:    v_readfirstlane_b32 s15, v4
 ; VI-NEXT:    v_readfirstlane_b32 s14, v5
 ; VI-NEXT:    v_readfirstlane_b32 s13, v6
@@ -31408,9 +31925,9 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; VI-NEXT:    v_writelane_b32 v28, s35, 3
 ; VI-NEXT:    s_cbranch_scc0 .LBB45_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s44, s7, 16
-; VI-NEXT:    s_lshr_b32 s45, s6, 16
-; VI-NEXT:    s_lshr_b32 s46, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s47, s9, 16
 ; VI-NEXT:    s_lshr_b32 s56, s10, 16
 ; VI-NEXT:    s_lshr_b32 s57, s11, 16
@@ -31418,24 +31935,24 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s59, s13, 16
 ; VI-NEXT:    s_lshr_b32 s60, s14, 16
 ; VI-NEXT:    s_lshr_b32 s61, s15, 16
-; VI-NEXT:    s_lshr_b32 s62, s40, 16
-; VI-NEXT:    s_lshr_b32 s63, s41, 16
-; VI-NEXT:    s_lshr_b32 s72, s42, 16
-; VI-NEXT:    s_lshr_b32 s73, s43, 16
-; VI-NEXT:    s_lshr_b32 s74, s29, 16
-; VI-NEXT:    s_lshr_b32 s75, s28, 16
-; VI-NEXT:    s_lshr_b32 s76, s27, 16
-; VI-NEXT:    s_lshr_b32 s77, s26, 16
-; VI-NEXT:    s_lshr_b32 s78, s25, 16
-; VI-NEXT:    s_lshr_b32 s79, s24, 16
-; VI-NEXT:    s_lshr_b32 s88, s23, 16
-; VI-NEXT:    s_lshr_b32 s89, s22, 16
-; VI-NEXT:    s_lshr_b32 s90, s21, 16
-; VI-NEXT:    s_lshr_b32 s91, s20, 16
-; VI-NEXT:    s_lshr_b32 s30, s19, 16
-; VI-NEXT:    s_lshr_b32 s31, s18, 16
-; VI-NEXT:    s_lshr_b32 s34, s17, 16
-; VI-NEXT:    s_lshr_b32 s35, s16, 16
+; VI-NEXT:    s_lshr_b32 s62, s16, 16
+; VI-NEXT:    s_lshr_b32 s63, s17, 16
+; VI-NEXT:    s_lshr_b32 s72, s18, 16
+; VI-NEXT:    s_lshr_b32 s73, s19, 16
+; VI-NEXT:    s_lshr_b32 s74, s20, 16
+; VI-NEXT:    s_lshr_b32 s75, s21, 16
+; VI-NEXT:    s_lshr_b32 s76, s22, 16
+; VI-NEXT:    s_lshr_b32 s77, s23, 16
+; VI-NEXT:    s_lshr_b32 s78, s24, 16
+; VI-NEXT:    s_lshr_b32 s79, s25, 16
+; VI-NEXT:    s_lshr_b32 s88, s26, 16
+; VI-NEXT:    s_lshr_b32 s89, s40, 16
+; VI-NEXT:    s_lshr_b32 s90, s41, 16
+; VI-NEXT:    s_lshr_b32 s91, s42, 16
+; VI-NEXT:    s_lshr_b32 s30, s43, 16
+; VI-NEXT:    s_lshr_b32 s31, s44, 16
+; VI-NEXT:    s_lshr_b32 s34, s45, 16
+; VI-NEXT:    s_lshr_b32 s35, s46, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB45_3
 ; VI-NEXT:  .LBB45_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -31448,27 +31965,27 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
 ; VI-NEXT:    s_add_u32 s15, s15, 3
 ; VI-NEXT:    s_addc_u32 s14, s14, 0
-; VI-NEXT:    s_add_u32 s41, s41, 3
-; VI-NEXT:    s_addc_u32 s40, s40, 0
-; VI-NEXT:    s_add_u32 s43, s43, 3
-; VI-NEXT:    s_addc_u32 s42, s42, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s44, s7, 16
-; VI-NEXT:    s_lshr_b32 s45, s6, 16
-; VI-NEXT:    s_lshr_b32 s46, s8, 16
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_add_u32 s42, s42, 3
+; VI-NEXT:    s_addc_u32 s41, s41, 0
+; VI-NEXT:    s_add_u32 s44, s44, 3
+; VI-NEXT:    s_addc_u32 s43, s43, 0
+; VI-NEXT:    s_add_u32 s46, s46, 3
+; VI-NEXT:    s_addc_u32 s45, s45, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s47, s9, 16
 ; VI-NEXT:    s_lshr_b32 s56, s10, 16
 ; VI-NEXT:    s_lshr_b32 s57, s11, 16
@@ -31476,127 +31993,127 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s59, s13, 16
 ; VI-NEXT:    s_lshr_b32 s60, s14, 16
 ; VI-NEXT:    s_lshr_b32 s61, s15, 16
-; VI-NEXT:    s_lshr_b32 s62, s40, 16
-; VI-NEXT:    s_lshr_b32 s63, s41, 16
-; VI-NEXT:    s_lshr_b32 s72, s42, 16
-; VI-NEXT:    s_lshr_b32 s73, s43, 16
-; VI-NEXT:    s_lshr_b32 s74, s29, 16
-; VI-NEXT:    s_lshr_b32 s75, s28, 16
-; VI-NEXT:    s_lshr_b32 s76, s27, 16
-; VI-NEXT:    s_lshr_b32 s77, s26, 16
-; VI-NEXT:    s_lshr_b32 s78, s25, 16
-; VI-NEXT:    s_lshr_b32 s79, s24, 16
-; VI-NEXT:    s_lshr_b32 s88, s23, 16
-; VI-NEXT:    s_lshr_b32 s89, s22, 16
-; VI-NEXT:    s_lshr_b32 s90, s21, 16
-; VI-NEXT:    s_lshr_b32 s91, s20, 16
-; VI-NEXT:    s_lshr_b32 s30, s19, 16
-; VI-NEXT:    s_lshr_b32 s31, s18, 16
-; VI-NEXT:    s_lshr_b32 s34, s17, 16
-; VI-NEXT:    s_lshr_b32 s35, s16, 16
+; VI-NEXT:    s_lshr_b32 s62, s16, 16
+; VI-NEXT:    s_lshr_b32 s63, s17, 16
+; VI-NEXT:    s_lshr_b32 s72, s18, 16
+; VI-NEXT:    s_lshr_b32 s73, s19, 16
+; VI-NEXT:    s_lshr_b32 s74, s20, 16
+; VI-NEXT:    s_lshr_b32 s75, s21, 16
+; VI-NEXT:    s_lshr_b32 s76, s22, 16
+; VI-NEXT:    s_lshr_b32 s77, s23, 16
+; VI-NEXT:    s_lshr_b32 s78, s24, 16
+; VI-NEXT:    s_lshr_b32 s79, s25, 16
+; VI-NEXT:    s_lshr_b32 s88, s26, 16
+; VI-NEXT:    s_lshr_b32 s89, s40, 16
+; VI-NEXT:    s_lshr_b32 s90, s41, 16
+; VI-NEXT:    s_lshr_b32 s91, s42, 16
+; VI-NEXT:    s_lshr_b32 s30, s43, 16
+; VI-NEXT:    s_lshr_b32 s31, s44, 16
+; VI-NEXT:    s_lshr_b32 s34, s45, 16
+; VI-NEXT:    s_lshr_b32 s35, s46, 16
 ; VI-NEXT:  .LBB45_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s46
 ; VI-NEXT:    s_lshl_b32 s5, s35, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s34, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s31, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s30, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s91, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s90, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s89, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s88, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s79, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s78, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s77, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s76, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s75, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s74, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s43
-; VI-NEXT:    s_lshl_b32 s29, s73, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s42
-; VI-NEXT:    s_lshl_b32 s42, s72, 16
-; VI-NEXT:    s_or_b32 s29, s29, s42
+; VI-NEXT:    s_and_b32 s5, 0xffff, s45
+; VI-NEXT:    s_lshl_b32 s45, s34, 16
+; VI-NEXT:    s_or_b32 s5, s5, s45
+; VI-NEXT:    s_and_b32 s44, 0xffff, s44
+; VI-NEXT:    s_lshl_b32 s45, s31, 16
+; VI-NEXT:    s_or_b32 s44, s44, s45
+; VI-NEXT:    s_and_b32 s43, 0xffff, s43
+; VI-NEXT:    s_lshl_b32 s45, s30, 16
+; VI-NEXT:    s_or_b32 s43, s43, s45
+; VI-NEXT:    s_and_b32 s42, 0xffff, s42
+; VI-NEXT:    s_lshl_b32 s45, s91, 16
+; VI-NEXT:    s_or_b32 s42, s42, s45
 ; VI-NEXT:    s_and_b32 s41, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s42, s63, 16
-; VI-NEXT:    s_or_b32 s41, s41, s42
+; VI-NEXT:    s_lshl_b32 s45, s90, 16
+; VI-NEXT:    s_or_b32 s41, s41, s45
 ; VI-NEXT:    s_and_b32 s40, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s42, s62, 16
-; VI-NEXT:    s_or_b32 s40, s40, s42
+; VI-NEXT:    s_lshl_b32 s45, s89, 16
+; VI-NEXT:    s_or_b32 s40, s40, s45
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s45, s88, 16
+; VI-NEXT:    s_or_b32 s26, s26, s45
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s45, s79, 16
+; VI-NEXT:    s_or_b32 s25, s25, s45
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s45, s78, 16
+; VI-NEXT:    s_or_b32 s24, s24, s45
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s45, s77, 16
+; VI-NEXT:    s_or_b32 s23, s23, s45
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s45, s76, 16
+; VI-NEXT:    s_or_b32 s22, s22, s45
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s45, s75, 16
+; VI-NEXT:    s_or_b32 s21, s21, s45
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s45, s74, 16
+; VI-NEXT:    s_or_b32 s20, s20, s45
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s45, s73, 16
+; VI-NEXT:    s_or_b32 s19, s19, s45
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s45, s72, 16
+; VI-NEXT:    s_or_b32 s18, s18, s45
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s45, s63, 16
+; VI-NEXT:    s_or_b32 s17, s17, s45
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s45, s62, 16
+; VI-NEXT:    s_or_b32 s16, s16, s45
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s42, s61, 16
-; VI-NEXT:    s_or_b32 s15, s15, s42
+; VI-NEXT:    s_lshl_b32 s45, s61, 16
+; VI-NEXT:    s_or_b32 s15, s15, s45
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s42, s60, 16
-; VI-NEXT:    s_or_b32 s14, s14, s42
+; VI-NEXT:    s_lshl_b32 s45, s60, 16
+; VI-NEXT:    s_or_b32 s14, s14, s45
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s42, s59, 16
-; VI-NEXT:    s_or_b32 s13, s13, s42
+; VI-NEXT:    s_lshl_b32 s45, s59, 16
+; VI-NEXT:    s_or_b32 s13, s13, s45
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s42, s58, 16
-; VI-NEXT:    s_or_b32 s12, s12, s42
+; VI-NEXT:    s_lshl_b32 s45, s58, 16
+; VI-NEXT:    s_or_b32 s12, s12, s45
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s42, s57, 16
-; VI-NEXT:    s_or_b32 s11, s11, s42
+; VI-NEXT:    s_lshl_b32 s45, s57, 16
+; VI-NEXT:    s_or_b32 s11, s11, s45
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s42, s56, 16
-; VI-NEXT:    s_or_b32 s10, s10, s42
+; VI-NEXT:    s_lshl_b32 s45, s56, 16
+; VI-NEXT:    s_or_b32 s10, s10, s45
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s42, s47, 16
-; VI-NEXT:    s_or_b32 s9, s9, s42
+; VI-NEXT:    s_lshl_b32 s45, s47, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s42, s46, 16
-; VI-NEXT:    s_or_b32 s8, s8, s42
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s42, s45, 16
-; VI-NEXT:    s_or_b32 s6, s6, s42
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s42, s44, 16
-; VI-NEXT:    s_or_b32 s7, s7, s42
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s45
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
-; VI-NEXT:    v_mov_b32_e32 v16, s41
-; VI-NEXT:    v_mov_b32_e32 v17, s40
+; VI-NEXT:    v_mov_b32_e32 v2, s44
+; VI-NEXT:    v_mov_b32_e32 v3, s43
+; VI-NEXT:    v_mov_b32_e32 v4, s42
+; VI-NEXT:    v_mov_b32_e32 v5, s41
+; VI-NEXT:    v_mov_b32_e32 v6, s40
+; VI-NEXT:    v_mov_b32_e32 v7, s26
+; VI-NEXT:    v_mov_b32_e32 v8, s25
+; VI-NEXT:    v_mov_b32_e32 v9, s24
+; VI-NEXT:    v_mov_b32_e32 v10, s23
+; VI-NEXT:    v_mov_b32_e32 v11, s22
+; VI-NEXT:    v_mov_b32_e32 v12, s21
+; VI-NEXT:    v_mov_b32_e32 v13, s20
+; VI-NEXT:    v_mov_b32_e32 v14, s19
+; VI-NEXT:    v_mov_b32_e32 v15, s18
+; VI-NEXT:    v_mov_b32_e32 v16, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s16
 ; VI-NEXT:    v_mov_b32_e32 v18, s15
 ; VI-NEXT:    v_mov_b32_e32 v19, s14
 ; VI-NEXT:    v_mov_b32_e32 v20, s13
@@ -31642,25 +32159,53 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr57
 ; VI-NEXT:    ; implicit-def: $sgpr56
 ; VI-NEXT:    ; implicit-def: $sgpr47
-; VI-NEXT:    ; implicit-def: $sgpr46
-; VI-NEXT:    ; implicit-def: $sgpr45
-; VI-NEXT:    ; implicit-def: $sgpr44
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB45_2
 ;
 ; GFX9-LABEL: bitcast_v14i64_to_v56f16_scalar:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v15, s16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s20
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s21
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s23
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v15
+; GFX9-NEXT:    v_mov_b32_e32 v15, s26
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v16
+; GFX9-NEXT:    v_mov_b32_e32 v16, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v15
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v16
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
 ; GFX9-NEXT:    v_readfirstlane_b32 s42, v12
@@ -31672,46 +32217,36 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; GFX9-NEXT:    s_lshr_b32 s45, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s46, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB45_3
 ; GFX9-NEXT:  .LBB45_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_u32 s42, s42, 3
 ; GFX9-NEXT:    s_addc_u32 s43, s43, 0
 ; GFX9-NEXT:    s_add_u32 s40, s40, 3
 ; GFX9-NEXT:    s_addc_u32 s41, s41, 0
-; GFX9-NEXT:    s_add_u32 s14, s14, 3
-; GFX9-NEXT:    s_addc_u32 s15, s15, 0
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_add_u32 s28, s28, 3
 ; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
@@ -31726,87 +32261,97 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_lshr_b32 s44, s43, 16
 ; GFX9-NEXT:    s_lshr_b32 s45, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s46, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s56, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s57, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s58, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s59, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s56, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s57, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s58, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s59, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s6, 16
 ; GFX9-NEXT:  .LBB45_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s95
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s94
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s93
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s92
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s60
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s59
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s58
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s57
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s56
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s95
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s94
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s93
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s92
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s59
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s58
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s57
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s56
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s47
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s46
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s40, s42, s45
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s41, s43, s44
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    v_mov_b32_e32 v26, s40
@@ -31846,45 +32391,72 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; GFX11-LABEL: bitcast_v14i64_to_v56f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v11, s0 :: v_dual_mov_b32 v12, s1
+; GFX11-NEXT:    v_dual_mov_b32 v13, s2 :: v_dual_mov_b32 v14, s3
+; GFX11-NEXT:    v_dual_mov_b32 v15, s16 :: v_dual_mov_b32 v16, s17
+; GFX11-NEXT:    v_dual_mov_b32 v17, s18 :: v_dual_mov_b32 v18, s19
+; GFX11-NEXT:    v_dual_mov_b32 v19, s20 :: v_dual_mov_b32 v20, s21
+; GFX11-NEXT:    v_dual_mov_b32 v21, s22 :: v_dual_mov_b32 v22, s23
+; GFX11-NEXT:    v_dual_mov_b32 v23, s24 :: v_dual_mov_b32 v24, s25
+; GFX11-NEXT:    v_dual_mov_b32 v25, s26 :: v_dual_mov_b32 v26, s27
+; GFX11-NEXT:    v_dual_mov_b32 v27, s28 :: v_dual_mov_b32 v28, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v10
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v7
-; GFX11-NEXT:    v_readfirstlane_b32 s13, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s12, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v27
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v28
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s27, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s26, v9
 ; GFX11-NEXT:    s_mov_b32 s90, 0
-; GFX11-NEXT:    s_and_b32 s14, vcc_lo, exec_lo
+; GFX11-NEXT:    s_and_b32 s28, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s14, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s78, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s79, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s88, s1, 16
@@ -31892,20 +32464,8 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s90
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB45_3
 ; GFX11-NEXT:  .LBB45_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s13, s13, 3
-; GFX11-NEXT:    s_addc_u32 s12, s12, 0
-; GFX11-NEXT:    s_add_u32 s10, s10, 3
-; GFX11-NEXT:    s_addc_u32 s11, s11, 0
-; GFX11-NEXT:    s_add_u32 s8, s8, 3
-; GFX11-NEXT:    s_addc_u32 s9, s9, 0
-; GFX11-NEXT:    s_add_u32 s6, s6, 3
-; GFX11-NEXT:    s_addc_u32 s7, s7, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
-; GFX11-NEXT:    s_add_u32 s26, s26, 3
-; GFX11-NEXT:    s_addc_u32 s27, s27, 0
+; GFX11-NEXT:    s_add_u32 s27, s27, 3
+; GFX11-NEXT:    s_addc_u32 s26, s26, 0
 ; GFX11-NEXT:    s_add_u32 s24, s24, 3
 ; GFX11-NEXT:    s_addc_u32 s25, s25, 0
 ; GFX11-NEXT:    s_add_u32 s22, s22, 3
@@ -31916,34 +32476,46 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s14, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s15, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s40, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s28, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s29, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s78, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s79, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s88, s1, 16
@@ -31954,44 +32526,44 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s88
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s79
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s78
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s77
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s76
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s75
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s40
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s15
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s14
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s77
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s76
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s75
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s74
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s29
+; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s28
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s10 :: v_dual_mov_b32 v25, s11
-; GFX11-NEXT:    v_dual_mov_b32 v26, s13 :: v_dual_mov_b32 v27, s12
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s24 :: v_dual_mov_b32 v25, s25
+; GFX11-NEXT:    v_dual_mov_b32 v26, s27 :: v_dual_mov_b32 v27, s26
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB45_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr89
@@ -32020,8 +32592,8 @@ define inreg <56 x half> @bitcast_v14i64_to_v56f16_scalar(<14 x i64> inreg %a, i
 ; GFX11-NEXT:    ; implicit-def: $sgpr42
 ; GFX11-NEXT:    ; implicit-def: $sgpr41
 ; GFX11-NEXT:    ; implicit-def: $sgpr40
-; GFX11-NEXT:    ; implicit-def: $sgpr15
-; GFX11-NEXT:    ; implicit-def: $sgpr14
+; GFX11-NEXT:    ; implicit-def: $sgpr29
+; GFX11-NEXT:    ; implicit-def: $sgpr28
 ; GFX11-NEXT:    s_branch .LBB45_2
   %cmp = icmp eq i32 %b, 0
   br i1 %cmp, label %cmp.true, label %cmp.false
@@ -36088,8 +36660,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; VI-NEXT:    v_mov_b32_e32 v19, s16
-; VI-NEXT:    v_mov_b32_e32 v20, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s16
+; VI-NEXT:    v_mov_b32_e32 v18, s17
 ; VI-NEXT:    v_mov_b32_e32 v15, s18
 ; VI-NEXT:    v_mov_b32_e32 v16, s19
 ; VI-NEXT:    v_mov_b32_e32 v32, s20
@@ -36101,8 +36673,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; VI-NEXT:    v_mov_b32_e32 v21, s26
 ; VI-NEXT:    v_mov_b32_e32 v22, s27
 ; VI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; VI-NEXT:    v_mov_b32_e32 v17, s28
-; VI-NEXT:    v_mov_b32_e32 v18, s29
+; VI-NEXT:    v_mov_b32_e32 v19, s28
+; VI-NEXT:    v_mov_b32_e32 v20, s29
 ; VI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; VI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; VI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
@@ -36127,8 +36699,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v44, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v45, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v20
+; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v21
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v24
@@ -36139,8 +36711,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v47, 16, v32
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
 ; VI-NEXT:    v_lshrrev_b32_e32 v30, 16, v15
-; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
-; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v19
+; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
 ; VI-NEXT:    s_cbranch_execnz .LBB49_3
 ; VI-NEXT:  .LBB49_2: ; %cmp.true
 ; VI-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
@@ -36150,13 +36722,13 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; VI-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; VI-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; VI-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; VI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; VI-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; VI-NEXT:    v_add_f64 v[25:26], v[25:26], 1.0
 ; VI-NEXT:    v_add_f64 v[32:33], v[32:33], 1.0
 ; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
-; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v12
 ; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
@@ -36171,8 +36743,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v44, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v45, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v20
+; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v21
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v24
@@ -36183,15 +36755,15 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; VI-NEXT:    v_lshrrev_b32_e32 v47, 16, v32
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
 ; VI-NEXT:    v_lshrrev_b32_e32 v30, 16, v15
-; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
-; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v19
+; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
 ; VI-NEXT:  .LBB49_3: ; %end
 ; VI-NEXT:    v_lshlrev_b32_e32 v28, 16, v28
-; VI-NEXT:    v_or_b32_sdwa v28, v19, v28 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v29
-; VI-NEXT:    v_or_b32_sdwa v29, v20, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v30
-; VI-NEXT:    v_or_b32_sdwa v30, v15, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v28, v17, v28 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v29
+; VI-NEXT:    v_or_b32_sdwa v29, v18, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v30
+; VI-NEXT:    v_or_b32_sdwa v30, v15, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v31
 ; VI-NEXT:    v_or_b32_sdwa v31, v16, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v47
@@ -36212,11 +36784,11 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; VI-NEXT:    v_or_b32_sdwa v39, v22, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v48
 ; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
-; VI-NEXT:    v_or_b32_sdwa v48, v17, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v48, v19, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v49
 ; VI-NEXT:    v_or_b32_sdwa v14, v0, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v45
-; VI-NEXT:    v_or_b32_sdwa v49, v18, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v49, v20, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v15, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v44
 ; VI-NEXT:    v_or_b32_sdwa v16, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -36301,8 +36873,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; GFX9-NEXT:    v_mov_b32_e32 v19, s16
-; GFX9-NEXT:    v_mov_b32_e32 v20, s17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s16
+; GFX9-NEXT:    v_mov_b32_e32 v18, s17
 ; GFX9-NEXT:    v_mov_b32_e32 v15, s18
 ; GFX9-NEXT:    v_mov_b32_e32 v16, s19
 ; GFX9-NEXT:    v_mov_b32_e32 v32, s20
@@ -36314,8 +36886,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX9-NEXT:    v_mov_b32_e32 v21, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v22, s27
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_mov_b32_e32 v17, s28
-; GFX9-NEXT:    v_mov_b32_e32 v18, s29
+; GFX9-NEXT:    v_mov_b32_e32 v19, s28
+; GFX9-NEXT:    v_mov_b32_e32 v20, s29
 ; GFX9-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GFX9-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GFX9-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
@@ -36340,8 +36912,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v44, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v45, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v20
+; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v21
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v24
@@ -36352,8 +36924,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v47, 16, v32
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
-; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v19
+; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
 ; GFX9-NEXT:    s_cbranch_execnz .LBB49_3
 ; GFX9-NEXT:  .LBB49_2: ; %cmp.true
 ; GFX9-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
@@ -36363,13 +36935,13 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX9-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; GFX9-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; GFX9-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; GFX9-NEXT:    v_add_f64 v[25:26], v[25:26], 1.0
 ; GFX9-NEXT:    v_add_f64 v[32:33], v[32:33], 1.0
 ; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
-; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v12
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
@@ -36384,8 +36956,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v44, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v45, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v20
+; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v21
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v24
@@ -36396,8 +36968,8 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v47, 16, v32
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
-; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v19
+; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
 ; GFX9-NEXT:  .LBB49_3: ; %end
 ; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v30, v30, 16, v15
@@ -36419,25 +36991,25 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX9-NEXT:    v_lshl_or_b32 v38, v38, 16, v15
 ; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v22
 ; GFX9-NEXT:    v_lshl_or_b32 v39, v39, 16, v15
-; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v17
+; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v19
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    v_lshl_or_b32 v48, v48, 16, v15
-; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v18
+; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v20
 ; GFX9-NEXT:    v_lshl_or_b32 v14, v14, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v1
+; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v49, v49, 16, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v15, v45, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
+; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v17
+; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v18
 ; GFX9-NEXT:    v_lshl_or_b32 v16, v44, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v3
-; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v19
+; GFX9-NEXT:    v_lshl_or_b32 v29, v29, 16, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v17, v43, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v4
-; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v19
-; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v20
 ; GFX9-NEXT:    v_lshl_or_b32 v18, v42, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v5
-; GFX9-NEXT:    v_lshl_or_b32 v29, v29, 16, v19
 ; GFX9-NEXT:    v_lshl_or_b32 v19, v41, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v6
 ; GFX9-NEXT:    v_lshl_or_b32 v20, v40, 16, v0
@@ -36693,9 +37265,9 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v21, s18 :: v_dual_mov_b32 v22, s19
 ; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v19, s20 :: v_dual_mov_b32 v20, s21
 ; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v11, s22 :: v_dual_mov_b32 v12, s23
-; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v17, s24 :: v_dual_mov_b32 v18, s25
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v15, s24 :: v_dual_mov_b32 v16, s25
 ; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v13, s26 :: v_dual_mov_b32 v14, s27
-; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v15, s28 :: v_dual_mov_b32 v16, s29
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v17, s28 :: v_dual_mov_b32 v18, s29
 ; GFX11-FAKE16-NEXT:    s_mov_b32 s0, 0
 ; GFX11-FAKE16-NEXT:    s_and_b32 s1, vcc_lo, exec_lo
 ; GFX11-FAKE16-NEXT:    s_cbranch_scc0 .LBB49_4
@@ -36710,12 +37282,12 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v53, 16, v2
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v54, 16, v1
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v55, 16, v0
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v64, 16, v16
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v65, 16, v15
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v64, 16, v18
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v65, 16, v17
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v66, 16, v14
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v67, 16, v13
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v68, 16, v18
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v69, 16, v17
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v68, 16, v16
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v69, 16, v15
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v70, 16, v12
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v10, 16, v11
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
@@ -36736,9 +37308,9 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX11-FAKE16-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
-; GFX11-FAKE16-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; GFX11-FAKE16-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; GFX11-FAKE16-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
@@ -36755,12 +37327,12 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v53, 16, v2
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v54, 16, v1
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v55, 16, v0
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v64, 16, v16
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v65, 16, v15
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v64, 16, v18
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v65, 16, v17
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v66, 16, v14
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v67, 16, v13
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v68, 16, v18
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v69, 16, v17
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v68, 16, v16
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v69, 16, v15
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v70, 16, v12
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v10, 16, v11
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
@@ -36774,56 +37346,54 @@ define inreg <56 x i16> @bitcast_v14f64_to_v56i16_scalar(<14 x double> inreg %a,
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v31, 16, v28
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v30, 16, v27
 ; GFX11-FAKE16-NEXT:  .LBB49_3: ; %end
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v28, 0xffff, v28
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v22, 0xffff, v22
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v28, 0xffff, v28
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v19, 0xffff, v19
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v25, 0xffff, v25
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v11, 0xffff, v11
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v31, v31, 16, v28
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v15, 0xffff, v15
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v37, v37, 16, v22
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v20, 0xffff, v20
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v31, v31, 16, v28
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v28, v71, 16, v19
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v21, 0xffff, v21
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v17, 0xffff, v17
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v19, 0xffff, v14
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v29, v29, 16, v20
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v12, 0xffff, v12
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v25, 0xffff, v25
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v36, v36, 16, v21
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v23, 0xffff, v23
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v10, v10, 16, v11
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v19, 0xffff, v14
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v22, v51, 16, v4
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v9, v29 :: v_dual_and_b32 v4, 0xffff, v9
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v11, v70, 16, v12
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v12, v69, 16, v15
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v15, 0xffff, v16
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v27, 0xffff, v27
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v32, v32, 16, v25
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v10, v10, 16, v11
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v20, 0xffff, v15
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v21, 0xffff, v16
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v15, v66, 16, v19
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v16, 0xffff, v13
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v13, v68, 16, v15
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v15, v66, 16, v19
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v19, v54, 16, v1
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v22, v51, 16, v4
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v6
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v9
-; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v6, v36
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v6, v36 :: v_dual_and_b32 v1, 0xffff, v6
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v34, v34, 16, v23
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v25, 0xffff, v26
-; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v9, v29
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v11, v70, 16, v12
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v12, v69, 16, v17
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v17, 0xffff, v18
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v30, v30, 16, v27
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v18, 0xffff, v13
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v17, 0xffff, v17
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v18, 0xffff, v18
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v13, v68, 16, v17
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v17, v64, 16, v21
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v21, v52, 16, v3
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v27, v38, 16, v4
 ; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, v34
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v33, v33, 16, v25
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v24, 0xffff, v24
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v14, v67, 16, v18
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v16, v65, 16, v20
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v14, v67, 16, v16
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v16, v65, 16, v17
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v17, v64, 16, v18
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v18, v55, 16, v0
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v20, v53, 16, v2
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v5
@@ -37352,7 +37922,7 @@ define <14 x double> @bitcast_v56i16_to_v14f64(<56 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v23, vcc, s6, v23
 ; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, s6, v25
-; SI-NEXT:    v_add_i32_e32 v26, vcc, s6, v26
+; SI-NEXT:    v_add_i32_e32 v26, vcc, 0x30000, v26
 ; SI-NEXT:    v_add_i32_e32 v27, vcc, 0x30000, v27
 ; SI-NEXT:  .LBB50_4: ; %end
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -40598,21 +41168,21 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v15
-; SI-NEXT:    v_readfirstlane_b32 s40, v1
-; SI-NEXT:    v_readfirstlane_b32 s41, v2
-; SI-NEXT:    v_readfirstlane_b32 s14, v3
-; SI-NEXT:    v_readfirstlane_b32 s15, v4
-; SI-NEXT:    v_readfirstlane_b32 s12, v5
-; SI-NEXT:    v_readfirstlane_b32 s13, v6
-; SI-NEXT:    v_readfirstlane_b32 s10, v7
-; SI-NEXT:    v_readfirstlane_b32 s11, v8
-; SI-NEXT:    v_readfirstlane_b32 s8, v9
-; SI-NEXT:    v_readfirstlane_b32 s9, v10
-; SI-NEXT:    v_readfirstlane_b32 s6, v11
-; SI-NEXT:    v_readfirstlane_b32 s7, v12
-; SI-NEXT:    v_readfirstlane_b32 s4, v13
-; SI-NEXT:    s_and_b64 s[42:43], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s5, v14
+; SI-NEXT:    v_mov_b32_e32 v25, s16
+; SI-NEXT:    v_mov_b32_e32 v26, s17
+; SI-NEXT:    v_mov_b32_e32 v21, s18
+; SI-NEXT:    v_mov_b32_e32 v22, s19
+; SI-NEXT:    v_mov_b32_e32 v27, s20
+; SI-NEXT:    v_mov_b32_e32 v28, s21
+; SI-NEXT:    v_mov_b32_e32 v23, s22
+; SI-NEXT:    v_mov_b32_e32 v24, s23
+; SI-NEXT:    v_mov_b32_e32 v19, s24
+; SI-NEXT:    v_mov_b32_e32 v20, s25
+; SI-NEXT:    v_mov_b32_e32 v17, s26
+; SI-NEXT:    v_mov_b32_e32 v18, s27
+; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
+; SI-NEXT:    v_mov_b32_e32 v15, s28
+; SI-NEXT:    v_mov_b32_e32 v16, s29
 ; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
@@ -40631,401 +41201,502 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_cbranch_scc0 .LBB53_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s42, s5, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s42
-; SI-NEXT:    s_lshr_b32 s42, s4, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s42
-; SI-NEXT:    s_lshr_b32 s42, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s42
-; SI-NEXT:    s_lshr_b32 s42, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s42
-; SI-NEXT:    s_lshr_b32 s42, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s42
-; SI-NEXT:    s_lshr_b32 s42, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s42
-; SI-NEXT:    s_lshr_b32 s42, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s42
-; SI-NEXT:    s_lshr_b32 s42, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s42
-; SI-NEXT:    s_lshr_b32 s42, s13, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s42
-; SI-NEXT:    s_lshr_b32 s42, s12, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s42
-; SI-NEXT:    s_lshr_b32 s42, s15, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s42
-; SI-NEXT:    s_lshr_b32 s42, s14, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s42
-; SI-NEXT:    s_lshr_b32 s42, s41, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s42
-; SI-NEXT:    s_lshr_b32 s42, s40, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s42
-; SI-NEXT:    s_lshr_b32 s42, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s42
-; SI-NEXT:    s_lshr_b32 s42, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s42
-; SI-NEXT:    s_lshr_b32 s42, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s42
-; SI-NEXT:    s_lshr_b32 s42, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s42
-; SI-NEXT:    s_lshr_b32 s42, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s42
-; SI-NEXT:    s_lshr_b32 s42, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s42
-; SI-NEXT:    s_lshr_b32 s42, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s42
-; SI-NEXT:    s_lshr_b32 s42, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s42
-; SI-NEXT:    s_lshr_b32 s42, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s42
-; SI-NEXT:    s_lshr_b32 s42, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s42
-; SI-NEXT:    s_lshr_b32 s42, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s42
-; SI-NEXT:    s_lshr_b32 s42, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s42
-; SI-NEXT:    s_lshr_b32 s42, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, s42
-; SI-NEXT:    s_lshr_b32 s42, s16, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s5
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
-; SI-NEXT:    s_waitcnt expcnt(6)
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s9
-; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_cvt_f32_f16_e32 v58, s8
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, s11
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, s10
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v13
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v29
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v10
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v29
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v7
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v13
+; SI-NEXT:    buffer_store_dword v29, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v5
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v11
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v2
+; SI-NEXT:    buffer_store_dword v29, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v1
+; SI-NEXT:    buffer_store_dword v29, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v23
+; SI-NEXT:    buffer_store_dword v29, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v2
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v27
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v18
+; SI-NEXT:    buffer_store_dword v29, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:132 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v24
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, v14
+; SI-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v25
 ; SI-NEXT:    s_cbranch_execnz .LBB53_3
 ; SI-NEXT:  .LBB53_2: ; %cmp.true
-; SI-NEXT:    v_add_f64 v[1:2], s[16:17], 1.0
-; SI-NEXT:    v_add_f64 v[42:43], s[18:19], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
-; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v42
-; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v43
-; SI-NEXT:    v_add_f64 v[22:23], s[14:15], 1.0
-; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_f64 v[3:4], s[4:5], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
-; SI-NEXT:    v_add_f64 v[18:19], s[12:13], 1.0
-; SI-NEXT:    v_add_f64 v[7:8], s[6:7], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v18
-; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v43
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, v42
-; SI-NEXT:    v_add_f64 v[49:50], s[22:23], 1.0
-; SI-NEXT:    v_add_f64 v[37:38], s[24:25], 1.0
-; SI-NEXT:    v_add_f64 v[15:16], s[10:11], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v49
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v37
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v38
-; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, v15
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v39
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, v44
-; SI-NEXT:    v_add_f64 v[53:54], s[20:21], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v7
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v54
-; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, v46
-; SI-NEXT:    v_add_f64 v[35:36], s[26:27], 1.0
-; SI-NEXT:    v_add_f64 v[30:31], s[28:29], 1.0
-; SI-NEXT:    v_add_f64 v[26:27], s[40:41], 1.0
-; SI-NEXT:    v_add_f64 v[11:12], s[8:9], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v50
-; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v35
-; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v36
-; SI-NEXT:    v_lshrrev_b32_e32 v62, 16, v30
-; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v31
-; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v26
-; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v27
-; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v23
-; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v19
-; SI-NEXT:    v_lshrrev_b32_e32 v10, 16, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v14, 16, v11
-; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v58, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v36
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v35
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v49
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SI-NEXT:    v_add_f64 v[1:2], v[1:2], 1.0
+; SI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v1
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, v25
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v10
+; SI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; SI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v2
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SI-NEXT:    v_add_f64 v[5:6], v[5:6], 1.0
+; SI-NEXT:    v_add_f64 v[9:10], v[9:10], 1.0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v6
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v57
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v10
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:132 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v47
+; SI-NEXT:    v_add_f64 v[3:4], v[3:4], 1.0
+; SI-NEXT:    v_add_f64 v[25:26], v[25:26], 1.0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v4
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v45
+; SI-NEXT:    v_add_f64 v[53:54], v[21:22], 1.0
+; SI-NEXT:    v_add_f64 v[27:28], v[27:28], 1.0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v29
+; SI-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
+; SI-NEXT:    v_add_f64 v[7:8], v[7:8], 1.0
+; SI-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
+; SI-NEXT:    v_mov_b32_e32 v45, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v43
+; SI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v22, 16, v26
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v53
+; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v54
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v28
+; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v23
+; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v62, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, v14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, v13
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v9
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v24
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v63
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v62
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v33
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v62
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v60
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v59
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v63
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v44
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v61
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v30
 ; SI-NEXT:    v_cvt_f32_f16_e32 v32, v32
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v61
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, v55
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, v56
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v21
+; SI-NEXT:    v_mov_b32_e32 v29, v14
+; SI-NEXT:    v_mov_b32_e32 v57, v11
+; SI-NEXT:    v_mov_b32_e32 v47, v12
+; SI-NEXT:    v_mov_b32_e32 v43, v13
+; SI-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
 ; SI-NEXT:  .LBB53_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v56
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v1
-; SI-NEXT:    v_cvt_f16_f32_e32 v9, v46
-; SI-NEXT:    v_cvt_f16_f32_e32 v14, v2
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v9
-; SI-NEXT:    buffer_store_dword v5, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 4, v0
-; SI-NEXT:    v_or_b32_e32 v6, v14, v6
-; SI-NEXT:    buffer_store_dword v6, v5, s[0:3], 0 offen
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v44
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v41
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v51
+; SI-NEXT:    v_cvt_f16_f32_e32 v4, v40
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v43
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 8, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
+; SI-NEXT:    v_or_b32_e32 v2, v4, v2
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v42
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v18
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 12, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v55
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v55
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v7
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 16, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v38
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v54
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v53
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v54
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 20, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v16
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 24, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v50
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 28, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v15
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 32, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v38
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 36, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v36
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 40, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v3
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v12
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v31
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v11
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v27
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v4, v4, v5
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v20
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v23
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v33
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v8
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v19
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x4c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v13
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v60
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x50, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v10
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v59
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v58
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x54, v0
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 0x58, v0
-; SI-NEXT:    v_or_b32_e32 v2, v3, v2
-; SI-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v17
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v40
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 0x5c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; SI-NEXT:    v_or_b32_e32 v2, v3, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v25
-; SI-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v36
 ; SI-NEXT:    v_cvt_f16_f32_e32 v2, v52
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v34
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v50
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v32
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v49
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v30
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v39
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:144 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v63
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:140 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v61
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:136 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v58
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:132 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v56
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:128 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v46
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:124 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v44
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v42
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:116 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v59
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v60
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x54, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v62
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x58, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v45
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x5c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v31
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v57
 ; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x60, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v47
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v57
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v33
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v47
 ; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x64, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v45
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v34
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v35
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v43
 ; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x68, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v41
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v21
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v37
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x6c, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
@@ -41049,70 +41720,91 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB53_4:
-; SI-NEXT:    ; implicit-def: $vgpr1
-; SI-NEXT:    ; implicit-def: $vgpr56
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr46
-; SI-NEXT:    ; implicit-def: $vgpr43
-; SI-NEXT:    ; implicit-def: $vgpr44
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr42
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr55
-; SI-NEXT:    ; implicit-def: $vgpr54
-; SI-NEXT:    ; implicit-def: $vgpr53
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr51
-; SI-NEXT:    ; implicit-def: $vgpr50
-; SI-NEXT:    ; implicit-def: $vgpr49
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr39
-; SI-NEXT:    ; implicit-def: $vgpr38
-; SI-NEXT:    ; implicit-def: $vgpr37
-; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr35
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr30
-; SI-NEXT:    ; implicit-def: $vgpr31
-; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr26
-; SI-NEXT:    ; implicit-def: $vgpr27
-; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr23
-; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr8
-; SI-NEXT:    ; implicit-def: $vgpr33
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr60
-; SI-NEXT:    ; implicit-def: $vgpr13
-; SI-NEXT:    ; implicit-def: $vgpr59
-; SI-NEXT:    ; implicit-def: $vgpr10
-; SI-NEXT:    ; implicit-def: $vgpr58
 ; SI-NEXT:    ; implicit-def: $vgpr29
-; SI-NEXT:    ; implicit-def: $vgpr40
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr52
-; SI-NEXT:    ; implicit-def: $vgpr25
-; SI-NEXT:    ; implicit-def: $vgpr57
-; SI-NEXT:    ; implicit-def: $vgpr47
-; SI-NEXT:    ; implicit-def: $vgpr34
-; SI-NEXT:    ; implicit-def: $vgpr45
-; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
 ; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr48
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr36
+; SI-NEXT:    ; implicit-def: $vgpr50
+; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; implicit-def: $vgpr49
+; SI-NEXT:    ; implicit-def: $vgpr32
+; SI-NEXT:    ; implicit-def: $vgpr39
+; SI-NEXT:    ; implicit-def: $vgpr30
+; SI-NEXT:    ; implicit-def: $vgpr63
+; SI-NEXT:    ; implicit-def: $vgpr61
+; SI-NEXT:    ; implicit-def: $vgpr58
+; SI-NEXT:    ; implicit-def: $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr59
+; SI-NEXT:    ; implicit-def: $vgpr60
+; SI-NEXT:    ; implicit-def: $vgpr62
+; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr57
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; implicit-def: $vgpr43
+; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
+; SI-NEXT:    ; kill: killed $vgpr29
+; SI-NEXT:    ; implicit-def: $vgpr29
 ; SI-NEXT:    s_branch .LBB53_2
 ;
 ; VI-LABEL: bitcast_v14f64_to_v56f16_scalar:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; VI-NEXT:    v_mov_b32_e32 v19, s16
-; VI-NEXT:    v_mov_b32_e32 v20, s17
+; VI-NEXT:    v_mov_b32_e32 v17, s16
+; VI-NEXT:    v_mov_b32_e32 v18, s17
 ; VI-NEXT:    v_mov_b32_e32 v15, s18
 ; VI-NEXT:    v_mov_b32_e32 v16, s19
 ; VI-NEXT:    v_mov_b32_e32 v32, s20
@@ -41124,8 +41816,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; VI-NEXT:    v_mov_b32_e32 v21, s26
 ; VI-NEXT:    v_mov_b32_e32 v22, s27
 ; VI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; VI-NEXT:    v_mov_b32_e32 v17, s28
-; VI-NEXT:    v_mov_b32_e32 v18, s29
+; VI-NEXT:    v_mov_b32_e32 v19, s28
+; VI-NEXT:    v_mov_b32_e32 v20, s29
 ; VI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; VI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; VI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
@@ -41150,8 +41842,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v44, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v45, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v20
+; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v21
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v24
@@ -41162,8 +41854,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v47, 16, v32
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
 ; VI-NEXT:    v_lshrrev_b32_e32 v30, 16, v15
-; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
-; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v19
+; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
 ; VI-NEXT:    s_cbranch_execnz .LBB53_3
 ; VI-NEXT:  .LBB53_2: ; %cmp.true
 ; VI-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
@@ -41173,13 +41865,13 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; VI-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; VI-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; VI-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; VI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; VI-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; VI-NEXT:    v_add_f64 v[25:26], v[25:26], 1.0
 ; VI-NEXT:    v_add_f64 v[32:33], v[32:33], 1.0
 ; VI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
-; VI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; VI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; VI-NEXT:    v_lshrrev_b32_e32 v27, 16, v13
 ; VI-NEXT:    v_lshrrev_b32_e32 v50, 16, v12
 ; VI-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
@@ -41194,8 +41886,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v44, 16, v2
 ; VI-NEXT:    v_lshrrev_b32_e32 v45, 16, v1
 ; VI-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v18
-; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v17
+; VI-NEXT:    v_lshrrev_b32_e32 v49, 16, v20
+; VI-NEXT:    v_lshrrev_b32_e32 v48, 16, v19
 ; VI-NEXT:    v_lshrrev_b32_e32 v39, 16, v22
 ; VI-NEXT:    v_lshrrev_b32_e32 v38, 16, v21
 ; VI-NEXT:    v_lshrrev_b32_e32 v37, 16, v24
@@ -41206,15 +41898,15 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; VI-NEXT:    v_lshrrev_b32_e32 v47, 16, v32
 ; VI-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
 ; VI-NEXT:    v_lshrrev_b32_e32 v30, 16, v15
-; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
-; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v19
+; VI-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; VI-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
 ; VI-NEXT:  .LBB53_3: ; %end
 ; VI-NEXT:    v_lshlrev_b32_e32 v28, 16, v28
-; VI-NEXT:    v_or_b32_sdwa v28, v19, v28 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v29
-; VI-NEXT:    v_or_b32_sdwa v29, v20, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; VI-NEXT:    v_lshlrev_b32_e32 v19, 16, v30
-; VI-NEXT:    v_or_b32_sdwa v30, v15, v19 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v28, v17, v28 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v29
+; VI-NEXT:    v_or_b32_sdwa v29, v18, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_lshlrev_b32_e32 v17, 16, v30
+; VI-NEXT:    v_or_b32_sdwa v30, v15, v17 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v31
 ; VI-NEXT:    v_or_b32_sdwa v31, v16, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v47
@@ -41235,11 +41927,11 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; VI-NEXT:    v_or_b32_sdwa v39, v22, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v48
 ; VI-NEXT:    v_lshlrev_b32_e32 v14, 16, v14
-; VI-NEXT:    v_or_b32_sdwa v48, v17, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v48, v19, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v15, 16, v49
 ; VI-NEXT:    v_or_b32_sdwa v14, v0, v14 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v45
-; VI-NEXT:    v_or_b32_sdwa v49, v18, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; VI-NEXT:    v_or_b32_sdwa v49, v20, v15 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_or_b32_sdwa v15, v1, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; VI-NEXT:    v_lshlrev_b32_e32 v0, 16, v44
 ; VI-NEXT:    v_or_b32_sdwa v16, v2, v0 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -41324,8 +42016,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; GFX9-NEXT:    v_mov_b32_e32 v19, s16
-; GFX9-NEXT:    v_mov_b32_e32 v20, s17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s16
+; GFX9-NEXT:    v_mov_b32_e32 v18, s17
 ; GFX9-NEXT:    v_mov_b32_e32 v15, s18
 ; GFX9-NEXT:    v_mov_b32_e32 v16, s19
 ; GFX9-NEXT:    v_mov_b32_e32 v32, s20
@@ -41337,8 +42029,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX9-NEXT:    v_mov_b32_e32 v21, s26
 ; GFX9-NEXT:    v_mov_b32_e32 v22, s27
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX9-NEXT:    v_mov_b32_e32 v17, s28
-; GFX9-NEXT:    v_mov_b32_e32 v18, s29
+; GFX9-NEXT:    v_mov_b32_e32 v19, s28
+; GFX9-NEXT:    v_mov_b32_e32 v20, s29
 ; GFX9-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
 ; GFX9-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; GFX9-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
@@ -41363,8 +42055,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v44, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v45, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v20
+; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v21
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v24
@@ -41375,8 +42067,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v47, 16, v32
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
-; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v19
+; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
 ; GFX9-NEXT:    s_cbranch_execnz .LBB53_3
 ; GFX9-NEXT:  .LBB53_2: ; %cmp.true
 ; GFX9-NEXT:    v_add_f64 v[12:13], v[12:13], 1.0
@@ -41386,13 +42078,13 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX9-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; GFX9-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
 ; GFX9-NEXT:    v_add_f64 v[23:24], v[23:24], 1.0
 ; GFX9-NEXT:    v_add_f64 v[25:26], v[25:26], 1.0
 ; GFX9-NEXT:    v_add_f64 v[32:33], v[32:33], 1.0
 ; GFX9-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
-; GFX9-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; GFX9-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v27, 16, v13
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v50, 16, v12
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v51, 16, v11
@@ -41407,8 +42099,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v44, 16, v2
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v45, 16, v1
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v17
+; GFX9-NEXT:    v_lshrrev_b32_e32 v49, 16, v20
+; GFX9-NEXT:    v_lshrrev_b32_e32 v48, 16, v19
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v39, 16, v22
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v38, 16, v21
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v37, 16, v24
@@ -41419,8 +42111,8 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v47, 16, v32
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v30, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
-; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v19
+; GFX9-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
+; GFX9-NEXT:    v_lshrrev_b32_e32 v28, 16, v17
 ; GFX9-NEXT:  .LBB53_3: ; %end
 ; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v30, v30, 16, v15
@@ -41442,25 +42134,25 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX9-NEXT:    v_lshl_or_b32 v38, v38, 16, v15
 ; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v22
 ; GFX9-NEXT:    v_lshl_or_b32 v39, v39, 16, v15
-; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v17
+; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v19
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    v_lshl_or_b32 v48, v48, 16, v15
-; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v18
+; GFX9-NEXT:    v_and_b32_e32 v15, 0xffff, v20
 ; GFX9-NEXT:    v_lshl_or_b32 v14, v14, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v1
+; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v49, v49, 16, v15
 ; GFX9-NEXT:    v_lshl_or_b32 v15, v45, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v2
+; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v17
+; GFX9-NEXT:    v_and_b32_e32 v17, 0xffff, v18
 ; GFX9-NEXT:    v_lshl_or_b32 v16, v44, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v3
-; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v19
+; GFX9-NEXT:    v_lshl_or_b32 v29, v29, 16, v17
 ; GFX9-NEXT:    v_lshl_or_b32 v17, v43, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v4
-; GFX9-NEXT:    v_lshl_or_b32 v28, v28, 16, v19
-; GFX9-NEXT:    v_and_b32_e32 v19, 0xffff, v20
 ; GFX9-NEXT:    v_lshl_or_b32 v18, v42, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v5
-; GFX9-NEXT:    v_lshl_or_b32 v29, v29, 16, v19
 ; GFX9-NEXT:    v_lshl_or_b32 v19, v41, 16, v0
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v6
 ; GFX9-NEXT:    v_lshl_or_b32 v20, v40, 16, v0
@@ -41716,9 +42408,9 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v21, s18 :: v_dual_mov_b32 v22, s19
 ; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v19, s20 :: v_dual_mov_b32 v20, s21
 ; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v11, s22 :: v_dual_mov_b32 v12, s23
-; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v17, s24 :: v_dual_mov_b32 v18, s25
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v15, s24 :: v_dual_mov_b32 v16, s25
 ; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v13, s26 :: v_dual_mov_b32 v14, s27
-; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v15, s28 :: v_dual_mov_b32 v16, s29
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v17, s28 :: v_dual_mov_b32 v18, s29
 ; GFX11-FAKE16-NEXT:    s_mov_b32 s0, 0
 ; GFX11-FAKE16-NEXT:    s_and_b32 s1, vcc_lo, exec_lo
 ; GFX11-FAKE16-NEXT:    s_cbranch_scc0 .LBB53_4
@@ -41733,12 +42425,12 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v53, 16, v2
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v54, 16, v1
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v55, 16, v0
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v64, 16, v16
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v65, 16, v15
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v64, 16, v18
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v65, 16, v17
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v66, 16, v14
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v67, 16, v13
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v68, 16, v18
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v69, 16, v17
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v68, 16, v16
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v69, 16, v15
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v70, 16, v12
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v10, 16, v11
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
@@ -41759,9 +42451,9 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[4:5], v[4:5], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX11-FAKE16-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
-; GFX11-FAKE16-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
+; GFX11-FAKE16-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; GFX11-FAKE16-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
 ; GFX11-FAKE16-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
@@ -41778,12 +42470,12 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v53, 16, v2
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v54, 16, v1
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v55, 16, v0
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v64, 16, v16
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v65, 16, v15
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v64, 16, v18
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v65, 16, v17
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v66, 16, v14
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v67, 16, v13
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v68, 16, v18
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v69, 16, v17
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v68, 16, v16
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v69, 16, v15
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v70, 16, v12
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v10, 16, v11
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v29, 16, v20
@@ -41797,56 +42489,54 @@ define inreg <56 x half> @bitcast_v14f64_to_v56f16_scalar(<14 x double> inreg %a
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v31, 16, v28
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v30, 16, v27
 ; GFX11-FAKE16-NEXT:  .LBB53_3: ; %end
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v28, 0xffff, v28
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v22, 0xffff, v22
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v28, 0xffff, v28
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v19, 0xffff, v19
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v25, 0xffff, v25
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v11, 0xffff, v11
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v31, v31, 16, v28
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v15, 0xffff, v15
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v37, v37, 16, v22
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v20, 0xffff, v20
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v31, v31, 16, v28
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v28, v71, 16, v19
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v21, 0xffff, v21
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v17, 0xffff, v17
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v19, 0xffff, v14
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v29, v29, 16, v20
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v12, 0xffff, v12
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v25, 0xffff, v25
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v36, v36, 16, v21
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v23, 0xffff, v23
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v10, v10, 16, v11
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v19, 0xffff, v14
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v22, v51, 16, v4
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v9, v29 :: v_dual_and_b32 v4, 0xffff, v9
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v11, v70, 16, v12
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v12, v69, 16, v15
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v15, 0xffff, v16
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v27, 0xffff, v27
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v32, v32, 16, v25
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v10, v10, 16, v11
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v20, 0xffff, v15
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v21, 0xffff, v16
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v15, v66, 16, v19
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v16, 0xffff, v13
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v13, v68, 16, v15
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v15, v66, 16, v19
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v19, v54, 16, v1
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v22, v51, 16, v4
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v6
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v4, 0xffff, v9
-; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v6, v36
+; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v6, v36 :: v_dual_and_b32 v1, 0xffff, v6
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v34, v34, 16, v23
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v25, 0xffff, v26
-; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v9, v29
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v11, v70, 16, v12
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v12, v69, 16, v17
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v17, 0xffff, v18
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v30, v30, 16, v27
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v18, 0xffff, v13
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v17, 0xffff, v17
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v18, 0xffff, v18
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xffff, v2
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v13, v68, 16, v17
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v17, v64, 16, v21
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v21, v52, 16, v3
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v8
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v27, v38, 16, v4
 ; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v4, v34
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v33, v33, 16, v25
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v24, 0xffff, v24
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v14, v67, 16, v18
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v16, v65, 16, v20
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v14, v67, 16, v16
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v16, v65, 16, v17
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v17, v64, 16, v18
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v18, v55, 16, v0
 ; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v20, v53, 16, v2
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v5

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.960bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.960bit.ll
@@ -3848,30 +3848,58 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_store_dword v18, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_writelane_b32 v18, s30, 0
-; SI-NEXT:    v_writelane_b32 v18, s31, 1
-; SI-NEXT:    v_writelane_b32 v18, s34, 2
-; SI-NEXT:    v_writelane_b32 v18, s35, 3
-; SI-NEXT:    v_writelane_b32 v18, s36, 4
-; SI-NEXT:    v_writelane_b32 v18, s37, 5
-; SI-NEXT:    v_writelane_b32 v18, s38, 6
-; SI-NEXT:    v_writelane_b32 v18, s39, 7
-; SI-NEXT:    v_writelane_b32 v18, s48, 8
-; SI-NEXT:    v_writelane_b32 v18, s49, 9
-; SI-NEXT:    v_writelane_b32 v18, s50, 10
-; SI-NEXT:    v_writelane_b32 v18, s51, 11
-; SI-NEXT:    v_writelane_b32 v18, s52, 12
-; SI-NEXT:    v_writelane_b32 v18, s53, 13
-; SI-NEXT:    v_writelane_b32 v18, s54, 14
+; SI-NEXT:    v_writelane_b32 v20, s30, 0
+; SI-NEXT:    v_writelane_b32 v20, s31, 1
+; SI-NEXT:    v_writelane_b32 v20, s34, 2
+; SI-NEXT:    v_writelane_b32 v20, s35, 3
+; SI-NEXT:    v_writelane_b32 v20, s36, 4
+; SI-NEXT:    v_writelane_b32 v20, s37, 5
+; SI-NEXT:    v_writelane_b32 v20, s38, 6
+; SI-NEXT:    v_writelane_b32 v20, s39, 7
+; SI-NEXT:    v_writelane_b32 v20, s48, 8
+; SI-NEXT:    v_mov_b32_e32 v18, s16
+; SI-NEXT:    v_mov_b32_e32 v19, s17
+; SI-NEXT:    v_writelane_b32 v20, s49, 9
+; SI-NEXT:    v_readfirstlane_b32 s46, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s18
+; SI-NEXT:    v_readfirstlane_b32 s47, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s19
+; SI-NEXT:    v_writelane_b32 v20, s50, 10
+; SI-NEXT:    v_readfirstlane_b32 s44, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s20
+; SI-NEXT:    v_readfirstlane_b32 s45, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s21
+; SI-NEXT:    v_writelane_b32 v20, s51, 11
+; SI-NEXT:    v_readfirstlane_b32 s42, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_readfirstlane_b32 s43, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_writelane_b32 v20, s52, 12
+; SI-NEXT:    v_readfirstlane_b32 s40, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s24
+; SI-NEXT:    v_readfirstlane_b32 s41, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s25
+; SI-NEXT:    v_writelane_b32 v20, s53, 13
+; SI-NEXT:    v_readfirstlane_b32 s24, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_writelane_b32 v20, s54, 14
+; SI-NEXT:    v_readfirstlane_b32 s22, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
-; SI-NEXT:    v_writelane_b32 v18, s55, 15
-; SI-NEXT:    v_readfirstlane_b32 s42, v1
-; SI-NEXT:    v_readfirstlane_b32 s43, v2
-; SI-NEXT:    v_readfirstlane_b32 s40, v3
-; SI-NEXT:    v_readfirstlane_b32 s41, v4
+; SI-NEXT:    v_writelane_b32 v20, s55, 15
+; SI-NEXT:    v_readfirstlane_b32 s20, v18
+; SI-NEXT:    v_readfirstlane_b32 s21, v19
+; SI-NEXT:    v_readfirstlane_b32 s18, v1
+; SI-NEXT:    v_readfirstlane_b32 s19, v2
+; SI-NEXT:    v_readfirstlane_b32 s16, v3
+; SI-NEXT:    v_readfirstlane_b32 s17, v4
 ; SI-NEXT:    v_readfirstlane_b32 s14, v5
 ; SI-NEXT:    v_readfirstlane_b32 s15, v6
 ; SI-NEXT:    v_readfirstlane_b32 s12, v7
@@ -3883,9 +3911,9 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v13
 ; SI-NEXT:    v_readfirstlane_b32 s7, v14
 ; SI-NEXT:    v_readfirstlane_b32 s4, v15
-; SI-NEXT:    s_and_b64 s[44:45], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v16
-; SI-NEXT:    v_writelane_b32 v18, s64, 16
+; SI-NEXT:    v_writelane_b32 v20, s64, 16
 ; SI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s34, s5, 16
@@ -3894,50 +3922,50 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s37, s11, 16
 ; SI-NEXT:    s_lshr_b32 s38, s13, 16
 ; SI-NEXT:    s_lshr_b32 s39, s15, 16
-; SI-NEXT:    s_lshr_b32 s48, s41, 16
-; SI-NEXT:    s_lshr_b32 s49, s43, 16
-; SI-NEXT:    s_lshr_b32 s50, s29, 16
-; SI-NEXT:    s_lshr_b32 s51, s27, 16
+; SI-NEXT:    s_lshr_b32 s48, s17, 16
+; SI-NEXT:    s_lshr_b32 s49, s19, 16
+; SI-NEXT:    s_lshr_b32 s50, s21, 16
+; SI-NEXT:    s_lshr_b32 s51, s23, 16
 ; SI-NEXT:    s_lshr_b32 s52, s25, 16
-; SI-NEXT:    s_lshr_b32 s53, s23, 16
-; SI-NEXT:    s_lshr_b32 s54, s21, 16
-; SI-NEXT:    s_lshr_b32 s55, s19, 16
-; SI-NEXT:    s_lshr_b32 s64, s17, 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s53, s41, 16
+; SI-NEXT:    s_lshr_b32 s54, s43, 16
+; SI-NEXT:    s_lshr_b32 s55, s45, 16
+; SI-NEXT:    s_lshr_b32 s64, s47, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[62:63], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[40:41], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[42:43], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[26:27], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[22:23], 16
 ; SI-NEXT:    s_lshr_b64 s[88:89], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[90:91], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[92:93], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[94:95], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[30:31], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[90:91], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[92:93], s[42:43], 16
+; SI-NEXT:    s_lshr_b64 s[94:95], s[44:45], 16
+; SI-NEXT:    s_lshr_b64 s[30:31], s[46:47], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB13_3
 ; SI-NEXT:  .LBB13_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s23, s23, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
-; SI-NEXT:    s_add_i32 s25, s25, 3
-; SI-NEXT:    s_add_i32 s24, s24, 3
-; SI-NEXT:    s_add_i32 s27, s27, 3
-; SI-NEXT:    s_add_i32 s26, s26, 3
-; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s28, s28, 3
+; SI-NEXT:    s_add_i32 s47, s47, 3
+; SI-NEXT:    s_add_i32 s46, s46, 3
+; SI-NEXT:    s_add_i32 s45, s45, 3
+; SI-NEXT:    s_add_i32 s44, s44, 3
 ; SI-NEXT:    s_add_i32 s43, s43, 3
 ; SI-NEXT:    s_add_i32 s42, s42, 3
 ; SI-NEXT:    s_add_i32 s41, s41, 3
 ; SI-NEXT:    s_add_i32 s40, s40, 3
+; SI-NEXT:    s_add_i32 s25, s25, 3
+; SI-NEXT:    s_add_i32 s24, s24, 3
+; SI-NEXT:    s_add_i32 s23, s23, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
 ; SI-NEXT:    s_add_i32 s15, s15, 3
 ; SI-NEXT:    s_add_i32 s14, s14, 3
 ; SI-NEXT:    s_add_i32 s13, s13, 3
@@ -3950,149 +3978,149 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s5, s5, 3
 ; SI-NEXT:    s_add_i32 s4, s4, 3
-; SI-NEXT:    s_lshr_b64 s[44:45], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[6:7], 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[62:63], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[40:41], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[42:43], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[18:19], 16
 ; SI-NEXT:    s_lshr_b32 s34, s5, 16
 ; SI-NEXT:    s_lshr_b32 s35, s7, 16
 ; SI-NEXT:    s_lshr_b32 s36, s9, 16
 ; SI-NEXT:    s_lshr_b32 s37, s11, 16
 ; SI-NEXT:    s_lshr_b32 s38, s13, 16
 ; SI-NEXT:    s_lshr_b32 s39, s15, 16
-; SI-NEXT:    s_lshr_b32 s48, s41, 16
-; SI-NEXT:    s_lshr_b32 s49, s43, 16
-; SI-NEXT:    s_lshr_b32 s50, s29, 16
-; SI-NEXT:    s_lshr_b32 s51, s27, 16
+; SI-NEXT:    s_lshr_b32 s48, s17, 16
+; SI-NEXT:    s_lshr_b32 s49, s19, 16
+; SI-NEXT:    s_lshr_b32 s50, s21, 16
+; SI-NEXT:    s_lshr_b32 s51, s23, 16
 ; SI-NEXT:    s_lshr_b32 s52, s25, 16
-; SI-NEXT:    s_lshr_b32 s53, s23, 16
-; SI-NEXT:    s_lshr_b32 s54, s21, 16
-; SI-NEXT:    s_lshr_b32 s55, s19, 16
-; SI-NEXT:    s_lshr_b32 s64, s17, 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[26:27], 16
+; SI-NEXT:    s_lshr_b32 s53, s41, 16
+; SI-NEXT:    s_lshr_b32 s54, s43, 16
+; SI-NEXT:    s_lshr_b32 s55, s45, 16
+; SI-NEXT:    s_lshr_b32 s64, s47, 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[22:23], 16
 ; SI-NEXT:    s_lshr_b64 s[88:89], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[90:91], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[92:93], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[94:95], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[30:31], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[90:91], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[92:93], s[42:43], 16
+; SI-NEXT:    s_lshr_b64 s[94:95], s[44:45], 16
+; SI-NEXT:    s_lshr_b64 s[30:31], s[46:47], 16
 ; SI-NEXT:  .LBB13_3: ; %end
-; SI-NEXT:    s_lshl_b32 s45, s30, 16
-; SI-NEXT:    s_and_b32 s16, s16, 0xffff
-; SI-NEXT:    s_or_b32 s16, s16, s45
-; SI-NEXT:    v_mov_b32_e32 v1, s16
-; SI-NEXT:    s_and_b32 s16, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s64, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_lshl_b32 s16, s94, 16
-; SI-NEXT:    s_and_b32 s17, s18, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
-; SI-NEXT:    v_mov_b32_e32 v3, s16
-; SI-NEXT:    s_and_b32 s16, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s55, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v4, s16
-; SI-NEXT:    s_lshl_b32 s16, s92, 16
-; SI-NEXT:    s_and_b32 s17, s20, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
-; SI-NEXT:    v_mov_b32_e32 v5, s16
-; SI-NEXT:    s_and_b32 s16, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s54, 16
+; SI-NEXT:    s_lshl_b32 s27, s30, 16
+; SI-NEXT:    s_and_b32 s29, s46, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s27
+; SI-NEXT:    s_and_b32 s27, s47, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s64, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_lshl_b32 s27, s94, 16
+; SI-NEXT:    s_and_b32 s29, s44, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v3, s27
+; SI-NEXT:    s_and_b32 s27, s45, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s55, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v4, s27
+; SI-NEXT:    s_lshl_b32 s27, s92, 16
+; SI-NEXT:    s_and_b32 s29, s42, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v5, s27
+; SI-NEXT:    s_and_b32 s27, s43, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s54, 16
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s27, s27, s29
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    v_mov_b32_e32 v6, s16
+; SI-NEXT:    v_mov_b32_e32 v6, s27
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_lshl_b32 s16, s90, 16
-; SI-NEXT:    s_and_b32 s17, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s90, 16
+; SI-NEXT:    s_and_b32 s29, s40, 0xffff
 ; SI-NEXT:    buffer_store_dword v4, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s16, s17, s16
+; SI-NEXT:    s_or_b32 s27, s29, s27
 ; SI-NEXT:    buffer_store_dword v5, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
 ; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s53, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_and_b32 s27, s41, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s53, 16
 ; SI-NEXT:    buffer_store_dword v6, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s27, s27, s29
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s88, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s88, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s27
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s52, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
+; SI-NEXT:    s_lshl_b32 s25, s52, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s25
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s78, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s24, s78, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s24
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s27, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s51, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s51, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s23
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s76, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s22, s76, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s50, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s50, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s42, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s74, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s74, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s43, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s49, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s49, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 56, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s40, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s72, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 60, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s41, 0xffff
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
 ; SI-NEXT:    s_lshl_b32 s17, s48, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 64, v0
 ; SI-NEXT:    s_or_b32 s16, s16, s17
@@ -4156,7 +4184,7 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s46, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x64, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -4170,7 +4198,7 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s44, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x6c, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -4184,25 +4212,25 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x74, v0
 ; SI-NEXT:    v_mov_b32_e32 v1, s4
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    v_readlane_b32 s64, v18, 16
-; SI-NEXT:    v_readlane_b32 s55, v18, 15
-; SI-NEXT:    v_readlane_b32 s54, v18, 14
-; SI-NEXT:    v_readlane_b32 s53, v18, 13
-; SI-NEXT:    v_readlane_b32 s52, v18, 12
-; SI-NEXT:    v_readlane_b32 s51, v18, 11
-; SI-NEXT:    v_readlane_b32 s50, v18, 10
-; SI-NEXT:    v_readlane_b32 s49, v18, 9
-; SI-NEXT:    v_readlane_b32 s48, v18, 8
-; SI-NEXT:    v_readlane_b32 s39, v18, 7
-; SI-NEXT:    v_readlane_b32 s38, v18, 6
-; SI-NEXT:    v_readlane_b32 s37, v18, 5
-; SI-NEXT:    v_readlane_b32 s36, v18, 4
-; SI-NEXT:    v_readlane_b32 s35, v18, 3
-; SI-NEXT:    v_readlane_b32 s34, v18, 2
-; SI-NEXT:    v_readlane_b32 s31, v18, 1
-; SI-NEXT:    v_readlane_b32 s30, v18, 0
+; SI-NEXT:    v_readlane_b32 s64, v20, 16
+; SI-NEXT:    v_readlane_b32 s55, v20, 15
+; SI-NEXT:    v_readlane_b32 s54, v20, 14
+; SI-NEXT:    v_readlane_b32 s53, v20, 13
+; SI-NEXT:    v_readlane_b32 s52, v20, 12
+; SI-NEXT:    v_readlane_b32 s51, v20, 11
+; SI-NEXT:    v_readlane_b32 s50, v20, 10
+; SI-NEXT:    v_readlane_b32 s49, v20, 9
+; SI-NEXT:    v_readlane_b32 s48, v20, 8
+; SI-NEXT:    v_readlane_b32 s39, v20, 7
+; SI-NEXT:    v_readlane_b32 s38, v20, 6
+; SI-NEXT:    v_readlane_b32 s37, v20, 5
+; SI-NEXT:    v_readlane_b32 s36, v20, 4
+; SI-NEXT:    v_readlane_b32 s35, v20, 3
+; SI-NEXT:    v_readlane_b32 s34, v20, 2
+; SI-NEXT:    v_readlane_b32 s31, v20, 1
+; SI-NEXT:    v_readlane_b32 s30, v20, 0
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 ; 4-byte Folded Reload
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -4233,10 +4261,10 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr37
 ; SI-NEXT:    ; implicit-def: $sgpr56
 ; SI-NEXT:    ; implicit-def: $sgpr36
-; SI-NEXT:    ; implicit-def: $sgpr46
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr35
 ; SI-NEXT:    ; implicit-def: $sgpr34
-; SI-NEXT:    ; implicit-def: $sgpr44
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    s_branch .LBB13_2
 ;
 ; VI-LABEL: bitcast_v30i32_to_v60i16_scalar:
@@ -4247,18 +4275,46 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; VI-NEXT:    s_mov_b64 exec, s[4:5]
 ; VI-NEXT:    v_writelane_b32 v30, s30, 0
 ; VI-NEXT:    v_writelane_b32 v30, s31, 1
+; VI-NEXT:    v_mov_b32_e32 v17, s16
+; VI-NEXT:    v_mov_b32_e32 v18, s17
 ; VI-NEXT:    v_writelane_b32 v30, s34, 2
+; VI-NEXT:    v_mov_b32_e32 v19, s18
+; VI-NEXT:    v_readfirstlane_b32 s56, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s19
+; VI-NEXT:    v_readfirstlane_b32 s47, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s20
 ; VI-NEXT:    v_writelane_b32 v30, s35, 3
+; VI-NEXT:    v_readfirstlane_b32 s46, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s21
+; VI-NEXT:    v_readfirstlane_b32 s45, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s23
 ; VI-NEXT:    v_writelane_b32 v30, s36, 4
+; VI-NEXT:    v_readfirstlane_b32 s43, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s26
 ; VI-NEXT:    v_writelane_b32 v30, s37, 5
+; VI-NEXT:    v_readfirstlane_b32 s40, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v16
 ; VI-NEXT:    v_writelane_b32 v30, s38, 6
-; VI-NEXT:    v_readfirstlane_b32 s45, v0
-; VI-NEXT:    v_readfirstlane_b32 s44, v1
-; VI-NEXT:    v_readfirstlane_b32 s43, v2
-; VI-NEXT:    v_readfirstlane_b32 s42, v3
-; VI-NEXT:    v_readfirstlane_b32 s41, v4
-; VI-NEXT:    v_readfirstlane_b32 s40, v5
+; VI-NEXT:    v_readfirstlane_b32 s24, v19
+; VI-NEXT:    v_readfirstlane_b32 s23, v17
+; VI-NEXT:    v_readfirstlane_b32 s22, v18
+; VI-NEXT:    v_readfirstlane_b32 s21, v0
+; VI-NEXT:    v_readfirstlane_b32 s20, v1
+; VI-NEXT:    v_readfirstlane_b32 s19, v2
+; VI-NEXT:    v_readfirstlane_b32 s18, v3
+; VI-NEXT:    v_readfirstlane_b32 s17, v4
+; VI-NEXT:    v_readfirstlane_b32 s16, v5
 ; VI-NEXT:    v_readfirstlane_b32 s15, v6
 ; VI-NEXT:    v_readfirstlane_b32 s14, v7
 ; VI-NEXT:    v_readfirstlane_b32 s13, v8
@@ -4273,9 +4329,9 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; VI-NEXT:    v_writelane_b32 v30, s39, 7
 ; VI-NEXT:    s_cbranch_scc0 .LBB13_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s46, s7, 16
-; VI-NEXT:    s_lshr_b32 s47, s6, 16
-; VI-NEXT:    s_lshr_b32 s56, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s57, s9, 16
 ; VI-NEXT:    s_lshr_b32 s58, s10, 16
 ; VI-NEXT:    s_lshr_b32 s59, s11, 16
@@ -4283,26 +4339,26 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s61, s13, 16
 ; VI-NEXT:    s_lshr_b32 s62, s14, 16
 ; VI-NEXT:    s_lshr_b32 s63, s15, 16
-; VI-NEXT:    s_lshr_b32 s72, s40, 16
-; VI-NEXT:    s_lshr_b32 s73, s41, 16
-; VI-NEXT:    s_lshr_b32 s74, s42, 16
-; VI-NEXT:    s_lshr_b32 s75, s43, 16
-; VI-NEXT:    s_lshr_b32 s76, s44, 16
-; VI-NEXT:    s_lshr_b32 s77, s45, 16
-; VI-NEXT:    s_lshr_b32 s78, s29, 16
-; VI-NEXT:    s_lshr_b32 s79, s28, 16
-; VI-NEXT:    s_lshr_b32 s88, s27, 16
-; VI-NEXT:    s_lshr_b32 s89, s26, 16
-; VI-NEXT:    s_lshr_b32 s90, s25, 16
-; VI-NEXT:    s_lshr_b32 s91, s24, 16
-; VI-NEXT:    s_lshr_b32 s30, s23, 16
-; VI-NEXT:    s_lshr_b32 s31, s22, 16
-; VI-NEXT:    s_lshr_b32 s34, s21, 16
-; VI-NEXT:    s_lshr_b32 s35, s20, 16
-; VI-NEXT:    s_lshr_b32 s36, s19, 16
-; VI-NEXT:    s_lshr_b32 s37, s18, 16
-; VI-NEXT:    s_lshr_b32 s38, s17, 16
-; VI-NEXT:    s_lshr_b32 s39, s16, 16
+; VI-NEXT:    s_lshr_b32 s72, s16, 16
+; VI-NEXT:    s_lshr_b32 s73, s17, 16
+; VI-NEXT:    s_lshr_b32 s74, s18, 16
+; VI-NEXT:    s_lshr_b32 s75, s19, 16
+; VI-NEXT:    s_lshr_b32 s76, s20, 16
+; VI-NEXT:    s_lshr_b32 s77, s21, 16
+; VI-NEXT:    s_lshr_b32 s78, s22, 16
+; VI-NEXT:    s_lshr_b32 s79, s23, 16
+; VI-NEXT:    s_lshr_b32 s88, s24, 16
+; VI-NEXT:    s_lshr_b32 s89, s25, 16
+; VI-NEXT:    s_lshr_b32 s90, s26, 16
+; VI-NEXT:    s_lshr_b32 s91, s40, 16
+; VI-NEXT:    s_lshr_b32 s30, s41, 16
+; VI-NEXT:    s_lshr_b32 s31, s42, 16
+; VI-NEXT:    s_lshr_b32 s34, s43, 16
+; VI-NEXT:    s_lshr_b32 s35, s44, 16
+; VI-NEXT:    s_lshr_b32 s36, s45, 16
+; VI-NEXT:    s_lshr_b32 s37, s46, 16
+; VI-NEXT:    s_lshr_b32 s38, s47, 16
+; VI-NEXT:    s_lshr_b32 s39, s56, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB13_3
 ; VI-NEXT:  .LBB13_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -4315,29 +4371,29 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; VI-NEXT:    s_add_i32 s13, s13, 3
 ; VI-NEXT:    s_add_i32 s14, s14, 3
 ; VI-NEXT:    s_add_i32 s15, s15, 3
+; VI-NEXT:    s_add_i32 s16, s16, 3
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
 ; VI-NEXT:    s_add_i32 s40, s40, 3
 ; VI-NEXT:    s_add_i32 s41, s41, 3
 ; VI-NEXT:    s_add_i32 s42, s42, 3
 ; VI-NEXT:    s_add_i32 s43, s43, 3
 ; VI-NEXT:    s_add_i32 s44, s44, 3
 ; VI-NEXT:    s_add_i32 s45, s45, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
-; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s46, s7, 16
-; VI-NEXT:    s_lshr_b32 s47, s6, 16
-; VI-NEXT:    s_lshr_b32 s56, s8, 16
+; VI-NEXT:    s_add_i32 s46, s46, 3
+; VI-NEXT:    s_add_i32 s47, s47, 3
+; VI-NEXT:    s_add_i32 s56, s56, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s57, s9, 16
 ; VI-NEXT:    s_lshr_b32 s58, s10, 16
 ; VI-NEXT:    s_lshr_b32 s59, s11, 16
@@ -4345,137 +4401,137 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s61, s13, 16
 ; VI-NEXT:    s_lshr_b32 s62, s14, 16
 ; VI-NEXT:    s_lshr_b32 s63, s15, 16
-; VI-NEXT:    s_lshr_b32 s72, s40, 16
-; VI-NEXT:    s_lshr_b32 s73, s41, 16
-; VI-NEXT:    s_lshr_b32 s74, s42, 16
-; VI-NEXT:    s_lshr_b32 s75, s43, 16
-; VI-NEXT:    s_lshr_b32 s76, s44, 16
-; VI-NEXT:    s_lshr_b32 s77, s45, 16
-; VI-NEXT:    s_lshr_b32 s78, s29, 16
-; VI-NEXT:    s_lshr_b32 s79, s28, 16
-; VI-NEXT:    s_lshr_b32 s88, s27, 16
-; VI-NEXT:    s_lshr_b32 s89, s26, 16
-; VI-NEXT:    s_lshr_b32 s90, s25, 16
-; VI-NEXT:    s_lshr_b32 s91, s24, 16
-; VI-NEXT:    s_lshr_b32 s30, s23, 16
-; VI-NEXT:    s_lshr_b32 s31, s22, 16
-; VI-NEXT:    s_lshr_b32 s34, s21, 16
-; VI-NEXT:    s_lshr_b32 s35, s20, 16
-; VI-NEXT:    s_lshr_b32 s36, s19, 16
-; VI-NEXT:    s_lshr_b32 s37, s18, 16
-; VI-NEXT:    s_lshr_b32 s38, s17, 16
-; VI-NEXT:    s_lshr_b32 s39, s16, 16
+; VI-NEXT:    s_lshr_b32 s72, s16, 16
+; VI-NEXT:    s_lshr_b32 s73, s17, 16
+; VI-NEXT:    s_lshr_b32 s74, s18, 16
+; VI-NEXT:    s_lshr_b32 s75, s19, 16
+; VI-NEXT:    s_lshr_b32 s76, s20, 16
+; VI-NEXT:    s_lshr_b32 s77, s21, 16
+; VI-NEXT:    s_lshr_b32 s78, s22, 16
+; VI-NEXT:    s_lshr_b32 s79, s23, 16
+; VI-NEXT:    s_lshr_b32 s88, s24, 16
+; VI-NEXT:    s_lshr_b32 s89, s25, 16
+; VI-NEXT:    s_lshr_b32 s90, s26, 16
+; VI-NEXT:    s_lshr_b32 s91, s40, 16
+; VI-NEXT:    s_lshr_b32 s30, s41, 16
+; VI-NEXT:    s_lshr_b32 s31, s42, 16
+; VI-NEXT:    s_lshr_b32 s34, s43, 16
+; VI-NEXT:    s_lshr_b32 s35, s44, 16
+; VI-NEXT:    s_lshr_b32 s36, s45, 16
+; VI-NEXT:    s_lshr_b32 s37, s46, 16
+; VI-NEXT:    s_lshr_b32 s38, s47, 16
+; VI-NEXT:    s_lshr_b32 s39, s56, 16
 ; VI-NEXT:  .LBB13_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s56
 ; VI-NEXT:    s_lshl_b32 s5, s39, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s38, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s37, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s36, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s35, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s34, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s31, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s30, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s91, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s90, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s89, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s88, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s79, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s78, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s45
-; VI-NEXT:    s_lshl_b32 s29, s77, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s44
-; VI-NEXT:    s_lshl_b32 s44, s76, 16
-; VI-NEXT:    s_or_b32 s29, s29, s44
+; VI-NEXT:    s_and_b32 s5, 0xffff, s47
+; VI-NEXT:    s_lshl_b32 s47, s38, 16
+; VI-NEXT:    s_or_b32 s5, s5, s47
+; VI-NEXT:    s_and_b32 s46, 0xffff, s46
+; VI-NEXT:    s_lshl_b32 s47, s37, 16
+; VI-NEXT:    s_or_b32 s46, s46, s47
+; VI-NEXT:    s_and_b32 s45, 0xffff, s45
+; VI-NEXT:    s_lshl_b32 s47, s36, 16
+; VI-NEXT:    s_or_b32 s45, s45, s47
+; VI-NEXT:    s_and_b32 s44, 0xffff, s44
+; VI-NEXT:    s_lshl_b32 s47, s35, 16
+; VI-NEXT:    s_or_b32 s44, s44, s47
 ; VI-NEXT:    s_and_b32 s43, 0xffff, s43
-; VI-NEXT:    s_lshl_b32 s44, s75, 16
-; VI-NEXT:    s_or_b32 s43, s43, s44
+; VI-NEXT:    s_lshl_b32 s47, s34, 16
+; VI-NEXT:    s_or_b32 s43, s43, s47
 ; VI-NEXT:    s_and_b32 s42, 0xffff, s42
-; VI-NEXT:    s_lshl_b32 s44, s74, 16
-; VI-NEXT:    s_or_b32 s42, s42, s44
+; VI-NEXT:    s_lshl_b32 s47, s31, 16
+; VI-NEXT:    s_or_b32 s42, s42, s47
 ; VI-NEXT:    s_and_b32 s41, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s44, s73, 16
-; VI-NEXT:    s_or_b32 s41, s41, s44
+; VI-NEXT:    s_lshl_b32 s47, s30, 16
+; VI-NEXT:    s_or_b32 s41, s41, s47
 ; VI-NEXT:    s_and_b32 s40, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s44, s72, 16
-; VI-NEXT:    s_or_b32 s40, s40, s44
+; VI-NEXT:    s_lshl_b32 s47, s91, 16
+; VI-NEXT:    s_or_b32 s40, s40, s47
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s47, s90, 16
+; VI-NEXT:    s_or_b32 s26, s26, s47
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s47, s89, 16
+; VI-NEXT:    s_or_b32 s25, s25, s47
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s47, s88, 16
+; VI-NEXT:    s_or_b32 s24, s24, s47
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s47, s79, 16
+; VI-NEXT:    s_or_b32 s23, s23, s47
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s47, s78, 16
+; VI-NEXT:    s_or_b32 s22, s22, s47
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s47, s77, 16
+; VI-NEXT:    s_or_b32 s21, s21, s47
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s47, s76, 16
+; VI-NEXT:    s_or_b32 s20, s20, s47
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s47, s75, 16
+; VI-NEXT:    s_or_b32 s19, s19, s47
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s47, s74, 16
+; VI-NEXT:    s_or_b32 s18, s18, s47
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s47, s73, 16
+; VI-NEXT:    s_or_b32 s17, s17, s47
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s47, s72, 16
+; VI-NEXT:    s_or_b32 s16, s16, s47
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s44, s63, 16
-; VI-NEXT:    s_or_b32 s15, s15, s44
+; VI-NEXT:    s_lshl_b32 s47, s63, 16
+; VI-NEXT:    s_or_b32 s15, s15, s47
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s44, s62, 16
-; VI-NEXT:    s_or_b32 s14, s14, s44
+; VI-NEXT:    s_lshl_b32 s47, s62, 16
+; VI-NEXT:    s_or_b32 s14, s14, s47
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s44, s61, 16
-; VI-NEXT:    s_or_b32 s13, s13, s44
+; VI-NEXT:    s_lshl_b32 s47, s61, 16
+; VI-NEXT:    s_or_b32 s13, s13, s47
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s44, s60, 16
-; VI-NEXT:    s_or_b32 s12, s12, s44
+; VI-NEXT:    s_lshl_b32 s47, s60, 16
+; VI-NEXT:    s_or_b32 s12, s12, s47
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s44, s59, 16
-; VI-NEXT:    s_or_b32 s11, s11, s44
+; VI-NEXT:    s_lshl_b32 s47, s59, 16
+; VI-NEXT:    s_or_b32 s11, s11, s47
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s44, s58, 16
-; VI-NEXT:    s_or_b32 s10, s10, s44
+; VI-NEXT:    s_lshl_b32 s47, s58, 16
+; VI-NEXT:    s_or_b32 s10, s10, s47
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s44, s57, 16
-; VI-NEXT:    s_or_b32 s9, s9, s44
+; VI-NEXT:    s_lshl_b32 s47, s57, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s44, s56, 16
-; VI-NEXT:    s_or_b32 s8, s8, s44
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s44, s47, 16
-; VI-NEXT:    s_or_b32 s6, s6, s44
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s44, s46, 16
-; VI-NEXT:    s_or_b32 s7, s7, s44
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s47
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
-; VI-NEXT:    v_mov_b32_e32 v16, s43
-; VI-NEXT:    v_mov_b32_e32 v17, s42
-; VI-NEXT:    v_mov_b32_e32 v18, s41
-; VI-NEXT:    v_mov_b32_e32 v19, s40
+; VI-NEXT:    v_mov_b32_e32 v2, s46
+; VI-NEXT:    v_mov_b32_e32 v3, s45
+; VI-NEXT:    v_mov_b32_e32 v4, s44
+; VI-NEXT:    v_mov_b32_e32 v5, s43
+; VI-NEXT:    v_mov_b32_e32 v6, s42
+; VI-NEXT:    v_mov_b32_e32 v7, s41
+; VI-NEXT:    v_mov_b32_e32 v8, s40
+; VI-NEXT:    v_mov_b32_e32 v9, s26
+; VI-NEXT:    v_mov_b32_e32 v10, s25
+; VI-NEXT:    v_mov_b32_e32 v11, s24
+; VI-NEXT:    v_mov_b32_e32 v12, s23
+; VI-NEXT:    v_mov_b32_e32 v13, s22
+; VI-NEXT:    v_mov_b32_e32 v14, s21
+; VI-NEXT:    v_mov_b32_e32 v15, s20
+; VI-NEXT:    v_mov_b32_e32 v16, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s18
+; VI-NEXT:    v_mov_b32_e32 v18, s17
+; VI-NEXT:    v_mov_b32_e32 v19, s16
 ; VI-NEXT:    v_mov_b32_e32 v20, s15
 ; VI-NEXT:    v_mov_b32_e32 v21, s14
 ; VI-NEXT:    v_mov_b32_e32 v22, s13
@@ -4527,9 +4583,9 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr59
 ; VI-NEXT:    ; implicit-def: $sgpr58
 ; VI-NEXT:    ; implicit-def: $sgpr57
-; VI-NEXT:    ; implicit-def: $sgpr56
-; VI-NEXT:    ; implicit-def: $sgpr47
-; VI-NEXT:    ; implicit-def: $sgpr46
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB13_2
 ;
 ; GFX9-LABEL: bitcast_v30i32_to_v60i16_scalar:
@@ -4538,20 +4594,48 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_xor_saveexec_b64 s[4:5], -1
 ; GFX9-NEXT:    buffer_store_dword v30, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GFX9-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9-NEXT:    v_mov_b32_e32 v17, s16
+; GFX9-NEXT:    v_mov_b32_e32 v18, s17
+; GFX9-NEXT:    v_mov_b32_e32 v19, s18
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s19
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s20
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s21
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s23
 ; GFX9-NEXT:    v_writelane_b32 v30, s30, 0
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s26
 ; GFX9-NEXT:    v_writelane_b32 v30, s31, 1
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v16
 ; GFX9-NEXT:    v_writelane_b32 v30, s34, 2
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
 ; GFX9-NEXT:    v_readfirstlane_b32 s42, v12
@@ -4568,30 +4652,30 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_lshr_b32 s57, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s58, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s59, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s30, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s31, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s34, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s35, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s30, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s31, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s34, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s35, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB13_3
 ; GFX9-NEXT:  .LBB13_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_i32 s45, s45, 3
@@ -4600,16 +4684,6 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_add_i32 s42, s42, 3
 ; GFX9-NEXT:    s_add_i32 s41, s41, 3
 ; GFX9-NEXT:    s_add_i32 s40, s40, 3
-; GFX9-NEXT:    s_add_i32 s15, s15, 3
-; GFX9-NEXT:    s_add_i32 s14, s14, 3
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_add_i32 s29, s29, 3
 ; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
@@ -4624,61 +4698,71 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_lshr_b32 s46, s45, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s44, 16
 ; GFX9-NEXT:    s_lshr_b32 s56, s43, 16
 ; GFX9-NEXT:    s_lshr_b32 s57, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s58, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s59, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s30, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s31, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s34, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s35, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s30, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s31, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s34, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s35, s6, 16
 ; GFX9-NEXT:  .LBB13_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s35
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s34
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s31
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s30
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s95
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s94
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s93
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s92
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s35
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s34
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s31
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s30
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s95
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s94
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s93
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s92
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s60
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s59
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s58
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s40, s42, s57
@@ -4687,28 +4771,28 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s43, s45, s46
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    v_mov_b32_e32 v26, s40
@@ -4760,49 +4844,76 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; GFX11-LABEL: bitcast_v30i32_to_v60i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v13, s0 :: v_dual_mov_b32 v14, s1
+; GFX11-NEXT:    v_dual_mov_b32 v15, s2 :: v_dual_mov_b32 v16, s3
+; GFX11-NEXT:    v_dual_mov_b32 v17, s16 :: v_dual_mov_b32 v18, s17
+; GFX11-NEXT:    v_dual_mov_b32 v19, s18 :: v_dual_mov_b32 v20, s19
+; GFX11-NEXT:    v_dual_mov_b32 v21, s20 :: v_dual_mov_b32 v22, s21
+; GFX11-NEXT:    v_dual_mov_b32 v23, s22 :: v_dual_mov_b32 v24, s23
+; GFX11-NEXT:    v_dual_mov_b32 v25, s24 :: v_dual_mov_b32 v26, s25
+; GFX11-NEXT:    v_dual_mov_b32 v27, s26 :: v_dual_mov_b32 v28, s27
+; GFX11-NEXT:    v_dual_mov_b32 v29, s28 :: v_dual_mov_b32 v30, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v12
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v7
-; GFX11-NEXT:    v_readfirstlane_b32 s12, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s13, v9
-; GFX11-NEXT:    v_readfirstlane_b32 s15, v10
-; GFX11-NEXT:    v_readfirstlane_b32 s14, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v27
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v28
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v29
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v30
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s26, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s27, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s29, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s28, v11
 ; GFX11-NEXT:    s_mov_b32 s94, 0
 ; GFX11-NEXT:    s_and_b32 s40, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB13_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s40, s14, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s15, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s78, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s79, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s88, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s28, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s29, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s79, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s88, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s89, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s90, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s91, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s92, s1, 16
@@ -4810,20 +4921,8 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s94
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB13_3
 ; GFX11-NEXT:  .LBB13_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s14, s14, 3
-; GFX11-NEXT:    s_add_i32 s15, s15, 3
-; GFX11-NEXT:    s_add_i32 s13, s13, 3
-; GFX11-NEXT:    s_add_i32 s12, s12, 3
-; GFX11-NEXT:    s_add_i32 s11, s11, 3
-; GFX11-NEXT:    s_add_i32 s10, s10, 3
-; GFX11-NEXT:    s_add_i32 s9, s9, 3
-; GFX11-NEXT:    s_add_i32 s8, s8, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
 ; GFX11-NEXT:    s_add_i32 s28, s28, 3
+; GFX11-NEXT:    s_add_i32 s29, s29, 3
 ; GFX11-NEXT:    s_add_i32 s27, s27, 3
 ; GFX11-NEXT:    s_add_i32 s26, s26, 3
 ; GFX11-NEXT:    s_add_i32 s25, s25, 3
@@ -4836,36 +4935,48 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s40, s14, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s15, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s78, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s79, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s88, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s28, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s29, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s79, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s88, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s89, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s90, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s91, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s92, s1, 16
@@ -4876,47 +4987,47 @@ define inreg <60 x i16> @bitcast_v30i32_to_v60i16_scalar(<30 x i32> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s92
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s91
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s90
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s89
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s88
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s79
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s78
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s77
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s76
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s75
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s89
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s88
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s79
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s78
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s77
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s76
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s75
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s74
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s40
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s10 :: v_dual_mov_b32 v25, s11
-; GFX11-NEXT:    v_dual_mov_b32 v26, s12 :: v_dual_mov_b32 v27, s13
-; GFX11-NEXT:    v_dual_mov_b32 v28, s15 :: v_dual_mov_b32 v29, s14
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s24 :: v_dual_mov_b32 v25, s25
+; GFX11-NEXT:    v_dual_mov_b32 v26, s26 :: v_dual_mov_b32 v27, s27
+; GFX11-NEXT:    v_dual_mov_b32 v28, s29 :: v_dual_mov_b32 v29, s28
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB13_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr93
@@ -5467,7 +5578,7 @@ define <30 x i32> @bitcast_v60i16_to_v30i32(<60 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, s6, v25
 ; SI-NEXT:    v_add_i32_e32 v26, vcc, s6, v26
-; SI-NEXT:    v_add_i32_e32 v27, vcc, s6, v27
+; SI-NEXT:    v_add_i32_e32 v27, vcc, 0x30000, v27
 ; SI-NEXT:    v_add_i32_e32 v28, vcc, 0x30000, v28
 ; SI-NEXT:    v_add_i32_e32 v29, vcc, 0x30000, v29
 ; SI-NEXT:  .LBB14_4: ; %end
@@ -9050,13 +9161,41 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; SI-LABEL: bitcast_v30i32_to_v60f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v18, s16
+; SI-NEXT:    v_mov_b32_e32 v19, s17
+; SI-NEXT:    v_readfirstlane_b32 s40, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s18
+; SI-NEXT:    v_readfirstlane_b32 s41, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s19
+; SI-NEXT:    v_readfirstlane_b32 s42, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s20
+; SI-NEXT:    v_readfirstlane_b32 s43, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s21
+; SI-NEXT:    v_readfirstlane_b32 s44, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_readfirstlane_b32 s45, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s23, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s24
+; SI-NEXT:    v_readfirstlane_b32 s24, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s25
+; SI-NEXT:    v_readfirstlane_b32 s25, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s26, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s27, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s28
+; SI-NEXT:    v_readfirstlane_b32 s28, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
-; SI-NEXT:    v_readfirstlane_b32 s45, v1
-; SI-NEXT:    v_readfirstlane_b32 s44, v2
-; SI-NEXT:    v_readfirstlane_b32 s43, v3
-; SI-NEXT:    v_readfirstlane_b32 s42, v4
-; SI-NEXT:    v_readfirstlane_b32 s41, v5
-; SI-NEXT:    v_readfirstlane_b32 s40, v6
+; SI-NEXT:    v_readfirstlane_b32 s29, v18
+; SI-NEXT:    v_readfirstlane_b32 s22, v19
+; SI-NEXT:    v_readfirstlane_b32 s21, v1
+; SI-NEXT:    v_readfirstlane_b32 s20, v2
+; SI-NEXT:    v_readfirstlane_b32 s19, v3
+; SI-NEXT:    v_readfirstlane_b32 s18, v4
+; SI-NEXT:    v_readfirstlane_b32 s17, v5
+; SI-NEXT:    v_readfirstlane_b32 s16, v6
 ; SI-NEXT:    v_readfirstlane_b32 s15, v7
 ; SI-NEXT:    v_readfirstlane_b32 s14, v8
 ; SI-NEXT:    v_readfirstlane_b32 s13, v9
@@ -9103,48 +9242,48 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s4
 ; SI-NEXT:    s_lshr_b32 s4, s15, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s4
-; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    s_lshr_b32 s4, s16, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s4
-; SI-NEXT:    s_lshr_b32 s4, s41, 16
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s42, 16
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s43, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
-; SI-NEXT:    s_lshr_b32 s4, s44, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
-; SI-NEXT:    s_lshr_b32 s4, s45, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s4
 ; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
+; SI-NEXT:    s_lshr_b32 s4, s22, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
+; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
+; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
+; SI-NEXT:    s_lshr_b32 s4, s27, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
+; SI-NEXT:    s_lshr_b32 s4, s26, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
+; SI-NEXT:    s_lshr_b32 s4, s24, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, s4
+; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, s4
+; SI-NEXT:    s_lshr_b32 s4, s45, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, s4
+; SI-NEXT:    s_lshr_b32 s4, s44, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, s4
+; SI-NEXT:    s_lshr_b32 s4, s43, 16
 ; SI-NEXT:    s_waitcnt expcnt(6)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v46, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    s_lshr_b32 s4, s42, 16
 ; SI-NEXT:    s_waitcnt expcnt(4)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v56, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    s_lshr_b32 s4, s41, 16
 ; SI-NEXT:    s_waitcnt expcnt(2)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v58, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v60, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s9
@@ -9157,35 +9296,34 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v20, s14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s44
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s45
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, s45
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, s44
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, s43
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, s42
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, s41
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, s40
 ; SI-NEXT:    s_cbranch_execnz .LBB17_3
 ; SI-NEXT:  .LBB17_2: ; %cmp.true
-; SI-NEXT:    s_add_i32 s16, s16, 3
-; SI-NEXT:    s_add_i32 s17, s17, 3
-; SI-NEXT:    s_add_i32 s18, s18, 3
-; SI-NEXT:    s_add_i32 s19, s19, 3
-; SI-NEXT:    s_add_i32 s20, s20, 3
-; SI-NEXT:    s_add_i32 s21, s21, 3
-; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s40, s40, 3
+; SI-NEXT:    s_add_i32 s41, s41, 3
+; SI-NEXT:    s_add_i32 s42, s42, 3
+; SI-NEXT:    s_add_i32 s43, s43, 3
+; SI-NEXT:    s_add_i32 s44, s44, 3
+; SI-NEXT:    s_add_i32 s45, s45, 3
 ; SI-NEXT:    s_add_i32 s23, s23, 3
 ; SI-NEXT:    s_add_i32 s24, s24, 3
 ; SI-NEXT:    s_add_i32 s25, s25, 3
@@ -9193,12 +9331,13 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; SI-NEXT:    s_add_i32 s27, s27, 3
 ; SI-NEXT:    s_add_i32 s28, s28, 3
 ; SI-NEXT:    s_add_i32 s29, s29, 3
-; SI-NEXT:    s_add_i32 s45, s45, 3
-; SI-NEXT:    s_add_i32 s44, s44, 3
-; SI-NEXT:    s_add_i32 s43, s43, 3
-; SI-NEXT:    s_add_i32 s42, s42, 3
-; SI-NEXT:    s_add_i32 s41, s41, 3
-; SI-NEXT:    s_add_i32 s40, s40, 3
+; SI-NEXT:    s_add_i32 s22, s22, 3
+; SI-NEXT:    s_add_i32 s21, s21, 3
+; SI-NEXT:    s_add_i32 s20, s20, 3
+; SI-NEXT:    s_add_i32 s19, s19, 3
+; SI-NEXT:    s_add_i32 s18, s18, 3
+; SI-NEXT:    s_add_i32 s17, s17, 3
+; SI-NEXT:    s_add_i32 s16, s16, 3
 ; SI-NEXT:    s_add_i32 s15, s15, 3
 ; SI-NEXT:    s_add_i32 s14, s14, 3
 ; SI-NEXT:    s_add_i32 s13, s13, 3
@@ -9209,26 +9348,26 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; SI-NEXT:    s_add_i32 s7, s7, 3
 ; SI-NEXT:    s_add_i32 s6, s6, 3
 ; SI-NEXT:    s_add_i32 s9, s9, 3
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
-; SI-NEXT:    s_lshr_b32 s5, s17, 16
-; SI-NEXT:    s_lshr_b32 s46, s18, 16
-; SI-NEXT:    s_lshr_b32 s47, s19, 16
-; SI-NEXT:    s_lshr_b32 s56, s20, 16
-; SI-NEXT:    s_lshr_b32 s57, s21, 16
-; SI-NEXT:    s_lshr_b32 s58, s22, 16
-; SI-NEXT:    s_lshr_b32 s59, s23, 16
-; SI-NEXT:    s_lshr_b32 s60, s24, 16
-; SI-NEXT:    s_lshr_b32 s61, s25, 16
-; SI-NEXT:    s_lshr_b32 s62, s26, 16
-; SI-NEXT:    s_lshr_b32 s63, s27, 16
-; SI-NEXT:    s_lshr_b32 s72, s28, 16
-; SI-NEXT:    s_lshr_b32 s73, s29, 16
-; SI-NEXT:    s_lshr_b32 s74, s45, 16
-; SI-NEXT:    s_lshr_b32 s75, s44, 16
-; SI-NEXT:    s_lshr_b32 s76, s43, 16
-; SI-NEXT:    s_lshr_b32 s77, s42, 16
-; SI-NEXT:    s_lshr_b32 s78, s41, 16
-; SI-NEXT:    s_lshr_b32 s79, s40, 16
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    s_lshr_b32 s5, s41, 16
+; SI-NEXT:    s_lshr_b32 s46, s42, 16
+; SI-NEXT:    s_lshr_b32 s47, s43, 16
+; SI-NEXT:    s_lshr_b32 s56, s44, 16
+; SI-NEXT:    s_lshr_b32 s57, s45, 16
+; SI-NEXT:    s_lshr_b32 s58, s23, 16
+; SI-NEXT:    s_lshr_b32 s59, s24, 16
+; SI-NEXT:    s_lshr_b32 s60, s25, 16
+; SI-NEXT:    s_lshr_b32 s61, s26, 16
+; SI-NEXT:    s_lshr_b32 s62, s27, 16
+; SI-NEXT:    s_lshr_b32 s63, s28, 16
+; SI-NEXT:    s_lshr_b32 s72, s29, 16
+; SI-NEXT:    s_lshr_b32 s73, s22, 16
+; SI-NEXT:    s_lshr_b32 s74, s21, 16
+; SI-NEXT:    s_lshr_b32 s75, s20, 16
+; SI-NEXT:    s_lshr_b32 s76, s19, 16
+; SI-NEXT:    s_lshr_b32 s77, s18, 16
+; SI-NEXT:    s_lshr_b32 s78, s17, 16
+; SI-NEXT:    s_lshr_b32 s79, s16, 16
 ; SI-NEXT:    s_lshr_b32 s88, s15, 16
 ; SI-NEXT:    s_lshr_b32 s89, s14, 16
 ; SI-NEXT:    s_lshr_b32 s90, s13, 16
@@ -9249,29 +9388,29 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s13
 ; SI-NEXT:    v_cvt_f32_f16_e32 v20, s14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s44
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s45
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s22
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s29
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s27
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s25
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, s45
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, s44
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, s43
 ; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, s42
 ; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, s41
 ; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, s40
 ; SI-NEXT:    v_cvt_f32_f16_e32 v1, vcc_hi
 ; SI-NEXT:    v_cvt_f32_f16_e32 v2, vcc_lo
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, s95
@@ -9599,18 +9738,46 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; VI-NEXT:    s_mov_b64 exec, s[4:5]
 ; VI-NEXT:    v_writelane_b32 v30, s30, 0
 ; VI-NEXT:    v_writelane_b32 v30, s31, 1
+; VI-NEXT:    v_mov_b32_e32 v17, s16
+; VI-NEXT:    v_mov_b32_e32 v18, s17
 ; VI-NEXT:    v_writelane_b32 v30, s34, 2
+; VI-NEXT:    v_mov_b32_e32 v19, s18
+; VI-NEXT:    v_readfirstlane_b32 s56, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s19
+; VI-NEXT:    v_readfirstlane_b32 s47, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s20
 ; VI-NEXT:    v_writelane_b32 v30, s35, 3
+; VI-NEXT:    v_readfirstlane_b32 s46, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s21
+; VI-NEXT:    v_readfirstlane_b32 s45, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s23
 ; VI-NEXT:    v_writelane_b32 v30, s36, 4
+; VI-NEXT:    v_readfirstlane_b32 s43, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s26
 ; VI-NEXT:    v_writelane_b32 v30, s37, 5
+; VI-NEXT:    v_readfirstlane_b32 s40, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v16
 ; VI-NEXT:    v_writelane_b32 v30, s38, 6
-; VI-NEXT:    v_readfirstlane_b32 s45, v0
-; VI-NEXT:    v_readfirstlane_b32 s44, v1
-; VI-NEXT:    v_readfirstlane_b32 s43, v2
-; VI-NEXT:    v_readfirstlane_b32 s42, v3
-; VI-NEXT:    v_readfirstlane_b32 s41, v4
-; VI-NEXT:    v_readfirstlane_b32 s40, v5
+; VI-NEXT:    v_readfirstlane_b32 s24, v19
+; VI-NEXT:    v_readfirstlane_b32 s23, v17
+; VI-NEXT:    v_readfirstlane_b32 s22, v18
+; VI-NEXT:    v_readfirstlane_b32 s21, v0
+; VI-NEXT:    v_readfirstlane_b32 s20, v1
+; VI-NEXT:    v_readfirstlane_b32 s19, v2
+; VI-NEXT:    v_readfirstlane_b32 s18, v3
+; VI-NEXT:    v_readfirstlane_b32 s17, v4
+; VI-NEXT:    v_readfirstlane_b32 s16, v5
 ; VI-NEXT:    v_readfirstlane_b32 s15, v6
 ; VI-NEXT:    v_readfirstlane_b32 s14, v7
 ; VI-NEXT:    v_readfirstlane_b32 s13, v8
@@ -9625,9 +9792,9 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; VI-NEXT:    v_writelane_b32 v30, s39, 7
 ; VI-NEXT:    s_cbranch_scc0 .LBB17_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s46, s7, 16
-; VI-NEXT:    s_lshr_b32 s47, s6, 16
-; VI-NEXT:    s_lshr_b32 s56, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s57, s9, 16
 ; VI-NEXT:    s_lshr_b32 s58, s10, 16
 ; VI-NEXT:    s_lshr_b32 s59, s11, 16
@@ -9635,26 +9802,26 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s61, s13, 16
 ; VI-NEXT:    s_lshr_b32 s62, s14, 16
 ; VI-NEXT:    s_lshr_b32 s63, s15, 16
-; VI-NEXT:    s_lshr_b32 s72, s40, 16
-; VI-NEXT:    s_lshr_b32 s73, s41, 16
-; VI-NEXT:    s_lshr_b32 s74, s42, 16
-; VI-NEXT:    s_lshr_b32 s75, s43, 16
-; VI-NEXT:    s_lshr_b32 s76, s44, 16
-; VI-NEXT:    s_lshr_b32 s77, s45, 16
-; VI-NEXT:    s_lshr_b32 s78, s29, 16
-; VI-NEXT:    s_lshr_b32 s79, s28, 16
-; VI-NEXT:    s_lshr_b32 s88, s27, 16
-; VI-NEXT:    s_lshr_b32 s89, s26, 16
-; VI-NEXT:    s_lshr_b32 s90, s25, 16
-; VI-NEXT:    s_lshr_b32 s91, s24, 16
-; VI-NEXT:    s_lshr_b32 s30, s23, 16
-; VI-NEXT:    s_lshr_b32 s31, s22, 16
-; VI-NEXT:    s_lshr_b32 s34, s21, 16
-; VI-NEXT:    s_lshr_b32 s35, s20, 16
-; VI-NEXT:    s_lshr_b32 s36, s19, 16
-; VI-NEXT:    s_lshr_b32 s37, s18, 16
-; VI-NEXT:    s_lshr_b32 s38, s17, 16
-; VI-NEXT:    s_lshr_b32 s39, s16, 16
+; VI-NEXT:    s_lshr_b32 s72, s16, 16
+; VI-NEXT:    s_lshr_b32 s73, s17, 16
+; VI-NEXT:    s_lshr_b32 s74, s18, 16
+; VI-NEXT:    s_lshr_b32 s75, s19, 16
+; VI-NEXT:    s_lshr_b32 s76, s20, 16
+; VI-NEXT:    s_lshr_b32 s77, s21, 16
+; VI-NEXT:    s_lshr_b32 s78, s22, 16
+; VI-NEXT:    s_lshr_b32 s79, s23, 16
+; VI-NEXT:    s_lshr_b32 s88, s24, 16
+; VI-NEXT:    s_lshr_b32 s89, s25, 16
+; VI-NEXT:    s_lshr_b32 s90, s26, 16
+; VI-NEXT:    s_lshr_b32 s91, s40, 16
+; VI-NEXT:    s_lshr_b32 s30, s41, 16
+; VI-NEXT:    s_lshr_b32 s31, s42, 16
+; VI-NEXT:    s_lshr_b32 s34, s43, 16
+; VI-NEXT:    s_lshr_b32 s35, s44, 16
+; VI-NEXT:    s_lshr_b32 s36, s45, 16
+; VI-NEXT:    s_lshr_b32 s37, s46, 16
+; VI-NEXT:    s_lshr_b32 s38, s47, 16
+; VI-NEXT:    s_lshr_b32 s39, s56, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB17_3
 ; VI-NEXT:  .LBB17_2: ; %cmp.true
 ; VI-NEXT:    s_add_i32 s7, s7, 3
@@ -9667,29 +9834,29 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; VI-NEXT:    s_add_i32 s13, s13, 3
 ; VI-NEXT:    s_add_i32 s14, s14, 3
 ; VI-NEXT:    s_add_i32 s15, s15, 3
+; VI-NEXT:    s_add_i32 s16, s16, 3
+; VI-NEXT:    s_add_i32 s17, s17, 3
+; VI-NEXT:    s_add_i32 s18, s18, 3
+; VI-NEXT:    s_add_i32 s19, s19, 3
+; VI-NEXT:    s_add_i32 s20, s20, 3
+; VI-NEXT:    s_add_i32 s21, s21, 3
+; VI-NEXT:    s_add_i32 s22, s22, 3
+; VI-NEXT:    s_add_i32 s23, s23, 3
+; VI-NEXT:    s_add_i32 s24, s24, 3
+; VI-NEXT:    s_add_i32 s25, s25, 3
+; VI-NEXT:    s_add_i32 s26, s26, 3
 ; VI-NEXT:    s_add_i32 s40, s40, 3
 ; VI-NEXT:    s_add_i32 s41, s41, 3
 ; VI-NEXT:    s_add_i32 s42, s42, 3
 ; VI-NEXT:    s_add_i32 s43, s43, 3
 ; VI-NEXT:    s_add_i32 s44, s44, 3
 ; VI-NEXT:    s_add_i32 s45, s45, 3
-; VI-NEXT:    s_add_i32 s29, s29, 3
-; VI-NEXT:    s_add_i32 s28, s28, 3
-; VI-NEXT:    s_add_i32 s27, s27, 3
-; VI-NEXT:    s_add_i32 s26, s26, 3
-; VI-NEXT:    s_add_i32 s25, s25, 3
-; VI-NEXT:    s_add_i32 s24, s24, 3
-; VI-NEXT:    s_add_i32 s23, s23, 3
-; VI-NEXT:    s_add_i32 s22, s22, 3
-; VI-NEXT:    s_add_i32 s21, s21, 3
-; VI-NEXT:    s_add_i32 s20, s20, 3
-; VI-NEXT:    s_add_i32 s19, s19, 3
-; VI-NEXT:    s_add_i32 s18, s18, 3
-; VI-NEXT:    s_add_i32 s17, s17, 3
-; VI-NEXT:    s_add_i32 s16, s16, 3
-; VI-NEXT:    s_lshr_b32 s46, s7, 16
-; VI-NEXT:    s_lshr_b32 s47, s6, 16
-; VI-NEXT:    s_lshr_b32 s56, s8, 16
+; VI-NEXT:    s_add_i32 s46, s46, 3
+; VI-NEXT:    s_add_i32 s47, s47, 3
+; VI-NEXT:    s_add_i32 s56, s56, 3
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s57, s9, 16
 ; VI-NEXT:    s_lshr_b32 s58, s10, 16
 ; VI-NEXT:    s_lshr_b32 s59, s11, 16
@@ -9697,137 +9864,137 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s61, s13, 16
 ; VI-NEXT:    s_lshr_b32 s62, s14, 16
 ; VI-NEXT:    s_lshr_b32 s63, s15, 16
-; VI-NEXT:    s_lshr_b32 s72, s40, 16
-; VI-NEXT:    s_lshr_b32 s73, s41, 16
-; VI-NEXT:    s_lshr_b32 s74, s42, 16
-; VI-NEXT:    s_lshr_b32 s75, s43, 16
-; VI-NEXT:    s_lshr_b32 s76, s44, 16
-; VI-NEXT:    s_lshr_b32 s77, s45, 16
-; VI-NEXT:    s_lshr_b32 s78, s29, 16
-; VI-NEXT:    s_lshr_b32 s79, s28, 16
-; VI-NEXT:    s_lshr_b32 s88, s27, 16
-; VI-NEXT:    s_lshr_b32 s89, s26, 16
-; VI-NEXT:    s_lshr_b32 s90, s25, 16
-; VI-NEXT:    s_lshr_b32 s91, s24, 16
-; VI-NEXT:    s_lshr_b32 s30, s23, 16
-; VI-NEXT:    s_lshr_b32 s31, s22, 16
-; VI-NEXT:    s_lshr_b32 s34, s21, 16
-; VI-NEXT:    s_lshr_b32 s35, s20, 16
-; VI-NEXT:    s_lshr_b32 s36, s19, 16
-; VI-NEXT:    s_lshr_b32 s37, s18, 16
-; VI-NEXT:    s_lshr_b32 s38, s17, 16
-; VI-NEXT:    s_lshr_b32 s39, s16, 16
+; VI-NEXT:    s_lshr_b32 s72, s16, 16
+; VI-NEXT:    s_lshr_b32 s73, s17, 16
+; VI-NEXT:    s_lshr_b32 s74, s18, 16
+; VI-NEXT:    s_lshr_b32 s75, s19, 16
+; VI-NEXT:    s_lshr_b32 s76, s20, 16
+; VI-NEXT:    s_lshr_b32 s77, s21, 16
+; VI-NEXT:    s_lshr_b32 s78, s22, 16
+; VI-NEXT:    s_lshr_b32 s79, s23, 16
+; VI-NEXT:    s_lshr_b32 s88, s24, 16
+; VI-NEXT:    s_lshr_b32 s89, s25, 16
+; VI-NEXT:    s_lshr_b32 s90, s26, 16
+; VI-NEXT:    s_lshr_b32 s91, s40, 16
+; VI-NEXT:    s_lshr_b32 s30, s41, 16
+; VI-NEXT:    s_lshr_b32 s31, s42, 16
+; VI-NEXT:    s_lshr_b32 s34, s43, 16
+; VI-NEXT:    s_lshr_b32 s35, s44, 16
+; VI-NEXT:    s_lshr_b32 s36, s45, 16
+; VI-NEXT:    s_lshr_b32 s37, s46, 16
+; VI-NEXT:    s_lshr_b32 s38, s47, 16
+; VI-NEXT:    s_lshr_b32 s39, s56, 16
 ; VI-NEXT:  .LBB17_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s56
 ; VI-NEXT:    s_lshl_b32 s5, s39, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s38, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s37, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s36, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s35, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s34, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s31, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s30, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s91, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s90, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s89, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s88, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s79, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s78, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s45
-; VI-NEXT:    s_lshl_b32 s29, s77, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s44
-; VI-NEXT:    s_lshl_b32 s44, s76, 16
-; VI-NEXT:    s_or_b32 s29, s29, s44
+; VI-NEXT:    s_and_b32 s5, 0xffff, s47
+; VI-NEXT:    s_lshl_b32 s47, s38, 16
+; VI-NEXT:    s_or_b32 s5, s5, s47
+; VI-NEXT:    s_and_b32 s46, 0xffff, s46
+; VI-NEXT:    s_lshl_b32 s47, s37, 16
+; VI-NEXT:    s_or_b32 s46, s46, s47
+; VI-NEXT:    s_and_b32 s45, 0xffff, s45
+; VI-NEXT:    s_lshl_b32 s47, s36, 16
+; VI-NEXT:    s_or_b32 s45, s45, s47
+; VI-NEXT:    s_and_b32 s44, 0xffff, s44
+; VI-NEXT:    s_lshl_b32 s47, s35, 16
+; VI-NEXT:    s_or_b32 s44, s44, s47
 ; VI-NEXT:    s_and_b32 s43, 0xffff, s43
-; VI-NEXT:    s_lshl_b32 s44, s75, 16
-; VI-NEXT:    s_or_b32 s43, s43, s44
+; VI-NEXT:    s_lshl_b32 s47, s34, 16
+; VI-NEXT:    s_or_b32 s43, s43, s47
 ; VI-NEXT:    s_and_b32 s42, 0xffff, s42
-; VI-NEXT:    s_lshl_b32 s44, s74, 16
-; VI-NEXT:    s_or_b32 s42, s42, s44
+; VI-NEXT:    s_lshl_b32 s47, s31, 16
+; VI-NEXT:    s_or_b32 s42, s42, s47
 ; VI-NEXT:    s_and_b32 s41, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s44, s73, 16
-; VI-NEXT:    s_or_b32 s41, s41, s44
+; VI-NEXT:    s_lshl_b32 s47, s30, 16
+; VI-NEXT:    s_or_b32 s41, s41, s47
 ; VI-NEXT:    s_and_b32 s40, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s44, s72, 16
-; VI-NEXT:    s_or_b32 s40, s40, s44
+; VI-NEXT:    s_lshl_b32 s47, s91, 16
+; VI-NEXT:    s_or_b32 s40, s40, s47
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s47, s90, 16
+; VI-NEXT:    s_or_b32 s26, s26, s47
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s47, s89, 16
+; VI-NEXT:    s_or_b32 s25, s25, s47
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s47, s88, 16
+; VI-NEXT:    s_or_b32 s24, s24, s47
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s47, s79, 16
+; VI-NEXT:    s_or_b32 s23, s23, s47
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s47, s78, 16
+; VI-NEXT:    s_or_b32 s22, s22, s47
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s47, s77, 16
+; VI-NEXT:    s_or_b32 s21, s21, s47
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s47, s76, 16
+; VI-NEXT:    s_or_b32 s20, s20, s47
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s47, s75, 16
+; VI-NEXT:    s_or_b32 s19, s19, s47
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s47, s74, 16
+; VI-NEXT:    s_or_b32 s18, s18, s47
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s47, s73, 16
+; VI-NEXT:    s_or_b32 s17, s17, s47
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s47, s72, 16
+; VI-NEXT:    s_or_b32 s16, s16, s47
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s44, s63, 16
-; VI-NEXT:    s_or_b32 s15, s15, s44
+; VI-NEXT:    s_lshl_b32 s47, s63, 16
+; VI-NEXT:    s_or_b32 s15, s15, s47
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s44, s62, 16
-; VI-NEXT:    s_or_b32 s14, s14, s44
+; VI-NEXT:    s_lshl_b32 s47, s62, 16
+; VI-NEXT:    s_or_b32 s14, s14, s47
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s44, s61, 16
-; VI-NEXT:    s_or_b32 s13, s13, s44
+; VI-NEXT:    s_lshl_b32 s47, s61, 16
+; VI-NEXT:    s_or_b32 s13, s13, s47
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s44, s60, 16
-; VI-NEXT:    s_or_b32 s12, s12, s44
+; VI-NEXT:    s_lshl_b32 s47, s60, 16
+; VI-NEXT:    s_or_b32 s12, s12, s47
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s44, s59, 16
-; VI-NEXT:    s_or_b32 s11, s11, s44
+; VI-NEXT:    s_lshl_b32 s47, s59, 16
+; VI-NEXT:    s_or_b32 s11, s11, s47
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s44, s58, 16
-; VI-NEXT:    s_or_b32 s10, s10, s44
+; VI-NEXT:    s_lshl_b32 s47, s58, 16
+; VI-NEXT:    s_or_b32 s10, s10, s47
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s44, s57, 16
-; VI-NEXT:    s_or_b32 s9, s9, s44
+; VI-NEXT:    s_lshl_b32 s47, s57, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s44, s56, 16
-; VI-NEXT:    s_or_b32 s8, s8, s44
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s44, s47, 16
-; VI-NEXT:    s_or_b32 s6, s6, s44
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s44, s46, 16
-; VI-NEXT:    s_or_b32 s7, s7, s44
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s47
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
-; VI-NEXT:    v_mov_b32_e32 v16, s43
-; VI-NEXT:    v_mov_b32_e32 v17, s42
-; VI-NEXT:    v_mov_b32_e32 v18, s41
-; VI-NEXT:    v_mov_b32_e32 v19, s40
+; VI-NEXT:    v_mov_b32_e32 v2, s46
+; VI-NEXT:    v_mov_b32_e32 v3, s45
+; VI-NEXT:    v_mov_b32_e32 v4, s44
+; VI-NEXT:    v_mov_b32_e32 v5, s43
+; VI-NEXT:    v_mov_b32_e32 v6, s42
+; VI-NEXT:    v_mov_b32_e32 v7, s41
+; VI-NEXT:    v_mov_b32_e32 v8, s40
+; VI-NEXT:    v_mov_b32_e32 v9, s26
+; VI-NEXT:    v_mov_b32_e32 v10, s25
+; VI-NEXT:    v_mov_b32_e32 v11, s24
+; VI-NEXT:    v_mov_b32_e32 v12, s23
+; VI-NEXT:    v_mov_b32_e32 v13, s22
+; VI-NEXT:    v_mov_b32_e32 v14, s21
+; VI-NEXT:    v_mov_b32_e32 v15, s20
+; VI-NEXT:    v_mov_b32_e32 v16, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s18
+; VI-NEXT:    v_mov_b32_e32 v18, s17
+; VI-NEXT:    v_mov_b32_e32 v19, s16
 ; VI-NEXT:    v_mov_b32_e32 v20, s15
 ; VI-NEXT:    v_mov_b32_e32 v21, s14
 ; VI-NEXT:    v_mov_b32_e32 v22, s13
@@ -9879,9 +10046,9 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr59
 ; VI-NEXT:    ; implicit-def: $sgpr58
 ; VI-NEXT:    ; implicit-def: $sgpr57
-; VI-NEXT:    ; implicit-def: $sgpr56
-; VI-NEXT:    ; implicit-def: $sgpr47
-; VI-NEXT:    ; implicit-def: $sgpr46
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB17_2
 ;
 ; GFX9-LABEL: bitcast_v30i32_to_v60f16_scalar:
@@ -9890,20 +10057,48 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; GFX9-NEXT:    s_xor_saveexec_b64 s[4:5], -1
 ; GFX9-NEXT:    buffer_store_dword v30, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GFX9-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9-NEXT:    v_mov_b32_e32 v17, s16
+; GFX9-NEXT:    v_mov_b32_e32 v18, s17
+; GFX9-NEXT:    v_mov_b32_e32 v19, s18
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s19
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s20
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s21
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s23
 ; GFX9-NEXT:    v_writelane_b32 v30, s30, 0
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s26
 ; GFX9-NEXT:    v_writelane_b32 v30, s31, 1
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v16
 ; GFX9-NEXT:    v_writelane_b32 v30, s34, 2
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
 ; GFX9-NEXT:    v_readfirstlane_b32 s42, v12
@@ -9920,30 +10115,30 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; GFX9-NEXT:    s_lshr_b32 s57, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s58, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s59, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s30, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s31, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s34, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s35, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s30, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s31, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s34, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s35, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB17_3
 ; GFX9-NEXT:  .LBB17_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_i32 s45, s45, 3
@@ -9952,16 +10147,6 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; GFX9-NEXT:    s_add_i32 s42, s42, 3
 ; GFX9-NEXT:    s_add_i32 s41, s41, 3
 ; GFX9-NEXT:    s_add_i32 s40, s40, 3
-; GFX9-NEXT:    s_add_i32 s15, s15, 3
-; GFX9-NEXT:    s_add_i32 s14, s14, 3
-; GFX9-NEXT:    s_add_i32 s13, s13, 3
-; GFX9-NEXT:    s_add_i32 s12, s12, 3
-; GFX9-NEXT:    s_add_i32 s11, s11, 3
-; GFX9-NEXT:    s_add_i32 s10, s10, 3
-; GFX9-NEXT:    s_add_i32 s9, s9, 3
-; GFX9-NEXT:    s_add_i32 s8, s8, 3
-; GFX9-NEXT:    s_add_i32 s7, s7, 3
-; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_add_i32 s29, s29, 3
 ; GFX9-NEXT:    s_add_i32 s28, s28, 3
 ; GFX9-NEXT:    s_add_i32 s27, s27, 3
@@ -9976,61 +10161,71 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; GFX9-NEXT:    s_add_i32 s18, s18, 3
 ; GFX9-NEXT:    s_add_i32 s17, s17, 3
 ; GFX9-NEXT:    s_add_i32 s16, s16, 3
+; GFX9-NEXT:    s_add_i32 s15, s15, 3
+; GFX9-NEXT:    s_add_i32 s14, s14, 3
+; GFX9-NEXT:    s_add_i32 s13, s13, 3
+; GFX9-NEXT:    s_add_i32 s12, s12, 3
+; GFX9-NEXT:    s_add_i32 s11, s11, 3
+; GFX9-NEXT:    s_add_i32 s10, s10, 3
+; GFX9-NEXT:    s_add_i32 s9, s9, 3
+; GFX9-NEXT:    s_add_i32 s8, s8, 3
+; GFX9-NEXT:    s_add_i32 s7, s7, 3
+; GFX9-NEXT:    s_add_i32 s6, s6, 3
 ; GFX9-NEXT:    s_lshr_b32 s46, s45, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s44, 16
 ; GFX9-NEXT:    s_lshr_b32 s56, s43, 16
 ; GFX9-NEXT:    s_lshr_b32 s57, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s58, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s59, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s30, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s31, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s34, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s35, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s30, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s31, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s34, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s35, s6, 16
 ; GFX9-NEXT:  .LBB17_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s35
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s34
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s31
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s30
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s95
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s94
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s93
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s92
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s35
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s34
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s31
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s30
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s95
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s94
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s93
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s92
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s60
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s59
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s58
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s40, s42, s57
@@ -10039,28 +10234,28 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s43, s45, s46
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    v_mov_b32_e32 v26, s40
@@ -10112,49 +10307,76 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; GFX11-LABEL: bitcast_v30i32_to_v60f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v13, s0 :: v_dual_mov_b32 v14, s1
+; GFX11-NEXT:    v_dual_mov_b32 v15, s2 :: v_dual_mov_b32 v16, s3
+; GFX11-NEXT:    v_dual_mov_b32 v17, s16 :: v_dual_mov_b32 v18, s17
+; GFX11-NEXT:    v_dual_mov_b32 v19, s18 :: v_dual_mov_b32 v20, s19
+; GFX11-NEXT:    v_dual_mov_b32 v21, s20 :: v_dual_mov_b32 v22, s21
+; GFX11-NEXT:    v_dual_mov_b32 v23, s22 :: v_dual_mov_b32 v24, s23
+; GFX11-NEXT:    v_dual_mov_b32 v25, s24 :: v_dual_mov_b32 v26, s25
+; GFX11-NEXT:    v_dual_mov_b32 v27, s26 :: v_dual_mov_b32 v28, s27
+; GFX11-NEXT:    v_dual_mov_b32 v29, s28 :: v_dual_mov_b32 v30, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v12
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v7
-; GFX11-NEXT:    v_readfirstlane_b32 s12, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s13, v9
-; GFX11-NEXT:    v_readfirstlane_b32 s15, v10
-; GFX11-NEXT:    v_readfirstlane_b32 s14, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v27
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v28
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v29
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v30
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s26, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s27, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s29, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s28, v11
 ; GFX11-NEXT:    s_mov_b32 s94, 0
 ; GFX11-NEXT:    s_and_b32 s40, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB17_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s40, s14, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s15, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s78, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s79, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s88, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s28, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s29, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s79, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s88, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s89, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s90, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s91, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s92, s1, 16
@@ -10162,20 +10384,8 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s94
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB17_3
 ; GFX11-NEXT:  .LBB17_2: ; %cmp.true
-; GFX11-NEXT:    s_add_i32 s14, s14, 3
-; GFX11-NEXT:    s_add_i32 s15, s15, 3
-; GFX11-NEXT:    s_add_i32 s13, s13, 3
-; GFX11-NEXT:    s_add_i32 s12, s12, 3
-; GFX11-NEXT:    s_add_i32 s11, s11, 3
-; GFX11-NEXT:    s_add_i32 s10, s10, 3
-; GFX11-NEXT:    s_add_i32 s9, s9, 3
-; GFX11-NEXT:    s_add_i32 s8, s8, 3
-; GFX11-NEXT:    s_add_i32 s7, s7, 3
-; GFX11-NEXT:    s_add_i32 s6, s6, 3
-; GFX11-NEXT:    s_add_i32 s5, s5, 3
-; GFX11-NEXT:    s_add_i32 s4, s4, 3
-; GFX11-NEXT:    s_add_i32 s29, s29, 3
 ; GFX11-NEXT:    s_add_i32 s28, s28, 3
+; GFX11-NEXT:    s_add_i32 s29, s29, 3
 ; GFX11-NEXT:    s_add_i32 s27, s27, 3
 ; GFX11-NEXT:    s_add_i32 s26, s26, 3
 ; GFX11-NEXT:    s_add_i32 s25, s25, 3
@@ -10188,36 +10398,48 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; GFX11-NEXT:    s_add_i32 s18, s18, 3
 ; GFX11-NEXT:    s_add_i32 s17, s17, 3
 ; GFX11-NEXT:    s_add_i32 s16, s16, 3
+; GFX11-NEXT:    s_add_i32 s15, s15, 3
+; GFX11-NEXT:    s_add_i32 s14, s14, 3
+; GFX11-NEXT:    s_add_i32 s13, s13, 3
+; GFX11-NEXT:    s_add_i32 s12, s12, 3
+; GFX11-NEXT:    s_add_i32 s11, s11, 3
+; GFX11-NEXT:    s_add_i32 s10, s10, 3
+; GFX11-NEXT:    s_add_i32 s9, s9, 3
+; GFX11-NEXT:    s_add_i32 s8, s8, 3
+; GFX11-NEXT:    s_add_i32 s7, s7, 3
+; GFX11-NEXT:    s_add_i32 s6, s6, 3
+; GFX11-NEXT:    s_add_i32 s5, s5, 3
+; GFX11-NEXT:    s_add_i32 s4, s4, 3
 ; GFX11-NEXT:    s_add_i32 s3, s3, 3
 ; GFX11-NEXT:    s_add_i32 s2, s2, 3
 ; GFX11-NEXT:    s_add_i32 s1, s1, 3
 ; GFX11-NEXT:    s_add_i32 s0, s0, 3
-; GFX11-NEXT:    s_lshr_b32 s40, s14, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s15, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s78, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s79, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s88, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s28, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s29, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s79, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s88, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s89, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s90, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s91, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s92, s1, 16
@@ -10228,47 +10450,47 @@ define inreg <60 x half> @bitcast_v30i32_to_v60f16_scalar(<30 x i32> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s92
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s91
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s90
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s89
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s88
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s79
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s78
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s77
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s76
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s75
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s89
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s88
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s79
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s78
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s77
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s76
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s75
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s74
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s40
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s10 :: v_dual_mov_b32 v25, s11
-; GFX11-NEXT:    v_dual_mov_b32 v26, s12 :: v_dual_mov_b32 v27, s13
-; GFX11-NEXT:    v_dual_mov_b32 v28, s15 :: v_dual_mov_b32 v29, s14
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s24 :: v_dual_mov_b32 v25, s25
+; GFX11-NEXT:    v_dual_mov_b32 v26, s26 :: v_dual_mov_b32 v27, s27
+; GFX11-NEXT:    v_dual_mov_b32 v28, s29 :: v_dual_mov_b32 v29, s28
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB17_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr93
@@ -17994,7 +18216,7 @@ define <30 x float> @bitcast_v60i16_to_v30f32(<60 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, s6, v25
 ; SI-NEXT:    v_add_i32_e32 v26, vcc, s6, v26
-; SI-NEXT:    v_add_i32_e32 v27, vcc, s6, v27
+; SI-NEXT:    v_add_i32_e32 v27, vcc, 0x30000, v27
 ; SI-NEXT:    v_add_i32_e32 v28, vcc, 0x30000, v28
 ; SI-NEXT:    v_add_i32_e32 v29, vcc, 0x30000, v29
 ; SI-NEXT:  .LBB30_4: ; %end
@@ -21548,23 +21770,21 @@ define inreg <60 x half> @bitcast_v30f32_to_v60f16_scalar(<30 x float> inreg %a,
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
-; SI-NEXT:    v_readfirstlane_b32 s45, v1
-; SI-NEXT:    v_readfirstlane_b32 s44, v2
-; SI-NEXT:    v_readfirstlane_b32 s43, v3
-; SI-NEXT:    v_readfirstlane_b32 s42, v4
-; SI-NEXT:    v_readfirstlane_b32 s41, v5
-; SI-NEXT:    v_readfirstlane_b32 s40, v6
-; SI-NEXT:    v_readfirstlane_b32 s15, v7
-; SI-NEXT:    v_readfirstlane_b32 s14, v8
-; SI-NEXT:    v_readfirstlane_b32 s13, v9
-; SI-NEXT:    v_readfirstlane_b32 s12, v10
-; SI-NEXT:    v_readfirstlane_b32 s11, v11
-; SI-NEXT:    v_readfirstlane_b32 s10, v12
-; SI-NEXT:    v_readfirstlane_b32 s8, v13
-; SI-NEXT:    v_readfirstlane_b32 s7, v14
-; SI-NEXT:    v_readfirstlane_b32 s6, v15
+; SI-NEXT:    v_mov_b32_e32 v31, s16
+; SI-NEXT:    v_mov_b32_e32 v29, s17
+; SI-NEXT:    v_mov_b32_e32 v50, s18
 ; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s9, v16
+; SI-NEXT:    v_mov_b32_e32 v51, s19
+; SI-NEXT:    v_mov_b32_e32 v49, s20
+; SI-NEXT:    v_mov_b32_e32 v48, s21
+; SI-NEXT:    v_mov_b32_e32 v39, s22
+; SI-NEXT:    v_mov_b32_e32 v38, s23
+; SI-NEXT:    v_mov_b32_e32 v37, s24
+; SI-NEXT:    v_mov_b32_e32 v36, s25
+; SI-NEXT:    v_mov_b32_e32 v35, s26
+; SI-NEXT:    v_mov_b32_e32 v34, s27
+; SI-NEXT:    v_mov_b32_e32 v33, s28
+; SI-NEXT:    v_mov_b32_e32 v32, s29
 ; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
@@ -21583,450 +21803,574 @@ define inreg <60 x half> @bitcast_v30f32_to_v60f16_scalar(<30 x float> inreg %a,
 ; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_cbranch_scc0 .LBB33_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s4, s9, 16
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, s4
-; SI-NEXT:    s_lshr_b32 s4, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s4
-; SI-NEXT:    s_lshr_b32 s4, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s4
-; SI-NEXT:    s_lshr_b32 s4, s8, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s4
-; SI-NEXT:    s_lshr_b32 s4, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, s4
-; SI-NEXT:    s_lshr_b32 s4, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s4
-; SI-NEXT:    s_lshr_b32 s4, s12, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s4
-; SI-NEXT:    s_lshr_b32 s4, s13, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s4
-; SI-NEXT:    s_lshr_b32 s4, s14, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s4
-; SI-NEXT:    s_lshr_b32 s4, s15, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s4
-; SI-NEXT:    s_lshr_b32 s4, s40, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s4
-; SI-NEXT:    s_lshr_b32 s4, s41, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s42, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s43, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
-; SI-NEXT:    s_lshr_b32 s4, s44, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
-; SI-NEXT:    s_lshr_b32 s4, s45, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
-; SI-NEXT:    s_lshr_b32 s4, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
-; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
-; SI-NEXT:    s_lshr_b32 s4, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s4
-; SI-NEXT:    s_lshr_b32 s4, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v58, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    s_waitcnt expcnt(5)
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v34
 ; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s10
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_cvt_f32_f16_e32 v61, s11
-; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_cvt_f32_f16_e32 v62, s12
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v35
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v63, s13
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s44
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s45
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v9, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v5, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s16
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v39
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v48
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v51
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v31
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v33
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v37
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v39
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v48
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v16
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v15
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v14
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v13
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v12
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v11
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v10
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v9
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v8
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v7
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:132 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v6
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v5
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v4
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:148 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v3
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:152 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v2
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:156 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v1
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:160 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v32
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:164 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v33
+; SI-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:168 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v37
 ; SI-NEXT:    s_cbranch_execnz .LBB33_3
 ; SI-NEXT:  .LBB33_2: ; %cmp.true
-; SI-NEXT:    v_add_f32_e64 v6, s16, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v6
-; SI-NEXT:    v_add_f32_e64 v2, s17, 1.0
-; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    v_add_f32_e32 v1, 1.0, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SI-NEXT:    v_add_f32_e32 v32, 1.0, v32
+; SI-NEXT:    v_add_f32_e32 v33, 1.0, v33
+; SI-NEXT:    v_add_f32_e32 v9, 1.0, v9
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:160 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v2
-; SI-NEXT:    v_add_f32_e64 v3, s18, 1.0
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v32
+; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v9
+; SI-NEXT:    v_add_f32_e32 v8, 1.0, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v8
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:164 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v33
+; SI-NEXT:    v_add_f32_e32 v7, 1.0, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v7
+; SI-NEXT:    v_add_f32_e32 v6, 1.0, v6
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:168 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v63
+; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v6
+; SI-NEXT:    v_add_f32_e32 v5, 1.0, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v5
 ; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
-; SI-NEXT:    v_add_f32_e64 v5, s19, 1.0
-; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; SI-NEXT:    v_add_f32_e64 v7, s20, 1.0
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v61
+; SI-NEXT:    v_add_f32_e32 v4, 1.0, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v4
+; SI-NEXT:    v_add_f32_e32 v3, 1.0, v3
 ; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
-; SI-NEXT:    v_add_f32_e64 v16, s12, 1.0
-; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
-; SI-NEXT:    v_add_f32_e64 v11, s22, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v4, 16, v16
-; SI-NEXT:    v_add_f32_e64 v40, s6, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v11
-; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v40
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v40
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v4
-; SI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
-; SI-NEXT:    v_add_f32_e64 v17, s25, 1.0
-; SI-NEXT:    v_add_f32_e64 v28, s45, 1.0
-; SI-NEXT:    v_add_f32_e64 v23, s40, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v17
-; SI-NEXT:    v_add_f32_e64 v19, s26, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v28
-; SI-NEXT:    v_lshrrev_b32_e32 v30, 16, v23
-; SI-NEXT:    v_add_f32_e64 v48, s8, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v19
-; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v19
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v49
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, v43
-; SI-NEXT:    v_add_f32_e64 v15, s24, 1.0
-; SI-NEXT:    v_add_f32_e64 v26, s29, 1.0
-; SI-NEXT:    v_add_f32_e64 v25, s41, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v15
-; SI-NEXT:    v_add_f32_e64 v22, s27, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v26
-; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v25
-; SI-NEXT:    v_add_f32_e64 v18, s13, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v12, 16, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v63, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v32
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, v46
-; SI-NEXT:    v_add_f32_e64 v13, s23, 1.0
-; SI-NEXT:    v_add_f32_e64 v24, s28, 1.0
-; SI-NEXT:    v_add_f32_e64 v27, s42, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v13
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v24
-; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v27
-; SI-NEXT:    v_add_f32_e64 v37, s10, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v37
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v59
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v3
+; SI-NEXT:    v_add_f32_e32 v2, 1.0, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v2
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v24
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v34
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, v56
-; SI-NEXT:    v_add_f32_e64 v29, s43, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v62, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v36
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v55
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, v58
-; SI-NEXT:    v_add_f32_e64 v9, s21, 1.0
-; SI-NEXT:    v_add_f32_e64 v31, s44, 1.0
-; SI-NEXT:    v_add_f32_e64 v21, s15, 1.0
-; SI-NEXT:    v_add_f32_e64 v20, s14, 1.0
-; SI-NEXT:    v_add_f32_e64 v33, s11, 1.0
-; SI-NEXT:    v_add_f32_e64 v52, s7, 1.0
-; SI-NEXT:    v_add_f32_e64 v44, s9, 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v9
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v31
-; SI-NEXT:    v_lshrrev_b32_e32 v8, 16, v21
-; SI-NEXT:    v_lshrrev_b32_e32 v10, 16, v20
-; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v33
-; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v52
-; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v44
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, v44
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, v52
-; SI-NEXT:    v_cvt_f32_f16_e32 v61, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v21
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v29
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v28
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v57
+; SI-NEXT:    v_add_f32_e32 v19, 1.0, v31
+; SI-NEXT:    v_add_f32_e32 v21, 1.0, v29
+; SI-NEXT:    v_add_f32_e32 v27, 1.0, v50
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v47
+; SI-NEXT:    v_add_f32_e32 v26, 1.0, v51
+; SI-NEXT:    v_add_f32_e32 v24, 1.0, v49
+; SI-NEXT:    v_add_f32_e32 v22, 1.0, v48
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v45
+; SI-NEXT:    v_add_f32_e32 v20, 1.0, v39
+; SI-NEXT:    v_add_f32_e32 v18, 1.0, v38
+; SI-NEXT:    v_add_f32_e32 v17, 1.0, v37
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v43
+; SI-NEXT:    v_add_f32_e32 v28, 1.0, v36
+; SI-NEXT:    v_add_f32_e32 v30, 1.0, v35
+; SI-NEXT:    v_add_f32_e32 v34, 1.0, v34
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v41
+; SI-NEXT:    v_add_f32_e32 v10, 1.0, v10
+; SI-NEXT:    v_add_f32_e32 v11, 1.0, v11
+; SI-NEXT:    v_add_f32_e32 v12, 1.0, v12
+; SI-NEXT:    v_add_f32_e32 v13, 1.0, v13
+; SI-NEXT:    v_add_f32_e32 v14, 1.0, v14
+; SI-NEXT:    v_add_f32_e32 v15, 1.0, v15
+; SI-NEXT:    v_add_f32_e32 v16, 1.0, v16
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v27
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v26
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v24
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v28
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v30
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v34
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v33
+; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v32
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v42, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
+; SI-NEXT:    v_cvt_f32_f16_e32 v14, v14
 ; SI-NEXT:    v_cvt_f32_f16_e32 v13, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v10
 ; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, v4
-; SI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
 ; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
 ; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, v59
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v18, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v20, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v22, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v24, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v26, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v28, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v30, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v44
 ; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, v57
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v10
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v39
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v41
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, v60
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, v4
-; SI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, v4
-; SI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v58, v4
-; SI-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v53
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v54
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v35
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v37
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v39
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v48
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v19, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v21, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
+; SI-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v14, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v13, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:132 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:148 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:152 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:156 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
 ; SI-NEXT:  .LBB33_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v60
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v7
-; SI-NEXT:    v_cvt_f16_f32_e32 v10, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v5
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v58
-; SI-NEXT:    buffer_store_dword v4, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 4, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v10, v6
-; SI-NEXT:    buffer_store_dword v6, v4, s[0:3], 0 offen
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v56
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v25
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v30
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v28
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v23
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v3
-; SI-NEXT:    v_add_i32_e32 v10, vcc, 8, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v6, v4
-; SI-NEXT:    buffer_store_dword v4, v10, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v46
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 12, v0
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v54
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v43
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v44
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 16, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v41
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v9
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 20, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v55
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v40
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 24, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v53
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v13
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 28, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v52
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 32, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v17
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 36, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v48
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 40, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v18
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v34
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v37
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v16
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v33
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v31
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v29
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v27
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v22
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v25
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x48, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v19
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v23
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x4c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v8
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v21
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x50, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v15
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v20
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x54, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v12
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v63
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x58, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v11
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v62
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x5c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v35
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v61
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v57
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v1
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v50
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v47
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x68, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; SI-NEXT:    v_or_b32_e32 v4, v5, v4
-; SI-NEXT:    buffer_store_dword v4, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v45
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x6c, v0
-; SI-NEXT:    v_or_b32_e32 v3, v4, v3
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v42
-; SI-NEXT:    buffer_store_dword v3, v5, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v38
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 0x70, v0
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
 ; SI-NEXT:    v_or_b32_e32 v2, v3, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v59
-; SI-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v21
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v14
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v27
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v19
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v26
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v63
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v24
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v61
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v22
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v59
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v20
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v57
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v18
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v47
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v17
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v45
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v62
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v43
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v60
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v41
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v58
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:168 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v54
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:164 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v52
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:136 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:160 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:128 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:156 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:152 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:148 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:144 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:140 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:132 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:124 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x54, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:116 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x58, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x5c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v55
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v40
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v42
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x68, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v44
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x6c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v46
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x70, v0
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x74, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v56
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    buffer_load_dword v63, off, s[0:3], s32 ; 4-byte Folded Reload
@@ -22048,66 +22392,93 @@ define inreg <60 x half> @bitcast_v30f32_to_v60f16_scalar(<30 x float> inreg %a,
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB33_4:
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr60
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr58
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr56
-; SI-NEXT:    ; implicit-def: $vgpr5
-; SI-NEXT:    ; implicit-def: $vgpr46
-; SI-NEXT:    ; implicit-def: $vgpr44
-; SI-NEXT:    ; implicit-def: $vgpr43
-; SI-NEXT:    ; implicit-def: $vgpr9
-; SI-NEXT:    ; implicit-def: $vgpr41
-; SI-NEXT:    ; implicit-def: $vgpr40
-; SI-NEXT:    ; implicit-def: $vgpr55
-; SI-NEXT:    ; implicit-def: $vgpr13
 ; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
 ; SI-NEXT:    ; implicit-def: $vgpr52
-; SI-NEXT:    ; implicit-def: $vgpr51
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr49
-; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr39
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr37
-; SI-NEXT:    ; implicit-def: $vgpr34
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr33
-; SI-NEXT:    ; implicit-def: $vgpr30
-; SI-NEXT:    ; implicit-def: $vgpr31
-; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr29
-; SI-NEXT:    ; implicit-def: $vgpr26
-; SI-NEXT:    ; implicit-def: $vgpr27
-; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr25
-; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr23
-; SI-NEXT:    ; implicit-def: $vgpr19
-; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr8
-; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr63
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr62
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr61
-; SI-NEXT:    ; implicit-def: $vgpr35
-; SI-NEXT:    ; implicit-def: $vgpr1
-; SI-NEXT:    ; implicit-def: $vgpr57
-; SI-NEXT:    ; implicit-def: $vgpr47
-; SI-NEXT:    ; implicit-def: $vgpr50
-; SI-NEXT:    ; implicit-def: $vgpr45
-; SI-NEXT:    ; implicit-def: $vgpr54
-; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr40
 ; SI-NEXT:    ; implicit-def: $vgpr42
-; SI-NEXT:    ; implicit-def: $vgpr14
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr30
+; SI-NEXT:    ; implicit-def: $vgpr25
+; SI-NEXT:    ; implicit-def: $vgpr28
+; SI-NEXT:    ; implicit-def: $vgpr23
+; SI-NEXT:    ; implicit-def: $vgpr27
+; SI-NEXT:    ; implicit-def: $vgpr21
+; SI-NEXT:    ; implicit-def: $vgpr26
+; SI-NEXT:    ; implicit-def: $vgpr19
+; SI-NEXT:    ; implicit-def: $vgpr24
+; SI-NEXT:    ; implicit-def: $vgpr63
+; SI-NEXT:    ; implicit-def: $vgpr22
+; SI-NEXT:    ; implicit-def: $vgpr61
+; SI-NEXT:    ; implicit-def: $vgpr20
 ; SI-NEXT:    ; implicit-def: $vgpr59
+; SI-NEXT:    ; implicit-def: $vgpr18
+; SI-NEXT:    ; implicit-def: $vgpr57
+; SI-NEXT:    ; implicit-def: $vgpr17
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr62
+; SI-NEXT:    ; implicit-def: $vgpr45
+; SI-NEXT:    ; implicit-def: $vgpr60
+; SI-NEXT:    ; implicit-def: $vgpr43
+; SI-NEXT:    ; implicit-def: $vgpr58
+; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr54
+; SI-NEXT:    ; kill: killed $vgpr52
+; SI-NEXT:    ; kill: killed $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr52
+; SI-NEXT:    ; kill: killed $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; kill: killed $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; kill: killed $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; kill: killed $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; kill: killed $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr56
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; kill: killed $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr53
 ; SI-NEXT:    s_branch .LBB33_2
 ;
 ; VI-LABEL: bitcast_v30f32_to_v60f16_scalar:
@@ -28034,30 +28405,58 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_store_dword v18, off, s[0:3], s32 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v20, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_writelane_b32 v18, s30, 0
-; SI-NEXT:    v_writelane_b32 v18, s31, 1
-; SI-NEXT:    v_writelane_b32 v18, s34, 2
-; SI-NEXT:    v_writelane_b32 v18, s35, 3
-; SI-NEXT:    v_writelane_b32 v18, s36, 4
-; SI-NEXT:    v_writelane_b32 v18, s37, 5
-; SI-NEXT:    v_writelane_b32 v18, s38, 6
-; SI-NEXT:    v_writelane_b32 v18, s39, 7
-; SI-NEXT:    v_writelane_b32 v18, s48, 8
-; SI-NEXT:    v_writelane_b32 v18, s49, 9
-; SI-NEXT:    v_writelane_b32 v18, s50, 10
-; SI-NEXT:    v_writelane_b32 v18, s51, 11
-; SI-NEXT:    v_writelane_b32 v18, s52, 12
-; SI-NEXT:    v_writelane_b32 v18, s53, 13
-; SI-NEXT:    v_writelane_b32 v18, s54, 14
+; SI-NEXT:    v_writelane_b32 v20, s30, 0
+; SI-NEXT:    v_writelane_b32 v20, s31, 1
+; SI-NEXT:    v_writelane_b32 v20, s34, 2
+; SI-NEXT:    v_writelane_b32 v20, s35, 3
+; SI-NEXT:    v_writelane_b32 v20, s36, 4
+; SI-NEXT:    v_writelane_b32 v20, s37, 5
+; SI-NEXT:    v_writelane_b32 v20, s38, 6
+; SI-NEXT:    v_writelane_b32 v20, s39, 7
+; SI-NEXT:    v_writelane_b32 v20, s48, 8
+; SI-NEXT:    v_mov_b32_e32 v18, s16
+; SI-NEXT:    v_mov_b32_e32 v19, s17
+; SI-NEXT:    v_writelane_b32 v20, s49, 9
+; SI-NEXT:    v_readfirstlane_b32 s46, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s18
+; SI-NEXT:    v_readfirstlane_b32 s47, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s19
+; SI-NEXT:    v_writelane_b32 v20, s50, 10
+; SI-NEXT:    v_readfirstlane_b32 s44, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s20
+; SI-NEXT:    v_readfirstlane_b32 s45, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s21
+; SI-NEXT:    v_writelane_b32 v20, s51, 11
+; SI-NEXT:    v_readfirstlane_b32 s42, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_readfirstlane_b32 s43, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_writelane_b32 v20, s52, 12
+; SI-NEXT:    v_readfirstlane_b32 s40, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s24
+; SI-NEXT:    v_readfirstlane_b32 s41, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s25
+; SI-NEXT:    v_writelane_b32 v20, s53, 13
+; SI-NEXT:    v_readfirstlane_b32 s24, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s25, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_writelane_b32 v20, s54, 14
+; SI-NEXT:    v_readfirstlane_b32 s22, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s28
+; SI-NEXT:    v_readfirstlane_b32 s23, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
-; SI-NEXT:    v_writelane_b32 v18, s55, 15
-; SI-NEXT:    v_readfirstlane_b32 s42, v1
-; SI-NEXT:    v_readfirstlane_b32 s43, v2
-; SI-NEXT:    v_readfirstlane_b32 s40, v3
-; SI-NEXT:    v_readfirstlane_b32 s41, v4
+; SI-NEXT:    v_writelane_b32 v20, s55, 15
+; SI-NEXT:    v_readfirstlane_b32 s20, v18
+; SI-NEXT:    v_readfirstlane_b32 s21, v19
+; SI-NEXT:    v_readfirstlane_b32 s18, v1
+; SI-NEXT:    v_readfirstlane_b32 s19, v2
+; SI-NEXT:    v_readfirstlane_b32 s16, v3
+; SI-NEXT:    v_readfirstlane_b32 s17, v4
 ; SI-NEXT:    v_readfirstlane_b32 s14, v5
 ; SI-NEXT:    v_readfirstlane_b32 s15, v6
 ; SI-NEXT:    v_readfirstlane_b32 s12, v7
@@ -28069,9 +28468,9 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; SI-NEXT:    v_readfirstlane_b32 s6, v13
 ; SI-NEXT:    v_readfirstlane_b32 s7, v14
 ; SI-NEXT:    v_readfirstlane_b32 s4, v15
-; SI-NEXT:    s_and_b64 s[44:45], vcc, exec
+; SI-NEXT:    s_and_b64 s[26:27], vcc, exec
 ; SI-NEXT:    v_readfirstlane_b32 s5, v16
-; SI-NEXT:    v_writelane_b32 v18, s64, 16
+; SI-NEXT:    v_writelane_b32 v20, s64, 16
 ; SI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
 ; SI-NEXT:    s_lshr_b32 s34, s5, 16
@@ -28080,30 +28479,30 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; SI-NEXT:    s_lshr_b32 s37, s11, 16
 ; SI-NEXT:    s_lshr_b32 s38, s13, 16
 ; SI-NEXT:    s_lshr_b32 s39, s15, 16
-; SI-NEXT:    s_lshr_b32 s48, s41, 16
-; SI-NEXT:    s_lshr_b32 s49, s43, 16
-; SI-NEXT:    s_lshr_b32 s50, s29, 16
-; SI-NEXT:    s_lshr_b32 s51, s27, 16
+; SI-NEXT:    s_lshr_b32 s48, s17, 16
+; SI-NEXT:    s_lshr_b32 s49, s19, 16
+; SI-NEXT:    s_lshr_b32 s50, s21, 16
+; SI-NEXT:    s_lshr_b32 s51, s23, 16
 ; SI-NEXT:    s_lshr_b32 s52, s25, 16
-; SI-NEXT:    s_lshr_b32 s53, s23, 16
-; SI-NEXT:    s_lshr_b32 s54, s21, 16
-; SI-NEXT:    s_lshr_b32 s55, s19, 16
-; SI-NEXT:    s_lshr_b32 s64, s17, 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s53, s41, 16
+; SI-NEXT:    s_lshr_b32 s54, s43, 16
+; SI-NEXT:    s_lshr_b32 s55, s45, 16
+; SI-NEXT:    s_lshr_b32 s64, s47, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[62:63], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[40:41], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[42:43], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[26:27], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[22:23], 16
 ; SI-NEXT:    s_lshr_b64 s[88:89], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[90:91], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[92:93], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[94:95], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[30:31], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[90:91], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[92:93], s[42:43], 16
+; SI-NEXT:    s_lshr_b64 s[94:95], s[44:45], 16
+; SI-NEXT:    s_lshr_b64 s[30:31], s[46:47], 16
 ; SI-NEXT:    s_cbranch_execnz .LBB41_3
 ; SI-NEXT:  .LBB41_2: ; %cmp.true
 ; SI-NEXT:    s_add_u32 s4, s4, 3
@@ -28118,167 +28517,167 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; SI-NEXT:    s_addc_u32 s13, s13, 0
 ; SI-NEXT:    s_add_u32 s14, s14, 3
 ; SI-NEXT:    s_addc_u32 s15, s15, 0
+; SI-NEXT:    s_add_u32 s16, s16, 3
+; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_add_u32 s20, s20, 3
+; SI-NEXT:    s_addc_u32 s21, s21, 0
+; SI-NEXT:    s_add_u32 s22, s22, 3
+; SI-NEXT:    s_addc_u32 s23, s23, 0
+; SI-NEXT:    s_add_u32 s24, s24, 3
+; SI-NEXT:    s_addc_u32 s25, s25, 0
 ; SI-NEXT:    s_add_u32 s40, s40, 3
 ; SI-NEXT:    s_addc_u32 s41, s41, 0
 ; SI-NEXT:    s_add_u32 s42, s42, 3
 ; SI-NEXT:    s_addc_u32 s43, s43, 0
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_add_u32 s20, s20, 3
-; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
-; SI-NEXT:    s_add_u32 s16, s16, 3
-; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_add_u32 s44, s44, 3
+; SI-NEXT:    s_addc_u32 s45, s45, 0
+; SI-NEXT:    s_add_u32 s46, s46, 3
+; SI-NEXT:    s_addc_u32 s47, s47, 0
 ; SI-NEXT:    s_lshr_b32 s34, s5, 16
 ; SI-NEXT:    s_lshr_b32 s35, s7, 16
 ; SI-NEXT:    s_lshr_b32 s36, s9, 16
 ; SI-NEXT:    s_lshr_b32 s37, s11, 16
 ; SI-NEXT:    s_lshr_b32 s38, s13, 16
 ; SI-NEXT:    s_lshr_b32 s39, s15, 16
-; SI-NEXT:    s_lshr_b32 s48, s41, 16
-; SI-NEXT:    s_lshr_b32 s49, s43, 16
-; SI-NEXT:    s_lshr_b32 s50, s29, 16
-; SI-NEXT:    s_lshr_b32 s51, s27, 16
+; SI-NEXT:    s_lshr_b32 s48, s17, 16
+; SI-NEXT:    s_lshr_b32 s49, s19, 16
+; SI-NEXT:    s_lshr_b32 s50, s21, 16
+; SI-NEXT:    s_lshr_b32 s51, s23, 16
 ; SI-NEXT:    s_lshr_b32 s52, s25, 16
-; SI-NEXT:    s_lshr_b32 s53, s23, 16
-; SI-NEXT:    s_lshr_b32 s54, s21, 16
-; SI-NEXT:    s_lshr_b32 s55, s19, 16
-; SI-NEXT:    s_lshr_b32 s64, s17, 16
-; SI-NEXT:    s_lshr_b64 s[44:45], s[4:5], 16
-; SI-NEXT:    s_lshr_b64 s[46:47], s[6:7], 16
+; SI-NEXT:    s_lshr_b32 s53, s41, 16
+; SI-NEXT:    s_lshr_b32 s54, s43, 16
+; SI-NEXT:    s_lshr_b32 s55, s45, 16
+; SI-NEXT:    s_lshr_b32 s64, s47, 16
+; SI-NEXT:    s_lshr_b64 s[26:27], s[4:5], 16
+; SI-NEXT:    s_lshr_b64 s[28:29], s[6:7], 16
 ; SI-NEXT:    s_lshr_b64 s[56:57], s[8:9], 16
 ; SI-NEXT:    s_lshr_b64 s[58:59], s[10:11], 16
 ; SI-NEXT:    s_lshr_b64 s[60:61], s[12:13], 16
 ; SI-NEXT:    s_lshr_b64 s[62:63], s[14:15], 16
-; SI-NEXT:    s_lshr_b64 s[72:73], s[40:41], 16
-; SI-NEXT:    s_lshr_b64 s[74:75], s[42:43], 16
-; SI-NEXT:    s_lshr_b64 s[76:77], s[28:29], 16
-; SI-NEXT:    s_lshr_b64 s[78:79], s[26:27], 16
+; SI-NEXT:    s_lshr_b64 s[72:73], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[74:75], s[18:19], 16
+; SI-NEXT:    s_lshr_b64 s[76:77], s[20:21], 16
+; SI-NEXT:    s_lshr_b64 s[78:79], s[22:23], 16
 ; SI-NEXT:    s_lshr_b64 s[88:89], s[24:25], 16
-; SI-NEXT:    s_lshr_b64 s[90:91], s[22:23], 16
-; SI-NEXT:    s_lshr_b64 s[92:93], s[20:21], 16
-; SI-NEXT:    s_lshr_b64 s[94:95], s[18:19], 16
-; SI-NEXT:    s_lshr_b64 s[30:31], s[16:17], 16
+; SI-NEXT:    s_lshr_b64 s[90:91], s[40:41], 16
+; SI-NEXT:    s_lshr_b64 s[92:93], s[42:43], 16
+; SI-NEXT:    s_lshr_b64 s[94:95], s[44:45], 16
+; SI-NEXT:    s_lshr_b64 s[30:31], s[46:47], 16
 ; SI-NEXT:  .LBB41_3: ; %end
-; SI-NEXT:    s_lshl_b32 s45, s30, 16
-; SI-NEXT:    s_and_b32 s16, s16, 0xffff
-; SI-NEXT:    s_or_b32 s16, s16, s45
-; SI-NEXT:    v_mov_b32_e32 v1, s16
-; SI-NEXT:    s_and_b32 s16, s17, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s64, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_lshl_b32 s16, s94, 16
-; SI-NEXT:    s_and_b32 s17, s18, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
-; SI-NEXT:    v_mov_b32_e32 v3, s16
-; SI-NEXT:    s_and_b32 s16, s19, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s55, 16
-; SI-NEXT:    s_or_b32 s16, s16, s17
-; SI-NEXT:    v_mov_b32_e32 v4, s16
-; SI-NEXT:    s_lshl_b32 s16, s92, 16
-; SI-NEXT:    s_and_b32 s17, s20, 0xffff
-; SI-NEXT:    s_or_b32 s16, s17, s16
-; SI-NEXT:    v_mov_b32_e32 v5, s16
-; SI-NEXT:    s_and_b32 s16, s21, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s54, 16
+; SI-NEXT:    s_lshl_b32 s27, s30, 16
+; SI-NEXT:    s_and_b32 s29, s46, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v1, s27
+; SI-NEXT:    s_and_b32 s27, s47, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s64, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_lshl_b32 s27, s94, 16
+; SI-NEXT:    s_and_b32 s29, s44, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v3, s27
+; SI-NEXT:    s_and_b32 s27, s45, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s55, 16
+; SI-NEXT:    s_or_b32 s27, s27, s29
+; SI-NEXT:    v_mov_b32_e32 v4, s27
+; SI-NEXT:    s_lshl_b32 s27, s92, 16
+; SI-NEXT:    s_and_b32 s29, s42, 0xffff
+; SI-NEXT:    s_or_b32 s27, s29, s27
+; SI-NEXT:    v_mov_b32_e32 v5, s27
+; SI-NEXT:    s_and_b32 s27, s43, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s54, 16
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s27, s27, s29
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 8, v0
-; SI-NEXT:    v_mov_b32_e32 v6, s16
+; SI-NEXT:    v_mov_b32_e32 v6, s27
 ; SI-NEXT:    buffer_store_dword v3, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 12, v0
-; SI-NEXT:    s_lshl_b32 s16, s90, 16
-; SI-NEXT:    s_and_b32 s17, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s90, 16
+; SI-NEXT:    s_and_b32 s29, s40, 0xffff
 ; SI-NEXT:    buffer_store_dword v4, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 16, v0
-; SI-NEXT:    s_or_b32 s16, s17, s16
+; SI-NEXT:    s_or_b32 s27, s29, s27
 ; SI-NEXT:    buffer_store_dword v5, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 20, v0
 ; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s23, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s53, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_and_b32 s27, s41, 0xffff
+; SI-NEXT:    s_lshl_b32 s29, s53, 16
 ; SI-NEXT:    buffer_store_dword v6, v1, s[0:3], 0 offen
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 24, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s27, s27, s29
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s24, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s88, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s27
+; SI-NEXT:    s_and_b32 s24, s24, 0xffff
+; SI-NEXT:    s_lshl_b32 s27, s88, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 28, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s27
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s25, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s52, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s24, s25, 0xffff
+; SI-NEXT:    s_lshl_b32 s25, s52, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 32, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s24, s24, s25
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s26, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s78, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s24
+; SI-NEXT:    s_and_b32 s22, s22, 0xffff
+; SI-NEXT:    s_lshl_b32 s24, s78, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 36, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s24
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s27, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s51, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s22, s23, 0xffff
+; SI-NEXT:    s_lshl_b32 s23, s51, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 40, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s22, s22, s23
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s28, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s76, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s22
+; SI-NEXT:    s_and_b32 s20, s20, 0xffff
+; SI-NEXT:    s_lshl_b32 s22, s76, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 44, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s22
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s29, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s50, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s20, s21, 0xffff
+; SI-NEXT:    s_lshl_b32 s21, s50, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 48, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s20, s20, s21
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s42, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s74, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s20
+; SI-NEXT:    s_and_b32 s18, s18, 0xffff
+; SI-NEXT:    s_lshl_b32 s20, s74, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 52, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s20
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s43, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s49, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s18, s19, 0xffff
+; SI-NEXT:    s_lshl_b32 s19, s49, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 56, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s18, s18, s19
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s40, 0xffff
-; SI-NEXT:    s_lshl_b32 s17, s72, 16
+; SI-NEXT:    v_mov_b32_e32 v2, s18
+; SI-NEXT:    s_and_b32 s16, s16, 0xffff
+; SI-NEXT:    s_lshl_b32 s18, s72, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 60, v0
-; SI-NEXT:    s_or_b32 s16, s16, s17
+; SI-NEXT:    s_or_b32 s16, s16, s18
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s16
-; SI-NEXT:    s_and_b32 s16, s41, 0xffff
+; SI-NEXT:    s_and_b32 s16, s17, 0xffff
 ; SI-NEXT:    s_lshl_b32 s17, s48, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 64, v0
 ; SI-NEXT:    s_or_b32 s16, s16, s17
@@ -28342,7 +28741,7 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s8
 ; SI-NEXT:    s_and_b32 s6, s6, 0xffff
-; SI-NEXT:    s_lshl_b32 s8, s46, 16
+; SI-NEXT:    s_lshl_b32 s8, s28, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x64, v0
 ; SI-NEXT:    s_or_b32 s6, s6, s8
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -28356,7 +28755,7 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
 ; SI-NEXT:    s_and_b32 s4, s4, 0xffff
-; SI-NEXT:    s_lshl_b32 s6, s44, 16
+; SI-NEXT:    s_lshl_b32 s6, s26, 16
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, 0x6c, v0
 ; SI-NEXT:    s_or_b32 s4, s4, s6
 ; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
@@ -28370,25 +28769,25 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x74, v0
 ; SI-NEXT:    v_mov_b32_e32 v1, s4
 ; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
-; SI-NEXT:    v_readlane_b32 s64, v18, 16
-; SI-NEXT:    v_readlane_b32 s55, v18, 15
-; SI-NEXT:    v_readlane_b32 s54, v18, 14
-; SI-NEXT:    v_readlane_b32 s53, v18, 13
-; SI-NEXT:    v_readlane_b32 s52, v18, 12
-; SI-NEXT:    v_readlane_b32 s51, v18, 11
-; SI-NEXT:    v_readlane_b32 s50, v18, 10
-; SI-NEXT:    v_readlane_b32 s49, v18, 9
-; SI-NEXT:    v_readlane_b32 s48, v18, 8
-; SI-NEXT:    v_readlane_b32 s39, v18, 7
-; SI-NEXT:    v_readlane_b32 s38, v18, 6
-; SI-NEXT:    v_readlane_b32 s37, v18, 5
-; SI-NEXT:    v_readlane_b32 s36, v18, 4
-; SI-NEXT:    v_readlane_b32 s35, v18, 3
-; SI-NEXT:    v_readlane_b32 s34, v18, 2
-; SI-NEXT:    v_readlane_b32 s31, v18, 1
-; SI-NEXT:    v_readlane_b32 s30, v18, 0
+; SI-NEXT:    v_readlane_b32 s64, v20, 16
+; SI-NEXT:    v_readlane_b32 s55, v20, 15
+; SI-NEXT:    v_readlane_b32 s54, v20, 14
+; SI-NEXT:    v_readlane_b32 s53, v20, 13
+; SI-NEXT:    v_readlane_b32 s52, v20, 12
+; SI-NEXT:    v_readlane_b32 s51, v20, 11
+; SI-NEXT:    v_readlane_b32 s50, v20, 10
+; SI-NEXT:    v_readlane_b32 s49, v20, 9
+; SI-NEXT:    v_readlane_b32 s48, v20, 8
+; SI-NEXT:    v_readlane_b32 s39, v20, 7
+; SI-NEXT:    v_readlane_b32 s38, v20, 6
+; SI-NEXT:    v_readlane_b32 s37, v20, 5
+; SI-NEXT:    v_readlane_b32 s36, v20, 4
+; SI-NEXT:    v_readlane_b32 s35, v20, 3
+; SI-NEXT:    v_readlane_b32 s34, v20, 2
+; SI-NEXT:    v_readlane_b32 s31, v20, 1
+; SI-NEXT:    v_readlane_b32 s30, v20, 0
 ; SI-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; SI-NEXT:    buffer_load_dword v18, off, s[0:3], s32 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 ; 4-byte Folded Reload
 ; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -28419,10 +28818,10 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; SI-NEXT:    ; implicit-def: $sgpr37
 ; SI-NEXT:    ; implicit-def: $sgpr56
 ; SI-NEXT:    ; implicit-def: $sgpr36
-; SI-NEXT:    ; implicit-def: $sgpr46
+; SI-NEXT:    ; implicit-def: $sgpr28
 ; SI-NEXT:    ; implicit-def: $sgpr35
 ; SI-NEXT:    ; implicit-def: $sgpr34
-; SI-NEXT:    ; implicit-def: $sgpr44
+; SI-NEXT:    ; implicit-def: $sgpr26
 ; SI-NEXT:    s_branch .LBB41_2
 ;
 ; VI-LABEL: bitcast_v15i64_to_v60i16_scalar:
@@ -28433,18 +28832,46 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; VI-NEXT:    s_mov_b64 exec, s[4:5]
 ; VI-NEXT:    v_writelane_b32 v30, s30, 0
 ; VI-NEXT:    v_writelane_b32 v30, s31, 1
+; VI-NEXT:    v_mov_b32_e32 v17, s16
+; VI-NEXT:    v_mov_b32_e32 v18, s17
 ; VI-NEXT:    v_writelane_b32 v30, s34, 2
+; VI-NEXT:    v_mov_b32_e32 v19, s18
+; VI-NEXT:    v_readfirstlane_b32 s56, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s19
+; VI-NEXT:    v_readfirstlane_b32 s47, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s20
 ; VI-NEXT:    v_writelane_b32 v30, s35, 3
+; VI-NEXT:    v_readfirstlane_b32 s46, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s21
+; VI-NEXT:    v_readfirstlane_b32 s45, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s23
 ; VI-NEXT:    v_writelane_b32 v30, s36, 4
+; VI-NEXT:    v_readfirstlane_b32 s43, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s26
 ; VI-NEXT:    v_writelane_b32 v30, s37, 5
+; VI-NEXT:    v_readfirstlane_b32 s40, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v16
 ; VI-NEXT:    v_writelane_b32 v30, s38, 6
-; VI-NEXT:    v_readfirstlane_b32 s45, v0
-; VI-NEXT:    v_readfirstlane_b32 s44, v1
-; VI-NEXT:    v_readfirstlane_b32 s43, v2
-; VI-NEXT:    v_readfirstlane_b32 s42, v3
-; VI-NEXT:    v_readfirstlane_b32 s41, v4
-; VI-NEXT:    v_readfirstlane_b32 s40, v5
+; VI-NEXT:    v_readfirstlane_b32 s24, v19
+; VI-NEXT:    v_readfirstlane_b32 s23, v17
+; VI-NEXT:    v_readfirstlane_b32 s22, v18
+; VI-NEXT:    v_readfirstlane_b32 s21, v0
+; VI-NEXT:    v_readfirstlane_b32 s20, v1
+; VI-NEXT:    v_readfirstlane_b32 s19, v2
+; VI-NEXT:    v_readfirstlane_b32 s18, v3
+; VI-NEXT:    v_readfirstlane_b32 s17, v4
+; VI-NEXT:    v_readfirstlane_b32 s16, v5
 ; VI-NEXT:    v_readfirstlane_b32 s15, v6
 ; VI-NEXT:    v_readfirstlane_b32 s14, v7
 ; VI-NEXT:    v_readfirstlane_b32 s13, v8
@@ -28459,9 +28886,9 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; VI-NEXT:    v_writelane_b32 v30, s39, 7
 ; VI-NEXT:    s_cbranch_scc0 .LBB41_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s46, s7, 16
-; VI-NEXT:    s_lshr_b32 s47, s6, 16
-; VI-NEXT:    s_lshr_b32 s56, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s57, s9, 16
 ; VI-NEXT:    s_lshr_b32 s58, s10, 16
 ; VI-NEXT:    s_lshr_b32 s59, s11, 16
@@ -28469,26 +28896,26 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s61, s13, 16
 ; VI-NEXT:    s_lshr_b32 s62, s14, 16
 ; VI-NEXT:    s_lshr_b32 s63, s15, 16
-; VI-NEXT:    s_lshr_b32 s72, s40, 16
-; VI-NEXT:    s_lshr_b32 s73, s41, 16
-; VI-NEXT:    s_lshr_b32 s74, s42, 16
-; VI-NEXT:    s_lshr_b32 s75, s43, 16
-; VI-NEXT:    s_lshr_b32 s76, s44, 16
-; VI-NEXT:    s_lshr_b32 s77, s45, 16
-; VI-NEXT:    s_lshr_b32 s78, s29, 16
-; VI-NEXT:    s_lshr_b32 s79, s28, 16
-; VI-NEXT:    s_lshr_b32 s88, s27, 16
-; VI-NEXT:    s_lshr_b32 s89, s26, 16
-; VI-NEXT:    s_lshr_b32 s90, s25, 16
-; VI-NEXT:    s_lshr_b32 s91, s24, 16
-; VI-NEXT:    s_lshr_b32 s30, s23, 16
-; VI-NEXT:    s_lshr_b32 s31, s22, 16
-; VI-NEXT:    s_lshr_b32 s34, s21, 16
-; VI-NEXT:    s_lshr_b32 s35, s20, 16
-; VI-NEXT:    s_lshr_b32 s36, s19, 16
-; VI-NEXT:    s_lshr_b32 s37, s18, 16
-; VI-NEXT:    s_lshr_b32 s38, s17, 16
-; VI-NEXT:    s_lshr_b32 s39, s16, 16
+; VI-NEXT:    s_lshr_b32 s72, s16, 16
+; VI-NEXT:    s_lshr_b32 s73, s17, 16
+; VI-NEXT:    s_lshr_b32 s74, s18, 16
+; VI-NEXT:    s_lshr_b32 s75, s19, 16
+; VI-NEXT:    s_lshr_b32 s76, s20, 16
+; VI-NEXT:    s_lshr_b32 s77, s21, 16
+; VI-NEXT:    s_lshr_b32 s78, s22, 16
+; VI-NEXT:    s_lshr_b32 s79, s23, 16
+; VI-NEXT:    s_lshr_b32 s88, s24, 16
+; VI-NEXT:    s_lshr_b32 s89, s25, 16
+; VI-NEXT:    s_lshr_b32 s90, s26, 16
+; VI-NEXT:    s_lshr_b32 s91, s40, 16
+; VI-NEXT:    s_lshr_b32 s30, s41, 16
+; VI-NEXT:    s_lshr_b32 s31, s42, 16
+; VI-NEXT:    s_lshr_b32 s34, s43, 16
+; VI-NEXT:    s_lshr_b32 s35, s44, 16
+; VI-NEXT:    s_lshr_b32 s36, s45, 16
+; VI-NEXT:    s_lshr_b32 s37, s46, 16
+; VI-NEXT:    s_lshr_b32 s38, s47, 16
+; VI-NEXT:    s_lshr_b32 s39, s56, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB41_3
 ; VI-NEXT:  .LBB41_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -28501,29 +28928,29 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
 ; VI-NEXT:    s_add_u32 s15, s15, 3
 ; VI-NEXT:    s_addc_u32 s14, s14, 0
-; VI-NEXT:    s_add_u32 s41, s41, 3
-; VI-NEXT:    s_addc_u32 s40, s40, 0
-; VI-NEXT:    s_add_u32 s43, s43, 3
-; VI-NEXT:    s_addc_u32 s42, s42, 0
-; VI-NEXT:    s_add_u32 s45, s45, 3
-; VI-NEXT:    s_addc_u32 s44, s44, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s46, s7, 16
-; VI-NEXT:    s_lshr_b32 s47, s6, 16
-; VI-NEXT:    s_lshr_b32 s56, s8, 16
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_add_u32 s42, s42, 3
+; VI-NEXT:    s_addc_u32 s41, s41, 0
+; VI-NEXT:    s_add_u32 s44, s44, 3
+; VI-NEXT:    s_addc_u32 s43, s43, 0
+; VI-NEXT:    s_add_u32 s46, s46, 3
+; VI-NEXT:    s_addc_u32 s45, s45, 0
+; VI-NEXT:    s_add_u32 s56, s56, 3
+; VI-NEXT:    s_addc_u32 s47, s47, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s57, s9, 16
 ; VI-NEXT:    s_lshr_b32 s58, s10, 16
 ; VI-NEXT:    s_lshr_b32 s59, s11, 16
@@ -28531,137 +28958,137 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; VI-NEXT:    s_lshr_b32 s61, s13, 16
 ; VI-NEXT:    s_lshr_b32 s62, s14, 16
 ; VI-NEXT:    s_lshr_b32 s63, s15, 16
-; VI-NEXT:    s_lshr_b32 s72, s40, 16
-; VI-NEXT:    s_lshr_b32 s73, s41, 16
-; VI-NEXT:    s_lshr_b32 s74, s42, 16
-; VI-NEXT:    s_lshr_b32 s75, s43, 16
-; VI-NEXT:    s_lshr_b32 s76, s44, 16
-; VI-NEXT:    s_lshr_b32 s77, s45, 16
-; VI-NEXT:    s_lshr_b32 s78, s29, 16
-; VI-NEXT:    s_lshr_b32 s79, s28, 16
-; VI-NEXT:    s_lshr_b32 s88, s27, 16
-; VI-NEXT:    s_lshr_b32 s89, s26, 16
-; VI-NEXT:    s_lshr_b32 s90, s25, 16
-; VI-NEXT:    s_lshr_b32 s91, s24, 16
-; VI-NEXT:    s_lshr_b32 s30, s23, 16
-; VI-NEXT:    s_lshr_b32 s31, s22, 16
-; VI-NEXT:    s_lshr_b32 s34, s21, 16
-; VI-NEXT:    s_lshr_b32 s35, s20, 16
-; VI-NEXT:    s_lshr_b32 s36, s19, 16
-; VI-NEXT:    s_lshr_b32 s37, s18, 16
-; VI-NEXT:    s_lshr_b32 s38, s17, 16
-; VI-NEXT:    s_lshr_b32 s39, s16, 16
+; VI-NEXT:    s_lshr_b32 s72, s16, 16
+; VI-NEXT:    s_lshr_b32 s73, s17, 16
+; VI-NEXT:    s_lshr_b32 s74, s18, 16
+; VI-NEXT:    s_lshr_b32 s75, s19, 16
+; VI-NEXT:    s_lshr_b32 s76, s20, 16
+; VI-NEXT:    s_lshr_b32 s77, s21, 16
+; VI-NEXT:    s_lshr_b32 s78, s22, 16
+; VI-NEXT:    s_lshr_b32 s79, s23, 16
+; VI-NEXT:    s_lshr_b32 s88, s24, 16
+; VI-NEXT:    s_lshr_b32 s89, s25, 16
+; VI-NEXT:    s_lshr_b32 s90, s26, 16
+; VI-NEXT:    s_lshr_b32 s91, s40, 16
+; VI-NEXT:    s_lshr_b32 s30, s41, 16
+; VI-NEXT:    s_lshr_b32 s31, s42, 16
+; VI-NEXT:    s_lshr_b32 s34, s43, 16
+; VI-NEXT:    s_lshr_b32 s35, s44, 16
+; VI-NEXT:    s_lshr_b32 s36, s45, 16
+; VI-NEXT:    s_lshr_b32 s37, s46, 16
+; VI-NEXT:    s_lshr_b32 s38, s47, 16
+; VI-NEXT:    s_lshr_b32 s39, s56, 16
 ; VI-NEXT:  .LBB41_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s56
 ; VI-NEXT:    s_lshl_b32 s5, s39, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s38, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s37, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s36, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s35, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s34, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s31, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s30, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s91, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s90, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s89, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s88, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s79, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s78, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s45
-; VI-NEXT:    s_lshl_b32 s29, s77, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s44
-; VI-NEXT:    s_lshl_b32 s44, s76, 16
-; VI-NEXT:    s_or_b32 s29, s29, s44
+; VI-NEXT:    s_and_b32 s5, 0xffff, s47
+; VI-NEXT:    s_lshl_b32 s47, s38, 16
+; VI-NEXT:    s_or_b32 s5, s5, s47
+; VI-NEXT:    s_and_b32 s46, 0xffff, s46
+; VI-NEXT:    s_lshl_b32 s47, s37, 16
+; VI-NEXT:    s_or_b32 s46, s46, s47
+; VI-NEXT:    s_and_b32 s45, 0xffff, s45
+; VI-NEXT:    s_lshl_b32 s47, s36, 16
+; VI-NEXT:    s_or_b32 s45, s45, s47
+; VI-NEXT:    s_and_b32 s44, 0xffff, s44
+; VI-NEXT:    s_lshl_b32 s47, s35, 16
+; VI-NEXT:    s_or_b32 s44, s44, s47
 ; VI-NEXT:    s_and_b32 s43, 0xffff, s43
-; VI-NEXT:    s_lshl_b32 s44, s75, 16
-; VI-NEXT:    s_or_b32 s43, s43, s44
+; VI-NEXT:    s_lshl_b32 s47, s34, 16
+; VI-NEXT:    s_or_b32 s43, s43, s47
 ; VI-NEXT:    s_and_b32 s42, 0xffff, s42
-; VI-NEXT:    s_lshl_b32 s44, s74, 16
-; VI-NEXT:    s_or_b32 s42, s42, s44
+; VI-NEXT:    s_lshl_b32 s47, s31, 16
+; VI-NEXT:    s_or_b32 s42, s42, s47
 ; VI-NEXT:    s_and_b32 s41, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s44, s73, 16
-; VI-NEXT:    s_or_b32 s41, s41, s44
+; VI-NEXT:    s_lshl_b32 s47, s30, 16
+; VI-NEXT:    s_or_b32 s41, s41, s47
 ; VI-NEXT:    s_and_b32 s40, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s44, s72, 16
-; VI-NEXT:    s_or_b32 s40, s40, s44
+; VI-NEXT:    s_lshl_b32 s47, s91, 16
+; VI-NEXT:    s_or_b32 s40, s40, s47
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s47, s90, 16
+; VI-NEXT:    s_or_b32 s26, s26, s47
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s47, s89, 16
+; VI-NEXT:    s_or_b32 s25, s25, s47
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s47, s88, 16
+; VI-NEXT:    s_or_b32 s24, s24, s47
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s47, s79, 16
+; VI-NEXT:    s_or_b32 s23, s23, s47
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s47, s78, 16
+; VI-NEXT:    s_or_b32 s22, s22, s47
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s47, s77, 16
+; VI-NEXT:    s_or_b32 s21, s21, s47
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s47, s76, 16
+; VI-NEXT:    s_or_b32 s20, s20, s47
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s47, s75, 16
+; VI-NEXT:    s_or_b32 s19, s19, s47
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s47, s74, 16
+; VI-NEXT:    s_or_b32 s18, s18, s47
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s47, s73, 16
+; VI-NEXT:    s_or_b32 s17, s17, s47
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s47, s72, 16
+; VI-NEXT:    s_or_b32 s16, s16, s47
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s44, s63, 16
-; VI-NEXT:    s_or_b32 s15, s15, s44
+; VI-NEXT:    s_lshl_b32 s47, s63, 16
+; VI-NEXT:    s_or_b32 s15, s15, s47
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s44, s62, 16
-; VI-NEXT:    s_or_b32 s14, s14, s44
+; VI-NEXT:    s_lshl_b32 s47, s62, 16
+; VI-NEXT:    s_or_b32 s14, s14, s47
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s44, s61, 16
-; VI-NEXT:    s_or_b32 s13, s13, s44
+; VI-NEXT:    s_lshl_b32 s47, s61, 16
+; VI-NEXT:    s_or_b32 s13, s13, s47
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s44, s60, 16
-; VI-NEXT:    s_or_b32 s12, s12, s44
+; VI-NEXT:    s_lshl_b32 s47, s60, 16
+; VI-NEXT:    s_or_b32 s12, s12, s47
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s44, s59, 16
-; VI-NEXT:    s_or_b32 s11, s11, s44
+; VI-NEXT:    s_lshl_b32 s47, s59, 16
+; VI-NEXT:    s_or_b32 s11, s11, s47
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s44, s58, 16
-; VI-NEXT:    s_or_b32 s10, s10, s44
+; VI-NEXT:    s_lshl_b32 s47, s58, 16
+; VI-NEXT:    s_or_b32 s10, s10, s47
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s44, s57, 16
-; VI-NEXT:    s_or_b32 s9, s9, s44
+; VI-NEXT:    s_lshl_b32 s47, s57, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s44, s56, 16
-; VI-NEXT:    s_or_b32 s8, s8, s44
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s44, s47, 16
-; VI-NEXT:    s_or_b32 s6, s6, s44
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s44, s46, 16
-; VI-NEXT:    s_or_b32 s7, s7, s44
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s47
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
-; VI-NEXT:    v_mov_b32_e32 v16, s43
-; VI-NEXT:    v_mov_b32_e32 v17, s42
-; VI-NEXT:    v_mov_b32_e32 v18, s41
-; VI-NEXT:    v_mov_b32_e32 v19, s40
+; VI-NEXT:    v_mov_b32_e32 v2, s46
+; VI-NEXT:    v_mov_b32_e32 v3, s45
+; VI-NEXT:    v_mov_b32_e32 v4, s44
+; VI-NEXT:    v_mov_b32_e32 v5, s43
+; VI-NEXT:    v_mov_b32_e32 v6, s42
+; VI-NEXT:    v_mov_b32_e32 v7, s41
+; VI-NEXT:    v_mov_b32_e32 v8, s40
+; VI-NEXT:    v_mov_b32_e32 v9, s26
+; VI-NEXT:    v_mov_b32_e32 v10, s25
+; VI-NEXT:    v_mov_b32_e32 v11, s24
+; VI-NEXT:    v_mov_b32_e32 v12, s23
+; VI-NEXT:    v_mov_b32_e32 v13, s22
+; VI-NEXT:    v_mov_b32_e32 v14, s21
+; VI-NEXT:    v_mov_b32_e32 v15, s20
+; VI-NEXT:    v_mov_b32_e32 v16, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s18
+; VI-NEXT:    v_mov_b32_e32 v18, s17
+; VI-NEXT:    v_mov_b32_e32 v19, s16
 ; VI-NEXT:    v_mov_b32_e32 v20, s15
 ; VI-NEXT:    v_mov_b32_e32 v21, s14
 ; VI-NEXT:    v_mov_b32_e32 v22, s13
@@ -28713,9 +29140,9 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; VI-NEXT:    ; implicit-def: $sgpr59
 ; VI-NEXT:    ; implicit-def: $sgpr58
 ; VI-NEXT:    ; implicit-def: $sgpr57
-; VI-NEXT:    ; implicit-def: $sgpr56
-; VI-NEXT:    ; implicit-def: $sgpr47
-; VI-NEXT:    ; implicit-def: $sgpr46
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB41_2
 ;
 ; GFX9-LABEL: bitcast_v15i64_to_v60i16_scalar:
@@ -28724,20 +29151,48 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_xor_saveexec_b64 s[4:5], -1
 ; GFX9-NEXT:    buffer_store_dword v30, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GFX9-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9-NEXT:    v_mov_b32_e32 v17, s16
+; GFX9-NEXT:    v_mov_b32_e32 v18, s17
+; GFX9-NEXT:    v_mov_b32_e32 v19, s18
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s19
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s20
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s21
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s23
 ; GFX9-NEXT:    v_writelane_b32 v30, s30, 0
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s26
 ; GFX9-NEXT:    v_writelane_b32 v30, s31, 1
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v16
 ; GFX9-NEXT:    v_writelane_b32 v30, s34, 2
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
 ; GFX9-NEXT:    v_readfirstlane_b32 s42, v12
@@ -28754,30 +29209,30 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_lshr_b32 s57, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s58, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s59, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s30, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s31, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s34, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s35, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s30, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s31, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s34, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s35, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB41_3
 ; GFX9-NEXT:  .LBB41_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_u32 s44, s44, 3
@@ -28786,16 +29241,6 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_addc_u32 s43, s43, 0
 ; GFX9-NEXT:    s_add_u32 s40, s40, 3
 ; GFX9-NEXT:    s_addc_u32 s41, s41, 0
-; GFX9-NEXT:    s_add_u32 s14, s14, 3
-; GFX9-NEXT:    s_addc_u32 s15, s15, 0
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_add_u32 s28, s28, 3
 ; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
@@ -28810,61 +29255,71 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_lshr_b32 s46, s45, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s44, 16
 ; GFX9-NEXT:    s_lshr_b32 s56, s43, 16
 ; GFX9-NEXT:    s_lshr_b32 s57, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s58, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s59, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s30, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s31, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s34, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s35, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s30, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s31, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s34, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s35, s6, 16
 ; GFX9-NEXT:  .LBB41_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s35
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s34
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s31
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s30
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s95
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s94
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s93
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s92
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s35
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s34
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s31
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s30
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s95
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s94
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s93
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s92
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s60
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s59
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s58
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s40, s42, s57
@@ -28873,28 +29328,28 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s43, s45, s46
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    v_mov_b32_e32 v26, s40
@@ -28946,49 +29401,76 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; GFX11-LABEL: bitcast_v15i64_to_v60i16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v13, s0 :: v_dual_mov_b32 v14, s1
+; GFX11-NEXT:    v_dual_mov_b32 v15, s2 :: v_dual_mov_b32 v16, s3
+; GFX11-NEXT:    v_dual_mov_b32 v17, s16 :: v_dual_mov_b32 v18, s17
+; GFX11-NEXT:    v_dual_mov_b32 v19, s18 :: v_dual_mov_b32 v20, s19
+; GFX11-NEXT:    v_dual_mov_b32 v21, s20 :: v_dual_mov_b32 v22, s21
+; GFX11-NEXT:    v_dual_mov_b32 v23, s22 :: v_dual_mov_b32 v24, s23
+; GFX11-NEXT:    v_dual_mov_b32 v25, s24 :: v_dual_mov_b32 v26, s25
+; GFX11-NEXT:    v_dual_mov_b32 v27, s26 :: v_dual_mov_b32 v28, s27
+; GFX11-NEXT:    v_dual_mov_b32 v29, s28 :: v_dual_mov_b32 v30, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v12
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v7
-; GFX11-NEXT:    v_readfirstlane_b32 s12, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s13, v9
-; GFX11-NEXT:    v_readfirstlane_b32 s15, v10
-; GFX11-NEXT:    v_readfirstlane_b32 s14, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v27
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v28
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v29
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v30
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s26, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s27, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s29, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s28, v11
 ; GFX11-NEXT:    s_mov_b32 s94, 0
 ; GFX11-NEXT:    s_and_b32 s40, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB41_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s40, s14, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s15, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s78, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s79, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s88, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s28, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s29, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s79, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s88, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s89, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s90, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s91, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s92, s1, 16
@@ -28996,20 +29478,8 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s94
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB41_3
 ; GFX11-NEXT:  .LBB41_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s15, s15, 3
-; GFX11-NEXT:    s_addc_u32 s14, s14, 0
-; GFX11-NEXT:    s_add_u32 s12, s12, 3
-; GFX11-NEXT:    s_addc_u32 s13, s13, 0
-; GFX11-NEXT:    s_add_u32 s10, s10, 3
-; GFX11-NEXT:    s_addc_u32 s11, s11, 0
-; GFX11-NEXT:    s_add_u32 s8, s8, 3
-; GFX11-NEXT:    s_addc_u32 s9, s9, 0
-; GFX11-NEXT:    s_add_u32 s6, s6, 3
-; GFX11-NEXT:    s_addc_u32 s7, s7, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
+; GFX11-NEXT:    s_add_u32 s29, s29, 3
+; GFX11-NEXT:    s_addc_u32 s28, s28, 0
 ; GFX11-NEXT:    s_add_u32 s26, s26, 3
 ; GFX11-NEXT:    s_addc_u32 s27, s27, 0
 ; GFX11-NEXT:    s_add_u32 s24, s24, 3
@@ -29022,36 +29492,48 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s40, s14, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s15, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s78, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s79, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s88, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s28, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s29, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s79, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s88, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s89, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s90, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s91, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s92, s1, 16
@@ -29062,47 +29544,47 @@ define inreg <60 x i16> @bitcast_v15i64_to_v60i16_scalar(<15 x i64> inreg %a, i3
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s92
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s91
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s90
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s89
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s88
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s79
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s78
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s77
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s76
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s75
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s89
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s88
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s79
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s78
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s77
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s76
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s75
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s74
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s40
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s10 :: v_dual_mov_b32 v25, s11
-; GFX11-NEXT:    v_dual_mov_b32 v26, s12 :: v_dual_mov_b32 v27, s13
-; GFX11-NEXT:    v_dual_mov_b32 v28, s15 :: v_dual_mov_b32 v29, s14
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s24 :: v_dual_mov_b32 v25, s25
+; GFX11-NEXT:    v_dual_mov_b32 v26, s26 :: v_dual_mov_b32 v27, s27
+; GFX11-NEXT:    v_dual_mov_b32 v28, s29 :: v_dual_mov_b32 v29, s28
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB41_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr93
@@ -29653,7 +30135,7 @@ define <15 x i64> @bitcast_v60i16_to_v15i64(<60 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, s6, v25
 ; SI-NEXT:    v_add_i32_e32 v26, vcc, s6, v26
-; SI-NEXT:    v_add_i32_e32 v27, vcc, s6, v27
+; SI-NEXT:    v_add_i32_e32 v27, vcc, 0x30000, v27
 ; SI-NEXT:    v_add_i32_e32 v28, vcc, 0x30000, v28
 ; SI-NEXT:    v_add_i32_e32 v29, vcc, 0x30000, v29
 ; SI-NEXT:  .LBB42_4: ; %end
@@ -33253,13 +33735,41 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; SI-LABEL: bitcast_v15i64_to_v60f16_scalar:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SI-NEXT:    v_mov_b32_e32 v18, s16
+; SI-NEXT:    v_mov_b32_e32 v19, s17
+; SI-NEXT:    v_readfirstlane_b32 s40, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s18
+; SI-NEXT:    v_readfirstlane_b32 s43, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s19
+; SI-NEXT:    v_readfirstlane_b32 s41, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s20
+; SI-NEXT:    v_readfirstlane_b32 s44, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s21
+; SI-NEXT:    v_readfirstlane_b32 s42, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s22
+; SI-NEXT:    v_readfirstlane_b32 s45, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s23
+; SI-NEXT:    v_readfirstlane_b32 s22, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s24
+; SI-NEXT:    v_readfirstlane_b32 s46, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s25
+; SI-NEXT:    v_readfirstlane_b32 s23, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s26
+; SI-NEXT:    v_readfirstlane_b32 s47, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s27
+; SI-NEXT:    v_readfirstlane_b32 s24, v18
+; SI-NEXT:    v_mov_b32_e32 v18, s28
+; SI-NEXT:    v_readfirstlane_b32 s27, v19
+; SI-NEXT:    v_mov_b32_e32 v19, s29
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
-; SI-NEXT:    v_readfirstlane_b32 s44, v1
-; SI-NEXT:    v_readfirstlane_b32 s45, v2
-; SI-NEXT:    v_readfirstlane_b32 s42, v3
-; SI-NEXT:    v_readfirstlane_b32 s43, v4
-; SI-NEXT:    v_readfirstlane_b32 s40, v5
-; SI-NEXT:    v_readfirstlane_b32 s41, v6
+; SI-NEXT:    v_readfirstlane_b32 s25, v18
+; SI-NEXT:    v_readfirstlane_b32 s26, v19
+; SI-NEXT:    v_readfirstlane_b32 s20, v1
+; SI-NEXT:    v_readfirstlane_b32 s21, v2
+; SI-NEXT:    v_readfirstlane_b32 s18, v3
+; SI-NEXT:    v_readfirstlane_b32 s19, v4
+; SI-NEXT:    v_readfirstlane_b32 s16, v5
+; SI-NEXT:    v_readfirstlane_b32 s17, v6
 ; SI-NEXT:    v_readfirstlane_b32 s14, v7
 ; SI-NEXT:    v_readfirstlane_b32 s15, v8
 ; SI-NEXT:    v_readfirstlane_b32 s12, v9
@@ -33306,48 +33816,48 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v15, s4
 ; SI-NEXT:    s_lshr_b32 s4, s14, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v17, s4
-; SI-NEXT:    s_lshr_b32 s4, s41, 16
+; SI-NEXT:    s_lshr_b32 s4, s17, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v19, s4
-; SI-NEXT:    s_lshr_b32 s4, s40, 16
+; SI-NEXT:    s_lshr_b32 s4, s16, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v22, s4
-; SI-NEXT:    s_lshr_b32 s4, s43, 16
+; SI-NEXT:    s_lshr_b32 s4, s19, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v24, s4
-; SI-NEXT:    s_lshr_b32 s4, s42, 16
+; SI-NEXT:    s_lshr_b32 s4, s18, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v26, s4
-; SI-NEXT:    s_lshr_b32 s4, s45, 16
+; SI-NEXT:    s_lshr_b32 s4, s21, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v28, s4
-; SI-NEXT:    s_lshr_b32 s4, s44, 16
+; SI-NEXT:    s_lshr_b32 s4, s20, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v30, s4
-; SI-NEXT:    s_lshr_b32 s4, s29, 16
+; SI-NEXT:    s_lshr_b32 s4, s26, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v32, s4
-; SI-NEXT:    s_lshr_b32 s4, s28, 16
+; SI-NEXT:    s_lshr_b32 s4, s25, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v34, s4
 ; SI-NEXT:    s_lshr_b32 s4, s27, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v36, s4
-; SI-NEXT:    s_lshr_b32 s4, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
-; SI-NEXT:    s_lshr_b32 s4, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
 ; SI-NEXT:    s_lshr_b32 s4, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, s4
+; SI-NEXT:    s_lshr_b32 s4, s47, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, s4
 ; SI-NEXT:    s_lshr_b32 s4, s23, 16
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, s4
+; SI-NEXT:    s_lshr_b32 s4, s46, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v53, s4
 ; SI-NEXT:    s_lshr_b32 s4, s22, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v55, s4
-; SI-NEXT:    s_lshr_b32 s4, s21, 16
+; SI-NEXT:    s_lshr_b32 s4, s45, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v41, s4
-; SI-NEXT:    s_lshr_b32 s4, s20, 16
+; SI-NEXT:    s_lshr_b32 s4, s42, 16
 ; SI-NEXT:    v_cvt_f32_f16_e32 v43, s4
-; SI-NEXT:    s_lshr_b32 s4, s19, 16
+; SI-NEXT:    s_lshr_b32 s4, s44, 16
 ; SI-NEXT:    s_waitcnt expcnt(6)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v46, s4
-; SI-NEXT:    s_lshr_b32 s4, s18, 16
+; SI-NEXT:    s_lshr_b32 s4, s41, 16
 ; SI-NEXT:    s_waitcnt expcnt(4)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v56, s4
-; SI-NEXT:    s_lshr_b32 s4, s17, 16
+; SI-NEXT:    s_lshr_b32 s4, s43, 16
 ; SI-NEXT:    s_waitcnt expcnt(2)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v58, s4
-; SI-NEXT:    s_lshr_b32 s4, s16, 16
+; SI-NEXT:    s_lshr_b32 s4, s40, 16
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v60, s4
 ; SI-NEXT:    v_cvt_f32_f16_e32 v4, s9
@@ -33360,68 +33870,68 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v20, s15
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s45
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s44
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s25
 ; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s47
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s46
 ; SI-NEXT:    v_cvt_f32_f16_e32 v40, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, s45
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, s42
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, s44
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, s41
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, s43
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, s40
 ; SI-NEXT:    s_cbranch_execnz .LBB45_3
 ; SI-NEXT:  .LBB45_2: ; %cmp.true
-; SI-NEXT:    s_add_u32 s4, s16, 3
-; SI-NEXT:    s_addc_u32 s5, s17, 0
-; SI-NEXT:    s_lshr_b32 s16, s4, 16
-; SI-NEXT:    s_lshr_b32 s17, s5, 16
-; SI-NEXT:    s_add_u32 s18, s18, 3
-; SI-NEXT:    s_addc_u32 s19, s19, 0
-; SI-NEXT:    s_lshr_b32 s46, s18, 16
-; SI-NEXT:    s_lshr_b32 s47, s19, 16
+; SI-NEXT:    s_add_u32 s4, s40, 3
+; SI-NEXT:    s_addc_u32 s5, s43, 0
+; SI-NEXT:    s_lshr_b32 s28, s4, 16
+; SI-NEXT:    s_lshr_b32 s29, s5, 16
+; SI-NEXT:    s_add_u32 s40, s41, 3
+; SI-NEXT:    s_addc_u32 s41, s44, 0
+; SI-NEXT:    s_lshr_b32 s43, s40, 16
+; SI-NEXT:    s_lshr_b32 s44, s41, 16
+; SI-NEXT:    s_add_u32 s42, s42, 3
+; SI-NEXT:    s_addc_u32 s45, s45, 0
+; SI-NEXT:    s_lshr_b32 s56, s42, 16
+; SI-NEXT:    s_lshr_b32 s57, s45, 16
+; SI-NEXT:    s_add_u32 s22, s22, 3
+; SI-NEXT:    s_addc_u32 s46, s46, 0
+; SI-NEXT:    s_lshr_b32 s58, s22, 16
+; SI-NEXT:    s_lshr_b32 s59, s46, 16
+; SI-NEXT:    s_add_u32 s23, s23, 3
+; SI-NEXT:    s_addc_u32 s47, s47, 0
+; SI-NEXT:    s_lshr_b32 s60, s23, 16
+; SI-NEXT:    s_lshr_b32 s61, s47, 16
+; SI-NEXT:    s_add_u32 s24, s24, 3
+; SI-NEXT:    s_addc_u32 s27, s27, 0
+; SI-NEXT:    s_lshr_b32 s62, s24, 16
+; SI-NEXT:    s_lshr_b32 s63, s27, 16
+; SI-NEXT:    s_add_u32 s25, s25, 3
+; SI-NEXT:    s_addc_u32 s26, s26, 0
+; SI-NEXT:    s_lshr_b32 s72, s25, 16
+; SI-NEXT:    s_lshr_b32 s73, s26, 16
 ; SI-NEXT:    s_add_u32 s20, s20, 3
 ; SI-NEXT:    s_addc_u32 s21, s21, 0
-; SI-NEXT:    s_lshr_b32 s56, s20, 16
-; SI-NEXT:    s_lshr_b32 s57, s21, 16
-; SI-NEXT:    s_add_u32 s22, s22, 3
-; SI-NEXT:    s_addc_u32 s23, s23, 0
-; SI-NEXT:    s_lshr_b32 s58, s22, 16
-; SI-NEXT:    s_lshr_b32 s59, s23, 16
-; SI-NEXT:    s_add_u32 s24, s24, 3
-; SI-NEXT:    s_addc_u32 s25, s25, 0
-; SI-NEXT:    s_lshr_b32 s60, s24, 16
-; SI-NEXT:    s_lshr_b32 s61, s25, 16
-; SI-NEXT:    s_add_u32 s26, s26, 3
-; SI-NEXT:    s_addc_u32 s27, s27, 0
-; SI-NEXT:    s_lshr_b32 s62, s26, 16
-; SI-NEXT:    s_lshr_b32 s63, s27, 16
-; SI-NEXT:    s_add_u32 s28, s28, 3
-; SI-NEXT:    s_addc_u32 s29, s29, 0
-; SI-NEXT:    s_lshr_b32 s72, s28, 16
-; SI-NEXT:    s_lshr_b32 s73, s29, 16
-; SI-NEXT:    s_add_u32 s44, s44, 3
-; SI-NEXT:    s_addc_u32 s45, s45, 0
-; SI-NEXT:    s_lshr_b32 s74, s44, 16
-; SI-NEXT:    s_lshr_b32 s75, s45, 16
-; SI-NEXT:    s_add_u32 s42, s42, 3
-; SI-NEXT:    s_addc_u32 s43, s43, 0
-; SI-NEXT:    s_lshr_b32 s76, s42, 16
-; SI-NEXT:    s_lshr_b32 s77, s43, 16
-; SI-NEXT:    s_add_u32 s40, s40, 3
-; SI-NEXT:    s_addc_u32 s41, s41, 0
-; SI-NEXT:    s_lshr_b32 s78, s40, 16
-; SI-NEXT:    s_lshr_b32 s79, s41, 16
+; SI-NEXT:    s_lshr_b32 s74, s20, 16
+; SI-NEXT:    s_lshr_b32 s75, s21, 16
+; SI-NEXT:    s_add_u32 s18, s18, 3
+; SI-NEXT:    s_addc_u32 s19, s19, 0
+; SI-NEXT:    s_lshr_b32 s76, s18, 16
+; SI-NEXT:    s_lshr_b32 s77, s19, 16
+; SI-NEXT:    s_add_u32 s16, s16, 3
+; SI-NEXT:    s_addc_u32 s17, s17, 0
+; SI-NEXT:    s_lshr_b32 s78, s16, 16
+; SI-NEXT:    s_lshr_b32 s79, s17, 16
 ; SI-NEXT:    s_add_u32 s14, s14, 3
 ; SI-NEXT:    s_addc_u32 s15, s15, 0
 ; SI-NEXT:    s_lshr_b32 s88, s14, 16
@@ -33452,25 +33962,25 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v18, s12
 ; SI-NEXT:    v_cvt_f32_f16_e32 v20, s15
 ; SI-NEXT:    v_cvt_f32_f16_e32 v21, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s45
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s44
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s28
+; SI-NEXT:    v_cvt_f32_f16_e32 v23, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v25, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v27, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v29, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, s21
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, s20
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, s26
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, s25
 ; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, s24
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, s47
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, s23
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, s46
 ; SI-NEXT:    v_cvt_f32_f16_e32 v40, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s19
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, s45
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, s42
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, s41
 ; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s18
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, s40
 ; SI-NEXT:    s_waitcnt expcnt(3)
 ; SI-NEXT:    v_cvt_f32_f16_e32 v57, s5
 ; SI-NEXT:    s_waitcnt expcnt(1)
@@ -33501,11 +34011,11 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; SI-NEXT:    v_cvt_f32_f16_e32 v55, s58
 ; SI-NEXT:    v_cvt_f32_f16_e32 v41, s57
 ; SI-NEXT:    v_cvt_f32_f16_e32 v43, s56
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, s47
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, s46
-; SI-NEXT:    v_cvt_f32_f16_e32 v58, s17
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, s44
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, s43
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, s29
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, s28
 ; SI-NEXT:  .LBB45_3: ; %end
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v60, v60
@@ -33802,18 +34312,46 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; VI-NEXT:    s_mov_b64 exec, s[4:5]
 ; VI-NEXT:    v_writelane_b32 v30, s30, 0
 ; VI-NEXT:    v_writelane_b32 v30, s31, 1
+; VI-NEXT:    v_mov_b32_e32 v17, s16
+; VI-NEXT:    v_mov_b32_e32 v18, s17
 ; VI-NEXT:    v_writelane_b32 v30, s34, 2
+; VI-NEXT:    v_mov_b32_e32 v19, s18
+; VI-NEXT:    v_readfirstlane_b32 s56, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s19
+; VI-NEXT:    v_readfirstlane_b32 s47, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s20
 ; VI-NEXT:    v_writelane_b32 v30, s35, 3
+; VI-NEXT:    v_readfirstlane_b32 s46, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s21
+; VI-NEXT:    v_readfirstlane_b32 s45, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s22
+; VI-NEXT:    v_readfirstlane_b32 s44, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s23
 ; VI-NEXT:    v_writelane_b32 v30, s36, 4
+; VI-NEXT:    v_readfirstlane_b32 s43, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s24
+; VI-NEXT:    v_readfirstlane_b32 s42, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s25
+; VI-NEXT:    v_readfirstlane_b32 s41, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s26
 ; VI-NEXT:    v_writelane_b32 v30, s37, 5
+; VI-NEXT:    v_readfirstlane_b32 s40, v19
+; VI-NEXT:    v_mov_b32_e32 v19, s27
+; VI-NEXT:    v_readfirstlane_b32 s26, v17
+; VI-NEXT:    v_mov_b32_e32 v17, s28
+; VI-NEXT:    v_readfirstlane_b32 s25, v18
+; VI-NEXT:    v_mov_b32_e32 v18, s29
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v16
 ; VI-NEXT:    v_writelane_b32 v30, s38, 6
-; VI-NEXT:    v_readfirstlane_b32 s45, v0
-; VI-NEXT:    v_readfirstlane_b32 s44, v1
-; VI-NEXT:    v_readfirstlane_b32 s43, v2
-; VI-NEXT:    v_readfirstlane_b32 s42, v3
-; VI-NEXT:    v_readfirstlane_b32 s41, v4
-; VI-NEXT:    v_readfirstlane_b32 s40, v5
+; VI-NEXT:    v_readfirstlane_b32 s24, v19
+; VI-NEXT:    v_readfirstlane_b32 s23, v17
+; VI-NEXT:    v_readfirstlane_b32 s22, v18
+; VI-NEXT:    v_readfirstlane_b32 s21, v0
+; VI-NEXT:    v_readfirstlane_b32 s20, v1
+; VI-NEXT:    v_readfirstlane_b32 s19, v2
+; VI-NEXT:    v_readfirstlane_b32 s18, v3
+; VI-NEXT:    v_readfirstlane_b32 s17, v4
+; VI-NEXT:    v_readfirstlane_b32 s16, v5
 ; VI-NEXT:    v_readfirstlane_b32 s15, v6
 ; VI-NEXT:    v_readfirstlane_b32 s14, v7
 ; VI-NEXT:    v_readfirstlane_b32 s13, v8
@@ -33828,9 +34366,9 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; VI-NEXT:    v_writelane_b32 v30, s39, 7
 ; VI-NEXT:    s_cbranch_scc0 .LBB45_4
 ; VI-NEXT:  ; %bb.1: ; %cmp.false
-; VI-NEXT:    s_lshr_b32 s46, s7, 16
-; VI-NEXT:    s_lshr_b32 s47, s6, 16
-; VI-NEXT:    s_lshr_b32 s56, s8, 16
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s57, s9, 16
 ; VI-NEXT:    s_lshr_b32 s58, s10, 16
 ; VI-NEXT:    s_lshr_b32 s59, s11, 16
@@ -33838,26 +34376,26 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s61, s13, 16
 ; VI-NEXT:    s_lshr_b32 s62, s14, 16
 ; VI-NEXT:    s_lshr_b32 s63, s15, 16
-; VI-NEXT:    s_lshr_b32 s72, s40, 16
-; VI-NEXT:    s_lshr_b32 s73, s41, 16
-; VI-NEXT:    s_lshr_b32 s74, s42, 16
-; VI-NEXT:    s_lshr_b32 s75, s43, 16
-; VI-NEXT:    s_lshr_b32 s76, s44, 16
-; VI-NEXT:    s_lshr_b32 s77, s45, 16
-; VI-NEXT:    s_lshr_b32 s78, s29, 16
-; VI-NEXT:    s_lshr_b32 s79, s28, 16
-; VI-NEXT:    s_lshr_b32 s88, s27, 16
-; VI-NEXT:    s_lshr_b32 s89, s26, 16
-; VI-NEXT:    s_lshr_b32 s90, s25, 16
-; VI-NEXT:    s_lshr_b32 s91, s24, 16
-; VI-NEXT:    s_lshr_b32 s30, s23, 16
-; VI-NEXT:    s_lshr_b32 s31, s22, 16
-; VI-NEXT:    s_lshr_b32 s34, s21, 16
-; VI-NEXT:    s_lshr_b32 s35, s20, 16
-; VI-NEXT:    s_lshr_b32 s36, s19, 16
-; VI-NEXT:    s_lshr_b32 s37, s18, 16
-; VI-NEXT:    s_lshr_b32 s38, s17, 16
-; VI-NEXT:    s_lshr_b32 s39, s16, 16
+; VI-NEXT:    s_lshr_b32 s72, s16, 16
+; VI-NEXT:    s_lshr_b32 s73, s17, 16
+; VI-NEXT:    s_lshr_b32 s74, s18, 16
+; VI-NEXT:    s_lshr_b32 s75, s19, 16
+; VI-NEXT:    s_lshr_b32 s76, s20, 16
+; VI-NEXT:    s_lshr_b32 s77, s21, 16
+; VI-NEXT:    s_lshr_b32 s78, s22, 16
+; VI-NEXT:    s_lshr_b32 s79, s23, 16
+; VI-NEXT:    s_lshr_b32 s88, s24, 16
+; VI-NEXT:    s_lshr_b32 s89, s25, 16
+; VI-NEXT:    s_lshr_b32 s90, s26, 16
+; VI-NEXT:    s_lshr_b32 s91, s40, 16
+; VI-NEXT:    s_lshr_b32 s30, s41, 16
+; VI-NEXT:    s_lshr_b32 s31, s42, 16
+; VI-NEXT:    s_lshr_b32 s34, s43, 16
+; VI-NEXT:    s_lshr_b32 s35, s44, 16
+; VI-NEXT:    s_lshr_b32 s36, s45, 16
+; VI-NEXT:    s_lshr_b32 s37, s46, 16
+; VI-NEXT:    s_lshr_b32 s38, s47, 16
+; VI-NEXT:    s_lshr_b32 s39, s56, 16
 ; VI-NEXT:    s_cbranch_execnz .LBB45_3
 ; VI-NEXT:  .LBB45_2: ; %cmp.true
 ; VI-NEXT:    s_add_u32 s6, s6, 3
@@ -33870,29 +34408,29 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; VI-NEXT:    s_addc_u32 s12, s12, 0
 ; VI-NEXT:    s_add_u32 s15, s15, 3
 ; VI-NEXT:    s_addc_u32 s14, s14, 0
-; VI-NEXT:    s_add_u32 s41, s41, 3
-; VI-NEXT:    s_addc_u32 s40, s40, 0
-; VI-NEXT:    s_add_u32 s43, s43, 3
-; VI-NEXT:    s_addc_u32 s42, s42, 0
-; VI-NEXT:    s_add_u32 s45, s45, 3
-; VI-NEXT:    s_addc_u32 s44, s44, 0
-; VI-NEXT:    s_add_u32 s28, s28, 3
-; VI-NEXT:    s_addc_u32 s29, s29, 0
-; VI-NEXT:    s_add_u32 s26, s26, 3
-; VI-NEXT:    s_addc_u32 s27, s27, 0
-; VI-NEXT:    s_add_u32 s24, s24, 3
-; VI-NEXT:    s_addc_u32 s25, s25, 0
-; VI-NEXT:    s_add_u32 s22, s22, 3
-; VI-NEXT:    s_addc_u32 s23, s23, 0
-; VI-NEXT:    s_add_u32 s20, s20, 3
-; VI-NEXT:    s_addc_u32 s21, s21, 0
-; VI-NEXT:    s_add_u32 s18, s18, 3
-; VI-NEXT:    s_addc_u32 s19, s19, 0
-; VI-NEXT:    s_add_u32 s16, s16, 3
-; VI-NEXT:    s_addc_u32 s17, s17, 0
-; VI-NEXT:    s_lshr_b32 s46, s7, 16
-; VI-NEXT:    s_lshr_b32 s47, s6, 16
-; VI-NEXT:    s_lshr_b32 s56, s8, 16
+; VI-NEXT:    s_add_u32 s17, s17, 3
+; VI-NEXT:    s_addc_u32 s16, s16, 0
+; VI-NEXT:    s_add_u32 s19, s19, 3
+; VI-NEXT:    s_addc_u32 s18, s18, 0
+; VI-NEXT:    s_add_u32 s21, s21, 3
+; VI-NEXT:    s_addc_u32 s20, s20, 0
+; VI-NEXT:    s_add_u32 s23, s23, 3
+; VI-NEXT:    s_addc_u32 s22, s22, 0
+; VI-NEXT:    s_add_u32 s25, s25, 3
+; VI-NEXT:    s_addc_u32 s24, s24, 0
+; VI-NEXT:    s_add_u32 s40, s40, 3
+; VI-NEXT:    s_addc_u32 s26, s26, 0
+; VI-NEXT:    s_add_u32 s42, s42, 3
+; VI-NEXT:    s_addc_u32 s41, s41, 0
+; VI-NEXT:    s_add_u32 s44, s44, 3
+; VI-NEXT:    s_addc_u32 s43, s43, 0
+; VI-NEXT:    s_add_u32 s46, s46, 3
+; VI-NEXT:    s_addc_u32 s45, s45, 0
+; VI-NEXT:    s_add_u32 s56, s56, 3
+; VI-NEXT:    s_addc_u32 s47, s47, 0
+; VI-NEXT:    s_lshr_b32 s27, s7, 16
+; VI-NEXT:    s_lshr_b32 s28, s6, 16
+; VI-NEXT:    s_lshr_b32 s29, s8, 16
 ; VI-NEXT:    s_lshr_b32 s57, s9, 16
 ; VI-NEXT:    s_lshr_b32 s58, s10, 16
 ; VI-NEXT:    s_lshr_b32 s59, s11, 16
@@ -33900,137 +34438,137 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; VI-NEXT:    s_lshr_b32 s61, s13, 16
 ; VI-NEXT:    s_lshr_b32 s62, s14, 16
 ; VI-NEXT:    s_lshr_b32 s63, s15, 16
-; VI-NEXT:    s_lshr_b32 s72, s40, 16
-; VI-NEXT:    s_lshr_b32 s73, s41, 16
-; VI-NEXT:    s_lshr_b32 s74, s42, 16
-; VI-NEXT:    s_lshr_b32 s75, s43, 16
-; VI-NEXT:    s_lshr_b32 s76, s44, 16
-; VI-NEXT:    s_lshr_b32 s77, s45, 16
-; VI-NEXT:    s_lshr_b32 s78, s29, 16
-; VI-NEXT:    s_lshr_b32 s79, s28, 16
-; VI-NEXT:    s_lshr_b32 s88, s27, 16
-; VI-NEXT:    s_lshr_b32 s89, s26, 16
-; VI-NEXT:    s_lshr_b32 s90, s25, 16
-; VI-NEXT:    s_lshr_b32 s91, s24, 16
-; VI-NEXT:    s_lshr_b32 s30, s23, 16
-; VI-NEXT:    s_lshr_b32 s31, s22, 16
-; VI-NEXT:    s_lshr_b32 s34, s21, 16
-; VI-NEXT:    s_lshr_b32 s35, s20, 16
-; VI-NEXT:    s_lshr_b32 s36, s19, 16
-; VI-NEXT:    s_lshr_b32 s37, s18, 16
-; VI-NEXT:    s_lshr_b32 s38, s17, 16
-; VI-NEXT:    s_lshr_b32 s39, s16, 16
+; VI-NEXT:    s_lshr_b32 s72, s16, 16
+; VI-NEXT:    s_lshr_b32 s73, s17, 16
+; VI-NEXT:    s_lshr_b32 s74, s18, 16
+; VI-NEXT:    s_lshr_b32 s75, s19, 16
+; VI-NEXT:    s_lshr_b32 s76, s20, 16
+; VI-NEXT:    s_lshr_b32 s77, s21, 16
+; VI-NEXT:    s_lshr_b32 s78, s22, 16
+; VI-NEXT:    s_lshr_b32 s79, s23, 16
+; VI-NEXT:    s_lshr_b32 s88, s24, 16
+; VI-NEXT:    s_lshr_b32 s89, s25, 16
+; VI-NEXT:    s_lshr_b32 s90, s26, 16
+; VI-NEXT:    s_lshr_b32 s91, s40, 16
+; VI-NEXT:    s_lshr_b32 s30, s41, 16
+; VI-NEXT:    s_lshr_b32 s31, s42, 16
+; VI-NEXT:    s_lshr_b32 s34, s43, 16
+; VI-NEXT:    s_lshr_b32 s35, s44, 16
+; VI-NEXT:    s_lshr_b32 s36, s45, 16
+; VI-NEXT:    s_lshr_b32 s37, s46, 16
+; VI-NEXT:    s_lshr_b32 s38, s47, 16
+; VI-NEXT:    s_lshr_b32 s39, s56, 16
 ; VI-NEXT:  .LBB45_3: ; %end
-; VI-NEXT:    s_and_b32 s4, 0xffff, s16
+; VI-NEXT:    s_and_b32 s4, 0xffff, s56
 ; VI-NEXT:    s_lshl_b32 s5, s39, 16
 ; VI-NEXT:    s_or_b32 s4, s4, s5
-; VI-NEXT:    s_and_b32 s5, 0xffff, s17
-; VI-NEXT:    s_lshl_b32 s16, s38, 16
-; VI-NEXT:    s_or_b32 s5, s5, s16
-; VI-NEXT:    s_and_b32 s16, 0xffff, s18
-; VI-NEXT:    s_lshl_b32 s17, s37, 16
-; VI-NEXT:    s_or_b32 s16, s16, s17
-; VI-NEXT:    s_and_b32 s17, 0xffff, s19
-; VI-NEXT:    s_lshl_b32 s18, s36, 16
-; VI-NEXT:    s_or_b32 s17, s17, s18
-; VI-NEXT:    s_and_b32 s18, 0xffff, s20
-; VI-NEXT:    s_lshl_b32 s19, s35, 16
-; VI-NEXT:    s_or_b32 s18, s18, s19
-; VI-NEXT:    s_and_b32 s19, 0xffff, s21
-; VI-NEXT:    s_lshl_b32 s20, s34, 16
-; VI-NEXT:    s_or_b32 s19, s19, s20
-; VI-NEXT:    s_and_b32 s20, 0xffff, s22
-; VI-NEXT:    s_lshl_b32 s21, s31, 16
-; VI-NEXT:    s_or_b32 s20, s20, s21
-; VI-NEXT:    s_and_b32 s21, 0xffff, s23
-; VI-NEXT:    s_lshl_b32 s22, s30, 16
-; VI-NEXT:    s_or_b32 s21, s21, s22
-; VI-NEXT:    s_and_b32 s22, 0xffff, s24
-; VI-NEXT:    s_lshl_b32 s23, s91, 16
-; VI-NEXT:    s_or_b32 s22, s22, s23
-; VI-NEXT:    s_and_b32 s23, 0xffff, s25
-; VI-NEXT:    s_lshl_b32 s24, s90, 16
-; VI-NEXT:    s_or_b32 s23, s23, s24
-; VI-NEXT:    s_and_b32 s24, 0xffff, s26
-; VI-NEXT:    s_lshl_b32 s25, s89, 16
-; VI-NEXT:    s_or_b32 s24, s24, s25
-; VI-NEXT:    s_and_b32 s25, 0xffff, s27
-; VI-NEXT:    s_lshl_b32 s26, s88, 16
-; VI-NEXT:    s_or_b32 s25, s25, s26
-; VI-NEXT:    s_and_b32 s26, 0xffff, s28
-; VI-NEXT:    s_lshl_b32 s27, s79, 16
-; VI-NEXT:    s_or_b32 s26, s26, s27
-; VI-NEXT:    s_and_b32 s27, 0xffff, s29
-; VI-NEXT:    s_lshl_b32 s28, s78, 16
-; VI-NEXT:    s_or_b32 s27, s27, s28
-; VI-NEXT:    s_and_b32 s28, 0xffff, s45
-; VI-NEXT:    s_lshl_b32 s29, s77, 16
-; VI-NEXT:    s_or_b32 s28, s28, s29
-; VI-NEXT:    s_and_b32 s29, 0xffff, s44
-; VI-NEXT:    s_lshl_b32 s44, s76, 16
-; VI-NEXT:    s_or_b32 s29, s29, s44
+; VI-NEXT:    s_and_b32 s5, 0xffff, s47
+; VI-NEXT:    s_lshl_b32 s47, s38, 16
+; VI-NEXT:    s_or_b32 s5, s5, s47
+; VI-NEXT:    s_and_b32 s46, 0xffff, s46
+; VI-NEXT:    s_lshl_b32 s47, s37, 16
+; VI-NEXT:    s_or_b32 s46, s46, s47
+; VI-NEXT:    s_and_b32 s45, 0xffff, s45
+; VI-NEXT:    s_lshl_b32 s47, s36, 16
+; VI-NEXT:    s_or_b32 s45, s45, s47
+; VI-NEXT:    s_and_b32 s44, 0xffff, s44
+; VI-NEXT:    s_lshl_b32 s47, s35, 16
+; VI-NEXT:    s_or_b32 s44, s44, s47
 ; VI-NEXT:    s_and_b32 s43, 0xffff, s43
-; VI-NEXT:    s_lshl_b32 s44, s75, 16
-; VI-NEXT:    s_or_b32 s43, s43, s44
+; VI-NEXT:    s_lshl_b32 s47, s34, 16
+; VI-NEXT:    s_or_b32 s43, s43, s47
 ; VI-NEXT:    s_and_b32 s42, 0xffff, s42
-; VI-NEXT:    s_lshl_b32 s44, s74, 16
-; VI-NEXT:    s_or_b32 s42, s42, s44
+; VI-NEXT:    s_lshl_b32 s47, s31, 16
+; VI-NEXT:    s_or_b32 s42, s42, s47
 ; VI-NEXT:    s_and_b32 s41, 0xffff, s41
-; VI-NEXT:    s_lshl_b32 s44, s73, 16
-; VI-NEXT:    s_or_b32 s41, s41, s44
+; VI-NEXT:    s_lshl_b32 s47, s30, 16
+; VI-NEXT:    s_or_b32 s41, s41, s47
 ; VI-NEXT:    s_and_b32 s40, 0xffff, s40
-; VI-NEXT:    s_lshl_b32 s44, s72, 16
-; VI-NEXT:    s_or_b32 s40, s40, s44
+; VI-NEXT:    s_lshl_b32 s47, s91, 16
+; VI-NEXT:    s_or_b32 s40, s40, s47
+; VI-NEXT:    s_and_b32 s26, 0xffff, s26
+; VI-NEXT:    s_lshl_b32 s47, s90, 16
+; VI-NEXT:    s_or_b32 s26, s26, s47
+; VI-NEXT:    s_and_b32 s25, 0xffff, s25
+; VI-NEXT:    s_lshl_b32 s47, s89, 16
+; VI-NEXT:    s_or_b32 s25, s25, s47
+; VI-NEXT:    s_and_b32 s24, 0xffff, s24
+; VI-NEXT:    s_lshl_b32 s47, s88, 16
+; VI-NEXT:    s_or_b32 s24, s24, s47
+; VI-NEXT:    s_and_b32 s23, 0xffff, s23
+; VI-NEXT:    s_lshl_b32 s47, s79, 16
+; VI-NEXT:    s_or_b32 s23, s23, s47
+; VI-NEXT:    s_and_b32 s22, 0xffff, s22
+; VI-NEXT:    s_lshl_b32 s47, s78, 16
+; VI-NEXT:    s_or_b32 s22, s22, s47
+; VI-NEXT:    s_and_b32 s21, 0xffff, s21
+; VI-NEXT:    s_lshl_b32 s47, s77, 16
+; VI-NEXT:    s_or_b32 s21, s21, s47
+; VI-NEXT:    s_and_b32 s20, 0xffff, s20
+; VI-NEXT:    s_lshl_b32 s47, s76, 16
+; VI-NEXT:    s_or_b32 s20, s20, s47
+; VI-NEXT:    s_and_b32 s19, 0xffff, s19
+; VI-NEXT:    s_lshl_b32 s47, s75, 16
+; VI-NEXT:    s_or_b32 s19, s19, s47
+; VI-NEXT:    s_and_b32 s18, 0xffff, s18
+; VI-NEXT:    s_lshl_b32 s47, s74, 16
+; VI-NEXT:    s_or_b32 s18, s18, s47
+; VI-NEXT:    s_and_b32 s17, 0xffff, s17
+; VI-NEXT:    s_lshl_b32 s47, s73, 16
+; VI-NEXT:    s_or_b32 s17, s17, s47
+; VI-NEXT:    s_and_b32 s16, 0xffff, s16
+; VI-NEXT:    s_lshl_b32 s47, s72, 16
+; VI-NEXT:    s_or_b32 s16, s16, s47
 ; VI-NEXT:    s_and_b32 s15, 0xffff, s15
-; VI-NEXT:    s_lshl_b32 s44, s63, 16
-; VI-NEXT:    s_or_b32 s15, s15, s44
+; VI-NEXT:    s_lshl_b32 s47, s63, 16
+; VI-NEXT:    s_or_b32 s15, s15, s47
 ; VI-NEXT:    s_and_b32 s14, 0xffff, s14
-; VI-NEXT:    s_lshl_b32 s44, s62, 16
-; VI-NEXT:    s_or_b32 s14, s14, s44
+; VI-NEXT:    s_lshl_b32 s47, s62, 16
+; VI-NEXT:    s_or_b32 s14, s14, s47
 ; VI-NEXT:    s_and_b32 s13, 0xffff, s13
-; VI-NEXT:    s_lshl_b32 s44, s61, 16
-; VI-NEXT:    s_or_b32 s13, s13, s44
+; VI-NEXT:    s_lshl_b32 s47, s61, 16
+; VI-NEXT:    s_or_b32 s13, s13, s47
 ; VI-NEXT:    s_and_b32 s12, 0xffff, s12
-; VI-NEXT:    s_lshl_b32 s44, s60, 16
-; VI-NEXT:    s_or_b32 s12, s12, s44
+; VI-NEXT:    s_lshl_b32 s47, s60, 16
+; VI-NEXT:    s_or_b32 s12, s12, s47
 ; VI-NEXT:    s_and_b32 s11, 0xffff, s11
-; VI-NEXT:    s_lshl_b32 s44, s59, 16
-; VI-NEXT:    s_or_b32 s11, s11, s44
+; VI-NEXT:    s_lshl_b32 s47, s59, 16
+; VI-NEXT:    s_or_b32 s11, s11, s47
 ; VI-NEXT:    s_and_b32 s10, 0xffff, s10
-; VI-NEXT:    s_lshl_b32 s44, s58, 16
-; VI-NEXT:    s_or_b32 s10, s10, s44
+; VI-NEXT:    s_lshl_b32 s47, s58, 16
+; VI-NEXT:    s_or_b32 s10, s10, s47
 ; VI-NEXT:    s_and_b32 s9, 0xffff, s9
-; VI-NEXT:    s_lshl_b32 s44, s57, 16
-; VI-NEXT:    s_or_b32 s9, s9, s44
+; VI-NEXT:    s_lshl_b32 s47, s57, 16
 ; VI-NEXT:    s_and_b32 s8, 0xffff, s8
-; VI-NEXT:    s_lshl_b32 s44, s56, 16
-; VI-NEXT:    s_or_b32 s8, s8, s44
+; VI-NEXT:    s_lshl_b32 s29, s29, 16
 ; VI-NEXT:    s_and_b32 s6, 0xffff, s6
-; VI-NEXT:    s_lshl_b32 s44, s47, 16
-; VI-NEXT:    s_or_b32 s6, s6, s44
+; VI-NEXT:    s_lshl_b32 s28, s28, 16
 ; VI-NEXT:    s_and_b32 s7, 0xffff, s7
-; VI-NEXT:    s_lshl_b32 s44, s46, 16
-; VI-NEXT:    s_or_b32 s7, s7, s44
+; VI-NEXT:    s_lshl_b32 s27, s27, 16
+; VI-NEXT:    s_or_b32 s9, s9, s47
+; VI-NEXT:    s_or_b32 s8, s8, s29
+; VI-NEXT:    s_or_b32 s6, s6, s28
+; VI-NEXT:    s_or_b32 s7, s7, s27
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    v_mov_b32_e32 v2, s16
-; VI-NEXT:    v_mov_b32_e32 v3, s17
-; VI-NEXT:    v_mov_b32_e32 v4, s18
-; VI-NEXT:    v_mov_b32_e32 v5, s19
-; VI-NEXT:    v_mov_b32_e32 v6, s20
-; VI-NEXT:    v_mov_b32_e32 v7, s21
-; VI-NEXT:    v_mov_b32_e32 v8, s22
-; VI-NEXT:    v_mov_b32_e32 v9, s23
-; VI-NEXT:    v_mov_b32_e32 v10, s24
-; VI-NEXT:    v_mov_b32_e32 v11, s25
-; VI-NEXT:    v_mov_b32_e32 v12, s26
-; VI-NEXT:    v_mov_b32_e32 v13, s27
-; VI-NEXT:    v_mov_b32_e32 v14, s28
-; VI-NEXT:    v_mov_b32_e32 v15, s29
-; VI-NEXT:    v_mov_b32_e32 v16, s43
-; VI-NEXT:    v_mov_b32_e32 v17, s42
-; VI-NEXT:    v_mov_b32_e32 v18, s41
-; VI-NEXT:    v_mov_b32_e32 v19, s40
+; VI-NEXT:    v_mov_b32_e32 v2, s46
+; VI-NEXT:    v_mov_b32_e32 v3, s45
+; VI-NEXT:    v_mov_b32_e32 v4, s44
+; VI-NEXT:    v_mov_b32_e32 v5, s43
+; VI-NEXT:    v_mov_b32_e32 v6, s42
+; VI-NEXT:    v_mov_b32_e32 v7, s41
+; VI-NEXT:    v_mov_b32_e32 v8, s40
+; VI-NEXT:    v_mov_b32_e32 v9, s26
+; VI-NEXT:    v_mov_b32_e32 v10, s25
+; VI-NEXT:    v_mov_b32_e32 v11, s24
+; VI-NEXT:    v_mov_b32_e32 v12, s23
+; VI-NEXT:    v_mov_b32_e32 v13, s22
+; VI-NEXT:    v_mov_b32_e32 v14, s21
+; VI-NEXT:    v_mov_b32_e32 v15, s20
+; VI-NEXT:    v_mov_b32_e32 v16, s19
+; VI-NEXT:    v_mov_b32_e32 v17, s18
+; VI-NEXT:    v_mov_b32_e32 v18, s17
+; VI-NEXT:    v_mov_b32_e32 v19, s16
 ; VI-NEXT:    v_mov_b32_e32 v20, s15
 ; VI-NEXT:    v_mov_b32_e32 v21, s14
 ; VI-NEXT:    v_mov_b32_e32 v22, s13
@@ -34082,9 +34620,9 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; VI-NEXT:    ; implicit-def: $sgpr59
 ; VI-NEXT:    ; implicit-def: $sgpr58
 ; VI-NEXT:    ; implicit-def: $sgpr57
-; VI-NEXT:    ; implicit-def: $sgpr56
-; VI-NEXT:    ; implicit-def: $sgpr47
-; VI-NEXT:    ; implicit-def: $sgpr46
+; VI-NEXT:    ; implicit-def: $sgpr29
+; VI-NEXT:    ; implicit-def: $sgpr28
+; VI-NEXT:    ; implicit-def: $sgpr27
 ; VI-NEXT:    s_branch .LBB45_2
 ;
 ; GFX9-LABEL: bitcast_v15i64_to_v60f16_scalar:
@@ -34093,20 +34631,48 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; GFX9-NEXT:    s_xor_saveexec_b64 s[4:5], -1
 ; GFX9-NEXT:    buffer_store_dword v30, off, s[0:3], s32 ; 4-byte Folded Spill
 ; GFX9-NEXT:    s_mov_b64 exec, s[4:5]
+; GFX9-NEXT:    v_mov_b32_e32 v17, s16
+; GFX9-NEXT:    v_mov_b32_e32 v18, s17
+; GFX9-NEXT:    v_mov_b32_e32 v19, s18
+; GFX9-NEXT:    v_readfirstlane_b32 s6, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s19
+; GFX9-NEXT:    v_readfirstlane_b32 s7, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s20
+; GFX9-NEXT:    v_readfirstlane_b32 s8, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s21
+; GFX9-NEXT:    v_readfirstlane_b32 s9, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s22
+; GFX9-NEXT:    v_readfirstlane_b32 s10, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s23
 ; GFX9-NEXT:    v_writelane_b32 v30, s30, 0
+; GFX9-NEXT:    v_readfirstlane_b32 s11, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s24
+; GFX9-NEXT:    v_readfirstlane_b32 s12, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s25
+; GFX9-NEXT:    v_readfirstlane_b32 s13, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s26
 ; GFX9-NEXT:    v_writelane_b32 v30, s31, 1
+; GFX9-NEXT:    v_readfirstlane_b32 s14, v19
+; GFX9-NEXT:    v_mov_b32_e32 v19, s27
+; GFX9-NEXT:    v_readfirstlane_b32 s15, v17
+; GFX9-NEXT:    v_mov_b32_e32 v17, s28
+; GFX9-NEXT:    v_readfirstlane_b32 s16, v18
+; GFX9-NEXT:    v_mov_b32_e32 v18, s29
 ; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v16
 ; GFX9-NEXT:    v_writelane_b32 v30, s34, 2
-; GFX9-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v4
-; GFX9-NEXT:    v_readfirstlane_b32 s11, v5
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v6
-; GFX9-NEXT:    v_readfirstlane_b32 s13, v7
-; GFX9-NEXT:    v_readfirstlane_b32 s14, v8
-; GFX9-NEXT:    v_readfirstlane_b32 s15, v9
+; GFX9-NEXT:    v_readfirstlane_b32 s17, v19
+; GFX9-NEXT:    v_readfirstlane_b32 s18, v17
+; GFX9-NEXT:    v_readfirstlane_b32 s19, v18
+; GFX9-NEXT:    v_readfirstlane_b32 s20, v0
+; GFX9-NEXT:    v_readfirstlane_b32 s21, v1
+; GFX9-NEXT:    v_readfirstlane_b32 s22, v2
+; GFX9-NEXT:    v_readfirstlane_b32 s23, v3
+; GFX9-NEXT:    v_readfirstlane_b32 s24, v4
+; GFX9-NEXT:    v_readfirstlane_b32 s25, v5
+; GFX9-NEXT:    v_readfirstlane_b32 s26, v6
+; GFX9-NEXT:    v_readfirstlane_b32 s27, v7
+; GFX9-NEXT:    v_readfirstlane_b32 s28, v8
+; GFX9-NEXT:    v_readfirstlane_b32 s29, v9
 ; GFX9-NEXT:    v_readfirstlane_b32 s40, v10
 ; GFX9-NEXT:    v_readfirstlane_b32 s41, v11
 ; GFX9-NEXT:    v_readfirstlane_b32 s42, v12
@@ -34123,30 +34689,30 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; GFX9-NEXT:    s_lshr_b32 s57, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s58, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s59, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s30, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s31, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s34, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s35, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s30, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s31, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s34, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s35, s6, 16
 ; GFX9-NEXT:    s_cbranch_execnz .LBB45_3
 ; GFX9-NEXT:  .LBB45_2: ; %cmp.true
 ; GFX9-NEXT:    s_add_u32 s44, s44, 3
@@ -34155,16 +34721,6 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; GFX9-NEXT:    s_addc_u32 s43, s43, 0
 ; GFX9-NEXT:    s_add_u32 s40, s40, 3
 ; GFX9-NEXT:    s_addc_u32 s41, s41, 0
-; GFX9-NEXT:    s_add_u32 s14, s14, 3
-; GFX9-NEXT:    s_addc_u32 s15, s15, 0
-; GFX9-NEXT:    s_add_u32 s12, s12, 3
-; GFX9-NEXT:    s_addc_u32 s13, s13, 0
-; GFX9-NEXT:    s_add_u32 s10, s10, 3
-; GFX9-NEXT:    s_addc_u32 s11, s11, 0
-; GFX9-NEXT:    s_add_u32 s8, s8, 3
-; GFX9-NEXT:    s_addc_u32 s9, s9, 0
-; GFX9-NEXT:    s_add_u32 s6, s6, 3
-; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_add_u32 s28, s28, 3
 ; GFX9-NEXT:    s_addc_u32 s29, s29, 0
 ; GFX9-NEXT:    s_add_u32 s26, s26, 3
@@ -34179,61 +34735,71 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; GFX9-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX9-NEXT:    s_add_u32 s16, s16, 3
 ; GFX9-NEXT:    s_addc_u32 s17, s17, 0
+; GFX9-NEXT:    s_add_u32 s14, s14, 3
+; GFX9-NEXT:    s_addc_u32 s15, s15, 0
+; GFX9-NEXT:    s_add_u32 s12, s12, 3
+; GFX9-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NEXT:    s_add_u32 s10, s10, 3
+; GFX9-NEXT:    s_addc_u32 s11, s11, 0
+; GFX9-NEXT:    s_add_u32 s8, s8, 3
+; GFX9-NEXT:    s_addc_u32 s9, s9, 0
+; GFX9-NEXT:    s_add_u32 s6, s6, 3
+; GFX9-NEXT:    s_addc_u32 s7, s7, 0
 ; GFX9-NEXT:    s_lshr_b32 s46, s45, 16
 ; GFX9-NEXT:    s_lshr_b32 s47, s44, 16
 ; GFX9-NEXT:    s_lshr_b32 s56, s43, 16
 ; GFX9-NEXT:    s_lshr_b32 s57, s42, 16
 ; GFX9-NEXT:    s_lshr_b32 s58, s41, 16
 ; GFX9-NEXT:    s_lshr_b32 s59, s40, 16
-; GFX9-NEXT:    s_lshr_b32 s60, s15, 16
-; GFX9-NEXT:    s_lshr_b32 s61, s14, 16
-; GFX9-NEXT:    s_lshr_b32 s62, s13, 16
-; GFX9-NEXT:    s_lshr_b32 s63, s12, 16
-; GFX9-NEXT:    s_lshr_b32 s72, s11, 16
-; GFX9-NEXT:    s_lshr_b32 s73, s10, 16
-; GFX9-NEXT:    s_lshr_b32 s74, s9, 16
-; GFX9-NEXT:    s_lshr_b32 s75, s8, 16
-; GFX9-NEXT:    s_lshr_b32 s76, s7, 16
-; GFX9-NEXT:    s_lshr_b32 s77, s6, 16
-; GFX9-NEXT:    s_lshr_b32 s78, s29, 16
-; GFX9-NEXT:    s_lshr_b32 s79, s28, 16
-; GFX9-NEXT:    s_lshr_b32 s88, s27, 16
-; GFX9-NEXT:    s_lshr_b32 s89, s26, 16
-; GFX9-NEXT:    s_lshr_b32 s90, s25, 16
-; GFX9-NEXT:    s_lshr_b32 s91, s24, 16
-; GFX9-NEXT:    s_lshr_b32 s92, s23, 16
-; GFX9-NEXT:    s_lshr_b32 s93, s22, 16
-; GFX9-NEXT:    s_lshr_b32 s94, s21, 16
-; GFX9-NEXT:    s_lshr_b32 s95, s20, 16
-; GFX9-NEXT:    s_lshr_b32 s30, s19, 16
-; GFX9-NEXT:    s_lshr_b32 s31, s18, 16
-; GFX9-NEXT:    s_lshr_b32 s34, s17, 16
-; GFX9-NEXT:    s_lshr_b32 s35, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s60, s29, 16
+; GFX9-NEXT:    s_lshr_b32 s61, s28, 16
+; GFX9-NEXT:    s_lshr_b32 s62, s27, 16
+; GFX9-NEXT:    s_lshr_b32 s63, s26, 16
+; GFX9-NEXT:    s_lshr_b32 s72, s25, 16
+; GFX9-NEXT:    s_lshr_b32 s73, s24, 16
+; GFX9-NEXT:    s_lshr_b32 s74, s23, 16
+; GFX9-NEXT:    s_lshr_b32 s75, s22, 16
+; GFX9-NEXT:    s_lshr_b32 s76, s21, 16
+; GFX9-NEXT:    s_lshr_b32 s77, s20, 16
+; GFX9-NEXT:    s_lshr_b32 s78, s19, 16
+; GFX9-NEXT:    s_lshr_b32 s79, s18, 16
+; GFX9-NEXT:    s_lshr_b32 s88, s17, 16
+; GFX9-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX9-NEXT:    s_lshr_b32 s90, s15, 16
+; GFX9-NEXT:    s_lshr_b32 s91, s14, 16
+; GFX9-NEXT:    s_lshr_b32 s92, s13, 16
+; GFX9-NEXT:    s_lshr_b32 s93, s12, 16
+; GFX9-NEXT:    s_lshr_b32 s94, s11, 16
+; GFX9-NEXT:    s_lshr_b32 s95, s10, 16
+; GFX9-NEXT:    s_lshr_b32 s30, s9, 16
+; GFX9-NEXT:    s_lshr_b32 s31, s8, 16
+; GFX9-NEXT:    s_lshr_b32 s34, s7, 16
+; GFX9-NEXT:    s_lshr_b32 s35, s6, 16
 ; GFX9-NEXT:  .LBB45_3: ; %end
-; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s16, s35
-; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s17, s34
-; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s31
-; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s30
-; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s95
-; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s94
-; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s93
-; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s92
-; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s91
-; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s90
-; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s89
-; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s88
-; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s79
-; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s78
-; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s6, s77
-; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s7, s76
-; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s8, s75
-; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s9, s74
-; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s10, s73
-; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s11, s72
-; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s12, s63
-; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s13, s62
-; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s14, s61
-; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s15, s60
+; GFX9-NEXT:    s_pack_ll_b32_b16 s4, s6, s35
+; GFX9-NEXT:    s_pack_ll_b32_b16 s5, s7, s34
+; GFX9-NEXT:    s_pack_ll_b32_b16 s6, s8, s31
+; GFX9-NEXT:    s_pack_ll_b32_b16 s7, s9, s30
+; GFX9-NEXT:    s_pack_ll_b32_b16 s8, s10, s95
+; GFX9-NEXT:    s_pack_ll_b32_b16 s9, s11, s94
+; GFX9-NEXT:    s_pack_ll_b32_b16 s10, s12, s93
+; GFX9-NEXT:    s_pack_ll_b32_b16 s11, s13, s92
+; GFX9-NEXT:    s_pack_ll_b32_b16 s12, s14, s91
+; GFX9-NEXT:    s_pack_ll_b32_b16 s13, s15, s90
+; GFX9-NEXT:    s_pack_ll_b32_b16 s14, s16, s89
+; GFX9-NEXT:    s_pack_ll_b32_b16 s15, s17, s88
+; GFX9-NEXT:    s_pack_ll_b32_b16 s16, s18, s79
+; GFX9-NEXT:    s_pack_ll_b32_b16 s17, s19, s78
+; GFX9-NEXT:    s_pack_ll_b32_b16 s18, s20, s77
+; GFX9-NEXT:    s_pack_ll_b32_b16 s19, s21, s76
+; GFX9-NEXT:    s_pack_ll_b32_b16 s20, s22, s75
+; GFX9-NEXT:    s_pack_ll_b32_b16 s21, s23, s74
+; GFX9-NEXT:    s_pack_ll_b32_b16 s22, s24, s73
+; GFX9-NEXT:    s_pack_ll_b32_b16 s23, s25, s72
+; GFX9-NEXT:    s_pack_ll_b32_b16 s24, s26, s63
+; GFX9-NEXT:    s_pack_ll_b32_b16 s25, s27, s62
+; GFX9-NEXT:    s_pack_ll_b32_b16 s26, s28, s61
+; GFX9-NEXT:    s_pack_ll_b32_b16 s27, s29, s60
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s28, s40, s59
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s29, s41, s58
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s40, s42, s57
@@ -34242,28 +34808,28 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; GFX9-NEXT:    s_pack_ll_b32_b16 s43, s45, s46
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9-NEXT:    v_mov_b32_e32 v2, s16
-; GFX9-NEXT:    v_mov_b32_e32 v3, s17
-; GFX9-NEXT:    v_mov_b32_e32 v4, s18
-; GFX9-NEXT:    v_mov_b32_e32 v5, s19
-; GFX9-NEXT:    v_mov_b32_e32 v6, s20
-; GFX9-NEXT:    v_mov_b32_e32 v7, s21
-; GFX9-NEXT:    v_mov_b32_e32 v8, s22
-; GFX9-NEXT:    v_mov_b32_e32 v9, s23
-; GFX9-NEXT:    v_mov_b32_e32 v10, s24
-; GFX9-NEXT:    v_mov_b32_e32 v11, s25
-; GFX9-NEXT:    v_mov_b32_e32 v12, s26
-; GFX9-NEXT:    v_mov_b32_e32 v13, s27
-; GFX9-NEXT:    v_mov_b32_e32 v14, s6
-; GFX9-NEXT:    v_mov_b32_e32 v15, s7
-; GFX9-NEXT:    v_mov_b32_e32 v16, s8
-; GFX9-NEXT:    v_mov_b32_e32 v17, s9
-; GFX9-NEXT:    v_mov_b32_e32 v18, s10
-; GFX9-NEXT:    v_mov_b32_e32 v19, s11
-; GFX9-NEXT:    v_mov_b32_e32 v20, s12
-; GFX9-NEXT:    v_mov_b32_e32 v21, s13
-; GFX9-NEXT:    v_mov_b32_e32 v22, s14
-; GFX9-NEXT:    v_mov_b32_e32 v23, s15
+; GFX9-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-NEXT:    v_mov_b32_e32 v26, s40
@@ -34315,49 +34881,76 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; GFX11-LABEL: bitcast_v15i64_to_v60f16_scalar:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_dual_mov_b32 v13, s0 :: v_dual_mov_b32 v14, s1
+; GFX11-NEXT:    v_dual_mov_b32 v15, s2 :: v_dual_mov_b32 v16, s3
+; GFX11-NEXT:    v_dual_mov_b32 v17, s16 :: v_dual_mov_b32 v18, s17
+; GFX11-NEXT:    v_dual_mov_b32 v19, s18 :: v_dual_mov_b32 v20, s19
+; GFX11-NEXT:    v_dual_mov_b32 v21, s20 :: v_dual_mov_b32 v22, s21
+; GFX11-NEXT:    v_dual_mov_b32 v23, s22 :: v_dual_mov_b32 v24, s23
+; GFX11-NEXT:    v_dual_mov_b32 v25, s24 :: v_dual_mov_b32 v26, s25
+; GFX11-NEXT:    v_dual_mov_b32 v27, s26 :: v_dual_mov_b32 v28, s27
+; GFX11-NEXT:    v_dual_mov_b32 v29, s28 :: v_dual_mov_b32 v30, s29
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v12
-; GFX11-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX11-NEXT:    v_readfirstlane_b32 s7, v3
-; GFX11-NEXT:    v_readfirstlane_b32 s8, v4
-; GFX11-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX11-NEXT:    v_readfirstlane_b32 s10, v6
-; GFX11-NEXT:    v_readfirstlane_b32 s11, v7
-; GFX11-NEXT:    v_readfirstlane_b32 s12, v8
-; GFX11-NEXT:    v_readfirstlane_b32 s13, v9
-; GFX11-NEXT:    v_readfirstlane_b32 s15, v10
-; GFX11-NEXT:    v_readfirstlane_b32 s14, v11
+; GFX11-NEXT:    v_readfirstlane_b32 s0, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s1, v14
+; GFX11-NEXT:    v_readfirstlane_b32 s2, v15
+; GFX11-NEXT:    v_readfirstlane_b32 s3, v16
+; GFX11-NEXT:    v_readfirstlane_b32 s4, v17
+; GFX11-NEXT:    v_readfirstlane_b32 s5, v18
+; GFX11-NEXT:    v_readfirstlane_b32 s6, v19
+; GFX11-NEXT:    v_readfirstlane_b32 s7, v20
+; GFX11-NEXT:    v_readfirstlane_b32 s8, v21
+; GFX11-NEXT:    v_readfirstlane_b32 s9, v22
+; GFX11-NEXT:    v_readfirstlane_b32 s10, v23
+; GFX11-NEXT:    v_readfirstlane_b32 s11, v24
+; GFX11-NEXT:    v_readfirstlane_b32 s12, v25
+; GFX11-NEXT:    v_readfirstlane_b32 s13, v26
+; GFX11-NEXT:    v_readfirstlane_b32 s14, v27
+; GFX11-NEXT:    v_readfirstlane_b32 s15, v28
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v29
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v30
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v0
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v1
+; GFX11-NEXT:    v_readfirstlane_b32 s20, v2
+; GFX11-NEXT:    v_readfirstlane_b32 s21, v3
+; GFX11-NEXT:    v_readfirstlane_b32 s22, v4
+; GFX11-NEXT:    v_readfirstlane_b32 s23, v5
+; GFX11-NEXT:    v_readfirstlane_b32 s24, v6
+; GFX11-NEXT:    v_readfirstlane_b32 s25, v7
+; GFX11-NEXT:    v_readfirstlane_b32 s26, v8
+; GFX11-NEXT:    v_readfirstlane_b32 s27, v9
+; GFX11-NEXT:    v_readfirstlane_b32 s29, v10
+; GFX11-NEXT:    v_readfirstlane_b32 s28, v11
 ; GFX11-NEXT:    s_mov_b32 s94, 0
 ; GFX11-NEXT:    s_and_b32 s40, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cbranch_scc0 .LBB45_4
 ; GFX11-NEXT:  ; %bb.1: ; %cmp.false
-; GFX11-NEXT:    s_lshr_b32 s40, s14, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s15, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s78, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s79, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s88, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s28, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s29, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s79, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s88, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s89, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s90, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s91, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s92, s1, 16
@@ -34365,20 +34958,8 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; GFX11-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s94
 ; GFX11-NEXT:    s_cbranch_vccnz .LBB45_3
 ; GFX11-NEXT:  .LBB45_2: ; %cmp.true
-; GFX11-NEXT:    s_add_u32 s15, s15, 3
-; GFX11-NEXT:    s_addc_u32 s14, s14, 0
-; GFX11-NEXT:    s_add_u32 s12, s12, 3
-; GFX11-NEXT:    s_addc_u32 s13, s13, 0
-; GFX11-NEXT:    s_add_u32 s10, s10, 3
-; GFX11-NEXT:    s_addc_u32 s11, s11, 0
-; GFX11-NEXT:    s_add_u32 s8, s8, 3
-; GFX11-NEXT:    s_addc_u32 s9, s9, 0
-; GFX11-NEXT:    s_add_u32 s6, s6, 3
-; GFX11-NEXT:    s_addc_u32 s7, s7, 0
-; GFX11-NEXT:    s_add_u32 s4, s4, 3
-; GFX11-NEXT:    s_addc_u32 s5, s5, 0
-; GFX11-NEXT:    s_add_u32 s28, s28, 3
-; GFX11-NEXT:    s_addc_u32 s29, s29, 0
+; GFX11-NEXT:    s_add_u32 s29, s29, 3
+; GFX11-NEXT:    s_addc_u32 s28, s28, 0
 ; GFX11-NEXT:    s_add_u32 s26, s26, 3
 ; GFX11-NEXT:    s_addc_u32 s27, s27, 0
 ; GFX11-NEXT:    s_add_u32 s24, s24, 3
@@ -34391,36 +34972,48 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; GFX11-NEXT:    s_addc_u32 s19, s19, 0
 ; GFX11-NEXT:    s_add_u32 s16, s16, 3
 ; GFX11-NEXT:    s_addc_u32 s17, s17, 0
+; GFX11-NEXT:    s_add_u32 s14, s14, 3
+; GFX11-NEXT:    s_addc_u32 s15, s15, 0
+; GFX11-NEXT:    s_add_u32 s12, s12, 3
+; GFX11-NEXT:    s_addc_u32 s13, s13, 0
+; GFX11-NEXT:    s_add_u32 s10, s10, 3
+; GFX11-NEXT:    s_addc_u32 s11, s11, 0
+; GFX11-NEXT:    s_add_u32 s8, s8, 3
+; GFX11-NEXT:    s_addc_u32 s9, s9, 0
+; GFX11-NEXT:    s_add_u32 s6, s6, 3
+; GFX11-NEXT:    s_addc_u32 s7, s7, 0
+; GFX11-NEXT:    s_add_u32 s4, s4, 3
+; GFX11-NEXT:    s_addc_u32 s5, s5, 0
 ; GFX11-NEXT:    s_add_u32 s2, s2, 3
 ; GFX11-NEXT:    s_addc_u32 s3, s3, 0
 ; GFX11-NEXT:    s_add_u32 s0, s0, 3
 ; GFX11-NEXT:    s_addc_u32 s1, s1, 0
-; GFX11-NEXT:    s_lshr_b32 s40, s14, 16
-; GFX11-NEXT:    s_lshr_b32 s41, s15, 16
-; GFX11-NEXT:    s_lshr_b32 s42, s13, 16
-; GFX11-NEXT:    s_lshr_b32 s43, s12, 16
-; GFX11-NEXT:    s_lshr_b32 s44, s11, 16
-; GFX11-NEXT:    s_lshr_b32 s45, s10, 16
-; GFX11-NEXT:    s_lshr_b32 s46, s9, 16
-; GFX11-NEXT:    s_lshr_b32 s47, s8, 16
-; GFX11-NEXT:    s_lshr_b32 s56, s7, 16
-; GFX11-NEXT:    s_lshr_b32 s57, s6, 16
-; GFX11-NEXT:    s_lshr_b32 s58, s5, 16
-; GFX11-NEXT:    s_lshr_b32 s59, s4, 16
-; GFX11-NEXT:    s_lshr_b32 s60, s29, 16
-; GFX11-NEXT:    s_lshr_b32 s61, s28, 16
-; GFX11-NEXT:    s_lshr_b32 s62, s27, 16
-; GFX11-NEXT:    s_lshr_b32 s63, s26, 16
-; GFX11-NEXT:    s_lshr_b32 s72, s25, 16
-; GFX11-NEXT:    s_lshr_b32 s73, s24, 16
-; GFX11-NEXT:    s_lshr_b32 s74, s23, 16
-; GFX11-NEXT:    s_lshr_b32 s75, s22, 16
-; GFX11-NEXT:    s_lshr_b32 s76, s21, 16
-; GFX11-NEXT:    s_lshr_b32 s77, s20, 16
-; GFX11-NEXT:    s_lshr_b32 s78, s19, 16
-; GFX11-NEXT:    s_lshr_b32 s79, s18, 16
-; GFX11-NEXT:    s_lshr_b32 s88, s17, 16
-; GFX11-NEXT:    s_lshr_b32 s89, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s40, s28, 16
+; GFX11-NEXT:    s_lshr_b32 s41, s29, 16
+; GFX11-NEXT:    s_lshr_b32 s42, s27, 16
+; GFX11-NEXT:    s_lshr_b32 s43, s26, 16
+; GFX11-NEXT:    s_lshr_b32 s44, s25, 16
+; GFX11-NEXT:    s_lshr_b32 s45, s24, 16
+; GFX11-NEXT:    s_lshr_b32 s46, s23, 16
+; GFX11-NEXT:    s_lshr_b32 s47, s22, 16
+; GFX11-NEXT:    s_lshr_b32 s56, s21, 16
+; GFX11-NEXT:    s_lshr_b32 s57, s20, 16
+; GFX11-NEXT:    s_lshr_b32 s58, s19, 16
+; GFX11-NEXT:    s_lshr_b32 s59, s18, 16
+; GFX11-NEXT:    s_lshr_b32 s60, s17, 16
+; GFX11-NEXT:    s_lshr_b32 s61, s16, 16
+; GFX11-NEXT:    s_lshr_b32 s62, s15, 16
+; GFX11-NEXT:    s_lshr_b32 s63, s14, 16
+; GFX11-NEXT:    s_lshr_b32 s72, s13, 16
+; GFX11-NEXT:    s_lshr_b32 s73, s12, 16
+; GFX11-NEXT:    s_lshr_b32 s74, s11, 16
+; GFX11-NEXT:    s_lshr_b32 s75, s10, 16
+; GFX11-NEXT:    s_lshr_b32 s76, s9, 16
+; GFX11-NEXT:    s_lshr_b32 s77, s8, 16
+; GFX11-NEXT:    s_lshr_b32 s78, s7, 16
+; GFX11-NEXT:    s_lshr_b32 s79, s6, 16
+; GFX11-NEXT:    s_lshr_b32 s88, s5, 16
+; GFX11-NEXT:    s_lshr_b32 s89, s4, 16
 ; GFX11-NEXT:    s_lshr_b32 s90, s3, 16
 ; GFX11-NEXT:    s_lshr_b32 s91, s2, 16
 ; GFX11-NEXT:    s_lshr_b32 s92, s1, 16
@@ -34431,47 +35024,47 @@ define inreg <60 x half> @bitcast_v15i64_to_v60f16_scalar(<15 x i64> inreg %a, i
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s1, s1, s92
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s2, s2, s91
 ; GFX11-NEXT:    s_pack_ll_b32_b16 s3, s3, s90
-; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s89
-; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s88
-; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s79
-; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s78
-; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s77
-; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s76
-; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s75
-; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s74
-; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s73
-; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s72
-; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s63
-; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s62
-; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s61
-; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s60
-; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s59
-; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s58
-; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s57
-; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s56
-; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s47
-; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s46
-; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s45
-; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s44
-; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s43
-; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s42
-; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s41
-; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s40
+; GFX11-NEXT:    s_pack_ll_b32_b16 s4, s4, s89
+; GFX11-NEXT:    s_pack_ll_b32_b16 s5, s5, s88
+; GFX11-NEXT:    s_pack_ll_b32_b16 s6, s6, s79
+; GFX11-NEXT:    s_pack_ll_b32_b16 s7, s7, s78
+; GFX11-NEXT:    s_pack_ll_b32_b16 s8, s8, s77
+; GFX11-NEXT:    s_pack_ll_b32_b16 s9, s9, s76
+; GFX11-NEXT:    s_pack_ll_b32_b16 s10, s10, s75
+; GFX11-NEXT:    s_pack_ll_b32_b16 s11, s11, s74
+; GFX11-NEXT:    s_pack_ll_b32_b16 s12, s12, s73
+; GFX11-NEXT:    s_pack_ll_b32_b16 s13, s13, s72
+; GFX11-NEXT:    s_pack_ll_b32_b16 s14, s14, s63
+; GFX11-NEXT:    s_pack_ll_b32_b16 s15, s15, s62
+; GFX11-NEXT:    s_pack_ll_b32_b16 s16, s16, s61
+; GFX11-NEXT:    s_pack_ll_b32_b16 s17, s17, s60
+; GFX11-NEXT:    s_pack_ll_b32_b16 s18, s18, s59
+; GFX11-NEXT:    s_pack_ll_b32_b16 s19, s19, s58
+; GFX11-NEXT:    s_pack_ll_b32_b16 s20, s20, s57
+; GFX11-NEXT:    s_pack_ll_b32_b16 s21, s21, s56
+; GFX11-NEXT:    s_pack_ll_b32_b16 s22, s22, s47
+; GFX11-NEXT:    s_pack_ll_b32_b16 s23, s23, s46
+; GFX11-NEXT:    s_pack_ll_b32_b16 s24, s24, s45
+; GFX11-NEXT:    s_pack_ll_b32_b16 s25, s25, s44
+; GFX11-NEXT:    s_pack_ll_b32_b16 s26, s26, s43
+; GFX11-NEXT:    s_pack_ll_b32_b16 s27, s27, s42
+; GFX11-NEXT:    s_pack_ll_b32_b16 s29, s29, s41
+; GFX11-NEXT:    s_pack_ll_b32_b16 s28, s28, s40
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    v_dual_mov_b32 v4, s16 :: v_dual_mov_b32 v5, s17
-; GFX11-NEXT:    v_dual_mov_b32 v6, s18 :: v_dual_mov_b32 v7, s19
-; GFX11-NEXT:    v_dual_mov_b32 v8, s20 :: v_dual_mov_b32 v9, s21
-; GFX11-NEXT:    v_dual_mov_b32 v10, s22 :: v_dual_mov_b32 v11, s23
-; GFX11-NEXT:    v_dual_mov_b32 v12, s24 :: v_dual_mov_b32 v13, s25
-; GFX11-NEXT:    v_dual_mov_b32 v14, s26 :: v_dual_mov_b32 v15, s27
-; GFX11-NEXT:    v_dual_mov_b32 v16, s28 :: v_dual_mov_b32 v17, s29
-; GFX11-NEXT:    v_dual_mov_b32 v18, s4 :: v_dual_mov_b32 v19, s5
-; GFX11-NEXT:    v_dual_mov_b32 v20, s6 :: v_dual_mov_b32 v21, s7
-; GFX11-NEXT:    v_dual_mov_b32 v22, s8 :: v_dual_mov_b32 v23, s9
-; GFX11-NEXT:    v_dual_mov_b32 v24, s10 :: v_dual_mov_b32 v25, s11
-; GFX11-NEXT:    v_dual_mov_b32 v26, s12 :: v_dual_mov_b32 v27, s13
-; GFX11-NEXT:    v_dual_mov_b32 v28, s15 :: v_dual_mov_b32 v29, s14
+; GFX11-NEXT:    v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+; GFX11-NEXT:    v_dual_mov_b32 v6, s6 :: v_dual_mov_b32 v7, s7
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s9
+; GFX11-NEXT:    v_dual_mov_b32 v10, s10 :: v_dual_mov_b32 v11, s11
+; GFX11-NEXT:    v_dual_mov_b32 v12, s12 :: v_dual_mov_b32 v13, s13
+; GFX11-NEXT:    v_dual_mov_b32 v14, s14 :: v_dual_mov_b32 v15, s15
+; GFX11-NEXT:    v_dual_mov_b32 v16, s16 :: v_dual_mov_b32 v17, s17
+; GFX11-NEXT:    v_dual_mov_b32 v18, s18 :: v_dual_mov_b32 v19, s19
+; GFX11-NEXT:    v_dual_mov_b32 v20, s20 :: v_dual_mov_b32 v21, s21
+; GFX11-NEXT:    v_dual_mov_b32 v22, s22 :: v_dual_mov_b32 v23, s23
+; GFX11-NEXT:    v_dual_mov_b32 v24, s24 :: v_dual_mov_b32 v25, s25
+; GFX11-NEXT:    v_dual_mov_b32 v26, s26 :: v_dual_mov_b32 v27, s27
+; GFX11-NEXT:    v_dual_mov_b32 v28, s29 :: v_dual_mov_b32 v29, s28
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ; GFX11-NEXT:  .LBB45_4:
 ; GFX11-NEXT:    ; implicit-def: $sgpr93
@@ -40290,7 +40883,7 @@ define <15 x double> @bitcast_v60i16_to_v15f64(<60 x i16> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v24, vcc, s6, v24
 ; SI-NEXT:    v_add_i32_e32 v25, vcc, s6, v25
 ; SI-NEXT:    v_add_i32_e32 v26, vcc, s6, v26
-; SI-NEXT:    v_add_i32_e32 v27, vcc, s6, v27
+; SI-NEXT:    v_add_i32_e32 v27, vcc, 0x30000, v27
 ; SI-NEXT:    v_add_i32_e32 v28, vcc, 0x30000, v28
 ; SI-NEXT:    v_add_i32_e32 v29, vcc, 0x30000, v29
 ; SI-NEXT:  .LBB50_4: ; %end
@@ -43784,23 +44377,21 @@ define inreg <60 x half> @bitcast_v15f64_to_v60f16_scalar(<15 x double> inreg %a
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v17
-; SI-NEXT:    v_readfirstlane_b32 s42, v1
-; SI-NEXT:    v_readfirstlane_b32 s43, v2
-; SI-NEXT:    v_readfirstlane_b32 s40, v3
-; SI-NEXT:    v_readfirstlane_b32 s41, v4
-; SI-NEXT:    v_readfirstlane_b32 s14, v5
-; SI-NEXT:    v_readfirstlane_b32 s15, v6
-; SI-NEXT:    v_readfirstlane_b32 s12, v7
-; SI-NEXT:    v_readfirstlane_b32 s13, v8
-; SI-NEXT:    v_readfirstlane_b32 s10, v9
-; SI-NEXT:    v_readfirstlane_b32 s11, v10
-; SI-NEXT:    v_readfirstlane_b32 s8, v11
-; SI-NEXT:    v_readfirstlane_b32 s9, v12
-; SI-NEXT:    v_readfirstlane_b32 s6, v13
-; SI-NEXT:    v_readfirstlane_b32 s7, v14
-; SI-NEXT:    v_readfirstlane_b32 s4, v15
-; SI-NEXT:    s_and_b64 s[44:45], vcc, exec
-; SI-NEXT:    v_readfirstlane_b32 s5, v16
+; SI-NEXT:    v_mov_b32_e32 v23, s16
+; SI-NEXT:    v_mov_b32_e32 v24, s17
+; SI-NEXT:    v_mov_b32_e32 v29, s18
+; SI-NEXT:    v_mov_b32_e32 v30, s19
+; SI-NEXT:    v_mov_b32_e32 v27, s20
+; SI-NEXT:    v_mov_b32_e32 v28, s21
+; SI-NEXT:    v_mov_b32_e32 v25, s22
+; SI-NEXT:    v_mov_b32_e32 v26, s23
+; SI-NEXT:    v_mov_b32_e32 v21, s24
+; SI-NEXT:    v_mov_b32_e32 v22, s25
+; SI-NEXT:    v_mov_b32_e32 v19, s26
+; SI-NEXT:    v_mov_b32_e32 v20, s27
+; SI-NEXT:    s_and_b64 s[4:5], vcc, exec
+; SI-NEXT:    v_mov_b32_e32 v17, s28
+; SI-NEXT:    v_mov_b32_e32 v18, s29
 ; SI-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
@@ -43819,438 +44410,565 @@ define inreg <60 x half> @bitcast_v15f64_to_v60f16_scalar(<15 x double> inreg %a
 ; SI-NEXT:    buffer_store_dword v63, off, s[0:3], s32 ; 4-byte Folded Spill
 ; SI-NEXT:    s_cbranch_scc0 .LBB53_4
 ; SI-NEXT:  ; %bb.1: ; %cmp.false
-; SI-NEXT:    s_lshr_b32 s44, s5, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, s44
-; SI-NEXT:    s_lshr_b32 s44, s4, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, s44
-; SI-NEXT:    s_lshr_b32 s44, s7, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, s44
-; SI-NEXT:    s_lshr_b32 s44, s6, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, s44
-; SI-NEXT:    s_lshr_b32 s44, s9, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, s44
-; SI-NEXT:    s_lshr_b32 s44, s8, 16
-; SI-NEXT:    s_waitcnt expcnt(4)
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, s44
-; SI-NEXT:    s_lshr_b32 s44, s11, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, s44
-; SI-NEXT:    s_lshr_b32 s44, s10, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, s44
-; SI-NEXT:    s_lshr_b32 s44, s13, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, s44
-; SI-NEXT:    s_lshr_b32 s44, s12, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, s44
-; SI-NEXT:    s_lshr_b32 s44, s15, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v14, s44
-; SI-NEXT:    s_lshr_b32 s44, s14, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, s44
-; SI-NEXT:    s_lshr_b32 s44, s41, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, s44
-; SI-NEXT:    s_lshr_b32 s44, s40, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, s44
-; SI-NEXT:    s_lshr_b32 s44, s43, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, s44
-; SI-NEXT:    s_lshr_b32 s44, s42, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, s44
-; SI-NEXT:    s_lshr_b32 s44, s29, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, s44
-; SI-NEXT:    s_lshr_b32 s44, s28, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, s44
-; SI-NEXT:    s_lshr_b32 s44, s27, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, s44
-; SI-NEXT:    s_lshr_b32 s44, s26, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, s44
-; SI-NEXT:    s_lshr_b32 s44, s25, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, s44
-; SI-NEXT:    s_lshr_b32 s44, s24, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, s44
-; SI-NEXT:    s_lshr_b32 s44, s23, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, s44
-; SI-NEXT:    s_lshr_b32 s44, s22, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, s44
-; SI-NEXT:    s_lshr_b32 s44, s21, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, s44
-; SI-NEXT:    s_lshr_b32 s44, s20, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, s44
-; SI-NEXT:    s_lshr_b32 s44, s19, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, s44
-; SI-NEXT:    s_lshr_b32 s44, s18, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, s44
-; SI-NEXT:    s_lshr_b32 s44, s17, 16
-; SI-NEXT:    v_cvt_f32_f16_e32 v58, s44
-; SI-NEXT:    s_lshr_b32 s44, s16, 16
-; SI-NEXT:    s_waitcnt expcnt(3)
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, s44
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, s5
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, s4
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, s7
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, s6
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, s9
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, s8
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, s11
-; SI-NEXT:    s_waitcnt expcnt(2)
-; SI-NEXT:    v_cvt_f32_f16_e32 v61, s10
-; SI-NEXT:    s_waitcnt expcnt(1)
-; SI-NEXT:    v_cvt_f32_f16_e32 v62, s13
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v15
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v63, s12
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, s15
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, s14
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, s41
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, s40
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, s43
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, s42
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, s29
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, s28
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, s27
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, s26
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, s25
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, s24
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, s23
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, s22
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, s21
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, s20
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, s19
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, s18
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, s17
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, s16
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v31
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v13
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v12
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v31
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v9
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v59, v31
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v6
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v5
+; SI-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v33, v15
+; SI-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v5
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v60, v14
+; SI-NEXT:    v_cvt_f32_f16_e32 v62, v13
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v2
+; SI-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:132 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v27
+; SI-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v3
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v29
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v17
+; SI-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v20
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v24
+; SI-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v1
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:148 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v23
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:152 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v22
+; SI-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v18
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v20
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:156 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v22
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v26
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:160 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v26
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v30
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:164 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v25
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v23
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v31
+; SI-NEXT:    v_cvt_f32_f16_e32 v31, v16
+; SI-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:168 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v28
 ; SI-NEXT:    s_cbranch_execnz .LBB53_3
 ; SI-NEXT:  .LBB53_2: ; %cmp.true
-; SI-NEXT:    v_add_f64 v[1:2], s[16:17], 1.0
+; SI-NEXT:    v_add_f64 v[1:2], v[1:2], 1.0
+; SI-NEXT:    v_add_f64 v[17:18], v[17:18], 1.0
 ; SI-NEXT:    s_waitcnt expcnt(5)
-; SI-NEXT:    v_add_f64 v[57:58], s[18:19], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SI-NEXT:    v_add_f64 v[19:20], v[19:20], 1.0
+; SI-NEXT:    v_add_f64 v[3:4], v[3:4], 1.0
+; SI-NEXT:    v_add_f64 v[7:8], v[7:8], 1.0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v3
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v7
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v17
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v31
+; SI-NEXT:    v_add_f64 v[21:22], v[21:22], 1.0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v20
+; SI-NEXT:    v_add_f64 v[5:6], v[5:6], 1.0
+; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v62, 16, v6
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:148 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v19
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v57
-; SI-NEXT:    v_add_f64 v[41:42], s[20:21], 1.0
-; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v62
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:152 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v8
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:132 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:156 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v21
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v33
 ; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v41
-; SI-NEXT:    v_add_f64 v[53:54], s[22:23], 1.0
-; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v60
+; SI-NEXT:    v_add_f64 v[25:26], v[25:26], 1.0
+; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v4
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:160 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v42
-; SI-NEXT:    v_add_f64 v[15:16], s[10:11], 1.0
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v26
 ; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v53
-; SI-NEXT:    v_add_f64 v[20:21], s[12:13], 1.0
-; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
-; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v15
-; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v20
-; SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v21
-; SI-NEXT:    v_cvt_f32_f16_e32 v62, v21
-; SI-NEXT:    v_cvt_f32_f16_e32 v63, v20
-; SI-NEXT:    v_cvt_f32_f16_e32 v20, v58
-; SI-NEXT:    v_cvt_f32_f16_e32 v21, v57
-; SI-NEXT:    v_lshrrev_b32_e32 v58, 16, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v57, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v1
-; SI-NEXT:    v_cvt_f32_f16_e32 v1, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
-; SI-NEXT:    v_add_f64 v[37:38], s[26:27], 1.0
-; SI-NEXT:    v_cvt_f32_f16_e32 v61, v15
-; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v38
-; SI-NEXT:    v_lshrrev_b32_e32 v44, 16, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v15, v37
-; SI-NEXT:    v_cvt_f32_f16_e32 v37, v55
-; SI-NEXT:    v_add_f64 v[7:8], s[6:7], 1.0
-; SI-NEXT:    v_add_f64 v[34:35], s[28:29], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v19, v8
-; SI-NEXT:    v_cvt_f32_f16_e32 v8, v41
-; SI-NEXT:    v_add_f64 v[30:31], s[42:43], 1.0
-; SI-NEXT:    v_add_f64 v[11:12], s[8:9], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v35
-; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v30
-; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v43, v12
-; SI-NEXT:    v_cvt_f32_f16_e32 v12, v30
-; SI-NEXT:    v_cvt_f32_f16_e32 v30, v32
-; SI-NEXT:    v_cvt_f32_f16_e32 v32, v39
-; SI-NEXT:    v_cvt_f32_f16_e32 v39, v44
-; SI-NEXT:    v_add_f64 v[49:50], s[24:25], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v46, 16, v50
-; SI-NEXT:    v_lshrrev_b32_e32 v56, 16, v49
-; SI-NEXT:    v_cvt_f32_f16_e32 v47, v16
-; SI-NEXT:    v_cvt_f32_f16_e32 v16, v49
-; SI-NEXT:    v_cvt_f32_f16_e32 v49, v46
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v59
+; SI-NEXT:    v_mov_b32_e32 v59, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v63
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:164 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_f64 v[3:4], s[4:5], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v34
-; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v13, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v34
-; SI-NEXT:    v_cvt_f32_f16_e32 v34, v51
-; SI-NEXT:    v_cvt_f32_f16_e32 v51, v56
-; SI-NEXT:    v_add_f64 v[26:27], s[40:41], 1.0
-; SI-NEXT:    v_add_f64 v[22:23], s[14:15], 1.0
-; SI-NEXT:    v_lshrrev_b32_e32 v60, 16, v54
-; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v31
-; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v26
-; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v27
-; SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v22
-; SI-NEXT:    v_lshrrev_b32_e32 v14, 16, v23
-; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v11
-; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v7
-; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v10, v4
-; SI-NEXT:    v_cvt_f32_f16_e32 v29, v7
-; SI-NEXT:    v_cvt_f32_f16_e32 v45, v11
-; SI-NEXT:    v_cvt_f32_f16_e32 v23, v23
-; SI-NEXT:    v_cvt_f32_f16_e32 v4, v22
-; SI-NEXT:    v_cvt_f32_f16_e32 v27, v27
-; SI-NEXT:    v_cvt_f32_f16_e32 v11, v26
-; SI-NEXT:    v_cvt_f32_f16_e32 v31, v31
-; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
-; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
-; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
-; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
-; SI-NEXT:    v_cvt_f32_f16_e32 v7, v53
-; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
-; SI-NEXT:    v_cvt_f32_f16_e32 v40, v40
-; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
-; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
-; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
-; SI-NEXT:    v_cvt_f32_f16_e32 v33, v33
-; SI-NEXT:    v_cvt_f32_f16_e32 v59, v59
-; SI-NEXT:    v_cvt_f32_f16_e32 v25, v25
-; SI-NEXT:    v_cvt_f32_f16_e32 v18, v18
-; SI-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; SI-NEXT:    v_cvt_f32_f16_e32 v1, v25
+; SI-NEXT:    v_add_f64 v[55:56], v[23:24], 1.0
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v61
+; SI-NEXT:    v_add_f64 v[29:30], v[29:30], 1.0
+; SI-NEXT:    v_add_f64 v[41:42], v[27:28], 1.0
+; SI-NEXT:    v_add_f64 v[9:10], v[9:10], 1.0
+; SI-NEXT:    v_add_f64 v[11:12], v[11:12], 1.0
+; SI-NEXT:    v_add_f64 v[13:14], v[13:14], 1.0
+; SI-NEXT:    v_add_f64 v[15:16], v[15:16], 1.0
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v55
+; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v30
+; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v41
+; SI-NEXT:    v_lshrrev_b32_e32 v50, 16, v42
+; SI-NEXT:    v_lshrrev_b32_e32 v48, 16, v25
+; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v26
+; SI-NEXT:    v_lshrrev_b32_e32 v36, 16, v21
+; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v32, 16, v19
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v20
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v17
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v18
+; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v11
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v13
+; SI-NEXT:    v_lshrrev_b32_e32 v52, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v54, 16, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v40, 16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; SI-NEXT:    v_cvt_f32_f16_e32 v15, v15
 ; SI-NEXT:    v_cvt_f32_f16_e32 v14, v14
-; SI-NEXT:    v_cvt_f32_f16_e32 v22, v6
-; SI-NEXT:    v_cvt_f32_f16_e32 v24, v24
-; SI-NEXT:    v_cvt_f32_f16_e32 v26, v9
-; SI-NEXT:    v_cvt_f32_f16_e32 v28, v28
-; SI-NEXT:    v_cvt_f32_f16_e32 v53, v60
-; SI-NEXT:    v_cvt_f32_f16_e32 v58, v58
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v55, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v41, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v44, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v46, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v56, v5
-; SI-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v60, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v13, v13
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:168 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v12, v12
+; SI-NEXT:    v_cvt_f32_f16_e32 v11, v11
+; SI-NEXT:    v_cvt_f32_f16_e32 v10, v10
+; SI-NEXT:    v_cvt_f32_f16_e32 v9, v9
+; SI-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; SI-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; SI-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; SI-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; SI-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; SI-NEXT:    v_cvt_f32_f16_e32 v42, v42
+; SI-NEXT:    v_cvt_f32_f16_e32 v44, v41
+; SI-NEXT:    v_cvt_f32_f16_e32 v46, v30
+; SI-NEXT:    v_cvt_f32_f16_e32 v47, v29
+; SI-NEXT:    v_cvt_f32_f16_e32 v56, v56
+; SI-NEXT:    v_cvt_f32_f16_e32 v57, v55
+; SI-NEXT:    v_cvt_f32_f16_e32 v40, v40
+; SI-NEXT:    v_cvt_f32_f16_e32 v54, v54
+; SI-NEXT:    v_cvt_f32_f16_e32 v52, v52
+; SI-NEXT:    v_cvt_f32_f16_e32 v51, v51
+; SI-NEXT:    v_cvt_f32_f16_e32 v49, v49
+; SI-NEXT:    v_cvt_f32_f16_e32 v39, v39
+; SI-NEXT:    v_cvt_f32_f16_e32 v37, v37
+; SI-NEXT:    v_cvt_f32_f16_e32 v35, v35
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v58
+; SI-NEXT:    v_cvt_f32_f16_e32 v58, v45
+; SI-NEXT:    v_cvt_f32_f16_e32 v61, v43
+; SI-NEXT:    v_cvt_f32_f16_e32 v63, v53
+; SI-NEXT:    v_cvt_f32_f16_e32 v32, v32
+; SI-NEXT:    v_cvt_f32_f16_e32 v34, v34
+; SI-NEXT:    v_cvt_f32_f16_e32 v36, v36
+; SI-NEXT:    v_cvt_f32_f16_e32 v38, v38
+; SI-NEXT:    v_cvt_f32_f16_e32 v48, v48
+; SI-NEXT:    v_cvt_f32_f16_e32 v50, v50
+; SI-NEXT:    v_cvt_f32_f16_e32 v53, v28
+; SI-NEXT:    v_cvt_f32_f16_e32 v55, v27
+; SI-NEXT:    v_cvt_f32_f16_e32 v41, v24
+; SI-NEXT:    v_cvt_f32_f16_e32 v43, v1
+; SI-NEXT:    v_cvt_f32_f16_e32 v45, v23
+; SI-NEXT:    v_mov_b32_e32 v33, v15
+; SI-NEXT:    v_mov_b32_e32 v31, v16
+; SI-NEXT:    v_mov_b32_e32 v62, v13
+; SI-NEXT:    v_mov_b32_e32 v60, v14
+; SI-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
 ; SI-NEXT:  .LBB53_3: ; %end
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v60
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v2
-; SI-NEXT:    v_cvt_f16_f32_e32 v9, v57
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v58
-; SI-NEXT:    buffer_store_dword v5, v0, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v45
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 4, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v6, 16, v6
-; SI-NEXT:    v_or_b32_e32 v6, v9, v6
-; SI-NEXT:    buffer_store_dword v6, v5, s[0:3], 0 offen
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v56
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v21
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 8, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v46
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v20
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 12, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v44
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v8
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 16, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v41
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v42
-; SI-NEXT:    v_add_i32_e32 v9, vcc, 20, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v9, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v55
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v7
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 24, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v53
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v54
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 28, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v51
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v16
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 32, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v49
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v50
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 36, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v39
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v15
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 40, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v37
-; SI-NEXT:    v_cvt_f16_f32_e32 v6, v38
-; SI-NEXT:    v_add_i32_e32 v7, vcc, 44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v5, v6, v5
-; SI-NEXT:    buffer_store_dword v5, v7, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v34
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 48, v0
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; SI-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; SI-NEXT:    v_or_b32_e32 v3, v3, v5
-; SI-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v32
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v35
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 52, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v5, v3
-; SI-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v30
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v12
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 56, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v5, v3
-; SI-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v28
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v31
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 60, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v5, v3
-; SI-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v26
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v11
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 64, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v5, v3
-; SI-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v24
-; SI-NEXT:    v_cvt_f16_f32_e32 v5, v27
-; SI-NEXT:    v_add_i32_e32 v6, vcc, 0x44, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v5, v3
-; SI-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v22
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x48, v0
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v4, v3
-; SI-NEXT:    buffer_store_dword v3, v5, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v14
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v23
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x4c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v4, v3
-; SI-NEXT:    buffer_store_dword v3, v5, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v17
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v63
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x50, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v4, v3
-; SI-NEXT:    buffer_store_dword v3, v5, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v18
-; SI-NEXT:    v_cvt_f16_f32_e32 v4, v62
-; SI-NEXT:    v_add_i32_e32 v5, vcc, 0x54, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; SI-NEXT:    v_or_b32_e32 v3, v4, v3
-; SI-NEXT:    buffer_store_dword v3, v5, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v61
-; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 0x58, v0
-; SI-NEXT:    v_or_b32_e32 v1, v3, v1
-; SI-NEXT:    buffer_store_dword v1, v4, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v25
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v47
-; SI-NEXT:    v_add_i32_e32 v4, vcc, 0x5c, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
-; SI-NEXT:    v_or_b32_e32 v1, v3, v1
-; SI-NEXT:    buffer_store_dword v1, v4, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v59
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v45
-; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x60, v0
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v57
+; SI-NEXT:    v_cvt_f16_f32_e32 v3, v56
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
-; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
-; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v33
 ; SI-NEXT:    v_cvt_f16_f32_e32 v2, v43
-; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x64, v0
+; SI-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_add_i32_e32 v1, vcc, 4, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; SI-NEXT:    v_or_b32_e32 v2, v3, v2
+; SI-NEXT:    buffer_store_dword v2, v1, s[0:3], 0 offen
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v41
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v47
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 8, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v55
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v46
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 12, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v53
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v44
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 16, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v50
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v42
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 20, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:168 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 24, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:164 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v38
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 28, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:160 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v1, v36
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v29
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 32, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:156 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v34
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 36, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:152 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v32
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 40, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:148 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v63
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 44, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:144 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v61
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 48, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:140 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v58
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 52, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:136 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 56, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:132 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 60, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:128 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 64, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:124 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x44, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x48, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:116 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x4c, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x50, v0
+; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v59
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x54, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v35
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x58, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v37
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x5c, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v39
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x60, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v49
+; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x64, v0
+; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; SI-NEXT:    s_waitcnt vmcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_or_b32_e32 v1, v2, v1
+; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v51
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v62
 ; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x68, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v48
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v19
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v52
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v60
 ; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x6c, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_cvt_f16_f32_e32 v1, v52
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v13
+; SI-NEXT:    v_cvt_f16_f32_e32 v1, v54
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v33
 ; SI-NEXT:    v_add_i32_e32 v3, vcc, 0x70, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
 ; SI-NEXT:    buffer_store_dword v1, v3, s[0:3], 0 offen
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_cvt_f16_f32_e32 v1, v40
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v10
+; SI-NEXT:    v_cvt_f16_f32_e32 v2, v31
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 0x74, v0
 ; SI-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; SI-NEXT:    v_or_b32_e32 v1, v2, v1
@@ -44274,66 +44992,93 @@ define inreg <60 x half> @bitcast_v15f64_to_v60f16_scalar(<15 x double> inreg %a
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB53_4:
-; SI-NEXT:    ; implicit-def: $vgpr2
-; SI-NEXT:    ; implicit-def: $vgpr60
-; SI-NEXT:    ; implicit-def: $vgpr57
-; SI-NEXT:    ; implicit-def: $vgpr58
-; SI-NEXT:    ; implicit-def: $vgpr21
-; SI-NEXT:    ; implicit-def: $vgpr56
-; SI-NEXT:    ; implicit-def: $vgpr20
-; SI-NEXT:    ; implicit-def: $vgpr46
-; SI-NEXT:    ; implicit-def: $vgpr8
-; SI-NEXT:    ; implicit-def: $vgpr44
-; SI-NEXT:    ; implicit-def: $vgpr42
-; SI-NEXT:    ; implicit-def: $vgpr41
-; SI-NEXT:    ; implicit-def: $vgpr7
-; SI-NEXT:    ; implicit-def: $vgpr55
-; SI-NEXT:    ; implicit-def: $vgpr54
-; SI-NEXT:    ; implicit-def: $vgpr53
-; SI-NEXT:    ; implicit-def: $vgpr16
-; SI-NEXT:    ; implicit-def: $vgpr51
-; SI-NEXT:    ; implicit-def: $vgpr50
-; SI-NEXT:    ; implicit-def: $vgpr49
-; SI-NEXT:    ; implicit-def: $vgpr15
-; SI-NEXT:    ; implicit-def: $vgpr39
-; SI-NEXT:    ; implicit-def: $vgpr38
-; SI-NEXT:    ; implicit-def: $vgpr37
-; SI-NEXT:    ; implicit-def: $vgpr3
-; SI-NEXT:    ; implicit-def: $vgpr34
-; SI-NEXT:    ; implicit-def: $vgpr35
-; SI-NEXT:    ; implicit-def: $vgpr32
-; SI-NEXT:    ; implicit-def: $vgpr12
-; SI-NEXT:    ; implicit-def: $vgpr30
 ; SI-NEXT:    ; implicit-def: $vgpr31
-; SI-NEXT:    ; implicit-def: $vgpr28
-; SI-NEXT:    ; implicit-def: $vgpr11
-; SI-NEXT:    ; implicit-def: $vgpr26
-; SI-NEXT:    ; implicit-def: $vgpr27
-; SI-NEXT:    ; implicit-def: $vgpr24
-; SI-NEXT:    ; implicit-def: $vgpr4
-; SI-NEXT:    ; implicit-def: $vgpr22
-; SI-NEXT:    ; implicit-def: $vgpr23
-; SI-NEXT:    ; implicit-def: $vgpr14
-; SI-NEXT:    ; implicit-def: $vgpr63
-; SI-NEXT:    ; implicit-def: $vgpr17
-; SI-NEXT:    ; implicit-def: $vgpr62
-; SI-NEXT:    ; implicit-def: $vgpr18
-; SI-NEXT:    ; implicit-def: $vgpr61
-; SI-NEXT:    ; implicit-def: $vgpr1
-; SI-NEXT:    ; implicit-def: $vgpr47
-; SI-NEXT:    ; implicit-def: $vgpr25
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr57
 ; SI-NEXT:    ; implicit-def: $vgpr45
-; SI-NEXT:    ; implicit-def: $vgpr59
+; SI-NEXT:    ; implicit-def: $vgpr56
 ; SI-NEXT:    ; implicit-def: $vgpr43
-; SI-NEXT:    ; implicit-def: $vgpr33
-; SI-NEXT:    ; implicit-def: $vgpr29
-; SI-NEXT:    ; implicit-def: $vgpr36
-; SI-NEXT:    ; implicit-def: $vgpr19
+; SI-NEXT:    ; implicit-def: $vgpr47
+; SI-NEXT:    ; implicit-def: $vgpr41
+; SI-NEXT:    ; implicit-def: $vgpr46
+; SI-NEXT:    ; implicit-def: $vgpr55
+; SI-NEXT:    ; implicit-def: $vgpr44
+; SI-NEXT:    ; implicit-def: $vgpr53
+; SI-NEXT:    ; implicit-def: $vgpr42
+; SI-NEXT:    ; implicit-def: $vgpr50
 ; SI-NEXT:    ; implicit-def: $vgpr48
-; SI-NEXT:    ; implicit-def: $vgpr13
+; SI-NEXT:    ; implicit-def: $vgpr38
+; SI-NEXT:    ; implicit-def: $vgpr36
+; SI-NEXT:    ; implicit-def: $vgpr34
+; SI-NEXT:    ; implicit-def: $vgpr32
+; SI-NEXT:    ; implicit-def: $vgpr63
+; SI-NEXT:    ; implicit-def: $vgpr61
+; SI-NEXT:    ; implicit-def: $vgpr58
+; SI-NEXT:    ; implicit-def: $vgpr59
+; SI-NEXT:    ; implicit-def: $vgpr35
+; SI-NEXT:    ; implicit-def: $vgpr37
+; SI-NEXT:    ; implicit-def: $vgpr39
+; SI-NEXT:    ; implicit-def: $vgpr49
+; SI-NEXT:    ; implicit-def: $vgpr62
+; SI-NEXT:    ; implicit-def: $vgpr51
+; SI-NEXT:    ; implicit-def: $vgpr60
 ; SI-NEXT:    ; implicit-def: $vgpr52
-; SI-NEXT:    ; implicit-def: $vgpr10
+; SI-NEXT:    ; implicit-def: $vgpr33
+; SI-NEXT:    ; implicit-def: $vgpr54
 ; SI-NEXT:    ; implicit-def: $vgpr40
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
+; SI-NEXT:    ; kill: killed $vgpr31
+; SI-NEXT:    ; implicit-def: $vgpr31
 ; SI-NEXT:    s_branch .LBB53_2
 ;
 ; VI-LABEL: bitcast_v15f64_to_v60f16_scalar:

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.96bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.96bit.ll
@@ -380,9 +380,9 @@ define <12 x i8> @bitcast_v3i32_to_v12i8(<3 x i32> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB4_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v11, s4, v8, 24
-; SI-NEXT:    v_alignbit_b32 v10, s4, v8, 16
-; SI-NEXT:    v_alignbit_b32 v9, s4, v8, 8
+; SI-NEXT:    v_alignbit_b32 v11, v0, v8, 24
+; SI-NEXT:    v_alignbit_b32 v10, v0, v8, 16
+; SI-NEXT:    v_alignbit_b32 v9, v0, v8, 8
 ; SI-NEXT:    v_alignbit_b32 v3, v4, v0, 24
 ; SI-NEXT:    v_alignbit_b32 v2, v4, v0, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v4, v0, 8
@@ -398,9 +398,9 @@ define <12 x i8> @bitcast_v3i32_to_v12i8(<3 x i32> %a, i32 %b) {
 ; SI-NEXT:    v_alignbit_b32 v3, v4, v0, 24
 ; SI-NEXT:    v_alignbit_b32 v2, v4, v0, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v4, v0, 8
-; SI-NEXT:    v_alignbit_b32 v11, s4, v8, 24
-; SI-NEXT:    v_alignbit_b32 v10, s4, v8, 16
-; SI-NEXT:    v_alignbit_b32 v9, s4, v8, 8
+; SI-NEXT:    v_alignbit_b32 v11, v0, v8, 24
+; SI-NEXT:    v_alignbit_b32 v10, v0, v8, 16
+; SI-NEXT:    v_alignbit_b32 v9, v0, v8, 8
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 24, v4
 ; SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v4
 ; SI-NEXT:    v_lshrrev_b32_e32 v5, 8, v4
@@ -3114,7 +3114,7 @@ define <6 x i16> @bitcast_v3i32_to_v6i16(<3 x i32> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB16_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v5, s4, v4, 16
+; SI-NEXT:    v_alignbit_b32 v5, v0, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; SI-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
@@ -3124,7 +3124,7 @@ define <6 x i16> @bitcast_v3i32_to_v6i16(<3 x i32> %a, i32 %b) {
 ; SI-NEXT:    v_add_i32_e32 v2, vcc, 3, v2
 ; SI-NEXT:    v_add_i32_e32 v0, vcc, 3, v0
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v5, s4, v4, 16
+; SI-NEXT:    v_alignbit_b32 v5, v0, v4, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
@@ -3575,9 +3575,9 @@ define <12 x i8> @bitcast_v3f32_to_v12i8(<3 x float> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB20_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v11, s4, v8, 24
-; SI-NEXT:    v_alignbit_b32 v10, s4, v8, 16
-; SI-NEXT:    v_alignbit_b32 v9, s4, v8, 8
+; SI-NEXT:    v_alignbit_b32 v11, v0, v8, 24
+; SI-NEXT:    v_alignbit_b32 v10, v0, v8, 16
+; SI-NEXT:    v_alignbit_b32 v9, v0, v8, 8
 ; SI-NEXT:    v_alignbit_b32 v3, v4, v0, 24
 ; SI-NEXT:    v_alignbit_b32 v2, v4, v0, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v4, v0, 8
@@ -3593,9 +3593,9 @@ define <12 x i8> @bitcast_v3f32_to_v12i8(<3 x float> %a, i32 %b) {
 ; SI-NEXT:    v_alignbit_b32 v3, v4, v0, 24
 ; SI-NEXT:    v_alignbit_b32 v2, v4, v0, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v4, v0, 8
-; SI-NEXT:    v_alignbit_b32 v11, s4, v8, 24
-; SI-NEXT:    v_alignbit_b32 v10, s4, v8, 16
-; SI-NEXT:    v_alignbit_b32 v9, s4, v8, 8
+; SI-NEXT:    v_alignbit_b32 v11, v0, v8, 24
+; SI-NEXT:    v_alignbit_b32 v10, v0, v8, 16
+; SI-NEXT:    v_alignbit_b32 v9, v0, v8, 8
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 24, v4
 ; SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v4
 ; SI-NEXT:    v_lshrrev_b32_e32 v5, 8, v4
@@ -6334,7 +6334,7 @@ define <6 x i16> @bitcast_v3f32_to_v6i16(<3 x float> %a, i32 %b) {
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]
 ; SI-NEXT:  .LBB32_3: ; %cmp.false
-; SI-NEXT:    v_alignbit_b32 v5, s4, v4, 16
+; SI-NEXT:    v_alignbit_b32 v5, v0, v4, 16
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; SI-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
@@ -6344,7 +6344,7 @@ define <6 x i16> @bitcast_v3f32_to_v6i16(<3 x float> %a, i32 %b) {
 ; SI-NEXT:    v_add_f32_e32 v2, 1.0, v2
 ; SI-NEXT:    v_add_f32_e32 v0, 1.0, v0
 ; SI-NEXT:    v_alignbit_b32 v1, v2, v0, 16
-; SI-NEXT:    v_alignbit_b32 v5, s4, v4, 16
+; SI-NEXT:    v_alignbit_b32 v5, v0, v4, 16
 ; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; SI-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; SI-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/atomic_optimizations_local_pointer.ll
+++ b/llvm/test/CodeGen/AMDGPU/atomic_optimizations_local_pointer.ll
@@ -14548,8 +14548,8 @@ define amdgpu_kernel void @umax_i64_constant(ptr addrspace(1) %out) {
 ; GFX7LESS-NEXT:    s_mov_b32 s2, -1
 ; GFX7LESS-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX7LESS-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX7LESS-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX7LESS-NEXT:    v_mov_b32_e32 v1, 0
+; GFX7LESS-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX7LESS-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX7LESS-NEXT:    v_cmp_gt_u64_e32 vcc, s[4:5], v[0:1]
 ; GFX7LESS-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
@@ -14579,8 +14579,8 @@ define amdgpu_kernel void @umax_i64_constant(ptr addrspace(1) %out) {
 ; GFX8-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX8-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX8-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX8-NEXT:    v_mov_b32_e32 v1, 0
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX8-NEXT:    v_cmp_gt_u64_e32 vcc, s[4:5], v[0:1]
 ; GFX8-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s5
@@ -14611,8 +14611,8 @@ define amdgpu_kernel void @umax_i64_constant(ptr addrspace(1) %out) {
 ; GFX9-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX9-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX9-NEXT:    v_mov_b32_e32 v1, 0
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX9-NEXT:    v_cmp_gt_u64_e32 vcc, s[4:5], v[0:1]
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
@@ -14645,8 +14645,8 @@ define amdgpu_kernel void @umax_i64_constant(ptr addrspace(1) %out) {
 ; GFX1064-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1064-NEXT:    v_readfirstlane_b32 s3, v1
 ; GFX1064-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1064-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX1064-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1064-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX1064-NEXT:    v_cmp_gt_u64_e32 vcc, s[2:3], v[0:1]
 ; GFX1064-NEXT:    v_cndmask_b32_e64 v0, v0, s2, vcc
 ; GFX1064-NEXT:    v_cndmask_b32_e64 v1, 0, s3, vcc
@@ -14676,8 +14676,8 @@ define amdgpu_kernel void @umax_i64_constant(ptr addrspace(1) %out) {
 ; GFX1032-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1032-NEXT:    v_readfirstlane_b32 s3, v1
 ; GFX1032-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1032-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc_lo
 ; GFX1032-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1032-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc_lo
 ; GFX1032-NEXT:    v_cmp_gt_u64_e32 vcc_lo, s[2:3], v[0:1]
 ; GFX1032-NEXT:    v_cndmask_b32_e64 v0, v0, s2, vcc_lo
 ; GFX1032-NEXT:    v_cndmask_b32_e64 v1, 0, s3, vcc_lo
@@ -14708,8 +14708,8 @@ define amdgpu_kernel void @umax_i64_constant(ptr addrspace(1) %out) {
 ; GFX1164-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1164-NEXT:    v_readfirstlane_b32 s3, v1
 ; GFX1164-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1164-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc
 ; GFX1164-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164-NEXT:    v_cmp_gt_u64_e32 vcc, s[2:3], v[0:1]
 ; GFX1164-NEXT:    s_waitcnt_depctr 0xfffd
@@ -14740,8 +14740,8 @@ define amdgpu_kernel void @umax_i64_constant(ptr addrspace(1) %out) {
 ; GFX1132-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1132-NEXT:    v_readfirstlane_b32 s3, v1
 ; GFX1132-NEXT:    v_readfirstlane_b32 s2, v0
-; GFX1132-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc_lo
 ; GFX1132-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132-NEXT:    v_cndmask_b32_e64 v0, 5, 0, vcc_lo
 ; GFX1132-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132-NEXT:    v_cmp_gt_u64_e32 vcc_lo, s[2:3], v[0:1]
 ; GFX1132-NEXT:    v_cndmask_b32_e64 v0, v0, s2, vcc_lo

--- a/llvm/test/CodeGen/AMDGPU/buffer-intrinsic-mmo-type.ll
+++ b/llvm/test/CodeGen/AMDGPU/buffer-intrinsic-mmo-type.ll
@@ -50,8 +50,7 @@ define amdgpu_ps void @buffer_store_v8f16(ptr addrspace(8) inreg %rsrc, <8 x hal
   ; GCN-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY12]], %subreg.sub0, killed [[COPY11]], %subreg.sub1, killed [[COPY10]], %subreg.sub2, killed [[COPY9]], %subreg.sub3
   ; GCN-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1, [[COPY2]], %subreg.sub2, [[COPY1]], %subreg.sub3
   ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; GCN-NEXT:   [[COPY13:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE3]]
-  ; GCN-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact killed [[COPY13]], [[COPY]], killed [[REG_SEQUENCE2]], killed [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
+  ; GCN-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact killed [[REG_SEQUENCE3]], [[COPY]], killed [[REG_SEQUENCE2]], killed [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
   ; GCN-NEXT:   S_ENDPGM 0
   call void @llvm.amdgcn.raw.ptr.buffer.store.v8f16(<8 x half> %data, ptr addrspace(8) %rsrc, i32 %offset, i32 0, i32 0)
   ret void

--- a/llvm/test/CodeGen/AMDGPU/cluster_stores.ll
+++ b/llvm/test/CodeGen/AMDGPU/cluster_stores.ll
@@ -391,27 +391,27 @@ entry:
 define amdgpu_ps void @cluster_image_sample(<8 x i32> inreg %src, <4 x i32> inreg %smp, <8 x i32> inreg %dst, i32 %x, i32 %y) {
 ; GFX9-LABEL: cluster_image_sample:
 ; GFX9:       ; %bb.0: ; %entry
-; GFX9-NEXT:    v_cvt_f32_i32_e32 v8, v0
-; GFX9-NEXT:    v_cvt_f32_i32_e32 v9, v1
-; GFX9-NEXT:    v_mov_b32_e32 v4, 0
-; GFX9-NEXT:    v_mov_b32_e32 v5, v4
-; GFX9-NEXT:    v_add_f32_e32 v2, 1.0, v8
-; GFX9-NEXT:    v_add_f32_e32 v3, 1.0, v9
-; GFX9-NEXT:    v_mov_b32_e32 v6, v4
-; GFX9-NEXT:    v_mov_b32_e32 v7, v4
-; GFX9-NEXT:    v_add_f32_e32 v8, 2.0, v8
-; GFX9-NEXT:    v_add_f32_e32 v9, 2.0, v9
-; GFX9-NEXT:    v_mov_b32_e32 v10, 1.0
+; GFX9-NEXT:    v_cvt_f32_i32_e32 v2, v0
+; GFX9-NEXT:    v_cvt_f32_i32_e32 v3, v1
+; GFX9-NEXT:    v_mov_b32_e32 v4, 1.0
+; GFX9-NEXT:    v_mov_b32_e32 v10, 0
+; GFX9-NEXT:    v_add_f32_e32 v8, 1.0, v2
+; GFX9-NEXT:    v_add_f32_e32 v9, 1.0, v3
 ; GFX9-NEXT:    v_mov_b32_e32 v11, v10
 ; GFX9-NEXT:    v_mov_b32_e32 v12, v10
 ; GFX9-NEXT:    v_mov_b32_e32 v13, v10
+; GFX9-NEXT:    v_add_f32_e32 v2, 2.0, v2
+; GFX9-NEXT:    v_add_f32_e32 v3, 2.0, v3
+; GFX9-NEXT:    v_mov_b32_e32 v5, v4
+; GFX9-NEXT:    v_mov_b32_e32 v6, v4
+; GFX9-NEXT:    v_mov_b32_e32 v7, v4
+; GFX9-NEXT:    image_sample_d v[8:11], v[8:13], s[0:7], s[8:11] dmask:0xf
 ; GFX9-NEXT:    image_sample_d v[2:5], v[2:7], s[0:7], s[8:11] dmask:0xf
-; GFX9-NEXT:    image_sample_d v[6:9], v[8:13], s[0:7], s[8:11] dmask:0xf
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    v_add_f32_e32 v5, v5, v9
-; GFX9-NEXT:    v_add_f32_e32 v4, v4, v8
-; GFX9-NEXT:    v_add_f32_e32 v3, v3, v7
-; GFX9-NEXT:    v_add_f32_e32 v2, v2, v6
+; GFX9-NEXT:    v_add_f32_e32 v5, v11, v5
+; GFX9-NEXT:    v_add_f32_e32 v4, v10, v4
+; GFX9-NEXT:    v_add_f32_e32 v3, v9, v3
+; GFX9-NEXT:    v_add_f32_e32 v2, v8, v2
 ; GFX9-NEXT:    image_store v[2:5], v[0:1], s[12:19] dmask:0xf unorm
 ; GFX9-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/dagcombine-fmul-sel.ll
+++ b/llvm/test/CodeGen/AMDGPU/dagcombine-fmul-sel.ll
@@ -1280,45 +1280,25 @@ define double @fmul_select_f64_test11(double %x, i32 %bool.arg1, i32 %bool.arg2)
 }
 
 define double @fmul_select_f64_test12(double %x, i32 %bool.arg1, i32 %bool.arg2) {
-; GFX7-SDAG-LABEL: fmul_select_f64_test12:
-; GFX7-SDAG:       ; %bb.0:
-; GFX7-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-SDAG-NEXT:    v_bfrev_b32_e32 v4, 1
-; GFX7-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
-; GFX7-SDAG-NEXT:    v_cndmask_b32_e64 v3, v4, 0, vcc
-; GFX7-SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; GFX7-SDAG-NEXT:    v_mul_f64 v[0:1], v[0:1], v[2:3]
-; GFX7-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX7-LABEL: fmul_select_f64_test12:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_bfrev_b32_e32 v5, 1
+; GFX7-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX7-NEXT:    v_mov_b32_e32 v4, 0
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
+; GFX7-NEXT:    v_mul_f64 v[0:1], v[0:1], v[4:5]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX7-GISEL-LABEL: fmul_select_f64_test12:
-; GFX7-GISEL:       ; %bb.0:
-; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-GISEL-NEXT:    v_bfrev_b32_e32 v5, 1
-; GFX7-GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
-; GFX7-GISEL-NEXT:    v_mov_b32_e32 v4, 0
-; GFX7-GISEL-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
-; GFX7-GISEL-NEXT:    v_mul_f64 v[0:1], v[0:1], v[4:5]
-; GFX7-GISEL-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX9-SDAG-LABEL: fmul_select_f64_test12:
-; GFX9-SDAG:       ; %bb.0:
-; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_bfrev_b32_e32 v4, 1
-; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v4, 0, vcc
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; GFX9-SDAG-NEXT:    v_mul_f64 v[0:1], v[0:1], v[2:3]
-; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX9-GISEL-LABEL: fmul_select_f64_test12:
-; GFX9-GISEL:       ; %bb.0:
-; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-GISEL-NEXT:    v_bfrev_b32_e32 v5, 1
-; GFX9-GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
-; GFX9-GISEL-NEXT:    v_mov_b32_e32 v4, 0
-; GFX9-GISEL-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
-; GFX9-GISEL-NEXT:    v_mul_f64 v[0:1], v[0:1], v[4:5]
-; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-LABEL: fmul_select_f64_test12:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_bfrev_b32_e32 v5, 1
+; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX9-NEXT:    v_mov_b32_e32 v4, 0
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
+; GFX9-NEXT:    v_mul_f64 v[0:1], v[0:1], v[4:5]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: fmul_select_f64_test12:
 ; GFX10:       ; %bb.0:
@@ -1345,45 +1325,25 @@ define double @fmul_select_f64_test12(double %x, i32 %bool.arg1, i32 %bool.arg2)
 }
 
 define double @fmul_select_f64_test13(double %x, i32 %bool.arg1, i32 %bool.arg2) {
-; GFX7-SDAG-LABEL: fmul_select_f64_test13:
-; GFX7-SDAG:       ; %bb.0:
-; GFX7-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-SDAG-NEXT:    v_mov_b32_e32 v4, 0x40300000
-; GFX7-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
-; GFX7-SDAG-NEXT:    v_cndmask_b32_e64 v3, v4, 0, vcc
-; GFX7-SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; GFX7-SDAG-NEXT:    v_mul_f64 v[0:1], v[0:1], v[2:3]
-; GFX7-SDAG-NEXT:    s_setpc_b64 s[30:31]
+; GFX7-LABEL: fmul_select_f64_test13:
+; GFX7:       ; %bb.0:
+; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX7-NEXT:    v_mov_b32_e32 v5, 0x40300000
+; GFX7-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX7-NEXT:    v_mov_b32_e32 v4, 0
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
+; GFX7-NEXT:    v_mul_f64 v[0:1], v[0:1], v[4:5]
+; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX7-GISEL-LABEL: fmul_select_f64_test13:
-; GFX7-GISEL:       ; %bb.0:
-; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-GISEL-NEXT:    v_mov_b32_e32 v5, 0x40300000
-; GFX7-GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
-; GFX7-GISEL-NEXT:    v_mov_b32_e32 v4, 0
-; GFX7-GISEL-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
-; GFX7-GISEL-NEXT:    v_mul_f64 v[0:1], v[0:1], v[4:5]
-; GFX7-GISEL-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX9-SDAG-LABEL: fmul_select_f64_test13:
-; GFX9-SDAG:       ; %bb.0:
-; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v4, 0x40300000
-; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v3, v4, 0, vcc
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; GFX9-SDAG-NEXT:    v_mul_f64 v[0:1], v[0:1], v[2:3]
-; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX9-GISEL-LABEL: fmul_select_f64_test13:
-; GFX9-GISEL:       ; %bb.0:
-; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-GISEL-NEXT:    v_mov_b32_e32 v5, 0x40300000
-; GFX9-GISEL-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
-; GFX9-GISEL-NEXT:    v_mov_b32_e32 v4, 0
-; GFX9-GISEL-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
-; GFX9-GISEL-NEXT:    v_mul_f64 v[0:1], v[0:1], v[4:5]
-; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
+; GFX9-LABEL: fmul_select_f64_test13:
+; GFX9:       ; %bb.0:
+; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9-NEXT:    v_mov_b32_e32 v5, 0x40300000
+; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX9-NEXT:    v_mov_b32_e32 v4, 0
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, v5, 0, vcc
+; GFX9-NEXT:    v_mul_f64 v[0:1], v[0:1], v[4:5]
+; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: fmul_select_f64_test13:
 ; GFX10:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/div_i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/div_i128.ll
@@ -351,8 +351,7 @@ define i128 @v_sdiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v14, v9
 ; GFX9-O0-NEXT:    v_cmp_eq_u64_e64 s[8:9], v[13:14], s[6:7]
 ; GFX9-O0-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
-; GFX9-O0-NEXT:    s_mov_b64 s[8:9], s[6:7]
-; GFX9-O0-NEXT:    v_cmp_ne_u64_e64 s[8:9], v[11:12], s[8:9]
+; GFX9-O0-NEXT:    v_cmp_ne_u64_e64 s[8:9], v[11:12], s[6:7]
 ; GFX9-O0-NEXT:    v_ffbh_u32_e64 v4, v4
 ; GFX9-O0-NEXT:    s_mov_b32 s12, 32
 ; GFX9-O0-NEXT:    v_add_u32_e64 v4, v4, s12
@@ -385,8 +384,7 @@ define i128 @v_sdiv_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-O0-NEXT:    v_cndmask_b32_e64 v8, v8, v9, s[8:9]
 ; GFX9-O0-NEXT:    ; kill: def $vgpr8 killed $vgpr8 def $vgpr8_vgpr9 killed $exec
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v9, v7
-; GFX9-O0-NEXT:    s_mov_b64 s[8:9], s[6:7]
-; GFX9-O0-NEXT:    v_cmp_ne_u64_e64 s[8:9], v[5:6], s[8:9]
+; GFX9-O0-NEXT:    v_cmp_ne_u64_e64 s[8:9], v[5:6], s[6:7]
 ; GFX9-O0-NEXT:    v_ffbh_u32_e64 v5, v0
 ; GFX9-O0-NEXT:    v_add_u32_e64 v5, v5, s12
 ; GFX9-O0-NEXT:    v_ffbh_u32_e64 v6, v1

--- a/llvm/test/CodeGen/AMDGPU/flat-saddr-atomics.ll
+++ b/llvm/test/CodeGen/AMDGPU/flat-saddr-atomics.ll
@@ -12749,20 +12749,19 @@ define void @flat_atomic_fmax_f32_saddr_nortn(ptr inreg %ptr, float %data) {
 ; GFX950-SDAG:       ; %bb.0:
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-SDAG-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
-; GFX950-SDAG-NEXT:    flat_load_dword v3, v[2:3] offset:40
+; GFX950-SDAG-NEXT:    flat_load_dword v1, v[2:3] offset:40
 ; GFX950-SDAG-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX950-SDAG-NEXT:    v_max_f32_e32 v4, v0, v0
-; GFX950-SDAG-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
 ; GFX950-SDAG-NEXT:  .LBB119_1: ; %atomicrmw.start
 ; GFX950-SDAG-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-SDAG-NEXT:    v_max_f32_e32 v2, v3, v3
-; GFX950-SDAG-NEXT:    v_max_f32_e32 v2, v2, v4
-; GFX950-SDAG-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-SDAG-NEXT:    v_max_f32_e32 v0, v1, v1
+; GFX950-SDAG-NEXT:    v_max_f32_e32 v0, v0, v4
+; GFX950-SDAG-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-SDAG-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-SDAG-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-SDAG-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-SDAG-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-SDAG-NEXT:    s_cbranch_execnz .LBB119_1
 ; GFX950-SDAG-NEXT:  ; %bb.2: ; %atomicrmw.end
@@ -12873,20 +12872,19 @@ define void @flat_atomic_fmin_f32_saddr_nortn(ptr inreg %ptr, float %data) {
 ; GFX950-SDAG:       ; %bb.0:
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-SDAG-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
-; GFX950-SDAG-NEXT:    flat_load_dword v3, v[2:3] offset:40
+; GFX950-SDAG-NEXT:    flat_load_dword v1, v[2:3] offset:40
 ; GFX950-SDAG-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX950-SDAG-NEXT:    v_max_f32_e32 v4, v0, v0
-; GFX950-SDAG-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
 ; GFX950-SDAG-NEXT:  .LBB121_1: ; %atomicrmw.start
 ; GFX950-SDAG-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-SDAG-NEXT:    v_max_f32_e32 v2, v3, v3
-; GFX950-SDAG-NEXT:    v_min_f32_e32 v2, v2, v4
-; GFX950-SDAG-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-SDAG-NEXT:    v_max_f32_e32 v0, v1, v1
+; GFX950-SDAG-NEXT:    v_min_f32_e32 v0, v0, v4
+; GFX950-SDAG-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-SDAG-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-SDAG-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-SDAG-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-SDAG-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-SDAG-NEXT:    s_cbranch_execnz .LBB121_1
 ; GFX950-SDAG-NEXT:  ; %bb.2: ; %atomicrmw.end
@@ -13100,21 +13098,20 @@ define void @flat_atomic_fmax_v2f16_saddr_nortn(ptr inreg %ptr, <2 x half> %data
 ; GFX950-SDAG:       ; %bb.0:
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-SDAG-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
-; GFX950-SDAG-NEXT:    flat_load_dword v3, v[2:3] offset:40
+; GFX950-SDAG-NEXT:    flat_load_dword v1, v[2:3] offset:40
 ; GFX950-SDAG-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX950-SDAG-NEXT:    v_pk_max_f16 v4, v0, v0
-; GFX950-SDAG-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
 ; GFX950-SDAG-NEXT:  .LBB125_1: ; %atomicrmw.start
 ; GFX950-SDAG-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-SDAG-NEXT:    v_pk_max_f16 v2, v3, v3
+; GFX950-SDAG-NEXT:    v_pk_max_f16 v0, v1, v1
 ; GFX950-SDAG-NEXT:    s_nop 0
-; GFX950-SDAG-NEXT:    v_pk_max_f16 v2, v2, v4
-; GFX950-SDAG-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-SDAG-NEXT:    v_pk_max_f16 v0, v0, v4
+; GFX950-SDAG-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-SDAG-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-SDAG-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-SDAG-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-SDAG-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-SDAG-NEXT:    s_cbranch_execnz .LBB125_1
 ; GFX950-SDAG-NEXT:  ; %bb.2: ; %atomicrmw.end
@@ -13265,21 +13262,20 @@ define void @flat_atomic_fmin_v2f16_saddr_nortn(ptr inreg %ptr, <2 x half> %data
 ; GFX950-SDAG:       ; %bb.0:
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-SDAG-NEXT:    v_mov_b64_e32 v[2:3], s[0:1]
-; GFX950-SDAG-NEXT:    flat_load_dword v3, v[2:3] offset:40
+; GFX950-SDAG-NEXT:    flat_load_dword v1, v[2:3] offset:40
 ; GFX950-SDAG-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX950-SDAG-NEXT:    v_pk_max_f16 v4, v0, v0
-; GFX950-SDAG-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
 ; GFX950-SDAG-NEXT:  .LBB127_1: ; %atomicrmw.start
 ; GFX950-SDAG-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-SDAG-NEXT:    v_pk_max_f16 v2, v3, v3
+; GFX950-SDAG-NEXT:    v_pk_max_f16 v0, v1, v1
 ; GFX950-SDAG-NEXT:    s_nop 0
-; GFX950-SDAG-NEXT:    v_pk_min_f16 v2, v2, v4
-; GFX950-SDAG-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:40 sc0
+; GFX950-SDAG-NEXT:    v_pk_min_f16 v0, v0, v4
+; GFX950-SDAG-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:40 sc0
 ; GFX950-SDAG-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GFX950-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GFX950-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GFX950-SDAG-NEXT:    s_or_b64 s[2:3], vcc, s[2:3]
-; GFX950-SDAG-NEXT:    v_mov_b32_e32 v3, v2
+; GFX950-SDAG-NEXT:    v_mov_b32_e32 v1, v0
 ; GFX950-SDAG-NEXT:    s_andn2_b64 exec, exec, s[2:3]
 ; GFX950-SDAG-NEXT:    s_cbranch_execnz .LBB127_1
 ; GFX950-SDAG-NEXT:  ; %bb.2: ; %atomicrmw.end

--- a/llvm/test/CodeGen/AMDGPU/flat_atomics_i32_system.ll
+++ b/llvm/test/CodeGen/AMDGPU/flat_atomics_i32_system.ll
@@ -9261,22 +9261,24 @@ define amdgpu_gfx void @flat_atomic_udec_wrap_i32_noret_scalar(ptr inreg %ptr, i
 ; GCN1-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN1-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN1-NEXT:    v_mov_b32_e32 v1, s5
-; GCN1-NEXT:    flat_load_dword v3, v[0:1]
+; GCN1-NEXT:    flat_load_dword v1, v[0:1]
+; GCN1-NEXT:    v_mov_b32_e32 v2, s4
 ; GCN1-NEXT:    s_mov_b64 s[36:37], 0
 ; GCN1-NEXT:    v_mov_b32_e32 v4, s6
+; GCN1-NEXT:    v_mov_b32_e32 v3, s5
 ; GCN1-NEXT:  .LBB145_1: ; %atomicrmw.start
 ; GCN1-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN1-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GCN1-NEXT:    v_subrev_i32_e32 v2, vcc, 1, v3
-; GCN1-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v3
+; GCN1-NEXT:    v_subrev_i32_e32 v0, vcc, 1, v1
+; GCN1-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v1
 ; GCN1-NEXT:    s_or_b64 vcc, vcc, s[34:35]
-; GCN1-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
-; GCN1-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] glc
+; GCN1-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
+; GCN1-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] glc
 ; GCN1-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GCN1-NEXT:    buffer_wbinvl1_vol
-; GCN1-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GCN1-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GCN1-NEXT:    s_or_b64 s[36:37], vcc, s[36:37]
-; GCN1-NEXT:    v_mov_b32_e32 v3, v2
+; GCN1-NEXT:    v_mov_b32_e32 v1, v0
 ; GCN1-NEXT:    s_andn2_b64 exec, exec, s[36:37]
 ; GCN1-NEXT:    s_cbranch_execnz .LBB145_1
 ; GCN1-NEXT:  ; %bb.2: ; %atomicrmw.end
@@ -9288,22 +9290,24 @@ define amdgpu_gfx void @flat_atomic_udec_wrap_i32_noret_scalar(ptr inreg %ptr, i
 ; GCN2-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN2-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN2-NEXT:    v_mov_b32_e32 v1, s5
-; GCN2-NEXT:    flat_load_dword v3, v[0:1]
+; GCN2-NEXT:    flat_load_dword v1, v[0:1]
+; GCN2-NEXT:    v_mov_b32_e32 v2, s4
 ; GCN2-NEXT:    s_mov_b64 s[36:37], 0
 ; GCN2-NEXT:    v_mov_b32_e32 v4, s6
+; GCN2-NEXT:    v_mov_b32_e32 v3, s5
 ; GCN2-NEXT:  .LBB145_1: ; %atomicrmw.start
 ; GCN2-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN2-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GCN2-NEXT:    v_subrev_u32_e32 v2, vcc, 1, v3
-; GCN2-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v3
+; GCN2-NEXT:    v_subrev_u32_e32 v0, vcc, 1, v1
+; GCN2-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v1
 ; GCN2-NEXT:    s_or_b64 vcc, vcc, s[34:35]
-; GCN2-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
-; GCN2-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] glc
+; GCN2-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
+; GCN2-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] glc
 ; GCN2-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GCN2-NEXT:    buffer_wbinvl1_vol
-; GCN2-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GCN2-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GCN2-NEXT:    s_or_b64 s[36:37], vcc, s[36:37]
-; GCN2-NEXT:    v_mov_b32_e32 v3, v2
+; GCN2-NEXT:    v_mov_b32_e32 v1, v0
 ; GCN2-NEXT:    s_andn2_b64 exec, exec, s[36:37]
 ; GCN2-NEXT:    s_cbranch_execnz .LBB145_1
 ; GCN2-NEXT:  ; %bb.2: ; %atomicrmw.end
@@ -9315,22 +9319,24 @@ define amdgpu_gfx void @flat_atomic_udec_wrap_i32_noret_scalar(ptr inreg %ptr, i
 ; GCN3-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN3-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN3-NEXT:    v_mov_b32_e32 v1, s5
-; GCN3-NEXT:    flat_load_dword v3, v[0:1]
+; GCN3-NEXT:    flat_load_dword v1, v[0:1]
+; GCN3-NEXT:    v_mov_b32_e32 v2, s4
 ; GCN3-NEXT:    s_mov_b64 s[36:37], 0
 ; GCN3-NEXT:    v_mov_b32_e32 v4, s6
+; GCN3-NEXT:    v_mov_b32_e32 v3, s5
 ; GCN3-NEXT:  .LBB145_1: ; %atomicrmw.start
 ; GCN3-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN3-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GCN3-NEXT:    v_subrev_co_u32_e32 v2, vcc, 1, v3
-; GCN3-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v3
+; GCN3-NEXT:    v_subrev_co_u32_e32 v0, vcc, 1, v1
+; GCN3-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v1
 ; GCN3-NEXT:    s_or_b64 vcc, vcc, s[34:35]
-; GCN3-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
-; GCN3-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] glc
+; GCN3-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
+; GCN3-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] glc
 ; GCN3-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GCN3-NEXT:    buffer_wbinvl1_vol
-; GCN3-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GCN3-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GCN3-NEXT:    s_or_b64 s[36:37], vcc, s[36:37]
-; GCN3-NEXT:    v_mov_b32_e32 v3, v2
+; GCN3-NEXT:    v_mov_b32_e32 v1, v0
 ; GCN3-NEXT:    s_andn2_b64 exec, exec, s[36:37]
 ; GCN3-NEXT:    s_cbranch_execnz .LBB145_1
 ; GCN3-NEXT:  ; %bb.2: ; %atomicrmw.end
@@ -9404,22 +9410,24 @@ define amdgpu_gfx void @flat_atomic_udec_wrap_i32_noret_offset_scalar(ptr inreg 
 ; GCN3-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN3-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN3-NEXT:    v_mov_b32_e32 v1, s5
-; GCN3-NEXT:    flat_load_dword v3, v[0:1] offset:16
+; GCN3-NEXT:    flat_load_dword v1, v[0:1] offset:16
+; GCN3-NEXT:    v_mov_b32_e32 v2, s4
 ; GCN3-NEXT:    s_mov_b64 s[36:37], 0
 ; GCN3-NEXT:    v_mov_b32_e32 v4, s6
+; GCN3-NEXT:    v_mov_b32_e32 v3, s5
 ; GCN3-NEXT:  .LBB146_1: ; %atomicrmw.start
 ; GCN3-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN3-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
-; GCN3-NEXT:    v_subrev_co_u32_e32 v2, vcc, 1, v3
-; GCN3-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v3
+; GCN3-NEXT:    v_subrev_co_u32_e32 v0, vcc, 1, v1
+; GCN3-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v1
 ; GCN3-NEXT:    s_or_b64 vcc, vcc, s[34:35]
-; GCN3-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
-; GCN3-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] offset:16 glc
+; GCN3-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
+; GCN3-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] offset:16 glc
 ; GCN3-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GCN3-NEXT:    buffer_wbinvl1_vol
-; GCN3-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; GCN3-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; GCN3-NEXT:    s_or_b64 s[36:37], vcc, s[36:37]
-; GCN3-NEXT:    v_mov_b32_e32 v3, v2
+; GCN3-NEXT:    v_mov_b32_e32 v1, v0
 ; GCN3-NEXT:    s_andn2_b64 exec, exec, s[36:37]
 ; GCN3-NEXT:    s_cbranch_execnz .LBB146_1
 ; GCN3-NEXT:  ; %bb.2: ; %atomicrmw.end

--- a/llvm/test/CodeGen/AMDGPU/fmul-to-ldexp.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmul-to-ldexp.ll
@@ -5140,11 +5140,11 @@ define double @v_contract_mul_add_f64_select_64_1(i32 %arg, double %x, double %y
 ; GFX9-SDAG-LABEL: v_contract_mul_add_f64_select_64_1:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0x3ff00000
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x40500000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x3ff00000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v7, 0x40500000
 ; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v5, v6, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
 ; GFX9-SDAG-NEXT:    v_fma_f64 v[0:1], v[1:2], v[5:6], v[3:4]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5204,11 +5204,11 @@ define double @v_contract_mul_add_f64_select_1_64(i32 %arg, double %x, double %y
 ; GFX9-SDAG-LABEL: v_contract_mul_add_f64_select_1_64:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0x40500000
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x3ff00000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x40500000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v7, 0x3ff00000
 ; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v5, v6, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
 ; GFX9-SDAG-NEXT:    v_fma_f64 v[0:1], v[1:2], v[5:6], v[3:4]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5268,11 +5268,11 @@ define double @v_contract_mul_add_f64_select_n64_n1(i32 %arg, double %x, double 
 ; GFX9-SDAG-LABEL: v_contract_mul_add_f64_select_n64_n1:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0xbff00000
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0xc0500000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0xbff00000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v7, 0xc0500000
 ; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v5, v6, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
 ; GFX9-SDAG-NEXT:    v_fma_f64 v[0:1], v[1:2], v[5:6], v[3:4]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5332,11 +5332,11 @@ define double @v_contract_mul_add_f64_select_n1_n64(i32 %arg, double %x, double 
 ; GFX9-SDAG-LABEL: v_contract_mul_add_f64_select_n1_n64:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0xc0500000
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0xbff00000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0xc0500000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v7, 0xbff00000
 ; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v5, v6, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
 ; GFX9-SDAG-NEXT:    v_fma_f64 v[0:1], v[1:2], v[5:6], v[3:4]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5396,11 +5396,11 @@ define double @v_contract_mul_add_f64_select_128_64(i32 %arg, double %x, double 
 ; GFX9-SDAG-LABEL: v_contract_mul_add_f64_select_128_64:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0x40500000
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x40600000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x40500000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v7, 0x40600000
 ; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v5, v6, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
 ; GFX9-SDAG-NEXT:    v_fma_f64 v[0:1], v[1:2], v[5:6], v[3:4]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5463,11 +5463,11 @@ define double @v_contract_mul_add_f64_select_128_4(i32 %arg, double %x, double %
 ; GFX9-SDAG-LABEL: v_contract_mul_add_f64_select_128_4:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0x40100000
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x40600000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x40100000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v7, 0x40600000
 ; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v5, v6, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
 ; GFX9-SDAG-NEXT:    v_fma_f64 v[0:1], v[1:2], v[5:6], v[3:4]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5527,10 +5527,10 @@ define double @v_contract_mul_add_f64_select_2_4(i32 %arg, double %x, double %y)
 ; GFX9-SDAG-LABEL: v_contract_mul_add_f64_select_2_4:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0x40100000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x40100000
 ; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, v5, 2.0, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e64 v6, v6, 2.0, vcc
 ; GFX9-SDAG-NEXT:    v_fma_f64 v[0:1], v[1:2], v[5:6], v[3:4]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5592,11 +5592,11 @@ define double @v_contract_mul_add_f64_select_4_128(i32 %arg, double %x, double %
 ; GFX9-SDAG-LABEL: v_contract_mul_add_f64_select_4_128:
 ; GFX9-SDAG:       ; %bb.0:
 ; GFX9-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0x40600000
-; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x40100000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v6, 0x40600000
+; GFX9-SDAG-NEXT:    v_mov_b32_e32 v7, 0x40100000
 ; GFX9-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v5, v6, vcc
 ; GFX9-SDAG-NEXT:    v_mov_b32_e32 v5, 0
+; GFX9-SDAG-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
 ; GFX9-SDAG-NEXT:    v_fma_f64 v[0:1], v[1:2], v[5:6], v[3:4]
 ; GFX9-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/fptoi.i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoi.i128.ll
@@ -52,41 +52,41 @@ define i128 @fptosi_f64_to_i128(double %x) {
 ; SDAG-NEXT:  ; %bb.3: ; %fp-to-i-if-else
 ; SDAG-NEXT:    v_sub_u32_e32 v0, 0x473, v6
 ; SDAG-NEXT:    v_add_u32_e32 v2, 0xfffffb8d, v6
-; SDAG-NEXT:    v_add_u32_e32 v7, 0xfffffbcd, v6
+; SDAG-NEXT:    v_add_u32_e32 v3, 0xfffffbcd, v6
 ; SDAG-NEXT:    v_lshrrev_b64 v[0:1], v0, v[4:5]
-; SDAG-NEXT:    v_lshlrev_b64 v[2:3], v2, v[4:5]
-; SDAG-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v7
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, v3, v1, s[4:5]
-; SDAG-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v7
-; SDAG-NEXT:    v_cndmask_b32_e64 v3, 0, v1, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v2, v2, v0, s[4:5]
-; SDAG-NEXT:    v_lshlrev_b64 v[0:1], v7, v[4:5]
-; SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v11, 0, v0, s[4:5]
-; SDAG-NEXT:    v_cndmask_b32_e64 v7, 0, v1, s[4:5]
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v11, v10, 0
-; SDAG-NEXT:    v_mul_lo_u32 v12, v8, v2
-; SDAG-NEXT:    v_mul_lo_u32 v13, v10, v3
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v10, v2, 0
+; SDAG-NEXT:    v_lshlrev_b64 v[6:7], v2, v[4:5]
+; SDAG-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v3
+; SDAG-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v3
+; SDAG-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v1, v7, v1, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s[6:7]
+; SDAG-NEXT:    v_cndmask_b32_e64 v0, v6, v0, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v7, 0, v3, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v5, 0, v0, s[6:7]
+; SDAG-NEXT:    v_mul_lo_u32 v12, v10, v1
+; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v7, v10, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v10, v[1:2]
-; SDAG-NEXT:    v_add3_u32 v4, v4, v13, v12
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v9, v11, v[3:4]
-; SDAG-NEXT:    v_mov_b32_e32 v1, v5
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v11, v8, v[1:2]
-; SDAG-NEXT:    v_mul_lo_u32 v10, v9, v7
-; SDAG-NEXT:    v_mul_lo_u32 v9, v9, v11
-; SDAG-NEXT:    v_add_co_u32_e64 v5, s[4:5], v6, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v6, s[4:5], 0, 0, s[4:5]
-; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v8, v[5:6]
-; SDAG-NEXT:    v_add3_u32 v4, v9, v4, v10
-; SDAG-NEXT:    ; implicit-def: $vgpr10
+; SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, v4, s[4:5]
+; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v10, v[1:2]
+; SDAG-NEXT:    v_mul_lo_u32 v11, v8, v5
+; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v10, v5, 0
+; SDAG-NEXT:    v_mov_b32_e32 v1, v3
+; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v7, v8, v[1:2]
+; SDAG-NEXT:    v_add3_u32 v6, v6, v12, v11
+; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v9, v7, v[5:6]
+; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v4, v2
+; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, s[4:5]
+; SDAG-NEXT:    v_mul_lo_u32 v10, v9, v13
+; SDAG-NEXT:    v_mul_lo_u32 v7, v9, v7
+; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v13, v8, v[2:3]
 ; SDAG-NEXT:    ; implicit-def: $vgpr8
 ; SDAG-NEXT:    ; implicit-def: $vgpr9
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v5, v3
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v6, v4, s[4:5]
+; SDAG-NEXT:    v_add3_u32 v4, v7, v6, v10
+; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v2, v5
+; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v4, s[4:5]
 ; SDAG-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; SDAG-NEXT:    ; implicit-def: $vgpr4_vgpr5
+; SDAG-NEXT:    ; implicit-def: $vgpr10
 ; SDAG-NEXT:  .LBB0_4: ; %Flow
 ; SDAG-NEXT:    s_andn2_saveexec_b64 s[12:13], s[12:13]
 ; SDAG-NEXT:    s_cbranch_execz .LBB0_6
@@ -417,41 +417,41 @@ define i128 @fptoui_f64_to_i128(double %x) {
 ; SDAG-NEXT:  ; %bb.3: ; %fp-to-i-if-else
 ; SDAG-NEXT:    v_sub_u32_e32 v0, 0x473, v6
 ; SDAG-NEXT:    v_add_u32_e32 v2, 0xfffffb8d, v6
-; SDAG-NEXT:    v_add_u32_e32 v7, 0xfffffbcd, v6
+; SDAG-NEXT:    v_add_u32_e32 v3, 0xfffffbcd, v6
 ; SDAG-NEXT:    v_lshrrev_b64 v[0:1], v0, v[4:5]
-; SDAG-NEXT:    v_lshlrev_b64 v[2:3], v2, v[4:5]
-; SDAG-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v7
-; SDAG-NEXT:    v_cndmask_b32_e64 v1, v3, v1, s[4:5]
-; SDAG-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v7
-; SDAG-NEXT:    v_cndmask_b32_e64 v3, 0, v1, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v2, v2, v0, s[4:5]
-; SDAG-NEXT:    v_lshlrev_b64 v[0:1], v7, v[4:5]
-; SDAG-NEXT:    v_cndmask_b32_e64 v2, 0, v2, s[6:7]
-; SDAG-NEXT:    v_cndmask_b32_e64 v11, 0, v0, s[4:5]
-; SDAG-NEXT:    v_cndmask_b32_e64 v7, 0, v1, s[4:5]
-; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[4:5], v11, v10, 0
-; SDAG-NEXT:    v_mul_lo_u32 v12, v8, v2
-; SDAG-NEXT:    v_mul_lo_u32 v13, v10, v3
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v10, v2, 0
+; SDAG-NEXT:    v_lshlrev_b64 v[6:7], v2, v[4:5]
+; SDAG-NEXT:    v_cmp_gt_u32_e64 s[4:5], 64, v3
+; SDAG-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v3
+; SDAG-NEXT:    v_lshlrev_b64 v[3:4], v3, v[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v1, v7, v1, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v1, 0, v1, s[6:7]
+; SDAG-NEXT:    v_cndmask_b32_e64 v0, v6, v0, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v7, 0, v3, s[4:5]
+; SDAG-NEXT:    v_cndmask_b32_e64 v5, 0, v0, s[6:7]
+; SDAG-NEXT:    v_mul_lo_u32 v12, v10, v1
+; SDAG-NEXT:    v_mad_u64_u32 v[0:1], s[6:7], v7, v10, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v2, 0
-; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v10, v[1:2]
-; SDAG-NEXT:    v_add3_u32 v4, v4, v13, v12
-; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v9, v11, v[3:4]
-; SDAG-NEXT:    v_mov_b32_e32 v1, v5
-; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v11, v8, v[1:2]
-; SDAG-NEXT:    v_mul_lo_u32 v10, v9, v7
-; SDAG-NEXT:    v_mul_lo_u32 v9, v9, v11
-; SDAG-NEXT:    v_add_co_u32_e64 v5, s[4:5], v6, v2
-; SDAG-NEXT:    v_addc_co_u32_e64 v6, s[4:5], 0, 0, s[4:5]
-; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v7, v8, v[5:6]
-; SDAG-NEXT:    v_add3_u32 v4, v9, v4, v10
-; SDAG-NEXT:    ; implicit-def: $vgpr10
+; SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, v4, s[4:5]
+; SDAG-NEXT:    v_mad_u64_u32 v[3:4], s[4:5], v13, v10, v[1:2]
+; SDAG-NEXT:    v_mul_lo_u32 v11, v8, v5
+; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[6:7], v10, v5, 0
+; SDAG-NEXT:    v_mov_b32_e32 v1, v3
+; SDAG-NEXT:    v_mad_u64_u32 v[1:2], s[4:5], v7, v8, v[1:2]
+; SDAG-NEXT:    v_add3_u32 v6, v6, v12, v11
+; SDAG-NEXT:    v_mad_u64_u32 v[5:6], s[4:5], v9, v7, v[5:6]
+; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v4, v2
+; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], 0, 0, s[4:5]
+; SDAG-NEXT:    v_mul_lo_u32 v10, v9, v13
+; SDAG-NEXT:    v_mul_lo_u32 v7, v9, v7
+; SDAG-NEXT:    v_mad_u64_u32 v[2:3], s[4:5], v13, v8, v[2:3]
 ; SDAG-NEXT:    ; implicit-def: $vgpr8
 ; SDAG-NEXT:    ; implicit-def: $vgpr9
-; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v5, v3
-; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v6, v4, s[4:5]
+; SDAG-NEXT:    v_add3_u32 v4, v7, v6, v10
+; SDAG-NEXT:    v_add_co_u32_e64 v2, s[4:5], v2, v5
+; SDAG-NEXT:    v_addc_co_u32_e64 v3, s[4:5], v3, v4, s[4:5]
 ; SDAG-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; SDAG-NEXT:    ; implicit-def: $vgpr4_vgpr5
+; SDAG-NEXT:    ; implicit-def: $vgpr10
 ; SDAG-NEXT:  .LBB1_4: ; %Flow
 ; SDAG-NEXT:    s_andn2_saveexec_b64 s[12:13], s[12:13]
 ; SDAG-NEXT:    s_cbranch_execz .LBB1_6

--- a/llvm/test/CodeGen/AMDGPU/frame-index-elimination.ll
+++ b/llvm/test/CodeGen/AMDGPU/frame-index-elimination.ll
@@ -244,9 +244,9 @@ declare void @func(ptr addrspace(5) nocapture) #0
 
 ; GCN-LABEL: {{^}}undefined_stack_store_reg:
 ; GCN: s_and_saveexec_b64
-; MUBUF: buffer_store_dword v0, off, s[0:3], s33 offset:
-; MUBUF: buffer_store_dword v0, off, s[0:3], s33 offset:
-; MUBUF: buffer_store_dword v0, off, s[0:3], s33 offset:
+; MUBUF: buffer_store_dword v{{[0-9]+}}, off, s[0:3], s33 offset:
+; MUBUF: buffer_store_dword v{{[0-9]+}}, off, s[0:3], s33 offset:
+; MUBUF: buffer_store_dword v{{[0-9]+}}, off, s[0:3], s33 offset:
 ; MUBUF: buffer_store_dword v{{[0-9]+}}, off, s[0:3], s33 offset:
 ; FLATSCR: scratch_store_dword v0, off, s33 offset:
 ; FLATSCR: scratch_store_dword v0, off, s33 offset:

--- a/llvm/test/CodeGen/AMDGPU/global-atomic-fadd.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-atomic-fadd.f64.ll
@@ -49,23 +49,22 @@ define amdgpu_ps double @global_atomic_fadd_f64_rtn_atomicrmw(ptr addrspace(1) %
   ; GFX90A-NEXT:   [[COPY8:%[0-9]+]]:av_32 = COPY [[V_ADD_F64_e64_]].sub0
   ; GFX90A-NEXT:   [[COPY9:%[0-9]+]]:av_32 = COPY [[PHI1]].sub1
   ; GFX90A-NEXT:   [[COPY10:%[0-9]+]]:av_32 = COPY [[PHI1]].sub0
-  ; GFX90A-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, killed [[COPY10]], %subreg.sub2, killed [[COPY9]], %subreg.sub3
-  ; GFX90A-NEXT:   [[COPY11:%[0-9]+]]:vreg_128_align2 = COPY [[REG_SEQUENCE2]]
-  ; GFX90A-NEXT:   [[GLOBAL_ATOMIC_CMPSWAP_X2_RTN:%[0-9]+]]:vreg_64_align2 = GLOBAL_ATOMIC_CMPSWAP_X2_RTN [[COPY5]], killed [[COPY11]], 0, 1, implicit $exec :: (load store syncscope("wavefront") monotonic monotonic (s64) on %ir.ptr, addrspace 1)
+  ; GFX90A-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128_align2 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, killed [[COPY10]], %subreg.sub2, killed [[COPY9]], %subreg.sub3
+  ; GFX90A-NEXT:   [[GLOBAL_ATOMIC_CMPSWAP_X2_RTN:%[0-9]+]]:vreg_64_align2 = GLOBAL_ATOMIC_CMPSWAP_X2_RTN [[COPY5]], killed [[REG_SEQUENCE2]], 0, 1, implicit $exec :: (load store syncscope("wavefront") monotonic monotonic (s64) on %ir.ptr, addrspace 1)
   ; GFX90A-NEXT:   [[V_CMP_EQ_U64_e64_:%[0-9]+]]:sreg_64 = V_CMP_EQ_U64_e64 [[GLOBAL_ATOMIC_CMPSWAP_X2_RTN]], [[PHI1]], implicit $exec
-  ; GFX90A-NEXT:   [[COPY12:%[0-9]+]]:av_64_align2 = COPY [[GLOBAL_ATOMIC_CMPSWAP_X2_RTN]]
+  ; GFX90A-NEXT:   [[COPY11:%[0-9]+]]:av_64_align2 = COPY [[GLOBAL_ATOMIC_CMPSWAP_X2_RTN]]
   ; GFX90A-NEXT:   [[SI_IF_BREAK:%[0-9]+]]:sreg_64 = SI_IF_BREAK killed [[V_CMP_EQ_U64_e64_]], [[PHI]], implicit-def dead $scc
   ; GFX90A-NEXT:   SI_LOOP [[SI_IF_BREAK]], %bb.1, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; GFX90A-NEXT:   S_BRANCH %bb.2
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.2.atomicrmw.end:
-  ; GFX90A-NEXT:   [[PHI2:%[0-9]+]]:av_64_align2 = PHI [[COPY12]], %bb.1
+  ; GFX90A-NEXT:   [[PHI2:%[0-9]+]]:av_64_align2 = PHI [[COPY11]], %bb.1
   ; GFX90A-NEXT:   [[PHI3:%[0-9]+]]:sreg_64 = PHI [[SI_IF_BREAK]], %bb.1
   ; GFX90A-NEXT:   SI_END_CF [[PHI3]], implicit-def dead $exec, implicit-def dead $scc, implicit $exec
-  ; GFX90A-NEXT:   [[COPY13:%[0-9]+]]:vgpr_32 = COPY [[PHI2]].sub0
-  ; GFX90A-NEXT:   [[V_READFIRSTLANE_B32_:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 killed [[COPY13]], implicit $exec
-  ; GFX90A-NEXT:   [[COPY14:%[0-9]+]]:vgpr_32 = COPY [[PHI2]].sub1
-  ; GFX90A-NEXT:   [[V_READFIRSTLANE_B32_1:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 killed [[COPY14]], implicit $exec
+  ; GFX90A-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY [[PHI2]].sub0
+  ; GFX90A-NEXT:   [[V_READFIRSTLANE_B32_:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 killed [[COPY12]], implicit $exec
+  ; GFX90A-NEXT:   [[COPY13:%[0-9]+]]:vgpr_32 = COPY [[PHI2]].sub1
+  ; GFX90A-NEXT:   [[V_READFIRSTLANE_B32_1:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 killed [[COPY13]], implicit $exec
   ; GFX90A-NEXT:   $sgpr0 = COPY [[V_READFIRSTLANE_B32_]]
   ; GFX90A-NEXT:   $sgpr1 = COPY [[V_READFIRSTLANE_B32_1]]
   ; GFX90A-NEXT:   SI_RETURN_TO_EPILOG $sgpr0, $sgpr1

--- a/llvm/test/CodeGen/AMDGPU/global-load-xcnt.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-load-xcnt.ll
@@ -264,7 +264,7 @@ define i64 @test_v16i64_load_store(ptr addrspace(1) %ptr_a, ptr addrspace(1) %pt
 ; GCN-SDAG-NEXT:    v_mov_b64_e32 v[52:53], 0x50
 ; GCN-SDAG-NEXT:    v_mov_b64_e32 v[54:55], 64
 ; GCN-SDAG-NEXT:    s_wait_xcnt 0x0
-; GCN-SDAG-NEXT:    v_dual_mov_b32 v0, 0xc8 :: v_dual_mov_b32 v1, 0
+; GCN-SDAG-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_mov_b32 v0, 0xc8
 ; GCN-SDAG-NEXT:    s_wait_loadcnt 0x7
 ; GCN-SDAG-NEXT:    global_store_b128 v[2:3], v[6:9], off
 ; GCN-SDAG-NEXT:    s_wait_loadcnt 0x6

--- a/llvm/test/CodeGen/AMDGPU/global_atomics_i32_system.ll
+++ b/llvm/test/CodeGen/AMDGPU/global_atomics_i32_system.ll
@@ -10578,22 +10578,24 @@ define amdgpu_gfx void @global_atomic_udec_wrap_i32_noret_scalar(ptr addrspace(1
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v0, s4
 ; VI-NEXT:    v_mov_b32_e32 v1, s5
-; VI-NEXT:    flat_load_dword v3, v[0:1]
+; VI-NEXT:    flat_load_dword v1, v[0:1]
+; VI-NEXT:    v_mov_b32_e32 v2, s4
 ; VI-NEXT:    s_mov_b64 s[36:37], 0
 ; VI-NEXT:    v_mov_b32_e32 v4, s6
+; VI-NEXT:    v_mov_b32_e32 v3, s5
 ; VI-NEXT:  .LBB148_1: ; %atomicrmw.start
 ; VI-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    v_subrev_u32_e32 v2, vcc, 1, v3
-; VI-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v3
+; VI-NEXT:    v_subrev_u32_e32 v0, vcc, 1, v1
+; VI-NEXT:    v_cmp_lt_u32_e64 s[34:35], s6, v1
 ; VI-NEXT:    s_or_b64 vcc, vcc, s[34:35]
-; VI-NEXT:    v_cndmask_b32_e32 v2, v2, v4, vcc
-; VI-NEXT:    flat_atomic_cmpswap v2, v[0:1], v[2:3] glc
+; VI-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
+; VI-NEXT:    flat_atomic_cmpswap v0, v[2:3], v[0:1] glc
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    buffer_wbinvl1_vol
-; VI-NEXT:    v_cmp_eq_u32_e32 vcc, v2, v3
+; VI-NEXT:    v_cmp_eq_u32_e32 vcc, v0, v1
 ; VI-NEXT:    s_or_b64 s[36:37], vcc, s[36:37]
-; VI-NEXT:    v_mov_b32_e32 v3, v2
+; VI-NEXT:    v_mov_b32_e32 v1, v0
 ; VI-NEXT:    s_andn2_b64 exec, exec, s[36:37]
 ; VI-NEXT:    s_cbranch_execnz .LBB148_1
 ; VI-NEXT:  ; %bb.2: ; %atomicrmw.end

--- a/llvm/test/CodeGen/AMDGPU/isel-amdgpu-cs-chain-preserve-cc.ll
+++ b/llvm/test/CodeGen/AMDGPU/isel-amdgpu-cs-chain-preserve-cc.ll
@@ -84,11 +84,10 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc(<4 x i32> inre
   ; DAGISEL-GFX11-WF32-NEXT:   [[V_ADD_U32_e64_1:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY5]], [[COPY1]], 0, implicit $exec
   ; DAGISEL-GFX11-WF32-NEXT:   [[V_ADD_U32_e64_2:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY6]], [[COPY2]], 0, implicit $exec
   ; DAGISEL-GFX11-WF32-NEXT:   [[V_ADD_U32_e64_3:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY7]], [[COPY3]], 0, implicit $exec
-  ; DAGISEL-GFX11-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_ADD_U32_e64_3]], %subreg.sub0, [[V_ADD_U32_e64_2]], %subreg.sub1, [[V_ADD_U32_e64_1]], %subreg.sub2, [[V_ADD_U32_e64_]], %subreg.sub3
+  ; DAGISEL-GFX11-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_ADD_U32_e64_3]], %subreg.sub0, killed [[V_ADD_U32_e64_2]], %subreg.sub1, killed [[V_ADD_U32_e64_1]], %subreg.sub2, killed [[V_ADD_U32_e64_]], %subreg.sub3
   ; DAGISEL-GFX11-WF32-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX11-WF32-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY9:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX11-WF32-NEXT:   FLAT_STORE_DWORDX4 killed [[COPY8]], killed [[COPY9]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`)
+  ; DAGISEL-GFX11-WF32-NEXT:   FLAT_STORE_DWORDX4 killed [[COPY8]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`)
   ; DAGISEL-GFX11-WF32-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX11-WF64-LABEL: name: amdgpu_cs_chain_preserve_cc
@@ -107,11 +106,10 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc(<4 x i32> inre
   ; DAGISEL-GFX11-WF64-NEXT:   [[V_ADD_U32_e64_1:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY5]], [[COPY1]], 0, implicit $exec
   ; DAGISEL-GFX11-WF64-NEXT:   [[V_ADD_U32_e64_2:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY6]], [[COPY2]], 0, implicit $exec
   ; DAGISEL-GFX11-WF64-NEXT:   [[V_ADD_U32_e64_3:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY7]], [[COPY3]], 0, implicit $exec
-  ; DAGISEL-GFX11-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_ADD_U32_e64_3]], %subreg.sub0, [[V_ADD_U32_e64_2]], %subreg.sub1, [[V_ADD_U32_e64_1]], %subreg.sub2, [[V_ADD_U32_e64_]], %subreg.sub3
+  ; DAGISEL-GFX11-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_ADD_U32_e64_3]], %subreg.sub0, killed [[V_ADD_U32_e64_2]], %subreg.sub1, killed [[V_ADD_U32_e64_1]], %subreg.sub2, killed [[V_ADD_U32_e64_]], %subreg.sub3
   ; DAGISEL-GFX11-WF64-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX11-WF64-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY9:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX11-WF64-NEXT:   FLAT_STORE_DWORDX4 killed [[COPY8]], killed [[COPY9]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`)
+  ; DAGISEL-GFX11-WF64-NEXT:   FLAT_STORE_DWORDX4 killed [[COPY8]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`)
   ; DAGISEL-GFX11-WF64-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX10-WF32-LABEL: name: amdgpu_cs_chain_preserve_cc
@@ -130,11 +128,10 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc(<4 x i32> inre
   ; DAGISEL-GFX10-WF32-NEXT:   [[V_ADD_U32_e64_1:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY5]], [[COPY1]], 0, implicit $exec
   ; DAGISEL-GFX10-WF32-NEXT:   [[V_ADD_U32_e64_2:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY6]], [[COPY2]], 0, implicit $exec
   ; DAGISEL-GFX10-WF32-NEXT:   [[V_ADD_U32_e64_3:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY7]], [[COPY3]], 0, implicit $exec
-  ; DAGISEL-GFX10-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_ADD_U32_e64_3]], %subreg.sub0, [[V_ADD_U32_e64_2]], %subreg.sub1, [[V_ADD_U32_e64_1]], %subreg.sub2, [[V_ADD_U32_e64_]], %subreg.sub3
+  ; DAGISEL-GFX10-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_ADD_U32_e64_3]], %subreg.sub0, killed [[V_ADD_U32_e64_2]], %subreg.sub1, killed [[V_ADD_U32_e64_1]], %subreg.sub2, killed [[V_ADD_U32_e64_]], %subreg.sub3
   ; DAGISEL-GFX10-WF32-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX10-WF32-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY9:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX10-WF32-NEXT:   FLAT_STORE_DWORDX4 killed [[COPY8]], killed [[COPY9]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`)
+  ; DAGISEL-GFX10-WF32-NEXT:   FLAT_STORE_DWORDX4 killed [[COPY8]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`)
   ; DAGISEL-GFX10-WF32-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX10-WF64-LABEL: name: amdgpu_cs_chain_preserve_cc
@@ -153,11 +150,10 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc(<4 x i32> inre
   ; DAGISEL-GFX10-WF64-NEXT:   [[V_ADD_U32_e64_1:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY5]], [[COPY1]], 0, implicit $exec
   ; DAGISEL-GFX10-WF64-NEXT:   [[V_ADD_U32_e64_2:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY6]], [[COPY2]], 0, implicit $exec
   ; DAGISEL-GFX10-WF64-NEXT:   [[V_ADD_U32_e64_3:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY7]], [[COPY3]], 0, implicit $exec
-  ; DAGISEL-GFX10-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_ADD_U32_e64_3]], %subreg.sub0, [[V_ADD_U32_e64_2]], %subreg.sub1, [[V_ADD_U32_e64_1]], %subreg.sub2, [[V_ADD_U32_e64_]], %subreg.sub3
+  ; DAGISEL-GFX10-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_ADD_U32_e64_3]], %subreg.sub0, killed [[V_ADD_U32_e64_2]], %subreg.sub1, killed [[V_ADD_U32_e64_1]], %subreg.sub2, killed [[V_ADD_U32_e64_]], %subreg.sub3
   ; DAGISEL-GFX10-WF64-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX10-WF64-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY9:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX10-WF64-NEXT:   FLAT_STORE_DWORDX4 killed [[COPY8]], killed [[COPY9]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`)
+  ; DAGISEL-GFX10-WF64-NEXT:   FLAT_STORE_DWORDX4 killed [[COPY8]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`)
   ; DAGISEL-GFX10-WF64-NEXT:   S_ENDPGM 0
   %c = add <4 x i32> %a, %b
   store <4 x i32> %c, ptr poison
@@ -488,15 +484,14 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc_struct( {ptr, 
   ; DAGISEL-GFX11-WF32-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY23]], killed [[REG_SEQUENCE1]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; DAGISEL-GFX11-WF32-NEXT:   [[DEF3:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX11-WF32-NEXT:   [[COPY24:%[0-9]+]]:vreg_64 = COPY [[DEF3]]
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY25:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX11-WF32-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY24]], killed [[COPY25]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison` + 16, addrspace 1)
+  ; DAGISEL-GFX11-WF32-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY24]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison` + 16, addrspace 1)
   ; DAGISEL-GFX11-WF32-NEXT:   [[DEF4:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY26:%[0-9]+]]:vreg_64 = COPY [[DEF4]]
-  ; DAGISEL-GFX11-WF32-NEXT:   GLOBAL_STORE_DWORD [[COPY26]], [[COPY4]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison` + 8, align 8, basealign 16, addrspace 1)
+  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY25:%[0-9]+]]:vreg_64 = COPY [[DEF4]]
+  ; DAGISEL-GFX11-WF32-NEXT:   GLOBAL_STORE_DWORD [[COPY25]], [[COPY4]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison` + 8, align 8, basealign 16, addrspace 1)
   ; DAGISEL-GFX11-WF32-NEXT:   [[DEF5:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY27:%[0-9]+]]:vreg_64 = COPY [[DEF5]]
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY28:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]]
-  ; DAGISEL-GFX11-WF32-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY27]], killed [[COPY28]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, align 16, addrspace 1)
+  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY26:%[0-9]+]]:vreg_64 = COPY [[DEF5]]
+  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY27:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]]
+  ; DAGISEL-GFX11-WF32-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY26]], killed [[COPY27]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; DAGISEL-GFX11-WF32-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX11-WF64-LABEL: name: amdgpu_cs_chain_preserve_cc_struct
@@ -539,15 +534,14 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc_struct( {ptr, 
   ; DAGISEL-GFX11-WF64-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY23]], killed [[REG_SEQUENCE1]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; DAGISEL-GFX11-WF64-NEXT:   [[DEF3:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX11-WF64-NEXT:   [[COPY24:%[0-9]+]]:vreg_64 = COPY [[DEF3]]
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY25:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX11-WF64-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY24]], killed [[COPY25]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison` + 16, addrspace 1)
+  ; DAGISEL-GFX11-WF64-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY24]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison` + 16, addrspace 1)
   ; DAGISEL-GFX11-WF64-NEXT:   [[DEF4:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY26:%[0-9]+]]:vreg_64 = COPY [[DEF4]]
-  ; DAGISEL-GFX11-WF64-NEXT:   GLOBAL_STORE_DWORD [[COPY26]], [[COPY4]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison` + 8, align 8, basealign 16, addrspace 1)
+  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY25:%[0-9]+]]:vreg_64 = COPY [[DEF4]]
+  ; DAGISEL-GFX11-WF64-NEXT:   GLOBAL_STORE_DWORD [[COPY25]], [[COPY4]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison` + 8, align 8, basealign 16, addrspace 1)
   ; DAGISEL-GFX11-WF64-NEXT:   [[DEF5:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY27:%[0-9]+]]:vreg_64 = COPY [[DEF5]]
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY28:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]]
-  ; DAGISEL-GFX11-WF64-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY27]], killed [[COPY28]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, align 16, addrspace 1)
+  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY26:%[0-9]+]]:vreg_64 = COPY [[DEF5]]
+  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY27:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]]
+  ; DAGISEL-GFX11-WF64-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY26]], killed [[COPY27]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; DAGISEL-GFX11-WF64-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX10-WF32-LABEL: name: amdgpu_cs_chain_preserve_cc_struct
@@ -590,15 +584,14 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc_struct( {ptr, 
   ; DAGISEL-GFX10-WF32-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY23]], killed [[REG_SEQUENCE1]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; DAGISEL-GFX10-WF32-NEXT:   [[DEF3:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX10-WF32-NEXT:   [[COPY24:%[0-9]+]]:vreg_64 = COPY [[DEF3]]
-  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY25:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX10-WF32-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY24]], killed [[COPY25]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison` + 16, addrspace 1)
+  ; DAGISEL-GFX10-WF32-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY24]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison` + 16, addrspace 1)
   ; DAGISEL-GFX10-WF32-NEXT:   [[DEF4:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY26:%[0-9]+]]:vreg_64 = COPY [[DEF4]]
-  ; DAGISEL-GFX10-WF32-NEXT:   GLOBAL_STORE_DWORD [[COPY26]], [[COPY4]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison` + 8, align 8, basealign 16, addrspace 1)
+  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY25:%[0-9]+]]:vreg_64 = COPY [[DEF4]]
+  ; DAGISEL-GFX10-WF32-NEXT:   GLOBAL_STORE_DWORD [[COPY25]], [[COPY4]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison` + 8, align 8, basealign 16, addrspace 1)
   ; DAGISEL-GFX10-WF32-NEXT:   [[DEF5:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY27:%[0-9]+]]:vreg_64 = COPY [[DEF5]]
-  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY28:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]]
-  ; DAGISEL-GFX10-WF32-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY27]], killed [[COPY28]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, align 16, addrspace 1)
+  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY26:%[0-9]+]]:vreg_64 = COPY [[DEF5]]
+  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY27:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]]
+  ; DAGISEL-GFX10-WF32-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY26]], killed [[COPY27]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; DAGISEL-GFX10-WF32-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX10-WF64-LABEL: name: amdgpu_cs_chain_preserve_cc_struct
@@ -641,15 +634,14 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc_struct( {ptr, 
   ; DAGISEL-GFX10-WF64-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY23]], killed [[REG_SEQUENCE1]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; DAGISEL-GFX10-WF64-NEXT:   [[DEF3:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX10-WF64-NEXT:   [[COPY24:%[0-9]+]]:vreg_64 = COPY [[DEF3]]
-  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY25:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX10-WF64-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY24]], killed [[COPY25]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison` + 16, addrspace 1)
+  ; DAGISEL-GFX10-WF64-NEXT:   GLOBAL_STORE_DWORDX4 [[COPY24]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec :: (store (s128) into `ptr addrspace(1) poison` + 16, addrspace 1)
   ; DAGISEL-GFX10-WF64-NEXT:   [[DEF4:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY26:%[0-9]+]]:vreg_64 = COPY [[DEF4]]
-  ; DAGISEL-GFX10-WF64-NEXT:   GLOBAL_STORE_DWORD [[COPY26]], [[COPY4]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison` + 8, align 8, basealign 16, addrspace 1)
+  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY25:%[0-9]+]]:vreg_64 = COPY [[DEF4]]
+  ; DAGISEL-GFX10-WF64-NEXT:   GLOBAL_STORE_DWORD [[COPY25]], [[COPY4]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison` + 8, align 8, basealign 16, addrspace 1)
   ; DAGISEL-GFX10-WF64-NEXT:   [[DEF5:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY27:%[0-9]+]]:vreg_64 = COPY [[DEF5]]
-  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY28:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]]
-  ; DAGISEL-GFX10-WF64-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY27]], killed [[COPY28]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, align 16, addrspace 1)
+  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY26:%[0-9]+]]:vreg_64 = COPY [[DEF5]]
+  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY27:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]]
+  ; DAGISEL-GFX10-WF64-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY26]], killed [[COPY27]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; DAGISEL-GFX10-WF64-NEXT:   S_ENDPGM 0
   %p = extractvalue {ptr, i32, <4 x i32>} %a, 0
   %i = extractvalue {ptr, i32, <4 x i32>} %a, 1
@@ -1233,16 +1225,14 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc_v16i16(<16 x i
   ; DAGISEL-GFX11-WF32-NEXT:   [[V_PK_ADD_U16_5:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY9]], 8, [[COPY1]], 0, 0, 0, 0, 0, implicit $exec
   ; DAGISEL-GFX11-WF32-NEXT:   [[V_PK_ADD_U16_6:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY10]], 8, [[COPY2]], 0, 0, 0, 0, 0, implicit $exec
   ; DAGISEL-GFX11-WF32-NEXT:   [[V_PK_ADD_U16_7:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY11]], 8, [[COPY3]], 0, 0, 0, 0, 0, implicit $exec
-  ; DAGISEL-GFX11-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_PK_ADD_U16_7]], %subreg.sub0, [[V_PK_ADD_U16_6]], %subreg.sub1, [[V_PK_ADD_U16_5]], %subreg.sub2, [[V_PK_ADD_U16_4]], %subreg.sub3
+  ; DAGISEL-GFX11-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_PK_ADD_U16_7]], %subreg.sub0, killed [[V_PK_ADD_U16_6]], %subreg.sub1, killed [[V_PK_ADD_U16_5]], %subreg.sub2, killed [[V_PK_ADD_U16_4]], %subreg.sub3
   ; DAGISEL-GFX11-WF32-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX11-WF32-NEXT:   [[COPY16:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY17:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX11-WF32-NEXT:   FLAT_STORE_DWORDX4 [[COPY16]], killed [[COPY17]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison` + 16)
-  ; DAGISEL-GFX11-WF32-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_PK_ADD_U16_3]], %subreg.sub0, [[V_PK_ADD_U16_2]], %subreg.sub1, [[V_PK_ADD_U16_1]], %subreg.sub2, [[V_PK_ADD_U16_]], %subreg.sub3
+  ; DAGISEL-GFX11-WF32-NEXT:   FLAT_STORE_DWORDX4 [[COPY16]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison` + 16)
+  ; DAGISEL-GFX11-WF32-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_PK_ADD_U16_3]], %subreg.sub0, killed [[V_PK_ADD_U16_2]], %subreg.sub1, killed [[V_PK_ADD_U16_1]], %subreg.sub2, killed [[V_PK_ADD_U16_]], %subreg.sub3
   ; DAGISEL-GFX11-WF32-NEXT:   [[DEF1:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY18:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY19:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE1]]
-  ; DAGISEL-GFX11-WF32-NEXT:   FLAT_STORE_DWORDX4 [[COPY18]], killed [[COPY19]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`, align 32)
+  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY17:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
+  ; DAGISEL-GFX11-WF32-NEXT:   FLAT_STORE_DWORDX4 [[COPY17]], killed [[REG_SEQUENCE1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`, align 32)
   ; DAGISEL-GFX11-WF32-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX11-WF64-LABEL: name: amdgpu_cs_chain_preserve_cc_v16i16
@@ -1273,16 +1263,14 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc_v16i16(<16 x i
   ; DAGISEL-GFX11-WF64-NEXT:   [[V_PK_ADD_U16_5:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY9]], 8, [[COPY1]], 0, 0, 0, 0, 0, implicit $exec
   ; DAGISEL-GFX11-WF64-NEXT:   [[V_PK_ADD_U16_6:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY10]], 8, [[COPY2]], 0, 0, 0, 0, 0, implicit $exec
   ; DAGISEL-GFX11-WF64-NEXT:   [[V_PK_ADD_U16_7:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY11]], 8, [[COPY3]], 0, 0, 0, 0, 0, implicit $exec
-  ; DAGISEL-GFX11-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_PK_ADD_U16_7]], %subreg.sub0, [[V_PK_ADD_U16_6]], %subreg.sub1, [[V_PK_ADD_U16_5]], %subreg.sub2, [[V_PK_ADD_U16_4]], %subreg.sub3
+  ; DAGISEL-GFX11-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_PK_ADD_U16_7]], %subreg.sub0, killed [[V_PK_ADD_U16_6]], %subreg.sub1, killed [[V_PK_ADD_U16_5]], %subreg.sub2, killed [[V_PK_ADD_U16_4]], %subreg.sub3
   ; DAGISEL-GFX11-WF64-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX11-WF64-NEXT:   [[COPY16:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY17:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX11-WF64-NEXT:   FLAT_STORE_DWORDX4 [[COPY16]], killed [[COPY17]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison` + 16)
-  ; DAGISEL-GFX11-WF64-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_PK_ADD_U16_3]], %subreg.sub0, [[V_PK_ADD_U16_2]], %subreg.sub1, [[V_PK_ADD_U16_1]], %subreg.sub2, [[V_PK_ADD_U16_]], %subreg.sub3
+  ; DAGISEL-GFX11-WF64-NEXT:   FLAT_STORE_DWORDX4 [[COPY16]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison` + 16)
+  ; DAGISEL-GFX11-WF64-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_PK_ADD_U16_3]], %subreg.sub0, killed [[V_PK_ADD_U16_2]], %subreg.sub1, killed [[V_PK_ADD_U16_1]], %subreg.sub2, killed [[V_PK_ADD_U16_]], %subreg.sub3
   ; DAGISEL-GFX11-WF64-NEXT:   [[DEF1:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY18:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY19:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE1]]
-  ; DAGISEL-GFX11-WF64-NEXT:   FLAT_STORE_DWORDX4 [[COPY18]], killed [[COPY19]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`, align 32)
+  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY17:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
+  ; DAGISEL-GFX11-WF64-NEXT:   FLAT_STORE_DWORDX4 [[COPY17]], killed [[REG_SEQUENCE1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`, align 32)
   ; DAGISEL-GFX11-WF64-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX10-WF32-LABEL: name: amdgpu_cs_chain_preserve_cc_v16i16
@@ -1313,16 +1301,14 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc_v16i16(<16 x i
   ; DAGISEL-GFX10-WF32-NEXT:   [[V_PK_ADD_U16_5:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY9]], 8, [[COPY1]], 0, 0, 0, 0, 0, implicit $exec
   ; DAGISEL-GFX10-WF32-NEXT:   [[V_PK_ADD_U16_6:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY10]], 8, [[COPY2]], 0, 0, 0, 0, 0, implicit $exec
   ; DAGISEL-GFX10-WF32-NEXT:   [[V_PK_ADD_U16_7:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY11]], 8, [[COPY3]], 0, 0, 0, 0, 0, implicit $exec
-  ; DAGISEL-GFX10-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_PK_ADD_U16_7]], %subreg.sub0, [[V_PK_ADD_U16_6]], %subreg.sub1, [[V_PK_ADD_U16_5]], %subreg.sub2, [[V_PK_ADD_U16_4]], %subreg.sub3
+  ; DAGISEL-GFX10-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_PK_ADD_U16_7]], %subreg.sub0, killed [[V_PK_ADD_U16_6]], %subreg.sub1, killed [[V_PK_ADD_U16_5]], %subreg.sub2, killed [[V_PK_ADD_U16_4]], %subreg.sub3
   ; DAGISEL-GFX10-WF32-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX10-WF32-NEXT:   [[COPY16:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY17:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX10-WF32-NEXT:   FLAT_STORE_DWORDX4 [[COPY16]], killed [[COPY17]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison` + 16)
-  ; DAGISEL-GFX10-WF32-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_PK_ADD_U16_3]], %subreg.sub0, [[V_PK_ADD_U16_2]], %subreg.sub1, [[V_PK_ADD_U16_1]], %subreg.sub2, [[V_PK_ADD_U16_]], %subreg.sub3
+  ; DAGISEL-GFX10-WF32-NEXT:   FLAT_STORE_DWORDX4 [[COPY16]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison` + 16)
+  ; DAGISEL-GFX10-WF32-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_PK_ADD_U16_3]], %subreg.sub0, killed [[V_PK_ADD_U16_2]], %subreg.sub1, killed [[V_PK_ADD_U16_1]], %subreg.sub2, killed [[V_PK_ADD_U16_]], %subreg.sub3
   ; DAGISEL-GFX10-WF32-NEXT:   [[DEF1:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY18:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
-  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY19:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE1]]
-  ; DAGISEL-GFX10-WF32-NEXT:   FLAT_STORE_DWORDX4 [[COPY18]], killed [[COPY19]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`, align 32)
+  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY17:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
+  ; DAGISEL-GFX10-WF32-NEXT:   FLAT_STORE_DWORDX4 [[COPY17]], killed [[REG_SEQUENCE1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`, align 32)
   ; DAGISEL-GFX10-WF32-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX10-WF64-LABEL: name: amdgpu_cs_chain_preserve_cc_v16i16
@@ -1353,16 +1339,14 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_cc_v16i16(<16 x i
   ; DAGISEL-GFX10-WF64-NEXT:   [[V_PK_ADD_U16_5:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY9]], 8, [[COPY1]], 0, 0, 0, 0, 0, implicit $exec
   ; DAGISEL-GFX10-WF64-NEXT:   [[V_PK_ADD_U16_6:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY10]], 8, [[COPY2]], 0, 0, 0, 0, 0, implicit $exec
   ; DAGISEL-GFX10-WF64-NEXT:   [[V_PK_ADD_U16_7:%[0-9]+]]:vgpr_32 = V_PK_ADD_U16 8, [[COPY11]], 8, [[COPY3]], 0, 0, 0, 0, 0, implicit $exec
-  ; DAGISEL-GFX10-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_PK_ADD_U16_7]], %subreg.sub0, [[V_PK_ADD_U16_6]], %subreg.sub1, [[V_PK_ADD_U16_5]], %subreg.sub2, [[V_PK_ADD_U16_4]], %subreg.sub3
+  ; DAGISEL-GFX10-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_PK_ADD_U16_7]], %subreg.sub0, killed [[V_PK_ADD_U16_6]], %subreg.sub1, killed [[V_PK_ADD_U16_5]], %subreg.sub2, killed [[V_PK_ADD_U16_4]], %subreg.sub3
   ; DAGISEL-GFX10-WF64-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX10-WF64-NEXT:   [[COPY16:%[0-9]+]]:vreg_64 = COPY [[DEF]]
-  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY17:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX10-WF64-NEXT:   FLAT_STORE_DWORDX4 [[COPY16]], killed [[COPY17]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison` + 16)
-  ; DAGISEL-GFX10-WF64-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[V_PK_ADD_U16_3]], %subreg.sub0, [[V_PK_ADD_U16_2]], %subreg.sub1, [[V_PK_ADD_U16_1]], %subreg.sub2, [[V_PK_ADD_U16_]], %subreg.sub3
+  ; DAGISEL-GFX10-WF64-NEXT:   FLAT_STORE_DWORDX4 [[COPY16]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison` + 16)
+  ; DAGISEL-GFX10-WF64-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[V_PK_ADD_U16_3]], %subreg.sub0, killed [[V_PK_ADD_U16_2]], %subreg.sub1, killed [[V_PK_ADD_U16_1]], %subreg.sub2, killed [[V_PK_ADD_U16_]], %subreg.sub3
   ; DAGISEL-GFX10-WF64-NEXT:   [[DEF1:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
-  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY18:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
-  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY19:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE1]]
-  ; DAGISEL-GFX10-WF64-NEXT:   FLAT_STORE_DWORDX4 [[COPY18]], killed [[COPY19]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`, align 32)
+  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY17:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
+  ; DAGISEL-GFX10-WF64-NEXT:   FLAT_STORE_DWORDX4 [[COPY17]], killed [[REG_SEQUENCE1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s128) into `ptr poison`, align 32)
   ; DAGISEL-GFX10-WF64-NEXT:   S_ENDPGM 0
   %c = add <16 x i16> %a, %b
   store <16 x i16> %c, ptr poison
@@ -1418,8 +1402,7 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_many_regs(<36 x i
   ; DAGISEL-GFX11-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]], %subreg.sub0, [[COPY]], %subreg.sub1
   ; DAGISEL-GFX11-WF32-NEXT:   [[DEF1:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX11-WF32-NEXT:   [[COPY5:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
-  ; DAGISEL-GFX11-WF32-NEXT:   [[COPY6:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX11-WF32-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY5]], killed [[COPY6]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
+  ; DAGISEL-GFX11-WF32-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY5]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; DAGISEL-GFX11-WF32-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX11-WF64-LABEL: name: amdgpu_cs_chain_preserve_many_regs
@@ -1436,8 +1419,7 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_many_regs(<36 x i
   ; DAGISEL-GFX11-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]], %subreg.sub0, [[COPY]], %subreg.sub1
   ; DAGISEL-GFX11-WF64-NEXT:   [[DEF1:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX11-WF64-NEXT:   [[COPY5:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
-  ; DAGISEL-GFX11-WF64-NEXT:   [[COPY6:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX11-WF64-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY5]], killed [[COPY6]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
+  ; DAGISEL-GFX11-WF64-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY5]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; DAGISEL-GFX11-WF64-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX10-WF32-LABEL: name: amdgpu_cs_chain_preserve_many_regs
@@ -1454,8 +1436,7 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_many_regs(<36 x i
   ; DAGISEL-GFX10-WF32-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]], %subreg.sub0, [[COPY]], %subreg.sub1
   ; DAGISEL-GFX10-WF32-NEXT:   [[DEF1:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX10-WF32-NEXT:   [[COPY5:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
-  ; DAGISEL-GFX10-WF32-NEXT:   [[COPY6:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX10-WF32-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY5]], killed [[COPY6]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
+  ; DAGISEL-GFX10-WF32-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY5]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; DAGISEL-GFX10-WF32-NEXT:   S_ENDPGM 0
   ;
   ; DAGISEL-GFX10-WF64-LABEL: name: amdgpu_cs_chain_preserve_many_regs
@@ -1472,8 +1453,7 @@ define amdgpu_cs_chain_preserve void @amdgpu_cs_chain_preserve_many_regs(<36 x i
   ; DAGISEL-GFX10-WF64-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]], %subreg.sub0, [[COPY]], %subreg.sub1
   ; DAGISEL-GFX10-WF64-NEXT:   [[DEF1:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
   ; DAGISEL-GFX10-WF64-NEXT:   [[COPY5:%[0-9]+]]:vreg_64 = COPY [[DEF1]]
-  ; DAGISEL-GFX10-WF64-NEXT:   [[COPY6:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]]
-  ; DAGISEL-GFX10-WF64-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY5]], killed [[COPY6]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
+  ; DAGISEL-GFX10-WF64-NEXT:   GLOBAL_STORE_DWORDX2 [[COPY5]], killed [[REG_SEQUENCE]], 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; DAGISEL-GFX10-WF64-NEXT:   S_ENDPGM 0
   %c = extractelement <36 x i32> %a, i32 35
   store i32 %c, ptr addrspace(1) poison

--- a/llvm/test/CodeGen/AMDGPU/issue92561-restore-undef-scc-verifier-error.ll
+++ b/llvm/test/CodeGen/AMDGPU/issue92561-restore-undef-scc-verifier-error.ll
@@ -42,13 +42,11 @@ define void @issue92561(ptr addrspace(1) %arg) {
 ; SDAG-NEXT:    s_and_saveexec_b32 s0, s0
 ; SDAG-NEXT:    image_sample_c_lz v9, [v8, v8, v8, v8], s[4:11], s[12:15] dmask:0x1 dim:SQ_RSRC_IMG_2D_ARRAY
 ; SDAG-NEXT:    ; implicit-def: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7
-; SDAG-NEXT:    ; implicit-def: $vgpr8
 ; SDAG-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
 ; SDAG-NEXT:    s_cbranch_execnz .LBB0_1
 ; SDAG-NEXT:  ; %bb.2:
 ; SDAG-NEXT:    s_mov_b32 exec_lo, s3
-; SDAG-NEXT:    v_dual_mov_b32 v0, 0x7fc00000 :: v_dual_mov_b32 v1, 0
-; SDAG-NEXT:    v_mov_b32_e32 v2, 1.0
+; SDAG-NEXT:    v_dual_mov_b32 v0, 0x7fc00000 :: v_dual_mov_b32 v1, 1.0
 ; SDAG-NEXT:    s_mov_b32 s0, s12
 ; SDAG-NEXT:    s_mov_b32 s1, s12
 ; SDAG-NEXT:    s_mov_b32 s2, s12
@@ -58,19 +56,18 @@ define void @issue92561(ptr addrspace(1) %arg) {
 ; SDAG-NEXT:    s_mov_b32 s6, s12
 ; SDAG-NEXT:    s_mov_b32 s7, s12
 ; SDAG-NEXT:    s_clause 0x2
-; SDAG-NEXT:    image_sample_c_lz v0, [v1, v1, v0, v1], s[0:7], s[12:15] dmask:0x1 dim:SQ_RSRC_IMG_2D_ARRAY
-; SDAG-NEXT:    image_sample_c_lz v3, [v1, v1, v1, v1], s[0:7], s[12:15] dmask:0x1 dim:SQ_RSRC_IMG_2D_ARRAY
-; SDAG-NEXT:    image_sample_c_lz v2, [v1, v2, v1, v1], s[0:7], s[12:15] dmask:0x1 dim:SQ_RSRC_IMG_2D_ARRAY
+; SDAG-NEXT:    image_sample_c_lz v0, [v8, v8, v0, v8], s[0:7], s[12:15] dmask:0x1 dim:SQ_RSRC_IMG_2D_ARRAY
+; SDAG-NEXT:    image_sample_c_lz v2, [v8, v8, v8, v8], s[0:7], s[12:15] dmask:0x1 dim:SQ_RSRC_IMG_2D_ARRAY
+; SDAG-NEXT:    image_sample_c_lz v1, [v8, v1, v8, v8], s[0:7], s[12:15] dmask:0x1 dim:SQ_RSRC_IMG_2D_ARRAY
 ; SDAG-NEXT:    s_waitcnt vmcnt(2)
-; SDAG-NEXT:    v_add_f32_e32 v0, v9, v0
+; SDAG-NEXT:    v_dual_add_f32 v0, v9, v0 :: v_dual_mov_b32 v9, v8
 ; SDAG-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; SDAG-NEXT:    v_add_f32_e32 v0, v1, v0
 ; SDAG-NEXT:    v_add_f32_e32 v0, v2, v0
-; SDAG-NEXT:    v_mov_b32_e32 v2, v1
-; SDAG-NEXT:    v_add_f32_e32 v0, v3, v0
 ; SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; SDAG-NEXT:    v_mul_f32_e32 v0, 0x3e800000, v0
-; SDAG-NEXT:    image_store v[0:2], [v1, v1], s[0:7] dim:SQ_RSRC_IMG_2D unorm
+; SDAG-NEXT:    v_dual_mul_f32 v7, 0x3e800000, v0 :: v_dual_mov_b32 v0, 0
+; SDAG-NEXT:    image_store v[7:9], [v0, v0], s[0:7] dim:SQ_RSRC_IMG_2D unorm
 ; SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-LABEL: issue92561:

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.buffer.store.format.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.buffer.store.format.f16.ll
@@ -160,7 +160,6 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1, [[COPY5]], %subreg.sub2, [[COPY4]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -184,7 +183,7 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -212,7 +211,6 @@ define void @raw_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1, [[COPY5]], %subreg.sub2, [[COPY4]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -236,7 +234,7 @@ define void @raw_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -506,7 +504,6 @@ define void @raw_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -530,7 +527,7 @@ define void @raw_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[COPY8]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[REG_SEQUENCE1]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.buffer.store.format.f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.buffer.store.format.f32.ll
@@ -112,7 +112,6 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1, [[COPY5]], %subreg.sub2, [[COPY4]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -136,7 +135,7 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -164,7 +163,6 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1, [[COPY6]], %subreg.sub2, [[COPY5]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1, [[COPY2]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -188,7 +186,7 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[COPY9]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -217,7 +215,6 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -241,7 +238,7 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY10]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -270,7 +267,6 @@ define void @raw_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -294,7 +290,7 @@ define void @raw_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY10]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -321,7 +317,6 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1, [[COPY4]], %subreg.sub2, [[COPY3]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY2]], %subreg.sub0, [[COPY1]], %subreg.sub1
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4095
-  ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -342,7 +337,7 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY7]], [[COPY]], killed [[REG_SEQUENCE4]], [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE1]], [[COPY]], killed [[REG_SEQUENCE4]], [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -369,7 +364,6 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1, [[COPY4]], %subreg.sub2, [[COPY3]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY2]], %subreg.sub0, [[COPY1]], %subreg.sub1
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
-  ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -390,7 +384,7 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY7]], [[COPY]], killed [[REG_SEQUENCE4]], [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE1]], [[COPY]], killed [[REG_SEQUENCE4]], [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -417,7 +411,6 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1, [[COPY5]], %subreg.sub2, [[COPY4]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -441,7 +434,7 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 16, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 16, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -469,7 +462,6 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1, [[COPY5]], %subreg.sub2, [[COPY4]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -493,7 +485,7 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 4095, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 4095, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -523,7 +515,6 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -547,7 +538,7 @@ define void @raw_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY8]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE1]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -581,7 +572,6 @@ define void @raw_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
-  ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -605,7 +595,7 @@ define void @raw_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_so
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY10]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE1]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.buffer.store.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.buffer.store.ll
@@ -598,7 +598,6 @@ define void @raw_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1, [[COPY5]], %subreg.sub2, [[COPY4]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -622,7 +621,7 @@ define void @raw_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -650,7 +649,6 @@ define void @raw_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1, [[COPY6]], %subreg.sub2, [[COPY5]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1, [[COPY2]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -674,7 +672,7 @@ define void @raw_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX3_OFFEN_exact [[COPY9]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX3_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -703,7 +701,6 @@ define void @raw_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -727,7 +724,7 @@ define void @raw_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact [[COPY10]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -949,7 +946,6 @@ define void @raw_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1, [[COPY5]], %subreg.sub2, [[COPY4]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -973,7 +969,7 @@ define void @raw_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -1000,7 +996,6 @@ define void @raw_buffer_store__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1, [[COPY5]], %subreg.sub2, [[COPY4]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1024,7 +1019,7 @@ define void @raw_buffer_store__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffset_v
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.load.format.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.load.format.f16.ll
@@ -20,7 +20,7 @@ define half @raw_ptr_buffer_load_format_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -74,7 +74,7 @@ define <2 x half> @raw_ptr_buffer_load_format_v2f16__sgpr_rsrc__vgpr_voffset__sg
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -128,7 +128,7 @@ define <4 x half> @raw_ptr_buffer_load_format_v4f16__sgpr_rsrc__vgpr_voffset__sg
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -186,7 +186,7 @@ define half @raw_ptr_buffer_load_format_f16__vgpr_rsrc__sgpr_voffset__vgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -240,7 +240,7 @@ define <4 x half> @raw_ptr_buffer_load_format_v4f16__sgpr_rsrc__vgpr_voffset__sg
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.load.format.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.load.format.ll
@@ -20,7 +20,7 @@ define float @raw_ptr_buffer_load_format_f32__sgpr_rsrc__vgpr_voffset__sgpr_soff
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -74,7 +74,7 @@ define <2 x float> @raw_ptr_buffer_load_format_v2f32__sgpr_rsrc__vgpr_voffset__s
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -131,7 +131,7 @@ define <3 x float> @raw_ptr_buffer_load_format_v3f32__sgpr_rsrc__vgpr_voffset__s
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -190,7 +190,7 @@ define <4 x float> @raw_ptr_buffer_load_format_v4f32__sgpr_rsrc__vgpr_voffset__s
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -252,7 +252,7 @@ define float @raw_ptr_buffer_load_format_f32__vgpr_rsrc__sgpr_voffset__vgpr_soff
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -306,7 +306,7 @@ define <4 x float> @raw_ptr_buffer_load_format_v4f32__sgpr_rsrc__vgpr_voffset__s
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.load.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.load.ll
@@ -20,7 +20,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(ptr
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -75,7 +75,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__sgpr_voffset__sgpr_soffset(ptr
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -130,7 +130,7 @@ define float @raw_ptr_buffer_load_f32__vgpr_rsrc__vgpr_voffset__sgpr_soffset(ptr
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -185,7 +185,7 @@ define float @raw_ptr_buffer_load_f32__vgpr_rsrc__vgpr_voffset__vgpr_soffset(ptr
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -240,7 +240,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_glc
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -295,7 +295,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -350,7 +350,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_dlc
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -405,7 +405,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -460,7 +460,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_glc
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -515,7 +515,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_glc
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -570,7 +570,7 @@ define <2 x float> @raw_ptr_buffer_load_v2f32__sgpr_rsrc__vgpr_voffset__sgpr_sof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -627,7 +627,7 @@ define <3 x float> @raw_ptr_buffer_load_v3f32__sgpr_rsrc__vgpr_voffset__sgpr_sof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -686,7 +686,7 @@ define <4 x float> @raw_ptr_buffer_load_v4f32__sgpr_rsrc__vgpr_voffset__sgpr_sof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -747,7 +747,7 @@ define half @raw_ptr_buffer_load_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset(ptr 
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -802,7 +802,7 @@ define <2 x half> @raw_ptr_buffer_load_v2f16__sgpr_rsrc__vgpr_voffset__sgpr_soff
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -856,7 +856,7 @@ define <4 x half> @raw_ptr_buffer_load_v4f16__sgpr_rsrc__vgpr_voffset__sgpr_soff
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -913,7 +913,7 @@ define float @raw_ptr_buffer_load_i8__sgpr_rsrc__vgpr_voffset__sgpr_soffset_zext
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -969,7 +969,7 @@ define float @raw_ptr_buffer_load_i8__sgpr_rsrc__vgpr_voffset__sgpr_soffset_sext
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1025,7 +1025,7 @@ define float @raw_ptr_buffer_load_i16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_zex
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1081,7 +1081,7 @@ define float @raw_ptr_buffer_load_i16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_sex
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1138,7 +1138,7 @@ define half @raw_ptr_buffer_load_f16__vgpr_rsrc__vgpr_voffset__sgpr_soffset(ptr 
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1194,7 +1194,7 @@ define float @raw_ptr_buffer_load_i8__vgpr_rsrc__vgpr_voffset__sgpr_soffset(ptr 
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1249,7 +1249,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vdpr_voffset__sgpr_soffset__vo
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1, [[COPY6]], %subreg.sub2, [[COPY5]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, killed [[COPY6]], %subreg.sub2, killed [[COPY5]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1302,7 +1302,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset__vo
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1, [[COPY6]], %subreg.sub2, [[COPY5]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, killed [[COPY6]], %subreg.sub2, killed [[COPY5]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1355,7 +1355,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset__vo
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1, [[COPY6]], %subreg.sub2, [[COPY5]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, killed [[COPY6]], %subreg.sub2, killed [[COPY5]], %subreg.sub3
   ; GFX908-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1410,7 +1410,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_vof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1465,7 +1465,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset__vo
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1520,7 +1520,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset__vo
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1576,7 +1576,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_sof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1, [[COPY6]], %subreg.sub2, [[COPY5]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, killed [[COPY6]], %subreg.sub2, killed [[COPY5]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4095
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1627,7 +1627,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_sof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1, [[COPY6]], %subreg.sub2, [[COPY5]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY8]], %subreg.sub0, killed [[COPY7]], %subreg.sub1, killed [[COPY6]], %subreg.sub2, killed [[COPY5]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1679,7 +1679,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_sof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 16
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1736,7 +1736,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_sof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4095
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1793,7 +1793,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_sof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1851,7 +1851,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_sof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 5000
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1909,7 +1909,7 @@ define float @raw_ptr_buffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_vof
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.store.format.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.store.format.f16.ll
@@ -20,7 +20,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -73,7 +73,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__voffset_4095__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -127,7 +127,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -182,9 +182,8 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -208,7 +207,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -240,9 +239,8 @@ define void @raw_ptr_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -266,7 +264,7 @@ define void @raw_ptr_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -295,7 +293,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4095
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -346,7 +344,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -398,7 +396,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -453,7 +451,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -508,7 +506,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -568,11 +566,10 @@ define void @raw_ptr_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -596,7 +593,7 @@ define void @raw_ptr_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[COPY12]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[REG_SEQUENCE3]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.store.format.f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.store.format.f32.ll
@@ -20,7 +20,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -73,7 +73,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__voffset_4095__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -128,9 +128,8 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -154,7 +153,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -186,9 +185,8 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY12]], %subreg.sub0, [[COPY11]], %subreg.sub1, [[COPY10]], %subreg.sub2, [[COPY9]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY12]], %subreg.sub0, killed [[COPY11]], %subreg.sub1, killed [[COPY10]], %subreg.sub2, killed [[COPY9]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1, [[COPY2]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY13:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -212,7 +210,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[COPY13]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -245,9 +243,8 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY13:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY13]], %subreg.sub0, [[COPY12]], %subreg.sub1, [[COPY11]], %subreg.sub2, [[COPY10]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY13]], %subreg.sub0, killed [[COPY12]], %subreg.sub1, killed [[COPY11]], %subreg.sub2, killed [[COPY10]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY14:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -271,7 +268,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY14]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -304,9 +301,8 @@ define void @raw_ptr_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY13:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY13]], %subreg.sub0, [[COPY12]], %subreg.sub1, [[COPY11]], %subreg.sub2, [[COPY10]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY13]], %subreg.sub0, killed [[COPY12]], %subreg.sub1, killed [[COPY11]], %subreg.sub2, killed [[COPY10]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY14:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -330,7 +326,7 @@ define void @raw_ptr_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY14]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -360,10 +356,9 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY2]], %subreg.sub0, [[COPY1]], %subreg.sub1
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4095
-  ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -384,7 +379,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY11]], [[COPY]], killed [[REG_SEQUENCE6]], [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE3]], [[COPY]], killed [[REG_SEQUENCE6]], [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -414,10 +409,9 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY2]], %subreg.sub0, [[COPY1]], %subreg.sub1
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
-  ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -438,7 +432,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY11]], [[COPY]], killed [[REG_SEQUENCE6]], [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE3]], [[COPY]], killed [[REG_SEQUENCE6]], [[S_MOV_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -469,9 +463,8 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -495,7 +488,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 16, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 16, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -527,9 +520,8 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -553,7 +545,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 4095, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 4095, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -585,11 +577,10 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -613,7 +604,7 @@ define void @raw_ptr_buffer_store_format__sgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY12]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE3]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -649,11 +640,10 @@ define void @raw_ptr_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY13:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY13]], %subreg.sub0, [[COPY12]], %subreg.sub1, [[COPY11]], %subreg.sub2, [[COPY10]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY13]], %subreg.sub0, killed [[COPY12]], %subreg.sub1, killed [[COPY11]], %subreg.sub2, killed [[COPY10]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
-  ; GFX908-NEXT:   [[COPY14:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -677,7 +667,7 @@ define void @raw_ptr_buffer_store_format__vgpr_rsrc__vgpr_val__vgpr_voffset__sgp
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY14]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE3]], [[V_ADD_U32_e64_]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.store.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.buffer.store.ll
@@ -21,7 +21,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -76,7 +76,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__sgpr_val__sgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -131,7 +131,7 @@ define void @raw_ptr_buffer_store__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -186,7 +186,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__vgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -241,7 +241,7 @@ define void @raw_ptr_buffer_store__vgpr_rsrc__vgpr_val__vgpr_voffset__vgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -295,7 +295,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -349,7 +349,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -403,7 +403,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -457,7 +457,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -511,7 +511,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -565,7 +565,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -619,7 +619,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -674,9 +674,8 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -700,7 +699,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -732,9 +731,8 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY12]], %subreg.sub0, [[COPY11]], %subreg.sub1, [[COPY10]], %subreg.sub2, [[COPY9]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY12]], %subreg.sub0, killed [[COPY11]], %subreg.sub1, killed [[COPY10]], %subreg.sub2, killed [[COPY9]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1, [[COPY2]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY13:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -758,7 +756,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX3_OFFEN_exact [[COPY13]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX3_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -791,9 +789,8 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY13:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY13]], %subreg.sub0, [[COPY12]], %subreg.sub1, [[COPY11]], %subreg.sub2, [[COPY10]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY13]], %subreg.sub0, killed [[COPY12]], %subreg.sub1, killed [[COPY11]], %subreg.sub2, killed [[COPY10]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY14:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -817,7 +814,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact [[COPY14]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -847,7 +844,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -902,7 +899,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -957,7 +954,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[COPY2]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1012,7 +1009,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1067,9 +1064,8 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1093,7 +1089,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -1124,9 +1120,8 @@ define void @raw_ptr_buffer_store__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1150,7 +1145,7 @@ define void @raw_ptr_buffer_store__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -1179,7 +1174,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__sgpr_soffset_f32_voffset
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1232,7 +1227,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__sgpr_soffset_f32_voffset
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1287,7 +1282,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1342,7 +1337,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1397,7 +1392,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1453,7 +1448,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4095
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1504,7 +1499,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1556,7 +1551,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1611,7 +1606,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -1666,7 +1661,7 @@ define void @raw_ptr_buffer_store__sgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1724,7 +1719,7 @@ define void @raw_ptr_buffer_store__vgpr_rsrc__vgpr_val__vgpr_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY6]], %subreg.sub0, [[COPY5]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1781,7 +1776,7 @@ define void @raw_ptr_buffer_store__vgpr_rsrc__vgpr_val__5000_voffset__sgpr_soffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.tbuffer.load.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.tbuffer.load.f16.ll
@@ -19,7 +19,7 @@ define half @raw_tbuffer_load_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset(ptr add
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -73,7 +73,7 @@ define <2 x half> @raw_tbuffer_load_v2f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -127,7 +127,7 @@ define <4 x half> @raw_tbuffer_load_v4f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -184,7 +184,7 @@ define half @raw_tbuffer_load_f16__vgpr_rsrc__sgpr_voffset__vgpr_soffset(ptr add
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -238,7 +238,7 @@ define half @raw_tbuffer_load_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_glc(ptr
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -292,7 +292,7 @@ define half @raw_tbuffer_load_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc(ptr
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -346,7 +346,7 @@ define half @raw_tbuffer_load_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc_glc
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -400,7 +400,7 @@ define half @raw_tbuffer_load_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_dlc(ptr
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.tbuffer.load.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.tbuffer.load.ll
@@ -19,7 +19,7 @@ define float @raw_tbuffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(ptr ad
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -73,7 +73,7 @@ define <2 x float> @raw_tbuffer_load_v2f32__sgpr_rsrc__vgpr_voffset__sgpr_soffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -130,7 +130,7 @@ define <3 x float> @raw_tbuffer_load_v3f32__sgpr_rsrc__vgpr_voffset__sgpr_soffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -189,7 +189,7 @@ define <4 x float> @raw_tbuffer_load_v4f32__sgpr_rsrc__vgpr_voffset__sgpr_soffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -250,7 +250,7 @@ define float @raw_tbuffer_load_f32__vgpr_rsrc__sgpr_voffset__vgpr_soffset(ptr ad
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -304,7 +304,7 @@ define float @raw_tbuffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_glc(pt
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -358,7 +358,7 @@ define float @raw_tbuffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc(pt
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -412,7 +412,7 @@ define float @raw_tbuffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc_gl
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -466,7 +466,7 @@ define float @raw_tbuffer_load_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_dlc(pt
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.tbuffer.store.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.tbuffer.store.f16.ll
@@ -20,7 +20,7 @@ define void @raw_tbuffer_store_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset(half %
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -74,7 +74,7 @@ define void @raw_tbuffer_store_v2f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<2 x
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -129,9 +129,8 @@ define void @raw_tbuffer_store_v4f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<4 x
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -155,7 +154,7 @@ define void @raw_tbuffer_store_v4f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<4 x
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -186,7 +185,7 @@ define void @raw_tbuffer_store_f16__vgpr_rsrc__vgpr_voffset__sgpr_soffset(half %
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -241,7 +240,7 @@ define void @raw_tbuffer_store_f16__vgpr_rsrc__vgpr_voffset__vgpr_soffset(half %
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -296,7 +295,7 @@ define void @raw_tbuffer_store_f16__vgpr_rsrc__sgpr_voffset__vgpr_soffset(half %
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -350,7 +349,7 @@ define void @raw_tbuffer_store_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_glc(ha
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -404,7 +403,7 @@ define void @raw_tbuffer_store_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc(ha
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -458,7 +457,7 @@ define void @raw_tbuffer_store_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc_gl
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -512,7 +511,7 @@ define void @raw_tbuffer_store_f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset_dlc(ha
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.tbuffer.store.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.ptr.tbuffer.store.ll
@@ -21,7 +21,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(float 
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -77,9 +77,8 @@ define void @raw_tbuffer_store_v2f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<2 x
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY11]], %subreg.sub0, [[COPY10]], %subreg.sub1, [[COPY9]], %subreg.sub2, [[COPY8]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY11]], %subreg.sub0, killed [[COPY10]], %subreg.sub1, killed [[COPY9]], %subreg.sub2, killed [[COPY8]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -103,7 +102,7 @@ define void @raw_tbuffer_store_v2f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<2 x
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY12]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s64) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -136,9 +135,8 @@ define void @raw_tbuffer_store_v3f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<3 x
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY12]], %subreg.sub0, [[COPY11]], %subreg.sub1, [[COPY10]], %subreg.sub2, [[COPY9]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY12]], %subreg.sub0, killed [[COPY11]], %subreg.sub1, killed [[COPY10]], %subreg.sub2, killed [[COPY9]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1, [[COPY6]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY13:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -162,7 +160,7 @@ define void @raw_tbuffer_store_v3f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<3 x
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[COPY13]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s96) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s96) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -196,9 +194,8 @@ define void @raw_tbuffer_store_v4f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<4 x
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY13:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY13]], %subreg.sub0, [[COPY12]], %subreg.sub1, [[COPY11]], %subreg.sub2, [[COPY10]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY13]], %subreg.sub0, killed [[COPY12]], %subreg.sub1, killed [[COPY11]], %subreg.sub2, killed [[COPY10]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY14:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE3]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -222,7 +219,7 @@ define void @raw_tbuffer_store_v4f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<4 x
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY14]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE3]], [[COPY1]], killed [[REG_SEQUENCE6]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s128) into %ir.rsrc, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -253,7 +250,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__sgpr_voffset__sgpr_soffset(float 
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -308,7 +305,7 @@ define void @raw_tbuffer_store_f32__vgpr_rsrc__vgpr_voffset__sgpr_soffset(float 
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -363,7 +360,7 @@ define void @raw_tbuffer_store_f32__vgpr_rsrc__vgpr_voffset__vgpr_soffset(float 
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -418,7 +415,7 @@ define void @raw_tbuffer_store_f32__vgpr_rsrc__sgpr_voffset__vgpr_soffset(float 
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -473,7 +470,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_glc(fl
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -528,7 +525,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc(fl
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -583,7 +580,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_slc_gl
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -638,7 +635,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_dlc(fl
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -691,7 +688,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vdpr_voffset__sgpr_soffset__voffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -744,7 +741,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset__voffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -797,7 +794,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset__voffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 4096, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -852,7 +849,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_voffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -907,7 +904,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset__voffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -962,7 +959,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset__voffs
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1018,7 +1015,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_soffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4095
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1069,7 +1066,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_soffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY9]], %subreg.sub0, killed [[COPY8]], %subreg.sub1, killed [[COPY7]], %subreg.sub2, killed [[COPY6]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1121,7 +1118,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_soffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 16
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1178,7 +1175,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_soffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4095
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1235,7 +1232,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_soffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1293,7 +1290,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_soffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 5000
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
@@ -1351,7 +1348,7 @@ define void @raw_tbuffer_store_f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset_voffse
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub1
   ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY10]], %subreg.sub0, [[COPY9]], %subreg.sub1, [[COPY8]], %subreg.sub2, [[COPY7]], %subreg.sub3
+  ; GFX908-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_128 = REG_SEQUENCE killed [[COPY10]], %subreg.sub0, killed [[COPY9]], %subreg.sub1, killed [[COPY8]], %subreg.sub2, killed [[COPY7]], %subreg.sub3
   ; GFX908-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4096
   ; GFX908-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 [[COPY1]], killed [[S_MOV_B32_]], 0, implicit $exec
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.tbuffer.store.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.tbuffer.store.f16.ll
@@ -113,7 +113,6 @@ define void @raw_tbuffer_store_v4f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<4 x
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -137,7 +136,7 @@ define void @raw_tbuffer_store_v4f16__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<4 x
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_D16_XYZW_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.tbuffer.store.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-amdgcn.raw.tbuffer.store.ll
@@ -67,7 +67,6 @@ define void @raw_tbuffer_store_v2f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<2 x
   ; GFX908-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY7]], %subreg.sub0, [[COPY6]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -91,7 +90,7 @@ define void @raw_tbuffer_store_v2f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<2 x
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY8]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -120,7 +119,6 @@ define void @raw_tbuffer_store_v3f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<3 x
   ; GFX908-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY8]], %subreg.sub0, [[COPY7]], %subreg.sub1, [[COPY6]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -144,7 +142,7 @@ define void @raw_tbuffer_store_v3f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<3 x
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[COPY9]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -174,7 +172,6 @@ define void @raw_tbuffer_store_v4f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<4 x
   ; GFX908-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
   ; GFX908-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY9]], %subreg.sub0, [[COPY8]], %subreg.sub1, [[COPY7]], %subreg.sub2, [[COPY6]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY10:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE1]]
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
@@ -198,7 +195,7 @@ define void @raw_tbuffer_store_v4f32__sgpr_rsrc__vgpr_voffset__sgpr_soffset(<4 x
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY10]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE1]], [[COPY1]], killed [[REG_SEQUENCE4]], killed [[V_READFIRSTLANE_B32_4]], 0, 78, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/legalize-soffset-mbuf.ll
+++ b/llvm/test/CodeGen/AMDGPU/legalize-soffset-mbuf.ll
@@ -374,7 +374,6 @@ define void @llvm_amdgcn_raw_buffer_store_v2f32(<2 x float> %val, i32 %voffset, 
   ; GFX908-NEXT:   [[COPY2:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -388,7 +387,7 @@ define void @llvm_amdgcn_raw_buffer_store_v2f32(<2 x float> %val, i32 %voffset, 
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[COPY4]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -410,7 +409,6 @@ define void @llvm_amdgcn_raw_tbuffer_store_v2f32(<2 x float> %val, i32 %voffset,
   ; GFX908-NEXT:   [[COPY2:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -424,7 +422,7 @@ define void @llvm_amdgcn_raw_tbuffer_store_v2f32(<2 x float> %val, i32 %voffset,
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY4]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s64), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -447,7 +445,6 @@ define void @llvm_amdgcn_raw_buffer_store_v3f32(<3 x float> %val, i32 %voffset, 
   ; GFX908-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1, [[COPY2]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY5:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -461,7 +458,7 @@ define void @llvm_amdgcn_raw_buffer_store_v3f32(<3 x float> %val, i32 %voffset, 
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX3_OFFEN_exact [[COPY5]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX3_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -484,7 +481,6 @@ define void @llvm_amdgcn_raw_tbuffer_store_v3f32(<3 x float> %val, i32 %voffset,
   ; GFX908-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1, [[COPY2]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY5:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -498,7 +494,7 @@ define void @llvm_amdgcn_raw_tbuffer_store_v3f32(<3 x float> %val, i32 %voffset,
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[COPY5]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s96), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -522,7 +518,6 @@ define void @llvm_amdgcn_raw_buffer_store_v4f32(<4 x float> %val, i32 %voffset, 
   ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY5:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY6:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -536,7 +531,7 @@ define void @llvm_amdgcn_raw_buffer_store_v4f32(<4 x float> %val, i32 %voffset, 
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact [[COPY6]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -560,7 +555,6 @@ define void @llvm_amdgcn_raw_tbuffer_store_v4f32(<4 x float> %val, i32 %voffset,
   ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY5:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY6:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -574,7 +568,7 @@ define void @llvm_amdgcn_raw_tbuffer_store_v4f32(<4 x float> %val, i32 %voffset,
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY6]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s128), align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -958,7 +952,6 @@ define void @llvm_amdgcn_raw_ptr_buffer_store_v2f32(<2 x float> %val, i32 %voffs
   ; GFX908-NEXT:   [[COPY2:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -972,7 +965,7 @@ define void @llvm_amdgcn_raw_ptr_buffer_store_v2f32(<2 x float> %val, i32 %voffs
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[COPY4]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into `ptr addrspace(8) poison`, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX2_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into `ptr addrspace(8) poison`, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -994,7 +987,6 @@ define void @llvm_amdgcn_raw_ptr_tbuffer_store_v2f32(<2 x float> %val, i32 %voff
   ; GFX908-NEXT:   [[COPY2:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY3]], %subreg.sub0, [[COPY2]], %subreg.sub1
-  ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1008,7 +1000,7 @@ define void @llvm_amdgcn_raw_ptr_tbuffer_store_v2f32(<2 x float> %val, i32 %voff
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XY_OFFEN_exact [[COPY4]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into `ptr addrspace(8) poison`, align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XY_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s64) into `ptr addrspace(8) poison`, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -1031,7 +1023,6 @@ define void @llvm_amdgcn_raw_ptr_buffer_store_v3f32(<3 x float> %val, i32 %voffs
   ; GFX908-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1, [[COPY2]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY5:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1045,7 +1036,7 @@ define void @llvm_amdgcn_raw_ptr_buffer_store_v3f32(<3 x float> %val, i32 %voffs
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX3_OFFEN_exact [[COPY5]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96) into `ptr addrspace(8) poison`, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX3_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s96) into `ptr addrspace(8) poison`, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -1068,7 +1059,6 @@ define void @llvm_amdgcn_raw_ptr_tbuffer_store_v3f32(<3 x float> %val, i32 %voff
   ; GFX908-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_96 = REG_SEQUENCE [[COPY4]], %subreg.sub0, [[COPY3]], %subreg.sub1, [[COPY2]], %subreg.sub2
-  ; GFX908-NEXT:   [[COPY5:%[0-9]+]]:vreg_96 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1082,7 +1072,7 @@ define void @llvm_amdgcn_raw_ptr_tbuffer_store_v3f32(<3 x float> %val, i32 %voff
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[COPY5]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s96) into `ptr addrspace(8) poison`, align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZ_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s96) into `ptr addrspace(8) poison`, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -1106,7 +1096,6 @@ define void @llvm_amdgcn_raw_ptr_buffer_store_v4f32(<4 x float> %val, i32 %voffs
   ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY5:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY6:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1120,7 +1109,7 @@ define void @llvm_amdgcn_raw_ptr_buffer_store_v4f32(<4 x float> %val, i32 %voffs
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact [[COPY6]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into `ptr addrspace(8) poison`, align 1, addrspace 8)
+  ; GFX908-NEXT:   BUFFER_STORE_DWORDX4_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into `ptr addrspace(8) poison`, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}
@@ -1144,7 +1133,6 @@ define void @llvm_amdgcn_raw_ptr_tbuffer_store_v4f32(<4 x float> %val, i32 %voff
   ; GFX908-NEXT:   [[COPY4:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; GFX908-NEXT:   [[COPY5:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX908-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY5]], %subreg.sub0, [[COPY4]], %subreg.sub1, [[COPY3]], %subreg.sub2, [[COPY2]], %subreg.sub3
-  ; GFX908-NEXT:   [[COPY6:%[0-9]+]]:vreg_128 = COPY [[REG_SEQUENCE]]
   ; GFX908-NEXT:   [[DEF:%[0-9]+]]:sgpr_128 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64_xexec = S_MOV_B64 $exec
   ; GFX908-NEXT: {{  $}}
@@ -1158,7 +1146,7 @@ define void @llvm_amdgcn_raw_ptr_tbuffer_store_v4f32(<4 x float> %val, i32 %voff
   ; GFX908-NEXT: bb.2:
   ; GFX908-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; GFX908-NEXT: {{  $}}
-  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[COPY6]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into `ptr addrspace(8) poison`, align 1, addrspace 8)
+  ; GFX908-NEXT:   TBUFFER_STORE_FORMAT_XYZW_OFFEN_exact [[REG_SEQUENCE]], [[COPY1]], [[DEF]], killed [[V_READFIRSTLANE_B32_]], 0, 0, 0, 0, implicit $exec :: (dereferenceable store (s128) into `ptr addrspace(8) poison`, align 1, addrspace 8)
   ; GFX908-NEXT:   $exec = S_XOR_B64_term $exec, [[S_AND_SAVEEXEC_B64_]], implicit-def $scc
   ; GFX908-NEXT:   SI_WATERFALL_LOOP %bb.1, implicit $exec
   ; GFX908-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.iglp.opt.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.iglp.opt.ll
@@ -159,100 +159,100 @@ define amdgpu_kernel void @test_iglp_opt_rev_mfma_gemm(ptr addrspace(3) noalias 
 ; GCN-NEXT:    v_mov_b32_e32 v1, 2.0
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    v_add_u32_e32 v3, s0, v0
-; GCN-NEXT:    ds_read_b128 a[156:159], v3 offset:112
-; GCN-NEXT:    ds_read_b128 a[152:155], v3 offset:96
-; GCN-NEXT:    ds_read_b128 a[148:151], v3 offset:80
-; GCN-NEXT:    ds_read_b128 a[144:147], v3 offset:64
-; GCN-NEXT:    ds_read_b128 a[128:131], v3
-; GCN-NEXT:    ds_read_b128 a[132:135], v3 offset:16
-; GCN-NEXT:    ds_read_b128 a[136:139], v3 offset:32
-; GCN-NEXT:    ds_read_b128 a[140:143], v3 offset:48
+; GCN-NEXT:    ds_read_b128 a[28:31], v3 offset:112
+; GCN-NEXT:    ds_read_b128 a[24:27], v3 offset:96
+; GCN-NEXT:    ds_read_b128 a[20:23], v3 offset:80
+; GCN-NEXT:    ds_read_b128 a[16:19], v3 offset:64
+; GCN-NEXT:    ds_read_b128 a[0:3], v3
+; GCN-NEXT:    ds_read_b128 a[4:7], v3 offset:16
+; GCN-NEXT:    ds_read_b128 a[8:11], v3 offset:32
+; GCN-NEXT:    ds_read_b128 a[12:15], v3 offset:48
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v2, v1, a[128:159]
-; GCN-NEXT:    ds_read_b128 a[124:127], v3 offset:8304
-; GCN-NEXT:    ds_read_b128 a[120:123], v3 offset:8288
-; GCN-NEXT:    ds_read_b128 a[116:119], v3 offset:8272
-; GCN-NEXT:    ds_read_b128 a[112:115], v3 offset:8256
-; GCN-NEXT:    ds_read_b128 a[108:111], v3 offset:8240
-; GCN-NEXT:    ds_read_b128 a[104:107], v3 offset:8224
-; GCN-NEXT:    ds_read_b128 a[100:103], v3 offset:8208
-; GCN-NEXT:    ds_read_b128 a[96:99], v3 offset:8192
+; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v2, v1, a[0:31]
+; GCN-NEXT:    ds_read_b128 a[156:159], v3 offset:8304
+; GCN-NEXT:    ds_read_b128 a[152:155], v3 offset:8288
+; GCN-NEXT:    ds_read_b128 a[148:151], v3 offset:8272
+; GCN-NEXT:    ds_read_b128 a[144:147], v3 offset:8256
+; GCN-NEXT:    ds_read_b128 a[140:143], v3 offset:8240
+; GCN-NEXT:    ds_read_b128 a[136:139], v3 offset:8224
+; GCN-NEXT:    ds_read_b128 a[132:135], v3 offset:8208
+; GCN-NEXT:    ds_read_b128 a[128:131], v3 offset:8192
 ; GCN-NEXT:    v_add_u32_e32 v4, 0x6000, v3
 ; GCN-NEXT:    v_add_u32_e32 v0, s1, v0
 ; GCN-NEXT:    ; iglp_opt mask(0x00000001)
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v2, v1, a[128:159]
+; GCN-NEXT:    ds_read_b128 a[124:127], v3 offset:24688
+; GCN-NEXT:    ds_read_b128 a[120:123], v3 offset:24672
+; GCN-NEXT:    ds_read_b128 a[116:119], v3 offset:24656
+; GCN-NEXT:    ds_read_b128 a[112:115], v3 offset:24640
+; GCN-NEXT:    ds_read_b128 a[108:111], v3 offset:24624
+; GCN-NEXT:    ds_read_b128 a[104:107], v3 offset:24608
+; GCN-NEXT:    ds_read_b128 a[100:103], v3 offset:24592
+; GCN-NEXT:    ds_read_b128 a[96:99], v3 offset:24576
+; GCN-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[96:127], v2, v1, a[96:127]
-; GCN-NEXT:    ds_read_b128 a[92:95], v3 offset:24688
-; GCN-NEXT:    ds_read_b128 a[88:91], v3 offset:24672
-; GCN-NEXT:    ds_read_b128 a[84:87], v3 offset:24656
-; GCN-NEXT:    ds_read_b128 a[80:83], v3 offset:24640
-; GCN-NEXT:    ds_read_b128 a[76:79], v3 offset:24624
-; GCN-NEXT:    ds_read_b128 a[72:75], v3 offset:24608
-; GCN-NEXT:    ds_read_b128 a[68:71], v3 offset:24592
-; GCN-NEXT:    ds_read_b128 a[64:67], v3 offset:24576
+; GCN-NEXT:    ds_read_b128 a[92:95], v3 offset:49264
+; GCN-NEXT:    ds_read_b128 a[88:91], v3 offset:49248
+; GCN-NEXT:    ds_read_b128 a[84:87], v3 offset:49232
+; GCN-NEXT:    ds_read_b128 a[80:83], v3 offset:49216
+; GCN-NEXT:    ds_read_b128 a[76:79], v3 offset:49200
+; GCN-NEXT:    ds_read_b128 a[72:75], v3 offset:49184
+; GCN-NEXT:    ds_read_b128 a[68:71], v3 offset:49168
+; GCN-NEXT:    ds_read_b128 a[64:67], v3 offset:49152
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[64:95], v2, v1, a[64:95]
-; GCN-NEXT:    ds_read_b128 a[60:63], v3 offset:49264
-; GCN-NEXT:    ds_read_b128 a[56:59], v3 offset:49248
-; GCN-NEXT:    ds_read_b128 a[52:55], v3 offset:49232
-; GCN-NEXT:    ds_read_b128 a[48:51], v3 offset:49216
-; GCN-NEXT:    ds_read_b128 a[44:47], v3 offset:49200
-; GCN-NEXT:    ds_read_b128 a[40:43], v3 offset:49184
-; GCN-NEXT:    ds_read_b128 a[36:39], v3 offset:49168
-; GCN-NEXT:    ds_read_b128 a[32:35], v3 offset:49152
+; GCN-NEXT:    ds_read_b128 a[60:63], v4 offset:57456
+; GCN-NEXT:    ds_read_b128 a[56:59], v4 offset:57440
+; GCN-NEXT:    ds_read_b128 a[52:55], v4 offset:57424
+; GCN-NEXT:    ds_read_b128 a[48:51], v4 offset:57408
+; GCN-NEXT:    ds_read_b128 a[32:35], v4 offset:57344
+; GCN-NEXT:    ds_read_b128 a[36:39], v4 offset:57360
+; GCN-NEXT:    ds_read_b128 a[40:43], v4 offset:57376
+; GCN-NEXT:    ds_read_b128 a[44:47], v4 offset:57392
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v2, v1, a[32:63]
-; GCN-NEXT:    ds_read_b128 a[28:31], v4 offset:57456
-; GCN-NEXT:    ds_read_b128 a[24:27], v4 offset:57440
-; GCN-NEXT:    ds_read_b128 a[20:23], v4 offset:57424
-; GCN-NEXT:    ds_read_b128 a[16:19], v4 offset:57408
-; GCN-NEXT:    ds_read_b128 a[0:3], v4 offset:57344
-; GCN-NEXT:    ds_read_b128 a[4:7], v4 offset:57360
-; GCN-NEXT:    ds_read_b128 a[8:11], v4 offset:57376
-; GCN-NEXT:    ds_read_b128 a[12:15], v4 offset:57392
-; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v2, v1, a[0:31]
-; GCN-NEXT:    ds_write_b128 v0, a[156:159] offset:112
-; GCN-NEXT:    ds_write_b128 v0, a[152:155] offset:96
-; GCN-NEXT:    ds_write_b128 v0, a[148:151] offset:80
-; GCN-NEXT:    ds_write_b128 v0, a[144:147] offset:64
-; GCN-NEXT:    ds_write_b128 v0, a[140:143] offset:48
-; GCN-NEXT:    ds_write_b128 v0, a[136:139] offset:32
-; GCN-NEXT:    ds_write_b128 v0, a[132:135] offset:16
-; GCN-NEXT:    ds_write_b128 v0, a[128:131]
+; GCN-NEXT:    ds_write_b128 v0, a[28:31] offset:112
+; GCN-NEXT:    ds_write_b128 v0, a[24:27] offset:96
+; GCN-NEXT:    ds_write_b128 v0, a[20:23] offset:80
+; GCN-NEXT:    ds_write_b128 v0, a[16:19] offset:64
+; GCN-NEXT:    ds_write_b128 v0, a[12:15] offset:48
+; GCN-NEXT:    ds_write_b128 v0, a[8:11] offset:32
+; GCN-NEXT:    ds_write_b128 v0, a[4:7] offset:16
+; GCN-NEXT:    ds_write_b128 v0, a[0:3]
 ; GCN-NEXT:    v_mov_b32_e32 v0, s1
-; GCN-NEXT:    ds_write_b128 v0, a[120:123] offset:8288
-; GCN-NEXT:    ds_write_b128 v0, a[124:127] offset:8304
-; GCN-NEXT:    ds_write_b128 v0, a[112:115] offset:8256
-; GCN-NEXT:    ds_write_b128 v0, a[116:119] offset:8272
-; GCN-NEXT:    ds_write_b128 v0, a[104:107] offset:8224
-; GCN-NEXT:    ds_write_b128 v0, a[108:111] offset:8240
-; GCN-NEXT:    ds_write_b128 v0, a[96:99] offset:8192
-; GCN-NEXT:    ds_write_b128 v0, a[100:103] offset:8208
-; GCN-NEXT:    ds_write_b128 v0, a[88:91] offset:16480
-; GCN-NEXT:    ds_write_b128 v0, a[92:95] offset:16496
-; GCN-NEXT:    ds_write_b128 v0, a[80:83] offset:16448
-; GCN-NEXT:    ds_write_b128 v0, a[84:87] offset:16464
-; GCN-NEXT:    ds_write_b128 v0, a[72:75] offset:16416
-; GCN-NEXT:    ds_write_b128 v0, a[76:79] offset:16432
-; GCN-NEXT:    ds_write_b128 v0, a[64:67] offset:16384
-; GCN-NEXT:    ds_write_b128 v0, a[68:71] offset:16400
-; GCN-NEXT:    ds_write_b128 v0, a[56:59] offset:24672
-; GCN-NEXT:    ds_write_b128 v0, a[60:63] offset:24688
-; GCN-NEXT:    ds_write_b128 v0, a[48:51] offset:24640
-; GCN-NEXT:    ds_write_b128 v0, a[52:55] offset:24656
-; GCN-NEXT:    ds_write_b128 v0, a[40:43] offset:24608
-; GCN-NEXT:    ds_write_b128 v0, a[44:47] offset:24624
-; GCN-NEXT:    ds_write_b128 v0, a[32:35] offset:24576
-; GCN-NEXT:    ds_write_b128 v0, a[36:39] offset:24592
-; GCN-NEXT:    ds_write_b128 v0, a[24:27] offset:32864
-; GCN-NEXT:    ds_write_b128 v0, a[28:31] offset:32880
-; GCN-NEXT:    ds_write_b128 v0, a[16:19] offset:32832
-; GCN-NEXT:    ds_write_b128 v0, a[20:23] offset:32848
-; GCN-NEXT:    ds_write_b128 v0, a[8:11] offset:32800
-; GCN-NEXT:    ds_write_b128 v0, a[12:15] offset:32816
-; GCN-NEXT:    ds_write_b128 v0, a[0:3] offset:32768
-; GCN-NEXT:    ds_write_b128 v0, a[4:7] offset:32784
+; GCN-NEXT:    ds_write_b128 v0, a[152:155] offset:8288
+; GCN-NEXT:    ds_write_b128 v0, a[156:159] offset:8304
+; GCN-NEXT:    ds_write_b128 v0, a[144:147] offset:8256
+; GCN-NEXT:    ds_write_b128 v0, a[148:151] offset:8272
+; GCN-NEXT:    ds_write_b128 v0, a[136:139] offset:8224
+; GCN-NEXT:    ds_write_b128 v0, a[140:143] offset:8240
+; GCN-NEXT:    ds_write_b128 v0, a[128:131] offset:8192
+; GCN-NEXT:    ds_write_b128 v0, a[132:135] offset:8208
+; GCN-NEXT:    ds_write_b128 v0, a[120:123] offset:16480
+; GCN-NEXT:    ds_write_b128 v0, a[124:127] offset:16496
+; GCN-NEXT:    ds_write_b128 v0, a[112:115] offset:16448
+; GCN-NEXT:    ds_write_b128 v0, a[116:119] offset:16464
+; GCN-NEXT:    ds_write_b128 v0, a[104:107] offset:16416
+; GCN-NEXT:    ds_write_b128 v0, a[108:111] offset:16432
+; GCN-NEXT:    ds_write_b128 v0, a[96:99] offset:16384
+; GCN-NEXT:    ds_write_b128 v0, a[100:103] offset:16400
+; GCN-NEXT:    ds_write_b128 v0, a[88:91] offset:24672
+; GCN-NEXT:    ds_write_b128 v0, a[92:95] offset:24688
+; GCN-NEXT:    ds_write_b128 v0, a[80:83] offset:24640
+; GCN-NEXT:    ds_write_b128 v0, a[84:87] offset:24656
+; GCN-NEXT:    ds_write_b128 v0, a[72:75] offset:24608
+; GCN-NEXT:    ds_write_b128 v0, a[76:79] offset:24624
+; GCN-NEXT:    ds_write_b128 v0, a[64:67] offset:24576
+; GCN-NEXT:    ds_write_b128 v0, a[68:71] offset:24592
+; GCN-NEXT:    ds_write_b128 v0, a[56:59] offset:32864
+; GCN-NEXT:    ds_write_b128 v0, a[60:63] offset:32880
+; GCN-NEXT:    ds_write_b128 v0, a[48:51] offset:32832
+; GCN-NEXT:    ds_write_b128 v0, a[52:55] offset:32848
+; GCN-NEXT:    ds_write_b128 v0, a[40:43] offset:32800
+; GCN-NEXT:    ds_write_b128 v0, a[44:47] offset:32816
+; GCN-NEXT:    ds_write_b128 v0, a[32:35] offset:32768
+; GCN-NEXT:    ds_write_b128 v0, a[36:39] offset:32784
 ; GCN-NEXT:    s_endpgm
 entry:
   call void @llvm.amdgcn.iglp.opt(i32 1)

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.image.atomic.dim.gfx90a.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.image.atomic.dim.gfx90a.ll
@@ -39,9 +39,7 @@ define amdgpu_ps void @atomic_cmpswap_1d_agpr(<8 x i32> inreg %rsrc, i32 %s) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def a1
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_accvgpr_read_b32 v2, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v3, a1
-; GFX90A-NEXT:    image_atomic_cmpswap v[2:3], v0, s[0:7] dmask:0x3 unorm glc
+; GFX90A-NEXT:    image_atomic_cmpswap a[0:1], v0, s[0:7] dmask:0x3 unorm glc
 ; GFX90A-NEXT:    s_endpgm
   %cmp = call i32 asm "; def $0", "=a"()
   %swap = call i32 asm "; def $0", "=a"()
@@ -70,14 +68,10 @@ define amdgpu_ps void @atomic_cmpswap_1d_64_agpr(<8 x i32> inreg %rsrc, i32 %s) 
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def a[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_accvgpr_read_b32 v3, a1
-; GFX90A-NEXT:    v_accvgpr_read_b32 v2, a0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def a[0:1]
+; GFX90A-NEXT:    ; def a[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_accvgpr_read_b32 v5, a1
-; GFX90A-NEXT:    v_accvgpr_read_b32 v4, a0
-; GFX90A-NEXT:    image_atomic_cmpswap v[2:5], v0, s[0:7] dmask:0xf unorm glc
+; GFX90A-NEXT:    image_atomic_cmpswap a[0:3], v0, s[0:7] dmask:0xf unorm glc
 ; GFX90A-NEXT:    s_endpgm
   %cmp = call i64 asm "; def $0", "=a"()
   %swap = call i64 asm "; def $0", "=a"()

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.intersect_ray.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.intersect_ray.ll
@@ -310,11 +310,11 @@ define amdgpu_kernel void @image_bvh_intersect_ray_nsa_reassign(ptr %p_node_ptr,
 ; GFX1013:       ; %bb.0: ; %main_body
 ; GFX1013-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
 ; GFX1013-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX1013-NEXT:    v_mov_b32_e32 v6, 4.0
-; GFX1013-NEXT:    v_mov_b32_e32 v7, 0x40a00000
-; GFX1013-NEXT:    v_mov_b32_e32 v8, 0x40c00000
-; GFX1013-NEXT:    v_mov_b32_e32 v9, 0x40e00000
 ; GFX1013-NEXT:    v_mov_b32_e32 v10, 0x41000000
+; GFX1013-NEXT:    v_mov_b32_e32 v9, 0x40e00000
+; GFX1013-NEXT:    v_mov_b32_e32 v8, 0x40c00000
+; GFX1013-NEXT:    v_mov_b32_e32 v7, 0x40a00000
+; GFX1013-NEXT:    v_mov_b32_e32 v6, 4.0
 ; GFX1013-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1013-NEXT:    v_add_co_u32 v2, s0, s8, v0
 ; GFX1013-NEXT:    v_add_co_ci_u32_e64 v3, s0, s9, 0, s0
@@ -323,9 +323,9 @@ define amdgpu_kernel void @image_bvh_intersect_ray_nsa_reassign(ptr %p_node_ptr,
 ; GFX1013-NEXT:    flat_load_dword v0, v[2:3]
 ; GFX1013-NEXT:    flat_load_dword v1, v[4:5]
 ; GFX1013-NEXT:    v_mov_b32_e32 v2, 0
-; GFX1013-NEXT:    v_mov_b32_e32 v3, 1.0
-; GFX1013-NEXT:    v_mov_b32_e32 v4, 2.0
 ; GFX1013-NEXT:    v_mov_b32_e32 v5, 0x40400000
+; GFX1013-NEXT:    v_mov_b32_e32 v4, 2.0
+; GFX1013-NEXT:    v_mov_b32_e32 v3, 1.0
 ; GFX1013-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX1013-NEXT:    image_bvh_intersect_ray v[0:3], v[0:10], s[12:15]
 ; GFX1013-NEXT:    s_waitcnt vmcnt(0)
@@ -474,8 +474,8 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX1013:       ; %bb.0: ; %main_body
 ; GFX1013-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
 ; GFX1013-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
-; GFX1013-NEXT:    v_mov_b32_e32 v6, 0x46004500
 ; GFX1013-NEXT:    v_mov_b32_e32 v7, 0x48004700
+; GFX1013-NEXT:    v_mov_b32_e32 v6, 0x46004500
 ; GFX1013-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1013-NEXT:    v_add_co_u32 v2, s0, s8, v0
 ; GFX1013-NEXT:    v_add_co_ci_u32_e64 v3, s0, s9, 0, s0
@@ -484,9 +484,9 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX1013-NEXT:    flat_load_dword v0, v[2:3]
 ; GFX1013-NEXT:    flat_load_dword v1, v[4:5]
 ; GFX1013-NEXT:    v_mov_b32_e32 v2, 0
-; GFX1013-NEXT:    v_mov_b32_e32 v3, 1.0
-; GFX1013-NEXT:    v_mov_b32_e32 v4, 2.0
 ; GFX1013-NEXT:    v_mov_b32_e32 v5, 0x44004200
+; GFX1013-NEXT:    v_mov_b32_e32 v4, 2.0
+; GFX1013-NEXT:    v_mov_b32_e32 v3, 1.0
 ; GFX1013-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX1013-NEXT:    image_bvh_intersect_ray v[0:3], v[0:7], s[12:15] a16
 ; GFX1013-NEXT:    s_waitcnt vmcnt(0)
@@ -625,20 +625,20 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_nsa_reassign(ptr %p_ray, <4
 ; GFX1013-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x34
 ; GFX1013-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX1013-NEXT:    v_mov_b32_e32 v3, 0
-; GFX1013-NEXT:    v_mov_b32_e32 v4, 1.0
-; GFX1013-NEXT:    v_mov_b32_e32 v5, 2.0
-; GFX1013-NEXT:    v_mov_b32_e32 v6, 0x40400000
-; GFX1013-NEXT:    v_mov_b32_e32 v7, 4.0
-; GFX1013-NEXT:    v_mov_b32_e32 v8, 0x40a00000
-; GFX1013-NEXT:    v_mov_b32_e32 v9, 0x40c00000
-; GFX1013-NEXT:    v_mov_b32_e32 v10, 0x40e00000
 ; GFX1013-NEXT:    v_mov_b32_e32 v11, 0x41000000
+; GFX1013-NEXT:    v_mov_b32_e32 v10, 0x40e00000
+; GFX1013-NEXT:    v_mov_b32_e32 v9, 0x40c00000
+; GFX1013-NEXT:    v_mov_b32_e32 v8, 0x40a00000
+; GFX1013-NEXT:    v_mov_b32_e32 v7, 4.0
+; GFX1013-NEXT:    v_mov_b32_e32 v6, 0x40400000
+; GFX1013-NEXT:    v_mov_b32_e32 v5, 2.0
+; GFX1013-NEXT:    v_mov_b32_e32 v4, 1.0
 ; GFX1013-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1013-NEXT:    v_add_co_u32 v0, s4, s6, v0
 ; GFX1013-NEXT:    v_add_co_ci_u32_e64 v1, s4, s7, 0, s4
 ; GFX1013-NEXT:    flat_load_dword v2, v[0:1]
-; GFX1013-NEXT:    v_mov_b32_e32 v0, 0xb36211c7
 ; GFX1013-NEXT:    v_bfrev_b32_e32 v1, 4.0
+; GFX1013-NEXT:    v_mov_b32_e32 v0, 0xb36211c7
 ; GFX1013-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX1013-NEXT:    image_bvh64_intersect_ray v[0:3], v[0:11], s[0:3]
 ; GFX1013-NEXT:    s_waitcnt vmcnt(0)
@@ -786,17 +786,17 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_a16_nsa_reassign(ptr %p_ray
 ; GFX1013-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x34
 ; GFX1013-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX1013-NEXT:    v_mov_b32_e32 v3, 0
-; GFX1013-NEXT:    v_mov_b32_e32 v4, 1.0
-; GFX1013-NEXT:    v_mov_b32_e32 v5, 2.0
-; GFX1013-NEXT:    v_mov_b32_e32 v6, 0x44004200
-; GFX1013-NEXT:    v_mov_b32_e32 v7, 0x46004500
 ; GFX1013-NEXT:    v_mov_b32_e32 v8, 0x48004700
+; GFX1013-NEXT:    v_mov_b32_e32 v7, 0x46004500
+; GFX1013-NEXT:    v_mov_b32_e32 v6, 0x44004200
+; GFX1013-NEXT:    v_mov_b32_e32 v5, 2.0
+; GFX1013-NEXT:    v_mov_b32_e32 v4, 1.0
 ; GFX1013-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1013-NEXT:    v_add_co_u32 v0, s4, s6, v0
 ; GFX1013-NEXT:    v_add_co_ci_u32_e64 v1, s4, s7, 0, s4
 ; GFX1013-NEXT:    flat_load_dword v2, v[0:1]
-; GFX1013-NEXT:    v_mov_b32_e32 v0, 0xb36211c6
 ; GFX1013-NEXT:    v_bfrev_b32_e32 v1, 4.0
+; GFX1013-NEXT:    v_mov_b32_e32 v0, 0xb36211c6
 ; GFX1013-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX1013-NEXT:    image_bvh64_intersect_ray v[0:3], v[0:8], s[0:3] a16
 ; GFX1013-NEXT:    s_waitcnt vmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.intersect_ray.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.intersect_ray.ll
@@ -497,10 +497,10 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX1030:       ; %bb.0: ; %main_body
 ; GFX1030-NEXT:    s_load_dwordx8 s[0:7], s[4:5], 0x24
 ; GFX1030-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
-; GFX1030-NEXT:    v_mov_b32_e32 v4, 2.0
-; GFX1030-NEXT:    v_mov_b32_e32 v5, 0x44004200
-; GFX1030-NEXT:    v_mov_b32_e32 v6, 0x46004500
 ; GFX1030-NEXT:    v_mov_b32_e32 v7, 0x48004700
+; GFX1030-NEXT:    v_mov_b32_e32 v6, 0x46004500
+; GFX1030-NEXT:    v_mov_b32_e32 v5, 0x44004200
+; GFX1030-NEXT:    v_mov_b32_e32 v4, 2.0
 ; GFX1030-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1030-NEXT:    v_add_co_u32 v0, s0, s0, v2
 ; GFX1030-NEXT:    v_add_co_ci_u32_e64 v1, null, s1, 0, s0
@@ -810,11 +810,11 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_a16_nsa_reassign(ptr %p_ray
 ; GFX1030-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x34
 ; GFX1030-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX1030-NEXT:    v_mov_b32_e32 v3, 0
+; GFX1030-NEXT:    v_mov_b32_e32 v8, 0x48004700
+; GFX1030-NEXT:    v_mov_b32_e32 v7, 0x46004500
+; GFX1030-NEXT:    v_mov_b32_e32 v6, 0x44004200
 ; GFX1030-NEXT:    v_mov_b32_e32 v5, 2.0
 ; GFX1030-NEXT:    v_mov_b32_e32 v4, 1.0
-; GFX1030-NEXT:    v_mov_b32_e32 v6, 0x44004200
-; GFX1030-NEXT:    v_mov_b32_e32 v7, 0x46004500
-; GFX1030-NEXT:    v_mov_b32_e32 v8, 0x48004700
 ; GFX1030-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1030-NEXT:    v_add_co_u32 v0, s4, s6, v0
 ; GFX1030-NEXT:    v_add_co_ci_u32_e64 v1, null, s7, 0, s4

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.make.buffer.rsrc.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.make.buffer.rsrc.ll
@@ -392,10 +392,11 @@ define amdgpu_ps float @general_case_load_with_waterfall(ptr %p, i16 %stride, i6
   ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 65535
   ; CHECK-NEXT:   [[V_AND_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_AND_OR_B32_e64 [[COPY3]], killed [[S_MOV_B32_]], killed [[V_LSHLREV_B32_e64_]], implicit $exec
   ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE]].sub0
-  ; CHECK-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sgpr_128 = REG_SEQUENCE [[COPY4]], %subreg.sub0, killed [[V_AND_OR_B32_e64_]], %subreg.sub1, killed [[COPY5]], %subreg.sub2, [[COPY]], %subreg.sub3
+  ; CHECK-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_128 = REG_SEQUENCE [[COPY4]], %subreg.sub0, killed [[V_AND_OR_B32_e64_]], %subreg.sub1, killed [[COPY5]], %subreg.sub2, [[COPY]], %subreg.sub3
   ; CHECK-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:vgpr_32 = COPY [[S_MOV_B32_1]]
-  ; CHECK-NEXT:   [[BUFFER_LOAD_DWORD_IDXEN:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_DWORD_IDXEN [[COPY6]], killed [[REG_SEQUENCE1]], [[S_MOV_B32_1]], 0, 0, 0, implicit $exec :: (dereferenceable load (s32) from %ir.rsrc, align 1, addrspace 8)
+  ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:sgpr_128 = COPY [[REG_SEQUENCE1]]
+  ; CHECK-NEXT:   [[BUFFER_LOAD_DWORD_IDXEN:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_DWORD_IDXEN [[COPY6]], killed [[COPY7]], [[S_MOV_B32_1]], 0, 0, 0, implicit $exec :: (dereferenceable load (s32) from %ir.rsrc, align 1, addrspace 8)
   ; CHECK-NEXT:   $vgpr0 = COPY [[BUFFER_LOAD_DWORD_IDXEN]]
   ; CHECK-NEXT:   SI_RETURN_TO_EPILOG $vgpr0
   ;
@@ -413,17 +414,17 @@ define amdgpu_ps float @general_case_load_with_waterfall(ptr %p, i16 %stride, i6
   ; CHECK45-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[COPY2]], %subreg.sub0, [[COPY1]], %subreg.sub1
   ; CHECK45-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 28
   ; CHECK45-NEXT:   [[V_LSHLREV_B32_e64_:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 killed [[S_MOV_B32_]], [[COPY]], implicit $exec
-  ; CHECK45-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; CHECK45-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[S_MOV_B32_1]], %subreg.sub0, killed [[V_LSHLREV_B32_e64_]], %subreg.sub1
+  ; CHECK45-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+  ; CHECK45-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_64_align2 = REG_SEQUENCE [[V_MOV_B32_e32_]], %subreg.sub0, killed [[V_LSHLREV_B32_e64_]], %subreg.sub1
   ; CHECK45-NEXT:   [[COPY6:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE2]].sub1
-  ; CHECK45-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 7
+  ; CHECK45-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 7
   ; CHECK45-NEXT:   [[COPY7:%[0-9]+]]:vreg_64_align2 = COPY [[REG_SEQUENCE1]]
-  ; CHECK45-NEXT:   [[V_LSHRREV_B64_e64_:%[0-9]+]]:vreg_64_align2 = V_LSHRREV_B64_e64 killed [[S_MOV_B32_2]], [[COPY7]], implicit $exec
+  ; CHECK45-NEXT:   [[V_LSHRREV_B64_e64_:%[0-9]+]]:vreg_64_align2 = V_LSHRREV_B64_e64 killed [[S_MOV_B32_1]], [[COPY7]], implicit $exec
   ; CHECK45-NEXT:   [[COPY8:%[0-9]+]]:vgpr_32 = COPY [[V_LSHRREV_B64_e64_]].sub1
   ; CHECK45-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY [[COPY3]]
-  ; CHECK45-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 12
-  ; CHECK45-NEXT:   [[V_LSHLREV_B32_e64_1:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 killed [[S_MOV_B32_3]], killed [[COPY9]], implicit $exec
-  ; CHECK45-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[S_MOV_B32_1]], %subreg.sub0, killed [[V_LSHLREV_B32_e64_1]], %subreg.sub1
+  ; CHECK45-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 12
+  ; CHECK45-NEXT:   [[V_LSHLREV_B32_e64_1:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 killed [[S_MOV_B32_2]], killed [[COPY9]], implicit $exec
+  ; CHECK45-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:vreg_64_align2 = REG_SEQUENCE [[V_MOV_B32_e32_]], %subreg.sub0, killed [[V_LSHLREV_B32_e64_1]], %subreg.sub1
   ; CHECK45-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE3]].sub1
   ; CHECK45-NEXT:   [[V_OR3_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR3_B32_e64 killed [[COPY8]], killed [[COPY10]], killed [[COPY6]], implicit $exec
   ; CHECK45-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE2]].sub0
@@ -435,9 +436,9 @@ define amdgpu_ps float @general_case_load_with_waterfall(ptr %p, i16 %stride, i6
   ; CHECK45-NEXT:   [[COPY15:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE4]].sub0
   ; CHECK45-NEXT:   [[COPY16:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE]].sub1
   ; CHECK45-NEXT:   [[COPY17:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE1]].sub0
-  ; CHECK45-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 25
-  ; CHECK45-NEXT:   [[V_LSHLREV_B32_e64_2:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 killed [[S_MOV_B32_4]], killed [[COPY17]], implicit $exec
-  ; CHECK45-NEXT:   [[REG_SEQUENCE5:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[S_MOV_B32_1]], %subreg.sub0, killed [[V_LSHLREV_B32_e64_2]], %subreg.sub1
+  ; CHECK45-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 25
+  ; CHECK45-NEXT:   [[V_LSHLREV_B32_e64_2:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 killed [[S_MOV_B32_3]], killed [[COPY17]], implicit $exec
+  ; CHECK45-NEXT:   [[REG_SEQUENCE5:%[0-9]+]]:vreg_64_align2 = REG_SEQUENCE [[V_MOV_B32_e32_]], %subreg.sub0, killed [[V_LSHLREV_B32_e64_2]], %subreg.sub1
   ; CHECK45-NEXT:   [[COPY18:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE5]].sub1
   ; CHECK45-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 killed [[COPY16]], killed [[COPY18]], implicit $exec
   ; CHECK45-NEXT:   [[COPY19:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE]].sub0
@@ -446,9 +447,9 @@ define amdgpu_ps float @general_case_load_with_waterfall(ptr %p, i16 %stride, i6
   ; CHECK45-NEXT:   [[REG_SEQUENCE6:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_OR_B32_e64_1]], %subreg.sub0, killed [[V_OR_B32_e64_]], %subreg.sub1
   ; CHECK45-NEXT:   [[COPY21:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE6]].sub1
   ; CHECK45-NEXT:   [[COPY22:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE6]].sub0
-  ; CHECK45-NEXT:   [[REG_SEQUENCE7:%[0-9]+]]:sgpr_128 = REG_SEQUENCE killed [[COPY22]], %subreg.sub0, killed [[COPY21]], %subreg.sub1, killed [[COPY15]], %subreg.sub2, killed [[COPY14]], %subreg.sub3
-  ; CHECK45-NEXT:   [[COPY23:%[0-9]+]]:vgpr_32 = COPY [[S_MOV_B32_1]]
-  ; CHECK45-NEXT:   [[BUFFER_LOAD_DWORD_VBUFFER_IDXEN:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_DWORD_VBUFFER_IDXEN [[COPY23]], killed [[REG_SEQUENCE7]], $sgpr_null, 0, 0, 0, implicit $exec :: (dereferenceable load (s32) from %ir.rsrc, align 1, addrspace 8)
+  ; CHECK45-NEXT:   [[REG_SEQUENCE7:%[0-9]+]]:vreg_128_align2 = REG_SEQUENCE killed [[COPY22]], %subreg.sub0, killed [[COPY21]], %subreg.sub1, killed [[COPY15]], %subreg.sub2, killed [[COPY14]], %subreg.sub3
+  ; CHECK45-NEXT:   [[COPY23:%[0-9]+]]:sgpr_128 = COPY [[REG_SEQUENCE7]]
+  ; CHECK45-NEXT:   [[BUFFER_LOAD_DWORD_VBUFFER_IDXEN:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_DWORD_VBUFFER_IDXEN [[V_MOV_B32_e32_]], killed [[COPY23]], $sgpr_null, 0, 0, 0, implicit $exec :: (dereferenceable load (s32) from %ir.rsrc, align 1, addrspace 8)
   ; CHECK45-NEXT:   $vgpr0 = COPY [[BUFFER_LOAD_DWORD_VBUFFER_IDXEN]]
   ; CHECK45-NEXT:   SI_RETURN_TO_EPILOG $vgpr0
   %rsrc = call ptr addrspace(8) @llvm.amdgcn.make.buffer.rsrc.p8.p0(ptr %p, i16 %stride, i64 %numVals, i32 %flags)

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sched.group.barrier.iterative.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sched.group.barrier.iterative.ll
@@ -26,6 +26,7 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave(ptr
 ; GCN-MINREG-NEXT:    v_add_u32_e32 v5, s1, v0
 ; GCN-MINREG-NEXT:    v_mov_b32_e32 v0, s1
 ; GCN-MINREG-NEXT:    v_add_u32_e32 v3, 0x6000, v4
+; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    s_nop 15
 ; GCN-MINREG-NEXT:    ds_write_b128 v5, a[28:31] offset:112
@@ -47,6 +48,7 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave(ptr
 ; GCN-MINREG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-MINREG-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v2, v1, a[0:31]
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000200) size(8) SyncID(0)
+; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    s_nop 15
 ; GCN-MINREG-NEXT:    s_nop 2
@@ -69,6 +71,7 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave(ptr
 ; GCN-MINREG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-MINREG-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v2, v1, a[0:31]
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000200) size(8) SyncID(0)
+; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    s_nop 15
 ; GCN-MINREG-NEXT:    s_nop 2
@@ -91,6 +94,7 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave(ptr
 ; GCN-MINREG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-MINREG-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v2, v1, a[0:31]
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000200) size(8) SyncID(0)
+; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    s_nop 15
 ; GCN-MINREG-NEXT:    s_nop 2
@@ -113,6 +117,7 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave(ptr
 ; GCN-MINREG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-MINREG-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v2, v1, a[0:31]
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000200) size(8) SyncID(0)
+; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    s_nop 15
 ; GCN-MINREG-NEXT:    s_nop 2
@@ -125,11 +130,6 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave(ptr
 ; GCN-MINREG-NEXT:    ds_write_b128 v0, a[0:3] offset:32768
 ; GCN-MINREG-NEXT:    ds_write_b128 v0, a[4:7] offset:32784
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000200) size(8) SyncID(0)
-; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
-; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
-; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
-; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
-; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    s_endpgm
 ;
 ; GCN-MAXOCC-LABEL: test_sched_group_barrier_pipeline_MFMA_interleave:
@@ -495,8 +495,8 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave_spl
 ; GCN-MINREG-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v1, v0, a[0:31]
 ; GCN-MINREG-NEXT:    v_mov_b32_e32 v2, s1
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000200) size(8) SyncID(0)
-; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
+; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    s_nop 15
 ; GCN-MINREG-NEXT:    s_nop 1
 ; GCN-MINREG-NEXT:    ds_write_b128 v2, a[24:27] offset:8288
@@ -520,6 +520,7 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave_spl
 ; GCN-MINREG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-MINREG-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v1, v0, a[0:31]
 ; GCN-MINREG-NEXT:    v_add_u32_e32 v4, 0x6000, v3
+; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    s_nop 15
 ; GCN-MINREG-NEXT:    s_nop 1
@@ -542,6 +543,7 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave_spl
 ; GCN-MINREG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-MINREG-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v1, v0, a[0:31]
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000200) size(8) SyncID(0)
+; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    s_nop 15
 ; GCN-MINREG-NEXT:    s_nop 2
@@ -564,6 +566,7 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave_spl
 ; GCN-MINREG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-MINREG-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v1, v0, a[0:31]
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000200) size(8) SyncID(0)
+; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-MINREG-NEXT:    s_nop 15
 ; GCN-MINREG-NEXT:    s_nop 2
@@ -576,9 +579,6 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_interleave_spl
 ; GCN-MINREG-NEXT:    ds_write_b128 v2, a[4:7] offset:32784
 ; GCN-MINREG-NEXT:    ds_write_b128 v2, a[0:3] offset:32768
 ; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000200) size(8) SyncID(0)
-; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
-; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
-; GCN-MINREG-NEXT:    ; sched_group_barrier mask(0x00000100) size(8) SyncID(0)
 ; GCN-MINREG-NEXT:    s_endpgm
 ;
 ; GCN-MAXOCC-LABEL: test_sched_group_barrier_pipeline_MFMA_interleave_split_region:

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sched.group.barrier.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sched.group.barrier.ll
@@ -627,23 +627,23 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_cluster(ptr ad
 ; GCN-NEXT:    v_mov_b32_e32 v1, 2.0
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    v_add_u32_e32 v3, s0, v0
-; GCN-NEXT:    ds_read_b128 a[156:159], v3 offset:112
-; GCN-NEXT:    ds_read_b128 a[152:155], v3 offset:96
-; GCN-NEXT:    ds_read_b128 a[148:151], v3 offset:80
-; GCN-NEXT:    ds_read_b128 a[144:147], v3 offset:64
-; GCN-NEXT:    ds_read_b128 a[128:131], v3
-; GCN-NEXT:    ds_read_b128 a[132:135], v3 offset:16
-; GCN-NEXT:    ds_read_b128 a[136:139], v3 offset:32
-; GCN-NEXT:    ds_read_b128 a[140:143], v3 offset:48
+; GCN-NEXT:    ds_read_b128 a[60:63], v3 offset:112
+; GCN-NEXT:    ds_read_b128 a[56:59], v3 offset:96
+; GCN-NEXT:    ds_read_b128 a[52:55], v3 offset:80
+; GCN-NEXT:    ds_read_b128 a[48:51], v3 offset:64
+; GCN-NEXT:    ds_read_b128 a[32:35], v3
+; GCN-NEXT:    ds_read_b128 a[36:39], v3 offset:16
+; GCN-NEXT:    ds_read_b128 a[40:43], v3 offset:32
+; GCN-NEXT:    ds_read_b128 a[44:47], v3 offset:48
 ; GCN-NEXT:    v_add_u32_e32 v4, 0x6000, v3
-; GCN-NEXT:    ds_read_b128 a[124:127], v3 offset:8304
-; GCN-NEXT:    ds_read_b128 a[120:123], v3 offset:8288
-; GCN-NEXT:    ds_read_b128 a[116:119], v3 offset:8272
-; GCN-NEXT:    ds_read_b128 a[112:115], v3 offset:8256
-; GCN-NEXT:    ds_read_b128 a[108:111], v3 offset:8240
-; GCN-NEXT:    ds_read_b128 a[104:107], v3 offset:8224
-; GCN-NEXT:    ds_read_b128 a[100:103], v3 offset:8208
-; GCN-NEXT:    ds_read_b128 a[96:99], v3 offset:8192
+; GCN-NEXT:    ds_read_b128 a[28:31], v3 offset:8304
+; GCN-NEXT:    ds_read_b128 a[24:27], v3 offset:8288
+; GCN-NEXT:    ds_read_b128 a[20:23], v3 offset:8272
+; GCN-NEXT:    ds_read_b128 a[16:19], v3 offset:8256
+; GCN-NEXT:    ds_read_b128 a[12:15], v3 offset:8240
+; GCN-NEXT:    ds_read_b128 a[8:11], v3 offset:8224
+; GCN-NEXT:    ds_read_b128 a[4:7], v3 offset:8208
+; GCN-NEXT:    ds_read_b128 a[0:3], v3 offset:8192
 ; GCN-NEXT:    ds_read_b128 a[92:95], v3 offset:24688
 ; GCN-NEXT:    ds_read_b128 a[88:91], v3 offset:24672
 ; GCN-NEXT:    ds_read_b128 a[84:87], v3 offset:24656
@@ -652,50 +652,50 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_cluster(ptr ad
 ; GCN-NEXT:    ds_read_b128 a[72:75], v3 offset:24608
 ; GCN-NEXT:    ds_read_b128 a[68:71], v3 offset:24592
 ; GCN-NEXT:    ds_read_b128 a[64:67], v3 offset:24576
-; GCN-NEXT:    ds_read_b128 a[60:63], v3 offset:49264
-; GCN-NEXT:    ds_read_b128 a[56:59], v3 offset:49248
-; GCN-NEXT:    ds_read_b128 a[52:55], v3 offset:49232
-; GCN-NEXT:    ds_read_b128 a[48:51], v3 offset:49216
-; GCN-NEXT:    ds_read_b128 a[44:47], v3 offset:49200
-; GCN-NEXT:    ds_read_b128 a[40:43], v3 offset:49184
-; GCN-NEXT:    ds_read_b128 a[36:39], v3 offset:49168
-; GCN-NEXT:    ds_read_b128 a[32:35], v3 offset:49152
-; GCN-NEXT:    ds_read_b128 a[28:31], v4 offset:57456
-; GCN-NEXT:    ds_read_b128 a[24:27], v4 offset:57440
-; GCN-NEXT:    ds_read_b128 a[20:23], v4 offset:57424
-; GCN-NEXT:    ds_read_b128 a[16:19], v4 offset:57408
-; GCN-NEXT:    ds_read_b128 a[0:3], v4 offset:57344
-; GCN-NEXT:    ds_read_b128 a[4:7], v4 offset:57360
-; GCN-NEXT:    ds_read_b128 a[8:11], v4 offset:57376
-; GCN-NEXT:    ds_read_b128 a[12:15], v4 offset:57392
+; GCN-NEXT:    ds_read_b128 a[124:127], v3 offset:49264
+; GCN-NEXT:    ds_read_b128 a[120:123], v3 offset:49248
+; GCN-NEXT:    ds_read_b128 a[116:119], v3 offset:49232
+; GCN-NEXT:    ds_read_b128 a[112:115], v3 offset:49216
+; GCN-NEXT:    ds_read_b128 a[108:111], v3 offset:49200
+; GCN-NEXT:    ds_read_b128 a[104:107], v3 offset:49184
+; GCN-NEXT:    ds_read_b128 a[100:103], v3 offset:49168
+; GCN-NEXT:    ds_read_b128 a[96:99], v3 offset:49152
+; GCN-NEXT:    ds_read_b128 a[156:159], v4 offset:57456
+; GCN-NEXT:    ds_read_b128 a[152:155], v4 offset:57440
+; GCN-NEXT:    ds_read_b128 a[148:151], v4 offset:57424
+; GCN-NEXT:    ds_read_b128 a[144:147], v4 offset:57408
+; GCN-NEXT:    ds_read_b128 a[128:131], v4 offset:57344
+; GCN-NEXT:    ds_read_b128 a[132:135], v4 offset:57360
+; GCN-NEXT:    ds_read_b128 a[136:139], v4 offset:57376
+; GCN-NEXT:    ds_read_b128 a[140:143], v4 offset:57392
 ; GCN-NEXT:    s_waitcnt lgkmcnt(14)
-; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v2, v1, a[128:159]
+; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v2, v1, a[32:63]
 ; GCN-NEXT:    v_add_u32_e32 v0, s1, v0
 ; GCN-NEXT:    ; sched_group_barrier mask(0x00000100) size(40) SyncID(0)
+; GCN-NEXT:    s_waitcnt lgkmcnt(8)
 ; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[96:127], v2, v1, a[96:127]
 ; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[64:95], v2, v1, a[64:95]
-; GCN-NEXT:    s_waitcnt lgkmcnt(8)
-; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v2, v1, a[32:63]
-; GCN-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v2, v1, a[0:31]
+; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v2, v1, a[128:159]
 ; GCN-NEXT:    s_nop 11
-; GCN-NEXT:    ds_write_b128 v0, a[156:159] offset:112
-; GCN-NEXT:    ds_write_b128 v0, a[152:155] offset:96
-; GCN-NEXT:    ds_write_b128 v0, a[148:151] offset:80
-; GCN-NEXT:    ds_write_b128 v0, a[144:147] offset:64
-; GCN-NEXT:    ds_write_b128 v0, a[140:143] offset:48
-; GCN-NEXT:    ds_write_b128 v0, a[136:139] offset:32
-; GCN-NEXT:    ds_write_b128 v0, a[132:135] offset:16
-; GCN-NEXT:    ds_write_b128 v0, a[128:131]
+; GCN-NEXT:    ds_write_b128 v0, a[60:63] offset:112
+; GCN-NEXT:    ds_write_b128 v0, a[56:59] offset:96
+; GCN-NEXT:    ds_write_b128 v0, a[52:55] offset:80
+; GCN-NEXT:    ds_write_b128 v0, a[48:51] offset:64
+; GCN-NEXT:    ds_write_b128 v0, a[44:47] offset:48
+; GCN-NEXT:    ds_write_b128 v0, a[40:43] offset:32
+; GCN-NEXT:    ds_write_b128 v0, a[36:39] offset:16
+; GCN-NEXT:    ds_write_b128 v0, a[32:35]
 ; GCN-NEXT:    v_mov_b32_e32 v0, s1
-; GCN-NEXT:    ds_write_b128 v0, a[120:123] offset:8288
-; GCN-NEXT:    ds_write_b128 v0, a[124:127] offset:8304
-; GCN-NEXT:    ds_write_b128 v0, a[112:115] offset:8256
-; GCN-NEXT:    ds_write_b128 v0, a[116:119] offset:8272
-; GCN-NEXT:    ds_write_b128 v0, a[104:107] offset:8224
-; GCN-NEXT:    ds_write_b128 v0, a[108:111] offset:8240
-; GCN-NEXT:    ds_write_b128 v0, a[96:99] offset:8192
-; GCN-NEXT:    ds_write_b128 v0, a[100:103] offset:8208
+; GCN-NEXT:    ds_write_b128 v0, a[24:27] offset:8288
+; GCN-NEXT:    ds_write_b128 v0, a[28:31] offset:8304
+; GCN-NEXT:    ds_write_b128 v0, a[16:19] offset:8256
+; GCN-NEXT:    ds_write_b128 v0, a[20:23] offset:8272
+; GCN-NEXT:    ds_write_b128 v0, a[8:11] offset:8224
+; GCN-NEXT:    ds_write_b128 v0, a[12:15] offset:8240
+; GCN-NEXT:    ds_write_b128 v0, a[0:3] offset:8192
+; GCN-NEXT:    ds_write_b128 v0, a[4:7] offset:8208
 ; GCN-NEXT:    ds_write_b128 v0, a[88:91] offset:16480
 ; GCN-NEXT:    ds_write_b128 v0, a[92:95] offset:16496
 ; GCN-NEXT:    ds_write_b128 v0, a[80:83] offset:16448
@@ -704,22 +704,22 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_cluster(ptr ad
 ; GCN-NEXT:    ds_write_b128 v0, a[76:79] offset:16432
 ; GCN-NEXT:    ds_write_b128 v0, a[64:67] offset:16384
 ; GCN-NEXT:    ds_write_b128 v0, a[68:71] offset:16400
-; GCN-NEXT:    ds_write_b128 v0, a[56:59] offset:24672
-; GCN-NEXT:    ds_write_b128 v0, a[60:63] offset:24688
-; GCN-NEXT:    ds_write_b128 v0, a[48:51] offset:24640
-; GCN-NEXT:    ds_write_b128 v0, a[52:55] offset:24656
-; GCN-NEXT:    ds_write_b128 v0, a[40:43] offset:24608
-; GCN-NEXT:    ds_write_b128 v0, a[44:47] offset:24624
-; GCN-NEXT:    ds_write_b128 v0, a[32:35] offset:24576
-; GCN-NEXT:    ds_write_b128 v0, a[36:39] offset:24592
-; GCN-NEXT:    ds_write_b128 v0, a[24:27] offset:32864
-; GCN-NEXT:    ds_write_b128 v0, a[28:31] offset:32880
-; GCN-NEXT:    ds_write_b128 v0, a[16:19] offset:32832
-; GCN-NEXT:    ds_write_b128 v0, a[20:23] offset:32848
-; GCN-NEXT:    ds_write_b128 v0, a[8:11] offset:32800
-; GCN-NEXT:    ds_write_b128 v0, a[12:15] offset:32816
-; GCN-NEXT:    ds_write_b128 v0, a[0:3] offset:32768
-; GCN-NEXT:    ds_write_b128 v0, a[4:7] offset:32784
+; GCN-NEXT:    ds_write_b128 v0, a[120:123] offset:24672
+; GCN-NEXT:    ds_write_b128 v0, a[124:127] offset:24688
+; GCN-NEXT:    ds_write_b128 v0, a[112:115] offset:24640
+; GCN-NEXT:    ds_write_b128 v0, a[116:119] offset:24656
+; GCN-NEXT:    ds_write_b128 v0, a[104:107] offset:24608
+; GCN-NEXT:    ds_write_b128 v0, a[108:111] offset:24624
+; GCN-NEXT:    ds_write_b128 v0, a[96:99] offset:24576
+; GCN-NEXT:    ds_write_b128 v0, a[100:103] offset:24592
+; GCN-NEXT:    ds_write_b128 v0, a[152:155] offset:32864
+; GCN-NEXT:    ds_write_b128 v0, a[156:159] offset:32880
+; GCN-NEXT:    ds_write_b128 v0, a[144:147] offset:32832
+; GCN-NEXT:    ds_write_b128 v0, a[148:151] offset:32848
+; GCN-NEXT:    ds_write_b128 v0, a[136:139] offset:32800
+; GCN-NEXT:    ds_write_b128 v0, a[140:143] offset:32816
+; GCN-NEXT:    ds_write_b128 v0, a[128:131] offset:32768
+; GCN-NEXT:    ds_write_b128 v0, a[132:135] offset:32784
 ; GCN-NEXT:    ; sched_group_barrier mask(0x00000008) size(5) SyncID(0)
 ; GCN-NEXT:    ; sched_group_barrier mask(0x00000200) size(40) SyncID(0)
 ; GCN-NEXT:    s_endpgm
@@ -733,23 +733,23 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_cluster(ptr ad
 ; EXACTCUTOFF-NEXT:    v_mov_b32_e32 v1, 2.0
 ; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(0)
 ; EXACTCUTOFF-NEXT:    v_add_u32_e32 v3, s0, v0
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[156:159], v3 offset:112
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[152:155], v3 offset:96
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[148:151], v3 offset:80
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[144:147], v3 offset:64
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[128:131], v3
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[132:135], v3 offset:16
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[136:139], v3 offset:32
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[140:143], v3 offset:48
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[60:63], v3 offset:112
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[56:59], v3 offset:96
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[52:55], v3 offset:80
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[48:51], v3 offset:64
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[32:35], v3
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[36:39], v3 offset:16
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[40:43], v3 offset:32
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[44:47], v3 offset:48
 ; EXACTCUTOFF-NEXT:    v_add_u32_e32 v4, 0x6000, v3
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[124:127], v3 offset:8304
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[120:123], v3 offset:8288
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[116:119], v3 offset:8272
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[112:115], v3 offset:8256
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[108:111], v3 offset:8240
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[104:107], v3 offset:8224
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[100:103], v3 offset:8208
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[96:99], v3 offset:8192
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[28:31], v3 offset:8304
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[24:27], v3 offset:8288
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[20:23], v3 offset:8272
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[16:19], v3 offset:8256
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[12:15], v3 offset:8240
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[8:11], v3 offset:8224
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[4:7], v3 offset:8208
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[0:3], v3 offset:8192
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[92:95], v3 offset:24688
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[88:91], v3 offset:24672
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[84:87], v3 offset:24656
@@ -758,50 +758,50 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_cluster(ptr ad
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[72:75], v3 offset:24608
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[68:71], v3 offset:24592
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[64:67], v3 offset:24576
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[60:63], v3 offset:49264
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[56:59], v3 offset:49248
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[52:55], v3 offset:49232
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[48:51], v3 offset:49216
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[44:47], v3 offset:49200
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[40:43], v3 offset:49184
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[36:39], v3 offset:49168
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[32:35], v3 offset:49152
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[28:31], v4 offset:57456
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[24:27], v4 offset:57440
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[20:23], v4 offset:57424
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[16:19], v4 offset:57408
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[0:3], v4 offset:57344
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[4:7], v4 offset:57360
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[8:11], v4 offset:57376
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[12:15], v4 offset:57392
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[124:127], v3 offset:49264
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[120:123], v3 offset:49248
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[116:119], v3 offset:49232
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[112:115], v3 offset:49216
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[108:111], v3 offset:49200
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[104:107], v3 offset:49184
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[100:103], v3 offset:49168
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[96:99], v3 offset:49152
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[156:159], v4 offset:57456
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[152:155], v4 offset:57440
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[148:151], v4 offset:57424
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[144:147], v4 offset:57408
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[128:131], v4 offset:57344
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[132:135], v4 offset:57360
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[136:139], v4 offset:57376
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[140:143], v4 offset:57392
 ; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(14)
-; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v2, v1, a[128:159]
+; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v2, v1, a[32:63]
 ; EXACTCUTOFF-NEXT:    v_add_u32_e32 v0, s1, v0
 ; EXACTCUTOFF-NEXT:    ; sched_group_barrier mask(0x00000100) size(40) SyncID(0)
+; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(8)
 ; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[96:127], v2, v1, a[96:127]
 ; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[64:95], v2, v1, a[64:95]
-; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(8)
-; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v2, v1, a[32:63]
-; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(0)
 ; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v2, v1, a[0:31]
+; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(0)
+; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v2, v1, a[128:159]
 ; EXACTCUTOFF-NEXT:    s_nop 11
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[156:159] offset:112
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[152:155] offset:96
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[148:151] offset:80
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[144:147] offset:64
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[140:143] offset:48
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[136:139] offset:32
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[132:135] offset:16
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[128:131]
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[60:63] offset:112
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[56:59] offset:96
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[52:55] offset:80
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[48:51] offset:64
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[44:47] offset:48
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[40:43] offset:32
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[36:39] offset:16
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[32:35]
 ; EXACTCUTOFF-NEXT:    v_mov_b32_e32 v0, s1
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[120:123] offset:8288
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[124:127] offset:8304
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[112:115] offset:8256
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[116:119] offset:8272
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[104:107] offset:8224
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[108:111] offset:8240
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[96:99] offset:8192
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[100:103] offset:8208
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[24:27] offset:8288
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[28:31] offset:8304
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[16:19] offset:8256
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[20:23] offset:8272
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[8:11] offset:8224
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[12:15] offset:8240
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[0:3] offset:8192
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[4:7] offset:8208
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[88:91] offset:16480
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[92:95] offset:16496
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[80:83] offset:16448
@@ -810,22 +810,22 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_MFMA_cluster(ptr ad
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[76:79] offset:16432
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[64:67] offset:16384
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[68:71] offset:16400
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[56:59] offset:24672
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[60:63] offset:24688
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[48:51] offset:24640
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[52:55] offset:24656
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[40:43] offset:24608
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[44:47] offset:24624
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[32:35] offset:24576
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[36:39] offset:24592
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[24:27] offset:32864
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[28:31] offset:32880
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[16:19] offset:32832
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[20:23] offset:32848
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[8:11] offset:32800
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[12:15] offset:32816
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[0:3] offset:32768
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[4:7] offset:32784
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[120:123] offset:24672
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[124:127] offset:24688
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[112:115] offset:24640
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[116:119] offset:24656
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[104:107] offset:24608
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[108:111] offset:24624
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[96:99] offset:24576
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[100:103] offset:24592
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[152:155] offset:32864
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[156:159] offset:32880
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[144:147] offset:32832
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[148:151] offset:32848
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[136:139] offset:32800
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[140:143] offset:32816
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[128:131] offset:32768
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[132:135] offset:32784
 ; EXACTCUTOFF-NEXT:    ; sched_group_barrier mask(0x00000008) size(5) SyncID(0)
 ; EXACTCUTOFF-NEXT:    ; sched_group_barrier mask(0x00000200) size(40) SyncID(0)
 ; EXACTCUTOFF-NEXT:    s_endpgm
@@ -1202,57 +1202,57 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_interleave_EXP_MFMA
 ; GCN-NEXT:    v_cvt_i32_f32_e32 v5, v5
 ; GCN-NEXT:    v_and_b32_e32 v0, 0x1ff80, v0
 ; GCN-NEXT:    v_add_u32_e32 v1, s6, v0
-; GCN-NEXT:    ds_read_b128 a[156:159], v1 offset:112
-; GCN-NEXT:    ds_read_b128 a[152:155], v1 offset:96
-; GCN-NEXT:    ds_read_b128 a[148:151], v1 offset:80
-; GCN-NEXT:    ds_read_b128 a[144:147], v1 offset:64
-; GCN-NEXT:    ds_read_b128 a[128:131], v1
-; GCN-NEXT:    ds_read_b128 a[132:135], v1 offset:16
-; GCN-NEXT:    ds_read_b128 a[136:139], v1 offset:32
-; GCN-NEXT:    ds_read_b128 a[140:143], v1 offset:48
-; GCN-NEXT:    v_mul_f32_e32 v9, s1, v3
-; GCN-NEXT:    v_mov_b32_e32 v12, 1.0
+; GCN-NEXT:    ds_read_b128 a[60:63], v1 offset:112
+; GCN-NEXT:    ds_read_b128 a[56:59], v1 offset:96
+; GCN-NEXT:    ds_read_b128 a[52:55], v1 offset:80
+; GCN-NEXT:    ds_read_b128 a[48:51], v1 offset:64
+; GCN-NEXT:    ds_read_b128 a[32:35], v1
+; GCN-NEXT:    ds_read_b128 a[36:39], v1 offset:16
+; GCN-NEXT:    ds_read_b128 a[40:43], v1 offset:32
+; GCN-NEXT:    ds_read_b128 a[44:47], v1 offset:48
+; GCN-NEXT:    v_mov_b32_e32 v9, 1.0
 ; GCN-NEXT:    v_ldexp_f32 v4, v4, v5
 ; GCN-NEXT:    v_mov_b32_e32 v5, 0xc2ce8ed0
-; GCN-NEXT:    v_rndne_f32_e32 v10, v9
+; GCN-NEXT:    v_mul_f32_e32 v10, s1, v3
 ; GCN-NEXT:    v_cmp_nlt_f32_e32 vcc, s0, v5
 ; GCN-NEXT:    v_mov_b32_e32 v6, 0x42b17218
-; GCN-NEXT:    v_sub_f32_e32 v11, v9, v10
-; GCN-NEXT:    v_fma_f32 v9, s1, v3, -v9
+; GCN-NEXT:    v_rndne_f32_e32 v11, v10
 ; GCN-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
 ; GCN-NEXT:    v_cmp_ngt_f32_e32 vcc, s0, v6
 ; GCN-NEXT:    v_mov_b32_e32 v8, 0x7f800000
-; GCN-NEXT:    v_fmac_f32_e32 v9, s1, v7
+; GCN-NEXT:    v_sub_f32_e32 v12, v10, v11
+; GCN-NEXT:    v_fma_f32 v10, s1, v3, -v10
 ; GCN-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GCN-NEXT:    v_add_f32_e32 v9, v11, v9
-; GCN-NEXT:    ds_read_b128 a[124:127], v1 offset:8304
+; GCN-NEXT:    v_fmac_f32_e32 v10, s1, v7
+; GCN-NEXT:    ds_read_b128 a[28:31], v1 offset:8304
 ; GCN-NEXT:    s_waitcnt lgkmcnt(1)
-; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v12, v4, a[128:159]
-; GCN-NEXT:    v_exp_f32_e32 v4, v9
-; GCN-NEXT:    v_cvt_i32_f32_e32 v9, v10
-; GCN-NEXT:    ds_read_b128 a[120:123], v1 offset:8288
-; GCN-NEXT:    ds_read_b128 a[116:119], v1 offset:8272
-; GCN-NEXT:    ds_read_b128 a[112:115], v1 offset:8256
-; GCN-NEXT:    ds_read_b128 a[108:111], v1 offset:8240
-; GCN-NEXT:    ds_read_b128 a[104:107], v1 offset:8224
-; GCN-NEXT:    ds_read_b128 a[100:103], v1 offset:8208
-; GCN-NEXT:    ds_read_b128 a[96:99], v1 offset:8192
-; GCN-NEXT:    v_ldexp_f32 v4, v4, v9
-; GCN-NEXT:    v_mul_f32_e32 v9, s2, v3
-; GCN-NEXT:    v_rndne_f32_e32 v10, v9
+; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v9, v4, a[32:63]
+; GCN-NEXT:    v_add_f32_e32 v4, v12, v10
+; GCN-NEXT:    v_exp_f32_e32 v4, v4
+; GCN-NEXT:    v_cvt_i32_f32_e32 v10, v11
+; GCN-NEXT:    ds_read_b128 a[24:27], v1 offset:8288
+; GCN-NEXT:    ds_read_b128 a[20:23], v1 offset:8272
+; GCN-NEXT:    ds_read_b128 a[16:19], v1 offset:8256
+; GCN-NEXT:    ds_read_b128 a[12:15], v1 offset:8240
+; GCN-NEXT:    ds_read_b128 a[8:11], v1 offset:8224
+; GCN-NEXT:    ds_read_b128 a[4:7], v1 offset:8208
+; GCN-NEXT:    ds_read_b128 a[0:3], v1 offset:8192
+; GCN-NEXT:    v_ldexp_f32 v4, v4, v10
 ; GCN-NEXT:    v_cmp_nlt_f32_e32 vcc, s1, v5
-; GCN-NEXT:    v_sub_f32_e32 v11, v9, v10
-; GCN-NEXT:    v_fma_f32 v9, s2, v3, -v9
 ; GCN-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
 ; GCN-NEXT:    v_cmp_ngt_f32_e32 vcc, s1, v6
-; GCN-NEXT:    v_fmac_f32_e32 v9, s2, v7
 ; GCN-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GCN-NEXT:    v_add_f32_e32 v9, v11, v9
+; GCN-NEXT:    v_mul_f32_e32 v10, s2, v3
+; GCN-NEXT:    v_rndne_f32_e32 v11, v10
+; GCN-NEXT:    s_waitcnt lgkmcnt(0)
+; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v9, v4, a[0:31]
+; GCN-NEXT:    v_fma_f32 v4, s2, v3, -v10
+; GCN-NEXT:    v_sub_f32_e32 v12, v10, v11
+; GCN-NEXT:    v_fmac_f32_e32 v4, s2, v7
+; GCN-NEXT:    v_add_f32_e32 v4, v12, v4
+; GCN-NEXT:    v_exp_f32_e32 v4, v4
+; GCN-NEXT:    v_cvt_i32_f32_e32 v10, v11
 ; GCN-NEXT:    ds_read_b128 a[92:95], v1 offset:24688
-; GCN-NEXT:    s_waitcnt lgkmcnt(1)
-; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[96:127], v12, v4, a[96:127]
-; GCN-NEXT:    v_exp_f32_e32 v4, v9
-; GCN-NEXT:    v_cvt_i32_f32_e32 v9, v10
 ; GCN-NEXT:    ds_read_b128 a[88:91], v1 offset:24672
 ; GCN-NEXT:    ds_read_b128 a[84:87], v1 offset:24656
 ; GCN-NEXT:    ds_read_b128 a[80:83], v1 offset:24640
@@ -1261,68 +1261,68 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_interleave_EXP_MFMA
 ; GCN-NEXT:    ds_read_b128 a[68:71], v1 offset:24592
 ; GCN-NEXT:    ds_read_b128 a[64:67], v1 offset:24576
 ; GCN-NEXT:    v_add_u32_e32 v2, 0x6000, v1
-; GCN-NEXT:    ds_read_b128 a[60:63], v1 offset:49264
-; GCN-NEXT:    ds_read_b128 a[56:59], v1 offset:49248
-; GCN-NEXT:    ds_read_b128 a[52:55], v1 offset:49232
-; GCN-NEXT:    ds_read_b128 a[48:51], v1 offset:49216
-; GCN-NEXT:    ds_read_b128 a[44:47], v1 offset:49200
-; GCN-NEXT:    ds_read_b128 a[40:43], v1 offset:49184
-; GCN-NEXT:    ds_read_b128 a[36:39], v1 offset:49168
-; GCN-NEXT:    ds_read_b128 a[32:35], v1 offset:49152
-; GCN-NEXT:    v_ldexp_f32 v1, v4, v9
-; GCN-NEXT:    v_mul_f32_e32 v4, s3, v3
+; GCN-NEXT:    ds_read_b128 a[124:127], v1 offset:49264
+; GCN-NEXT:    ds_read_b128 a[120:123], v1 offset:49248
+; GCN-NEXT:    ds_read_b128 a[116:119], v1 offset:49232
+; GCN-NEXT:    ds_read_b128 a[112:115], v1 offset:49216
+; GCN-NEXT:    ds_read_b128 a[108:111], v1 offset:49200
+; GCN-NEXT:    ds_read_b128 a[104:107], v1 offset:49184
+; GCN-NEXT:    ds_read_b128 a[100:103], v1 offset:49168
+; GCN-NEXT:    ds_read_b128 a[96:99], v1 offset:49152
+; GCN-NEXT:    v_ldexp_f32 v1, v4, v10
 ; GCN-NEXT:    v_cmp_nlt_f32_e32 vcc, s2, v5
-; GCN-NEXT:    v_rndne_f32_e32 v9, v4
 ; GCN-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
 ; GCN-NEXT:    v_cmp_ngt_f32_e32 vcc, s2, v6
-; GCN-NEXT:    v_sub_f32_e32 v10, v4, v9
-; GCN-NEXT:    v_fma_f32 v4, s3, v3, -v4
+; GCN-NEXT:    v_mul_f32_e32 v4, s3, v3
 ; GCN-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
-; GCN-NEXT:    v_fmac_f32_e32 v4, s3, v7
+; GCN-NEXT:    v_rndne_f32_e32 v10, v4
 ; GCN-NEXT:    s_load_dword s8, s[4:5], 0x54
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[64:95], v12, v1, a[64:95]
-; GCN-NEXT:    v_add_f32_e32 v1, v10, v4
+; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[64:95], v9, v1, a[64:95]
+; GCN-NEXT:    v_sub_f32_e32 v1, v4, v10
+; GCN-NEXT:    v_fma_f32 v4, s3, v3, -v4
+; GCN-NEXT:    v_fmac_f32_e32 v4, s3, v7
+; GCN-NEXT:    v_add_f32_e32 v1, v1, v4
 ; GCN-NEXT:    v_exp_f32_e32 v1, v1
-; GCN-NEXT:    v_cvt_i32_f32_e32 v4, v9
+; GCN-NEXT:    v_cvt_i32_f32_e32 v4, v10
 ; GCN-NEXT:    v_cmp_nlt_f32_e32 vcc, s3, v5
-; GCN-NEXT:    ds_read_b128 a[28:31], v2 offset:57456
-; GCN-NEXT:    ds_read_b128 a[24:27], v2 offset:57440
+; GCN-NEXT:    ds_read_b128 a[156:159], v2 offset:57456
+; GCN-NEXT:    ds_read_b128 a[152:155], v2 offset:57440
 ; GCN-NEXT:    v_ldexp_f32 v1, v1, v4
 ; GCN-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
 ; GCN-NEXT:    v_cmp_ngt_f32_e32 vcc, s3, v6
-; GCN-NEXT:    v_mul_f32_e32 v4, s8, v3
 ; GCN-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
-; GCN-NEXT:    v_rndne_f32_e32 v9, v4
+; GCN-NEXT:    v_mul_f32_e32 v4, s8, v3
 ; GCN-NEXT:    v_fma_f32 v3, s8, v3, -v4
+; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[96:127], v9, v1, a[96:127]
+; GCN-NEXT:    v_rndne_f32_e32 v1, v4
+; GCN-NEXT:    v_sub_f32_e32 v10, v4, v1
 ; GCN-NEXT:    v_fmac_f32_e32 v3, s8, v7
-; GCN-NEXT:    ds_read_b128 a[20:23], v2 offset:57424
-; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v12, v1, a[32:63]
-; GCN-NEXT:    v_sub_f32_e32 v1, v4, v9
-; GCN-NEXT:    v_add_f32_e32 v1, v1, v3
-; GCN-NEXT:    v_exp_f32_e32 v1, v1
-; GCN-NEXT:    v_cvt_i32_f32_e32 v3, v9
-; GCN-NEXT:    ds_read_b128 a[16:19], v2 offset:57408
-; GCN-NEXT:    ds_read_b128 a[0:3], v2 offset:57344
-; GCN-NEXT:    ds_read_b128 a[4:7], v2 offset:57360
-; GCN-NEXT:    ds_read_b128 a[8:11], v2 offset:57376
-; GCN-NEXT:    ds_read_b128 a[12:15], v2 offset:57392
-; GCN-NEXT:    v_ldexp_f32 v1, v1, v3
+; GCN-NEXT:    v_add_f32_e32 v3, v10, v3
+; GCN-NEXT:    v_exp_f32_e32 v3, v3
+; GCN-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; GCN-NEXT:    ds_read_b128 a[148:151], v2 offset:57424
+; GCN-NEXT:    ds_read_b128 a[144:147], v2 offset:57408
+; GCN-NEXT:    ds_read_b128 a[128:131], v2 offset:57344
+; GCN-NEXT:    ds_read_b128 a[132:135], v2 offset:57360
+; GCN-NEXT:    ds_read_b128 a[136:139], v2 offset:57376
+; GCN-NEXT:    ds_read_b128 a[140:143], v2 offset:57392
+; GCN-NEXT:    v_ldexp_f32 v1, v3, v1
 ; GCN-NEXT:    v_cmp_nlt_f32_e32 vcc, s8, v5
 ; GCN-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
 ; GCN-NEXT:    v_cmp_ngt_f32_e32 vcc, s8, v6
 ; GCN-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
 ; GCN-NEXT:    v_add_u32_e32 v0, s7, v0
-; GCN-NEXT:    ds_write_b128 v0, a[156:159] offset:112
+; GCN-NEXT:    ds_write_b128 v0, a[60:63] offset:112
 ; GCN-NEXT:    s_waitcnt lgkmcnt(1)
-; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v12, v1, a[0:31]
-; GCN-NEXT:    ds_write_b128 v0, a[152:155] offset:96
-; GCN-NEXT:    ds_write_b128 v0, a[148:151] offset:80
-; GCN-NEXT:    ds_write_b128 v0, a[144:147] offset:64
-; GCN-NEXT:    ds_write_b128 v0, a[140:143] offset:48
-; GCN-NEXT:    ds_write_b128 v0, a[136:139] offset:32
-; GCN-NEXT:    ds_write_b128 v0, a[132:135] offset:16
-; GCN-NEXT:    ds_write_b128 v0, a[128:131]
+; GCN-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v9, v1, a[128:159]
+; GCN-NEXT:    ds_write_b128 v0, a[56:59] offset:96
+; GCN-NEXT:    ds_write_b128 v0, a[52:55] offset:80
+; GCN-NEXT:    ds_write_b128 v0, a[48:51] offset:64
+; GCN-NEXT:    ds_write_b128 v0, a[44:47] offset:48
+; GCN-NEXT:    ds_write_b128 v0, a[40:43] offset:32
+; GCN-NEXT:    ds_write_b128 v0, a[36:39] offset:16
+; GCN-NEXT:    ds_write_b128 v0, a[32:35]
 ; GCN-NEXT:    v_mov_b32_e32 v0, s7
 ; GCN-NEXT:    ; kill: killed $sgpr4_sgpr5
 ; GCN-NEXT:    ; sched_group_barrier mask(0x00000400) size(1) SyncID(0)
@@ -1335,14 +1335,14 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_interleave_EXP_MFMA
 ; GCN-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; GCN-NEXT:    ; sched_group_barrier mask(0x00000400) size(1) SyncID(0)
 ; GCN-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
-; GCN-NEXT:    ds_write_b128 v0, a[120:123] offset:8288
-; GCN-NEXT:    ds_write_b128 v0, a[124:127] offset:8304
-; GCN-NEXT:    ds_write_b128 v0, a[112:115] offset:8256
-; GCN-NEXT:    ds_write_b128 v0, a[116:119] offset:8272
-; GCN-NEXT:    ds_write_b128 v0, a[104:107] offset:8224
-; GCN-NEXT:    ds_write_b128 v0, a[108:111] offset:8240
-; GCN-NEXT:    ds_write_b128 v0, a[96:99] offset:8192
-; GCN-NEXT:    ds_write_b128 v0, a[100:103] offset:8208
+; GCN-NEXT:    ds_write_b128 v0, a[24:27] offset:8288
+; GCN-NEXT:    ds_write_b128 v0, a[28:31] offset:8304
+; GCN-NEXT:    ds_write_b128 v0, a[16:19] offset:8256
+; GCN-NEXT:    ds_write_b128 v0, a[20:23] offset:8272
+; GCN-NEXT:    ds_write_b128 v0, a[8:11] offset:8224
+; GCN-NEXT:    ds_write_b128 v0, a[12:15] offset:8240
+; GCN-NEXT:    ds_write_b128 v0, a[0:3] offset:8192
+; GCN-NEXT:    ds_write_b128 v0, a[4:7] offset:8208
 ; GCN-NEXT:    ds_write_b128 v0, a[88:91] offset:16480
 ; GCN-NEXT:    ds_write_b128 v0, a[92:95] offset:16496
 ; GCN-NEXT:    ds_write_b128 v0, a[80:83] offset:16448
@@ -1351,22 +1351,22 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_interleave_EXP_MFMA
 ; GCN-NEXT:    ds_write_b128 v0, a[76:79] offset:16432
 ; GCN-NEXT:    ds_write_b128 v0, a[64:67] offset:16384
 ; GCN-NEXT:    ds_write_b128 v0, a[68:71] offset:16400
-; GCN-NEXT:    ds_write_b128 v0, a[56:59] offset:24672
-; GCN-NEXT:    ds_write_b128 v0, a[60:63] offset:24688
-; GCN-NEXT:    ds_write_b128 v0, a[48:51] offset:24640
-; GCN-NEXT:    ds_write_b128 v0, a[52:55] offset:24656
-; GCN-NEXT:    ds_write_b128 v0, a[40:43] offset:24608
-; GCN-NEXT:    ds_write_b128 v0, a[44:47] offset:24624
-; GCN-NEXT:    ds_write_b128 v0, a[32:35] offset:24576
-; GCN-NEXT:    ds_write_b128 v0, a[36:39] offset:24592
-; GCN-NEXT:    ds_write_b128 v0, a[24:27] offset:32864
-; GCN-NEXT:    ds_write_b128 v0, a[28:31] offset:32880
-; GCN-NEXT:    ds_write_b128 v0, a[16:19] offset:32832
-; GCN-NEXT:    ds_write_b128 v0, a[20:23] offset:32848
-; GCN-NEXT:    ds_write_b128 v0, a[8:11] offset:32800
-; GCN-NEXT:    ds_write_b128 v0, a[12:15] offset:32816
-; GCN-NEXT:    ds_write_b128 v0, a[0:3] offset:32768
-; GCN-NEXT:    ds_write_b128 v0, a[4:7] offset:32784
+; GCN-NEXT:    ds_write_b128 v0, a[120:123] offset:24672
+; GCN-NEXT:    ds_write_b128 v0, a[124:127] offset:24688
+; GCN-NEXT:    ds_write_b128 v0, a[112:115] offset:24640
+; GCN-NEXT:    ds_write_b128 v0, a[116:119] offset:24656
+; GCN-NEXT:    ds_write_b128 v0, a[104:107] offset:24608
+; GCN-NEXT:    ds_write_b128 v0, a[108:111] offset:24624
+; GCN-NEXT:    ds_write_b128 v0, a[96:99] offset:24576
+; GCN-NEXT:    ds_write_b128 v0, a[100:103] offset:24592
+; GCN-NEXT:    ds_write_b128 v0, a[152:155] offset:32864
+; GCN-NEXT:    ds_write_b128 v0, a[156:159] offset:32880
+; GCN-NEXT:    ds_write_b128 v0, a[144:147] offset:32832
+; GCN-NEXT:    ds_write_b128 v0, a[148:151] offset:32848
+; GCN-NEXT:    ds_write_b128 v0, a[136:139] offset:32800
+; GCN-NEXT:    ds_write_b128 v0, a[140:143] offset:32816
+; GCN-NEXT:    ds_write_b128 v0, a[128:131] offset:32768
+; GCN-NEXT:    ds_write_b128 v0, a[132:135] offset:32784
 ; GCN-NEXT:    s_endpgm
 ;
 ; EXACTCUTOFF-LABEL: test_sched_group_barrier_pipeline_interleave_EXP_MFMA:
@@ -1387,57 +1387,57 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_interleave_EXP_MFMA
 ; EXACTCUTOFF-NEXT:    v_cvt_i32_f32_e32 v5, v5
 ; EXACTCUTOFF-NEXT:    v_and_b32_e32 v0, 0x1ff80, v0
 ; EXACTCUTOFF-NEXT:    v_add_u32_e32 v1, s6, v0
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[156:159], v1 offset:112
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[152:155], v1 offset:96
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[148:151], v1 offset:80
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[144:147], v1 offset:64
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[128:131], v1
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[132:135], v1 offset:16
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[136:139], v1 offset:32
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[140:143], v1 offset:48
-; EXACTCUTOFF-NEXT:    v_mul_f32_e32 v9, s1, v3
-; EXACTCUTOFF-NEXT:    v_mov_b32_e32 v12, 1.0
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[60:63], v1 offset:112
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[56:59], v1 offset:96
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[52:55], v1 offset:80
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[48:51], v1 offset:64
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[32:35], v1
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[36:39], v1 offset:16
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[40:43], v1 offset:32
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[44:47], v1 offset:48
+; EXACTCUTOFF-NEXT:    v_mov_b32_e32 v9, 1.0
 ; EXACTCUTOFF-NEXT:    v_ldexp_f32 v4, v4, v5
 ; EXACTCUTOFF-NEXT:    v_mov_b32_e32 v5, 0xc2ce8ed0
-; EXACTCUTOFF-NEXT:    v_rndne_f32_e32 v10, v9
+; EXACTCUTOFF-NEXT:    v_mul_f32_e32 v10, s1, v3
 ; EXACTCUTOFF-NEXT:    v_cmp_nlt_f32_e32 vcc, s0, v5
 ; EXACTCUTOFF-NEXT:    v_mov_b32_e32 v6, 0x42b17218
-; EXACTCUTOFF-NEXT:    v_sub_f32_e32 v11, v9, v10
-; EXACTCUTOFF-NEXT:    v_fma_f32 v9, s1, v3, -v9
+; EXACTCUTOFF-NEXT:    v_rndne_f32_e32 v11, v10
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
 ; EXACTCUTOFF-NEXT:    v_cmp_ngt_f32_e32 vcc, s0, v6
 ; EXACTCUTOFF-NEXT:    v_mov_b32_e32 v8, 0x7f800000
-; EXACTCUTOFF-NEXT:    v_fmac_f32_e32 v9, s1, v7
+; EXACTCUTOFF-NEXT:    v_sub_f32_e32 v12, v10, v11
+; EXACTCUTOFF-NEXT:    v_fma_f32 v10, s1, v3, -v10
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; EXACTCUTOFF-NEXT:    v_add_f32_e32 v9, v11, v9
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[124:127], v1 offset:8304
+; EXACTCUTOFF-NEXT:    v_fmac_f32_e32 v10, s1, v7
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[28:31], v1 offset:8304
 ; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(1)
-; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v12, v4, a[128:159]
-; EXACTCUTOFF-NEXT:    v_exp_f32_e32 v4, v9
-; EXACTCUTOFF-NEXT:    v_cvt_i32_f32_e32 v9, v10
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[120:123], v1 offset:8288
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[116:119], v1 offset:8272
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[112:115], v1 offset:8256
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[108:111], v1 offset:8240
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[104:107], v1 offset:8224
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[100:103], v1 offset:8208
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[96:99], v1 offset:8192
-; EXACTCUTOFF-NEXT:    v_ldexp_f32 v4, v4, v9
-; EXACTCUTOFF-NEXT:    v_mul_f32_e32 v9, s2, v3
-; EXACTCUTOFF-NEXT:    v_rndne_f32_e32 v10, v9
+; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v9, v4, a[32:63]
+; EXACTCUTOFF-NEXT:    v_add_f32_e32 v4, v12, v10
+; EXACTCUTOFF-NEXT:    v_exp_f32_e32 v4, v4
+; EXACTCUTOFF-NEXT:    v_cvt_i32_f32_e32 v10, v11
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[24:27], v1 offset:8288
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[20:23], v1 offset:8272
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[16:19], v1 offset:8256
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[12:15], v1 offset:8240
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[8:11], v1 offset:8224
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[4:7], v1 offset:8208
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[0:3], v1 offset:8192
+; EXACTCUTOFF-NEXT:    v_ldexp_f32 v4, v4, v10
 ; EXACTCUTOFF-NEXT:    v_cmp_nlt_f32_e32 vcc, s1, v5
-; EXACTCUTOFF-NEXT:    v_sub_f32_e32 v11, v9, v10
-; EXACTCUTOFF-NEXT:    v_fma_f32 v9, s2, v3, -v9
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
 ; EXACTCUTOFF-NEXT:    v_cmp_ngt_f32_e32 vcc, s1, v6
-; EXACTCUTOFF-NEXT:    v_fmac_f32_e32 v9, s2, v7
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; EXACTCUTOFF-NEXT:    v_add_f32_e32 v9, v11, v9
+; EXACTCUTOFF-NEXT:    v_mul_f32_e32 v10, s2, v3
+; EXACTCUTOFF-NEXT:    v_rndne_f32_e32 v11, v10
+; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(0)
+; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v9, v4, a[0:31]
+; EXACTCUTOFF-NEXT:    v_fma_f32 v4, s2, v3, -v10
+; EXACTCUTOFF-NEXT:    v_sub_f32_e32 v12, v10, v11
+; EXACTCUTOFF-NEXT:    v_fmac_f32_e32 v4, s2, v7
+; EXACTCUTOFF-NEXT:    v_add_f32_e32 v4, v12, v4
+; EXACTCUTOFF-NEXT:    v_exp_f32_e32 v4, v4
+; EXACTCUTOFF-NEXT:    v_cvt_i32_f32_e32 v10, v11
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[92:95], v1 offset:24688
-; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(1)
-; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[96:127], v12, v4, a[96:127]
-; EXACTCUTOFF-NEXT:    v_exp_f32_e32 v4, v9
-; EXACTCUTOFF-NEXT:    v_cvt_i32_f32_e32 v9, v10
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[88:91], v1 offset:24672
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[84:87], v1 offset:24656
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[80:83], v1 offset:24640
@@ -1446,68 +1446,68 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_interleave_EXP_MFMA
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[68:71], v1 offset:24592
 ; EXACTCUTOFF-NEXT:    ds_read_b128 a[64:67], v1 offset:24576
 ; EXACTCUTOFF-NEXT:    v_add_u32_e32 v2, 0x6000, v1
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[60:63], v1 offset:49264
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[56:59], v1 offset:49248
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[52:55], v1 offset:49232
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[48:51], v1 offset:49216
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[44:47], v1 offset:49200
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[40:43], v1 offset:49184
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[36:39], v1 offset:49168
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[32:35], v1 offset:49152
-; EXACTCUTOFF-NEXT:    v_ldexp_f32 v1, v4, v9
-; EXACTCUTOFF-NEXT:    v_mul_f32_e32 v4, s3, v3
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[124:127], v1 offset:49264
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[120:123], v1 offset:49248
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[116:119], v1 offset:49232
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[112:115], v1 offset:49216
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[108:111], v1 offset:49200
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[104:107], v1 offset:49184
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[100:103], v1 offset:49168
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[96:99], v1 offset:49152
+; EXACTCUTOFF-NEXT:    v_ldexp_f32 v1, v4, v10
 ; EXACTCUTOFF-NEXT:    v_cmp_nlt_f32_e32 vcc, s2, v5
-; EXACTCUTOFF-NEXT:    v_rndne_f32_e32 v9, v4
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
 ; EXACTCUTOFF-NEXT:    v_cmp_ngt_f32_e32 vcc, s2, v6
-; EXACTCUTOFF-NEXT:    v_sub_f32_e32 v10, v4, v9
-; EXACTCUTOFF-NEXT:    v_fma_f32 v4, s3, v3, -v4
+; EXACTCUTOFF-NEXT:    v_mul_f32_e32 v4, s3, v3
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
-; EXACTCUTOFF-NEXT:    v_fmac_f32_e32 v4, s3, v7
+; EXACTCUTOFF-NEXT:    v_rndne_f32_e32 v10, v4
 ; EXACTCUTOFF-NEXT:    s_load_dword s8, s[4:5], 0x54
 ; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(0)
-; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[64:95], v12, v1, a[64:95]
-; EXACTCUTOFF-NEXT:    v_add_f32_e32 v1, v10, v4
+; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[64:95], v9, v1, a[64:95]
+; EXACTCUTOFF-NEXT:    v_sub_f32_e32 v1, v4, v10
+; EXACTCUTOFF-NEXT:    v_fma_f32 v4, s3, v3, -v4
+; EXACTCUTOFF-NEXT:    v_fmac_f32_e32 v4, s3, v7
+; EXACTCUTOFF-NEXT:    v_add_f32_e32 v1, v1, v4
 ; EXACTCUTOFF-NEXT:    v_exp_f32_e32 v1, v1
-; EXACTCUTOFF-NEXT:    v_cvt_i32_f32_e32 v4, v9
+; EXACTCUTOFF-NEXT:    v_cvt_i32_f32_e32 v4, v10
 ; EXACTCUTOFF-NEXT:    v_cmp_nlt_f32_e32 vcc, s3, v5
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[28:31], v2 offset:57456
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[24:27], v2 offset:57440
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[156:159], v2 offset:57456
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[152:155], v2 offset:57440
 ; EXACTCUTOFF-NEXT:    v_ldexp_f32 v1, v1, v4
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
 ; EXACTCUTOFF-NEXT:    v_cmp_ngt_f32_e32 vcc, s3, v6
-; EXACTCUTOFF-NEXT:    v_mul_f32_e32 v4, s8, v3
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
-; EXACTCUTOFF-NEXT:    v_rndne_f32_e32 v9, v4
+; EXACTCUTOFF-NEXT:    v_mul_f32_e32 v4, s8, v3
 ; EXACTCUTOFF-NEXT:    v_fma_f32 v3, s8, v3, -v4
+; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[96:127], v9, v1, a[96:127]
+; EXACTCUTOFF-NEXT:    v_rndne_f32_e32 v1, v4
+; EXACTCUTOFF-NEXT:    v_sub_f32_e32 v10, v4, v1
 ; EXACTCUTOFF-NEXT:    v_fmac_f32_e32 v3, s8, v7
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[20:23], v2 offset:57424
-; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v12, v1, a[32:63]
-; EXACTCUTOFF-NEXT:    v_sub_f32_e32 v1, v4, v9
-; EXACTCUTOFF-NEXT:    v_add_f32_e32 v1, v1, v3
-; EXACTCUTOFF-NEXT:    v_exp_f32_e32 v1, v1
-; EXACTCUTOFF-NEXT:    v_cvt_i32_f32_e32 v3, v9
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[16:19], v2 offset:57408
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[0:3], v2 offset:57344
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[4:7], v2 offset:57360
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[8:11], v2 offset:57376
-; EXACTCUTOFF-NEXT:    ds_read_b128 a[12:15], v2 offset:57392
-; EXACTCUTOFF-NEXT:    v_ldexp_f32 v1, v1, v3
+; EXACTCUTOFF-NEXT:    v_add_f32_e32 v3, v10, v3
+; EXACTCUTOFF-NEXT:    v_exp_f32_e32 v3, v3
+; EXACTCUTOFF-NEXT:    v_cvt_i32_f32_e32 v1, v1
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[148:151], v2 offset:57424
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[144:147], v2 offset:57408
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[128:131], v2 offset:57344
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[132:135], v2 offset:57360
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[136:139], v2 offset:57376
+; EXACTCUTOFF-NEXT:    ds_read_b128 a[140:143], v2 offset:57392
+; EXACTCUTOFF-NEXT:    v_ldexp_f32 v1, v3, v1
 ; EXACTCUTOFF-NEXT:    v_cmp_nlt_f32_e32 vcc, s8, v5
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v1, 0, v1, vcc
 ; EXACTCUTOFF-NEXT:    v_cmp_ngt_f32_e32 vcc, s8, v6
 ; EXACTCUTOFF-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
 ; EXACTCUTOFF-NEXT:    v_add_u32_e32 v0, s7, v0
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[156:159] offset:112
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[60:63] offset:112
 ; EXACTCUTOFF-NEXT:    s_waitcnt lgkmcnt(1)
-; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v12, v1, a[0:31]
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[152:155] offset:96
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[148:151] offset:80
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[144:147] offset:64
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[140:143] offset:48
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[136:139] offset:32
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[132:135] offset:16
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[128:131]
+; EXACTCUTOFF-NEXT:    v_mfma_f32_32x32x1f32 a[128:159], v9, v1, a[128:159]
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[56:59] offset:96
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[52:55] offset:80
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[48:51] offset:64
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[44:47] offset:48
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[40:43] offset:32
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[36:39] offset:16
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[32:35]
 ; EXACTCUTOFF-NEXT:    v_mov_b32_e32 v0, s7
 ; EXACTCUTOFF-NEXT:    ; kill: killed $sgpr4_sgpr5
 ; EXACTCUTOFF-NEXT:    ; sched_group_barrier mask(0x00000400) size(1) SyncID(0)
@@ -1520,14 +1520,14 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_interleave_EXP_MFMA
 ; EXACTCUTOFF-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
 ; EXACTCUTOFF-NEXT:    ; sched_group_barrier mask(0x00000400) size(1) SyncID(0)
 ; EXACTCUTOFF-NEXT:    ; sched_group_barrier mask(0x00000008) size(1) SyncID(0)
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[120:123] offset:8288
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[124:127] offset:8304
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[112:115] offset:8256
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[116:119] offset:8272
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[104:107] offset:8224
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[108:111] offset:8240
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[96:99] offset:8192
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[100:103] offset:8208
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[24:27] offset:8288
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[28:31] offset:8304
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[16:19] offset:8256
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[20:23] offset:8272
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[8:11] offset:8224
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[12:15] offset:8240
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[0:3] offset:8192
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[4:7] offset:8208
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[88:91] offset:16480
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[92:95] offset:16496
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[80:83] offset:16448
@@ -1536,22 +1536,22 @@ define amdgpu_kernel void @test_sched_group_barrier_pipeline_interleave_EXP_MFMA
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[76:79] offset:16432
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[64:67] offset:16384
 ; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[68:71] offset:16400
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[56:59] offset:24672
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[60:63] offset:24688
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[48:51] offset:24640
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[52:55] offset:24656
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[40:43] offset:24608
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[44:47] offset:24624
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[32:35] offset:24576
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[36:39] offset:24592
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[24:27] offset:32864
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[28:31] offset:32880
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[16:19] offset:32832
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[20:23] offset:32848
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[8:11] offset:32800
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[12:15] offset:32816
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[0:3] offset:32768
-; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[4:7] offset:32784
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[120:123] offset:24672
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[124:127] offset:24688
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[112:115] offset:24640
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[116:119] offset:24656
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[104:107] offset:24608
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[108:111] offset:24624
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[96:99] offset:24576
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[100:103] offset:24592
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[152:155] offset:32864
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[156:159] offset:32880
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[144:147] offset:32832
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[148:151] offset:32848
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[136:139] offset:32800
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[140:143] offset:32816
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[128:131] offset:32768
+; EXACTCUTOFF-NEXT:    ds_write_b128 v0, a[132:135] offset:32784
 ; EXACTCUTOFF-NEXT:    s_endpgm
 entry:
   %idx = call i32 @llvm.amdgcn.workitem.id.x()

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.wqm.demote.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.wqm.demote.ll
@@ -746,9 +746,9 @@ define amdgpu_ps void @wqm_deriv(<2 x float> %input, float %arg, i32 %index) {
 ; GFX9-NEXT:    s_mov_b64 exec, 0
 ; GFX9-NEXT:  .LBB6_6: ; %.continue1
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX9-NEXT:    v_mov_b32_e32 v0, 0x3c00
-; GFX9-NEXT:    v_bfrev_b32_e32 v1, 60
-; GFX9-NEXT:    exp mrt0 v0, v0, v1, v1 done compr vm
+; GFX9-NEXT:    v_bfrev_b32_e32 v0, 60
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x3c00
+; GFX9-NEXT:    exp mrt0 v1, v1, v0, v0 done compr vm
 ; GFX9-NEXT:    s_endpgm
 ; GFX9-NEXT:  .LBB6_7:
 ; GFX9-NEXT:    s_mov_b64 exec, 0
@@ -792,9 +792,9 @@ define amdgpu_ps void @wqm_deriv(<2 x float> %input, float %arg, i32 %index) {
 ; GFX10-32-NEXT:    s_mov_b32 exec_lo, 0
 ; GFX10-32-NEXT:  .LBB6_6: ; %.continue1
 ; GFX10-32-NEXT:    s_or_b32 exec_lo, exec_lo, s1
-; GFX10-32-NEXT:    v_mov_b32_e32 v0, 0x3c00
-; GFX10-32-NEXT:    v_bfrev_b32_e32 v1, 60
-; GFX10-32-NEXT:    exp mrt0 v0, v0, v1, v1 done compr vm
+; GFX10-32-NEXT:    v_bfrev_b32_e32 v0, 60
+; GFX10-32-NEXT:    v_mov_b32_e32 v1, 0x3c00
+; GFX10-32-NEXT:    exp mrt0 v1, v1, v0, v0 done compr vm
 ; GFX10-32-NEXT:    s_endpgm
 ; GFX10-32-NEXT:  .LBB6_7:
 ; GFX10-32-NEXT:    s_mov_b32 exec_lo, 0
@@ -838,9 +838,9 @@ define amdgpu_ps void @wqm_deriv(<2 x float> %input, float %arg, i32 %index) {
 ; GFX10-64-NEXT:    s_mov_b64 exec, 0
 ; GFX10-64-NEXT:  .LBB6_6: ; %.continue1
 ; GFX10-64-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX10-64-NEXT:    v_mov_b32_e32 v0, 0x3c00
-; GFX10-64-NEXT:    v_bfrev_b32_e32 v1, 60
-; GFX10-64-NEXT:    exp mrt0 v0, v0, v1, v1 done compr vm
+; GFX10-64-NEXT:    v_bfrev_b32_e32 v0, 60
+; GFX10-64-NEXT:    v_mov_b32_e32 v1, 0x3c00
+; GFX10-64-NEXT:    exp mrt0 v1, v1, v0, v0 done compr vm
 ; GFX10-64-NEXT:    s_endpgm
 ; GFX10-64-NEXT:  .LBB6_7:
 ; GFX10-64-NEXT:    s_mov_b64 exec, 0
@@ -1005,9 +1005,9 @@ define amdgpu_ps void @wqm_deriv_loop(<2 x float> %input, float %arg, i32 %index
 ; GFX9-NEXT:  .LBB7_8: ; %.return
 ; GFX9-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9-NEXT:    s_and_b64 exec, exec, s[0:1]
-; GFX9-NEXT:    v_mov_b32_e32 v0, 0x3c00
-; GFX9-NEXT:    v_bfrev_b32_e32 v1, 60
-; GFX9-NEXT:    exp mrt0 v0, v0, v1, v1 done compr vm
+; GFX9-NEXT:    v_bfrev_b32_e32 v0, 60
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x3c00
+; GFX9-NEXT:    exp mrt0 v1, v1, v0, v0 done compr vm
 ; GFX9-NEXT:    s_endpgm
 ; GFX9-NEXT:  .LBB7_9:
 ; GFX9-NEXT:    s_mov_b64 exec, 0
@@ -1068,9 +1068,9 @@ define amdgpu_ps void @wqm_deriv_loop(<2 x float> %input, float %arg, i32 %index
 ; GFX10-32-NEXT:  .LBB7_8: ; %.return
 ; GFX10-32-NEXT:    s_or_b32 exec_lo, exec_lo, s1
 ; GFX10-32-NEXT:    s_and_b32 exec_lo, exec_lo, s0
-; GFX10-32-NEXT:    v_mov_b32_e32 v0, 0x3c00
-; GFX10-32-NEXT:    v_bfrev_b32_e32 v1, 60
-; GFX10-32-NEXT:    exp mrt0 v0, v0, v1, v1 done compr vm
+; GFX10-32-NEXT:    v_bfrev_b32_e32 v0, 60
+; GFX10-32-NEXT:    v_mov_b32_e32 v1, 0x3c00
+; GFX10-32-NEXT:    exp mrt0 v1, v1, v0, v0 done compr vm
 ; GFX10-32-NEXT:    s_endpgm
 ; GFX10-32-NEXT:  .LBB7_9:
 ; GFX10-32-NEXT:    s_mov_b32 exec_lo, 0
@@ -1131,9 +1131,9 @@ define amdgpu_ps void @wqm_deriv_loop(<2 x float> %input, float %arg, i32 %index
 ; GFX10-64-NEXT:  .LBB7_8: ; %.return
 ; GFX10-64-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX10-64-NEXT:    s_and_b64 exec, exec, s[0:1]
-; GFX10-64-NEXT:    v_mov_b32_e32 v0, 0x3c00
-; GFX10-64-NEXT:    v_bfrev_b32_e32 v1, 60
-; GFX10-64-NEXT:    exp mrt0 v0, v0, v1, v1 done compr vm
+; GFX10-64-NEXT:    v_bfrev_b32_e32 v0, 60
+; GFX10-64-NEXT:    v_mov_b32_e32 v1, 0x3c00
+; GFX10-64-NEXT:    exp mrt0 v1, v1, v0, v0 done compr vm
 ; GFX10-64-NEXT:    s_endpgm
 ; GFX10-64-NEXT:  .LBB7_9:
 ; GFX10-64-NEXT:    s_mov_b64 exec, 0

--- a/llvm/test/CodeGen/AMDGPU/llvm.maximum.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.maximum.f64.ll
@@ -2375,8 +2375,8 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    v_accvgpr_write_b32 a7, v47 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a8, v56 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a9, v57 ; Reload Reuse
-; GFX950-NEXT:    scratch_load_dword v33, off, s32 offset:8
-; GFX950-NEXT:    scratch_load_dword v32, off, s32 offset:4
+; GFX950-NEXT:    scratch_load_dword v35, off, s32 offset:8
+; GFX950-NEXT:    scratch_load_dword v34, off, s32 offset:4
 ; GFX950-NEXT:    scratch_load_dword v37, off, s32 offset:16
 ; GFX950-NEXT:    scratch_load_dword v36, off, s32 offset:12
 ; GFX950-NEXT:    scratch_load_dword v39, off, s32 offset:24
@@ -2400,8 +2400,8 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    scratch_load_dword v49, off, s32 offset:96
 ; GFX950-NEXT:    scratch_load_dword v48, off, s32 offset:92
 ; GFX950-NEXT:    scratch_load_dword v31, off, s32
-; GFX950-NEXT:    scratch_load_dword v35, off, s32 offset:104
-; GFX950-NEXT:    scratch_load_dword v34, off, s32 offset:100
+; GFX950-NEXT:    scratch_load_dword v33, off, s32 offset:104
+; GFX950-NEXT:    scratch_load_dword v32, off, s32 offset:100
 ; GFX950-NEXT:    v_accvgpr_write_b32 a10, v58 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a11, v59 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a12, v60 ; Reload Reuse
@@ -2409,10 +2409,10 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    v_accvgpr_write_b32 a14, v62 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a15, v63 ; Reload Reuse
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
-; GFX950-NEXT:    v_max_f64 v[58:59], v[0:1], v[32:33]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[32:33]
-; GFX950-NEXT:    scratch_load_dword v33, off, s32 offset:112
-; GFX950-NEXT:    scratch_load_dword v32, off, s32 offset:108
+; GFX950-NEXT:    v_max_f64 v[58:59], v[0:1], v[34:35]
+; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[34:35]
+; GFX950-NEXT:    scratch_load_dword v35, off, s32 offset:112
+; GFX950-NEXT:    scratch_load_dword v34, off, s32 offset:108
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_max_f64 v[60:61], v[2:3], v[36:37]
 ; GFX950-NEXT:    v_cmp_u_f64_e64 s[0:1], v[2:3], v[36:37]
@@ -2486,16 +2486,16 @@ define <16 x double> @v_maximum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    v_cndmask_b32_e64 v22, v0, 0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v23, v1, v2, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(6)
-; GFX950-NEXT:    v_max_f64 v[0:1], v[24:25], v[34:35]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[24:25], v[34:35]
+; GFX950-NEXT:    v_max_f64 v[0:1], v[24:25], v[32:33]
+; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[24:25], v[32:33]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v42, a2 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v41, a1 ; Reload Reuse
 ; GFX950-NEXT:    v_cndmask_b32_e64 v24, v0, 0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v25, v1, v2, vcc
 ; GFX950-NEXT:    v_accvgpr_read_b32 v40, a0 ; Reload Reuse
 ; GFX950-NEXT:    s_waitcnt vmcnt(4)
-; GFX950-NEXT:    v_max_f64 v[0:1], v[26:27], v[32:33]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[26:27], v[32:33]
+; GFX950-NEXT:    v_max_f64 v[0:1], v[26:27], v[34:35]
+; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[26:27], v[34:35]
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v26, v0, 0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v27, v1, v2, vcc

--- a/llvm/test/CodeGen/AMDGPU/llvm.minimum.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.minimum.f64.ll
@@ -2375,8 +2375,8 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    v_accvgpr_write_b32 a7, v47 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a8, v56 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a9, v57 ; Reload Reuse
-; GFX950-NEXT:    scratch_load_dword v33, off, s32 offset:8
-; GFX950-NEXT:    scratch_load_dword v32, off, s32 offset:4
+; GFX950-NEXT:    scratch_load_dword v35, off, s32 offset:8
+; GFX950-NEXT:    scratch_load_dword v34, off, s32 offset:4
 ; GFX950-NEXT:    scratch_load_dword v37, off, s32 offset:16
 ; GFX950-NEXT:    scratch_load_dword v36, off, s32 offset:12
 ; GFX950-NEXT:    scratch_load_dword v39, off, s32 offset:24
@@ -2400,8 +2400,8 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    scratch_load_dword v49, off, s32 offset:96
 ; GFX950-NEXT:    scratch_load_dword v48, off, s32 offset:92
 ; GFX950-NEXT:    scratch_load_dword v31, off, s32
-; GFX950-NEXT:    scratch_load_dword v35, off, s32 offset:104
-; GFX950-NEXT:    scratch_load_dword v34, off, s32 offset:100
+; GFX950-NEXT:    scratch_load_dword v33, off, s32 offset:104
+; GFX950-NEXT:    scratch_load_dword v32, off, s32 offset:100
 ; GFX950-NEXT:    v_accvgpr_write_b32 a10, v58 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a11, v59 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a12, v60 ; Reload Reuse
@@ -2409,10 +2409,10 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    v_accvgpr_write_b32 a14, v62 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_write_b32 a15, v63 ; Reload Reuse
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
-; GFX950-NEXT:    v_min_f64 v[58:59], v[0:1], v[32:33]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[32:33]
-; GFX950-NEXT:    scratch_load_dword v33, off, s32 offset:112
-; GFX950-NEXT:    scratch_load_dword v32, off, s32 offset:108
+; GFX950-NEXT:    v_min_f64 v[58:59], v[0:1], v[34:35]
+; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[34:35]
+; GFX950-NEXT:    scratch_load_dword v35, off, s32 offset:112
+; GFX950-NEXT:    scratch_load_dword v34, off, s32 offset:108
 ; GFX950-NEXT:    s_waitcnt vmcnt(25)
 ; GFX950-NEXT:    v_min_f64 v[60:61], v[2:3], v[36:37]
 ; GFX950-NEXT:    v_cmp_u_f64_e64 s[0:1], v[2:3], v[36:37]
@@ -2486,16 +2486,16 @@ define <16 x double> @v_minimum_v16f64(<16 x double> %src0, <16 x double> %src1)
 ; GFX950-NEXT:    v_cndmask_b32_e64 v22, v0, 0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v23, v1, v2, vcc
 ; GFX950-NEXT:    s_waitcnt vmcnt(6)
-; GFX950-NEXT:    v_min_f64 v[0:1], v[24:25], v[34:35]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[24:25], v[34:35]
+; GFX950-NEXT:    v_min_f64 v[0:1], v[24:25], v[32:33]
+; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[24:25], v[32:33]
 ; GFX950-NEXT:    v_accvgpr_read_b32 v42, a2 ; Reload Reuse
 ; GFX950-NEXT:    v_accvgpr_read_b32 v41, a1 ; Reload Reuse
 ; GFX950-NEXT:    v_cndmask_b32_e64 v24, v0, 0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v25, v1, v2, vcc
 ; GFX950-NEXT:    v_accvgpr_read_b32 v40, a0 ; Reload Reuse
 ; GFX950-NEXT:    s_waitcnt vmcnt(4)
-; GFX950-NEXT:    v_min_f64 v[0:1], v[26:27], v[32:33]
-; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[26:27], v[32:33]
+; GFX950-NEXT:    v_min_f64 v[0:1], v[26:27], v[34:35]
+; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[26:27], v[34:35]
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v26, v0, 0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v27, v1, v2, vcc

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-agent.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-agent.ll
@@ -187,7 +187,6 @@ define amdgpu_kernel void @private_agent_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -387,7 +386,6 @@ define amdgpu_kernel void @private_agent_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -587,7 +585,6 @@ define amdgpu_kernel void @private_agent_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -788,7 +785,6 @@ define amdgpu_kernel void @private_agent_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -971,7 +967,6 @@ define amdgpu_kernel void @private_agent_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1150,7 +1145,6 @@ define amdgpu_kernel void @private_agent_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1329,7 +1323,6 @@ define amdgpu_kernel void @private_agent_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1511,7 +1504,6 @@ define amdgpu_kernel void @private_agent_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1693,7 +1685,6 @@ define amdgpu_kernel void @private_agent_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1872,7 +1863,6 @@ define amdgpu_kernel void @private_agent_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2053,7 +2043,6 @@ define amdgpu_kernel void @private_agent_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2235,7 +2224,6 @@ define amdgpu_kernel void @private_agent_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2419,7 +2407,6 @@ define amdgpu_kernel void @private_agent_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2657,7 +2644,6 @@ define amdgpu_kernel void @private_agent_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -2894,7 +2880,6 @@ define amdgpu_kernel void @private_agent_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3134,7 +3119,6 @@ define amdgpu_kernel void @private_agent_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3407,7 +3391,6 @@ define amdgpu_kernel void @private_agent_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3677,7 +3660,6 @@ define amdgpu_kernel void @private_agent_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3949,7 +3931,6 @@ define amdgpu_kernel void @private_agent_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4222,7 +4203,6 @@ define amdgpu_kernel void @private_agent_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4497,7 +4477,6 @@ define amdgpu_kernel void @private_agent_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4772,7 +4751,6 @@ define amdgpu_kernel void @private_agent_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5044,7 +5022,6 @@ define amdgpu_kernel void @private_agent_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5316,7 +5293,6 @@ define amdgpu_kernel void @private_agent_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5591,7 +5567,6 @@ define amdgpu_kernel void @private_agent_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5866,7 +5841,6 @@ define amdgpu_kernel void @private_agent_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6141,7 +6115,6 @@ define amdgpu_kernel void @private_agent_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6416,7 +6389,6 @@ define amdgpu_kernel void @private_agent_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6691,7 +6663,6 @@ define amdgpu_kernel void @private_agent_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6966,7 +6937,6 @@ define amdgpu_kernel void @private_agent_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7241,7 +7211,6 @@ define amdgpu_kernel void @private_agent_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7544,7 +7513,6 @@ define amdgpu_kernel void @private_agent_monotonic_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -7846,7 +7814,6 @@ define amdgpu_kernel void @private_agent_acquire_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8149,7 +8116,6 @@ define amdgpu_kernel void @private_agent_release_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8454,7 +8420,6 @@ define amdgpu_kernel void @private_agent_acq_rel_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8760,7 +8725,6 @@ define amdgpu_kernel void @private_agent_seq_cst_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9066,7 +9030,6 @@ define amdgpu_kernel void @private_agent_monotonic_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9369,7 +9332,6 @@ define amdgpu_kernel void @private_agent_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9672,7 +9634,6 @@ define amdgpu_kernel void @private_agent_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9978,7 +9939,6 @@ define amdgpu_kernel void @private_agent_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10284,7 +10244,6 @@ define amdgpu_kernel void @private_agent_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10590,7 +10549,6 @@ define amdgpu_kernel void @private_agent_monotonic_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10896,7 +10854,6 @@ define amdgpu_kernel void @private_agent_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11202,7 +11159,6 @@ define amdgpu_kernel void @private_agent_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11508,7 +11464,6 @@ define amdgpu_kernel void @private_agent_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11814,7 +11769,6 @@ define amdgpu_kernel void @private_agent_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -12025,7 +11979,6 @@ define amdgpu_kernel void @private_agent_one_as_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12225,7 +12178,6 @@ define amdgpu_kernel void @private_agent_one_as_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12425,7 +12377,6 @@ define amdgpu_kernel void @private_agent_one_as_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12627,7 +12578,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12811,7 +12761,6 @@ define amdgpu_kernel void @private_agent_one_as_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12990,7 +12939,6 @@ define amdgpu_kernel void @private_agent_one_as_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13169,7 +13117,6 @@ define amdgpu_kernel void @private_agent_one_as_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13351,7 +13298,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13533,7 +13479,6 @@ define amdgpu_kernel void @private_agent_one_as_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13712,7 +13657,6 @@ define amdgpu_kernel void @private_agent_one_as_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13893,7 +13837,6 @@ define amdgpu_kernel void @private_agent_one_as_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14075,7 +14018,6 @@ define amdgpu_kernel void @private_agent_one_as_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14259,7 +14201,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14497,7 +14438,6 @@ define amdgpu_kernel void @private_agent_one_as_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14735,7 +14675,6 @@ define amdgpu_kernel void @private_agent_one_as_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14976,7 +14915,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -15250,7 +15188,6 @@ define amdgpu_kernel void @private_agent_one_as_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15520,7 +15457,6 @@ define amdgpu_kernel void @private_agent_one_as_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15792,7 +15728,6 @@ define amdgpu_kernel void @private_agent_one_as_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16065,7 +16000,6 @@ define amdgpu_kernel void @private_agent_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16340,7 +16274,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16615,7 +16548,6 @@ define amdgpu_kernel void @private_agent_one_as_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16887,7 +16819,6 @@ define amdgpu_kernel void @private_agent_one_as_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17159,7 +17090,6 @@ define amdgpu_kernel void @private_agent_one_as_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17434,7 +17364,6 @@ define amdgpu_kernel void @private_agent_one_as_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17709,7 +17638,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17984,7 +17912,6 @@ define amdgpu_kernel void @private_agent_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18259,7 +18186,6 @@ define amdgpu_kernel void @private_agent_one_as_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18534,7 +18460,6 @@ define amdgpu_kernel void @private_agent_one_as_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18809,7 +18734,6 @@ define amdgpu_kernel void @private_agent_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -19084,7 +19008,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -19387,7 +19310,6 @@ define amdgpu_kernel void @private_agent_one_as_monotonic_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19689,7 +19611,6 @@ define amdgpu_kernel void @private_agent_one_as_acquire_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19993,7 +19914,6 @@ define amdgpu_kernel void @private_agent_one_as_acq_rel_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20300,7 +20220,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20607,7 +20526,6 @@ define amdgpu_kernel void @private_agent_one_as_monotonic_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20911,7 +20829,6 @@ define amdgpu_kernel void @private_agent_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21215,7 +21132,6 @@ define amdgpu_kernel void @private_agent_one_as_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21522,7 +21438,6 @@ define amdgpu_kernel void @private_agent_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21829,7 +21744,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22136,7 +22050,6 @@ define amdgpu_kernel void @private_agent_one_as_monotonic_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22443,7 +22356,6 @@ define amdgpu_kernel void @private_agent_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22750,7 +22662,6 @@ define amdgpu_kernel void @private_agent_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23057,7 +22968,6 @@ define amdgpu_kernel void @private_agent_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23364,7 +23274,6 @@ define amdgpu_kernel void @private_agent_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-cluster.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-cluster.ll
@@ -187,7 +187,6 @@ define amdgpu_kernel void @private_cluster_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -387,7 +386,6 @@ define amdgpu_kernel void @private_cluster_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -587,7 +585,6 @@ define amdgpu_kernel void @private_cluster_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -788,7 +785,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -971,7 +967,6 @@ define amdgpu_kernel void @private_cluster_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1150,7 +1145,6 @@ define amdgpu_kernel void @private_cluster_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1329,7 +1323,6 @@ define amdgpu_kernel void @private_cluster_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1510,7 +1503,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1691,7 +1683,6 @@ define amdgpu_kernel void @private_cluster_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1870,7 +1861,6 @@ define amdgpu_kernel void @private_cluster_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2051,7 +2041,6 @@ define amdgpu_kernel void @private_cluster_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2232,7 +2221,6 @@ define amdgpu_kernel void @private_cluster_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2415,7 +2403,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2652,7 +2639,6 @@ define amdgpu_kernel void @private_cluster_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -2889,7 +2875,6 @@ define amdgpu_kernel void @private_cluster_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3128,7 +3113,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3400,7 +3384,6 @@ define amdgpu_kernel void @private_cluster_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3670,7 +3653,6 @@ define amdgpu_kernel void @private_cluster_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3942,7 +3924,6 @@ define amdgpu_kernel void @private_cluster_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4214,7 +4195,6 @@ define amdgpu_kernel void @private_cluster_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4488,7 +4468,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4762,7 +4741,6 @@ define amdgpu_kernel void @private_cluster_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5034,7 +5012,6 @@ define amdgpu_kernel void @private_cluster_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5306,7 +5283,6 @@ define amdgpu_kernel void @private_cluster_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5580,7 +5556,6 @@ define amdgpu_kernel void @private_cluster_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5854,7 +5829,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6128,7 +6102,6 @@ define amdgpu_kernel void @private_cluster_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6402,7 +6375,6 @@ define amdgpu_kernel void @private_cluster_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6676,7 +6648,6 @@ define amdgpu_kernel void @private_cluster_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6950,7 +6921,6 @@ define amdgpu_kernel void @private_cluster_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7224,7 +7194,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7526,7 +7495,6 @@ define amdgpu_kernel void @private_cluster_monotonic_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -7828,7 +7796,6 @@ define amdgpu_kernel void @private_cluster_acquire_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8131,7 +8098,6 @@ define amdgpu_kernel void @private_cluster_release_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8435,7 +8401,6 @@ define amdgpu_kernel void @private_cluster_acq_rel_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8740,7 +8705,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9045,7 +9009,6 @@ define amdgpu_kernel void @private_cluster_monotonic_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9348,7 +9311,6 @@ define amdgpu_kernel void @private_cluster_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9651,7 +9613,6 @@ define amdgpu_kernel void @private_cluster_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9956,7 +9917,6 @@ define amdgpu_kernel void @private_cluster_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10261,7 +10221,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10566,7 +10525,6 @@ define amdgpu_kernel void @private_cluster_monotonic_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10871,7 +10829,6 @@ define amdgpu_kernel void @private_cluster_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11176,7 +11133,6 @@ define amdgpu_kernel void @private_cluster_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11481,7 +11437,6 @@ define amdgpu_kernel void @private_cluster_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11786,7 +11741,6 @@ define amdgpu_kernel void @private_cluster_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11996,7 +11950,6 @@ define amdgpu_kernel void @private_cluster_one_as_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12196,7 +12149,6 @@ define amdgpu_kernel void @private_cluster_one_as_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12396,7 +12348,6 @@ define amdgpu_kernel void @private_cluster_one_as_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12598,7 +12549,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12782,7 +12732,6 @@ define amdgpu_kernel void @private_cluster_one_as_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12961,7 +12910,6 @@ define amdgpu_kernel void @private_cluster_one_as_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13140,7 +13088,6 @@ define amdgpu_kernel void @private_cluster_one_as_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13321,7 +13268,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13502,7 +13448,6 @@ define amdgpu_kernel void @private_cluster_one_as_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13681,7 +13626,6 @@ define amdgpu_kernel void @private_cluster_one_as_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13862,7 +13806,6 @@ define amdgpu_kernel void @private_cluster_one_as_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14043,7 +13986,6 @@ define amdgpu_kernel void @private_cluster_one_as_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14226,7 +14168,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14463,7 +14404,6 @@ define amdgpu_kernel void @private_cluster_one_as_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14701,7 +14641,6 @@ define amdgpu_kernel void @private_cluster_one_as_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14941,7 +14880,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -15214,7 +15152,6 @@ define amdgpu_kernel void @private_cluster_one_as_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15484,7 +15421,6 @@ define amdgpu_kernel void @private_cluster_one_as_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15756,7 +15692,6 @@ define amdgpu_kernel void @private_cluster_one_as_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16028,7 +15963,6 @@ define amdgpu_kernel void @private_cluster_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16302,7 +16236,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16576,7 +16509,6 @@ define amdgpu_kernel void @private_cluster_one_as_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16848,7 +16780,6 @@ define amdgpu_kernel void @private_cluster_one_as_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17120,7 +17051,6 @@ define amdgpu_kernel void @private_cluster_one_as_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17394,7 +17324,6 @@ define amdgpu_kernel void @private_cluster_one_as_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17668,7 +17597,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17942,7 +17870,6 @@ define amdgpu_kernel void @private_cluster_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18216,7 +18143,6 @@ define amdgpu_kernel void @private_cluster_one_as_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18490,7 +18416,6 @@ define amdgpu_kernel void @private_cluster_one_as_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18764,7 +18689,6 @@ define amdgpu_kernel void @private_cluster_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -19038,7 +18962,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -19340,7 +19263,6 @@ define amdgpu_kernel void @private_cluster_one_as_monotonic_monotonic_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19642,7 +19564,6 @@ define amdgpu_kernel void @private_cluster_one_as_acquire_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19946,7 +19867,6 @@ define amdgpu_kernel void @private_cluster_one_as_acq_rel_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20252,7 +20172,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20558,7 +20477,6 @@ define amdgpu_kernel void @private_cluster_one_as_monotonic_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20862,7 +20780,6 @@ define amdgpu_kernel void @private_cluster_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21166,7 +21083,6 @@ define amdgpu_kernel void @private_cluster_one_as_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21472,7 +21388,6 @@ define amdgpu_kernel void @private_cluster_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21778,7 +21693,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22084,7 +21998,6 @@ define amdgpu_kernel void @private_cluster_one_as_monotonic_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22390,7 +22303,6 @@ define amdgpu_kernel void @private_cluster_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22696,7 +22608,6 @@ define amdgpu_kernel void @private_cluster_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23002,7 +22913,6 @@ define amdgpu_kernel void @private_cluster_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23308,7 +23218,6 @@ define amdgpu_kernel void @private_cluster_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-singlethread.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-singlethread.ll
@@ -187,7 +187,6 @@ define amdgpu_kernel void @private_singlethread_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -387,7 +386,6 @@ define amdgpu_kernel void @private_singlethread_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -587,7 +585,6 @@ define amdgpu_kernel void @private_singlethread_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -787,7 +784,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -967,7 +963,6 @@ define amdgpu_kernel void @private_singlethread_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1146,7 +1141,6 @@ define amdgpu_kernel void @private_singlethread_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1325,7 +1319,6 @@ define amdgpu_kernel void @private_singlethread_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1504,7 +1497,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1683,7 +1675,6 @@ define amdgpu_kernel void @private_singlethread_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1862,7 +1853,6 @@ define amdgpu_kernel void @private_singlethread_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2041,7 +2031,6 @@ define amdgpu_kernel void @private_singlethread_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2220,7 +2209,6 @@ define amdgpu_kernel void @private_singlethread_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2399,7 +2387,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2632,7 +2619,6 @@ define amdgpu_kernel void @private_singlethread_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -2868,7 +2854,6 @@ define amdgpu_kernel void @private_singlethread_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3104,7 +3089,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3373,7 +3357,6 @@ define amdgpu_kernel void @private_singlethread_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3643,7 +3626,6 @@ define amdgpu_kernel void @private_singlethread_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3913,7 +3895,6 @@ define amdgpu_kernel void @private_singlethread_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4183,7 +4164,6 @@ define amdgpu_kernel void @private_singlethread_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4453,7 +4433,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4723,7 +4702,6 @@ define amdgpu_kernel void @private_singlethread_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4993,7 +4971,6 @@ define amdgpu_kernel void @private_singlethread_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5263,7 +5240,6 @@ define amdgpu_kernel void @private_singlethread_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5533,7 +5509,6 @@ define amdgpu_kernel void @private_singlethread_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5803,7 +5778,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6073,7 +6047,6 @@ define amdgpu_kernel void @private_singlethread_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6343,7 +6316,6 @@ define amdgpu_kernel void @private_singlethread_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6613,7 +6585,6 @@ define amdgpu_kernel void @private_singlethread_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6883,7 +6854,6 @@ define amdgpu_kernel void @private_singlethread_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7153,7 +7123,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7451,7 +7420,6 @@ define amdgpu_kernel void @private_singlethread_monotonic_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -7753,7 +7721,6 @@ define amdgpu_kernel void @private_singlethread_acquire_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8055,7 +8022,6 @@ define amdgpu_kernel void @private_singlethread_release_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8357,7 +8323,6 @@ define amdgpu_kernel void @private_singlethread_acq_rel_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8659,7 +8624,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8961,7 +8925,6 @@ define amdgpu_kernel void @private_singlethread_monotonic_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9263,7 +9226,6 @@ define amdgpu_kernel void @private_singlethread_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9565,7 +9527,6 @@ define amdgpu_kernel void @private_singlethread_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9867,7 +9828,6 @@ define amdgpu_kernel void @private_singlethread_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10169,7 +10129,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10471,7 +10430,6 @@ define amdgpu_kernel void @private_singlethread_monotonic_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10773,7 +10731,6 @@ define amdgpu_kernel void @private_singlethread_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11075,7 +11032,6 @@ define amdgpu_kernel void @private_singlethread_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11377,7 +11333,6 @@ define amdgpu_kernel void @private_singlethread_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11679,7 +11634,6 @@ define amdgpu_kernel void @private_singlethread_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11886,7 +11840,6 @@ define amdgpu_kernel void @private_singlethread_one_as_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12086,7 +12039,6 @@ define amdgpu_kernel void @private_singlethread_one_as_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12286,7 +12238,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12486,7 +12437,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12666,7 +12616,6 @@ define amdgpu_kernel void @private_singlethread_one_as_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12845,7 +12794,6 @@ define amdgpu_kernel void @private_singlethread_one_as_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13024,7 +12972,6 @@ define amdgpu_kernel void @private_singlethread_one_as_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13203,7 +13150,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13382,7 +13328,6 @@ define amdgpu_kernel void @private_singlethread_one_as_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13561,7 +13506,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13740,7 +13684,6 @@ define amdgpu_kernel void @private_singlethread_one_as_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13919,7 +13862,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14098,7 +14040,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14331,7 +14272,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14567,7 +14507,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14803,7 +14742,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -15072,7 +15010,6 @@ define amdgpu_kernel void @private_singlethread_one_as_monotonic_monotonic_cmpxc
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15342,7 +15279,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acquire_monotonic_cmpxchg
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15612,7 +15548,6 @@ define amdgpu_kernel void @private_singlethread_one_as_release_monotonic_cmpxchg
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15882,7 +15817,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acq_rel_monotonic_cmpxchg
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16152,7 +16086,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_monotonic_cmpxchg
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16422,7 +16355,6 @@ define amdgpu_kernel void @private_singlethread_one_as_monotonic_acquire_cmpxchg
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16692,7 +16624,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16962,7 +16893,6 @@ define amdgpu_kernel void @private_singlethread_one_as_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17232,7 +17162,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17502,7 +17431,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17772,7 +17700,6 @@ define amdgpu_kernel void @private_singlethread_one_as_monotonic_seq_cst_cmpxchg
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18042,7 +17969,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18312,7 +18238,6 @@ define amdgpu_kernel void @private_singlethread_one_as_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18582,7 +18507,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18852,7 +18776,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -19150,7 +19073,6 @@ define amdgpu_kernel void @private_singlethread_one_as_monotonic_monotonic_ret_c
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19452,7 +19374,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acquire_monotonic_ret_cmp
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19754,7 +19675,6 @@ define amdgpu_kernel void @private_singlethread_one_as_release_monotonic_ret_cmp
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20056,7 +19976,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acq_rel_monotonic_ret_cmp
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20358,7 +20277,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_monotonic_ret_cmp
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20660,7 +20578,6 @@ define amdgpu_kernel void @private_singlethread_one_as_monotonic_acquire_ret_cmp
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20962,7 +20879,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acquire_acquire_ret_cmpxc
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21264,7 +21180,6 @@ define amdgpu_kernel void @private_singlethread_one_as_release_acquire_ret_cmpxc
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21566,7 +21481,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acq_rel_acquire_ret_cmpxc
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21868,7 +21782,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_acquire_ret_cmpxc
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22170,7 +22083,6 @@ define amdgpu_kernel void @private_singlethread_one_as_monotonic_seq_cst_ret_cmp
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22472,7 +22384,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acquire_seq_cst_ret_cmpxc
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22774,7 +22685,6 @@ define amdgpu_kernel void @private_singlethread_one_as_release_seq_cst_ret_cmpxc
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23076,7 +22986,6 @@ define amdgpu_kernel void @private_singlethread_one_as_acq_rel_seq_cst_ret_cmpxc
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23378,7 +23287,6 @@ define amdgpu_kernel void @private_singlethread_one_as_seq_cst_seq_cst_ret_cmpxc
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-system.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-system.ll
@@ -187,7 +187,6 @@ define amdgpu_kernel void @private_system_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -387,7 +386,6 @@ define amdgpu_kernel void @private_system_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -587,7 +585,6 @@ define amdgpu_kernel void @private_system_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -788,7 +785,6 @@ define amdgpu_kernel void @private_system_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -971,7 +967,6 @@ define amdgpu_kernel void @private_system_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1150,7 +1145,6 @@ define amdgpu_kernel void @private_system_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1329,7 +1323,6 @@ define amdgpu_kernel void @private_system_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1511,7 +1504,6 @@ define amdgpu_kernel void @private_system_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1693,7 +1685,6 @@ define amdgpu_kernel void @private_system_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1872,7 +1863,6 @@ define amdgpu_kernel void @private_system_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2053,7 +2043,6 @@ define amdgpu_kernel void @private_system_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2235,7 +2224,6 @@ define amdgpu_kernel void @private_system_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2419,7 +2407,6 @@ define amdgpu_kernel void @private_system_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2657,7 +2644,6 @@ define amdgpu_kernel void @private_system_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -2894,7 +2880,6 @@ define amdgpu_kernel void @private_system_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3134,7 +3119,6 @@ define amdgpu_kernel void @private_system_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3407,7 +3391,6 @@ define amdgpu_kernel void @private_system_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3677,7 +3660,6 @@ define amdgpu_kernel void @private_system_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3949,7 +3931,6 @@ define amdgpu_kernel void @private_system_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4222,7 +4203,6 @@ define amdgpu_kernel void @private_system_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4497,7 +4477,6 @@ define amdgpu_kernel void @private_system_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4772,7 +4751,6 @@ define amdgpu_kernel void @private_system_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5044,7 +5022,6 @@ define amdgpu_kernel void @private_system_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5316,7 +5293,6 @@ define amdgpu_kernel void @private_system_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5591,7 +5567,6 @@ define amdgpu_kernel void @private_system_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5866,7 +5841,6 @@ define amdgpu_kernel void @private_system_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6141,7 +6115,6 @@ define amdgpu_kernel void @private_system_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6444,7 +6417,6 @@ define amdgpu_kernel void @private_system_monotonic_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -6746,7 +6718,6 @@ define amdgpu_kernel void @private_system_acquire_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -7049,7 +7020,6 @@ define amdgpu_kernel void @private_system_acq_rel_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -7355,7 +7325,6 @@ define amdgpu_kernel void @private_system_seq_cst_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -7661,7 +7630,6 @@ define amdgpu_kernel void @private_system_monotonic_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -7964,7 +7932,6 @@ define amdgpu_kernel void @private_system_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8267,7 +8234,6 @@ define amdgpu_kernel void @private_system_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8573,7 +8539,6 @@ define amdgpu_kernel void @private_system_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8879,7 +8844,6 @@ define amdgpu_kernel void @private_system_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9185,7 +9149,6 @@ define amdgpu_kernel void @private_system_monotonic_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9491,7 +9454,6 @@ define amdgpu_kernel void @private_system_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9797,7 +9759,6 @@ define amdgpu_kernel void @private_system_relese_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10103,7 +10064,6 @@ define amdgpu_kernel void @private_system_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10409,7 +10369,6 @@ define amdgpu_kernel void @private_system_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10620,7 +10579,6 @@ define amdgpu_kernel void @private_system_one_as_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -10820,7 +10778,6 @@ define amdgpu_kernel void @private_system_one_as_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -11020,7 +10977,6 @@ define amdgpu_kernel void @private_system_one_as_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -11222,7 +11178,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -11406,7 +11361,6 @@ define amdgpu_kernel void @private_system_one_as_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -11585,7 +11539,6 @@ define amdgpu_kernel void @private_system_one_as_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -11764,7 +11717,6 @@ define amdgpu_kernel void @private_system_one_as_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -11946,7 +11898,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12128,7 +12079,6 @@ define amdgpu_kernel void @private_system_one_as_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12307,7 +12257,6 @@ define amdgpu_kernel void @private_system_one_as_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12488,7 +12437,6 @@ define amdgpu_kernel void @private_system_one_as_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12670,7 +12618,6 @@ define amdgpu_kernel void @private_system_one_as_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12854,7 +12801,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13092,7 +13038,6 @@ define amdgpu_kernel void @private_system_one_as_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -13330,7 +13275,6 @@ define amdgpu_kernel void @private_system_one_as_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -13571,7 +13515,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -13845,7 +13788,6 @@ define amdgpu_kernel void @private_system_one_as_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14115,7 +14057,6 @@ define amdgpu_kernel void @private_system_one_as_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14387,7 +14328,6 @@ define amdgpu_kernel void @private_system_one_as_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14660,7 +14600,6 @@ define amdgpu_kernel void @private_system_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14935,7 +14874,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15210,7 +15148,6 @@ define amdgpu_kernel void @private_system_one_as_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15482,7 +15419,6 @@ define amdgpu_kernel void @private_system_one_as_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15754,7 +15690,6 @@ define amdgpu_kernel void @private_system_one_as_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16029,7 +15964,6 @@ define amdgpu_kernel void @private_system_one_as_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16304,7 +16238,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16579,7 +16512,6 @@ define amdgpu_kernel void @private_system_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16854,7 +16786,6 @@ define amdgpu_kernel void @private_system_one_as_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17129,7 +17060,6 @@ define amdgpu_kernel void @private_system_one_as_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17404,7 +17334,6 @@ define amdgpu_kernel void @private_system_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17679,7 +17608,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17982,7 +17910,6 @@ define amdgpu_kernel void @private_system_one_as_monotonic_monotonic_ret_cmpxchg
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -18284,7 +18211,6 @@ define amdgpu_kernel void @private_system_one_as_acquire_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -18588,7 +18514,6 @@ define amdgpu_kernel void @private_system_one_as_release_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -18893,7 +18818,6 @@ define amdgpu_kernel void @private_system_one_as_acq_rel_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19200,7 +19124,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19507,7 +19430,6 @@ define amdgpu_kernel void @private_system_one_as_monotonic_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19811,7 +19733,6 @@ define amdgpu_kernel void @private_system_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20115,7 +20036,6 @@ define amdgpu_kernel void @private_system_one_as_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20422,7 +20342,6 @@ define amdgpu_kernel void @private_system_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20729,7 +20648,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21036,7 +20954,6 @@ define amdgpu_kernel void @private_system_one_as_monotonic_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21343,7 +21260,6 @@ define amdgpu_kernel void @private_system_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21650,7 +21566,6 @@ define amdgpu_kernel void @private_system_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21957,7 +21872,6 @@ define amdgpu_kernel void @private_system_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22264,7 +22178,6 @@ define amdgpu_kernel void @private_system_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-wavefront.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-wavefront.ll
@@ -187,7 +187,6 @@ define amdgpu_kernel void @private_wavefront_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -387,7 +386,6 @@ define amdgpu_kernel void @private_wavefront_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -587,7 +585,6 @@ define amdgpu_kernel void @private_wavefront_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -787,7 +784,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -967,7 +963,6 @@ define amdgpu_kernel void @private_wavefront_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1146,7 +1141,6 @@ define amdgpu_kernel void @private_wavefront_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1325,7 +1319,6 @@ define amdgpu_kernel void @private_wavefront_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1504,7 +1497,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1683,7 +1675,6 @@ define amdgpu_kernel void @private_wavefront_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1862,7 +1853,6 @@ define amdgpu_kernel void @private_wavefront_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2041,7 +2031,6 @@ define amdgpu_kernel void @private_wavefront_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2220,7 +2209,6 @@ define amdgpu_kernel void @private_wavefront_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2399,7 +2387,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2632,7 +2619,6 @@ define amdgpu_kernel void @private_wavefront_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -2868,7 +2854,6 @@ define amdgpu_kernel void @private_wavefront_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3104,7 +3089,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3373,7 +3357,6 @@ define amdgpu_kernel void @private_wavefront_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3643,7 +3626,6 @@ define amdgpu_kernel void @private_wavefront_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3913,7 +3895,6 @@ define amdgpu_kernel void @private_wavefront_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4183,7 +4164,6 @@ define amdgpu_kernel void @private_wavefront_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4453,7 +4433,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4723,7 +4702,6 @@ define amdgpu_kernel void @private_wavefront_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4993,7 +4971,6 @@ define amdgpu_kernel void @private_wavefront_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5263,7 +5240,6 @@ define amdgpu_kernel void @private_wavefront_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5533,7 +5509,6 @@ define amdgpu_kernel void @private_wavefront_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5803,7 +5778,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6073,7 +6047,6 @@ define amdgpu_kernel void @private_wavefront_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6343,7 +6316,6 @@ define amdgpu_kernel void @private_wavefront_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6613,7 +6585,6 @@ define amdgpu_kernel void @private_wavefront_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6883,7 +6854,6 @@ define amdgpu_kernel void @private_wavefront_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7153,7 +7123,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7451,7 +7420,6 @@ define amdgpu_kernel void @private_wavefront_monotonic_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -7753,7 +7721,6 @@ define amdgpu_kernel void @private_wavefront_acquire_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8055,7 +8022,6 @@ define amdgpu_kernel void @private_wavefront_release_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8357,7 +8323,6 @@ define amdgpu_kernel void @private_wavefront_acq_rel_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8659,7 +8624,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8961,7 +8925,6 @@ define amdgpu_kernel void @private_wavefront_monotonic_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9263,7 +9226,6 @@ define amdgpu_kernel void @private_wavefront_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9565,7 +9527,6 @@ define amdgpu_kernel void @private_wavefront_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9867,7 +9828,6 @@ define amdgpu_kernel void @private_wavefront_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10169,7 +10129,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10471,7 +10430,6 @@ define amdgpu_kernel void @private_wavefront_monotonic_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10773,7 +10731,6 @@ define amdgpu_kernel void @private_wavefront_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11075,7 +11032,6 @@ define amdgpu_kernel void @private_wavefront_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11377,7 +11333,6 @@ define amdgpu_kernel void @private_wavefront_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11679,7 +11634,6 @@ define amdgpu_kernel void @private_wavefront_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11886,7 +11840,6 @@ define amdgpu_kernel void @private_wavefront_one_as_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12086,7 +12039,6 @@ define amdgpu_kernel void @private_wavefront_one_as_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12286,7 +12238,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12486,7 +12437,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12666,7 +12616,6 @@ define amdgpu_kernel void @private_wavefront_one_as_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12845,7 +12794,6 @@ define amdgpu_kernel void @private_wavefront_one_as_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13024,7 +12972,6 @@ define amdgpu_kernel void @private_wavefront_one_as_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13203,7 +13150,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13382,7 +13328,6 @@ define amdgpu_kernel void @private_wavefront_one_as_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13561,7 +13506,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13740,7 +13684,6 @@ define amdgpu_kernel void @private_wavefront_one_as_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13919,7 +13862,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14098,7 +14040,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14331,7 +14272,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14567,7 +14507,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14803,7 +14742,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -15072,7 +15010,6 @@ define amdgpu_kernel void @private_wavefront_one_as_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15342,7 +15279,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15612,7 +15548,6 @@ define amdgpu_kernel void @private_wavefront_one_as_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15882,7 +15817,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16152,7 +16086,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16422,7 +16355,6 @@ define amdgpu_kernel void @private_wavefront_one_as_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16692,7 +16624,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16962,7 +16893,6 @@ define amdgpu_kernel void @private_wavefront_one_as_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17232,7 +17162,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17502,7 +17431,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17772,7 +17700,6 @@ define amdgpu_kernel void @private_wavefront_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18042,7 +17969,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18312,7 +18238,6 @@ define amdgpu_kernel void @private_wavefront_one_as_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18582,7 +18507,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18852,7 +18776,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -19150,7 +19073,6 @@ define amdgpu_kernel void @private_wavefront_one_as_monotonic_monotonic_ret_cmpx
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19452,7 +19374,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acquire_monotonic_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19754,7 +19675,6 @@ define amdgpu_kernel void @private_wavefront_one_as_release_monotonic_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20056,7 +19976,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acq_rel_monotonic_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20358,7 +20277,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_monotonic_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20660,7 +20578,6 @@ define amdgpu_kernel void @private_wavefront_one_as_monotonic_acquire_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20962,7 +20879,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21264,7 +21180,6 @@ define amdgpu_kernel void @private_wavefront_one_as_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21566,7 +21481,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21868,7 +21782,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22170,7 +22083,6 @@ define amdgpu_kernel void @private_wavefront_one_as_monotonic_seq_cst_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22472,7 +22384,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22774,7 +22685,6 @@ define amdgpu_kernel void @private_wavefront_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23076,7 +22986,6 @@ define amdgpu_kernel void @private_wavefront_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23378,7 +23287,6 @@ define amdgpu_kernel void @private_wavefront_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-workgroup.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-private-workgroup.ll
@@ -187,7 +187,6 @@ define amdgpu_kernel void @private_workgroup_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -387,7 +386,6 @@ define amdgpu_kernel void @private_workgroup_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -587,7 +585,6 @@ define amdgpu_kernel void @private_workgroup_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -787,7 +784,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -969,7 +965,6 @@ define amdgpu_kernel void @private_workgroup_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1148,7 +1143,6 @@ define amdgpu_kernel void @private_workgroup_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1327,7 +1321,6 @@ define amdgpu_kernel void @private_workgroup_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1508,7 +1501,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1689,7 +1681,6 @@ define amdgpu_kernel void @private_workgroup_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -1868,7 +1859,6 @@ define amdgpu_kernel void @private_workgroup_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2048,7 +2038,6 @@ define amdgpu_kernel void @private_workgroup_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2229,7 +2218,6 @@ define amdgpu_kernel void @private_workgroup_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2411,7 +2399,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -2647,7 +2634,6 @@ define amdgpu_kernel void @private_workgroup_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -2883,7 +2869,6 @@ define amdgpu_kernel void @private_workgroup_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3121,7 +3106,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -3392,7 +3376,6 @@ define amdgpu_kernel void @private_workgroup_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3662,7 +3645,6 @@ define amdgpu_kernel void @private_workgroup_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -3933,7 +3915,6 @@ define amdgpu_kernel void @private_workgroup_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4205,7 +4186,6 @@ define amdgpu_kernel void @private_workgroup_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4478,7 +4458,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -4751,7 +4730,6 @@ define amdgpu_kernel void @private_workgroup_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5022,7 +5000,6 @@ define amdgpu_kernel void @private_workgroup_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5293,7 +5270,6 @@ define amdgpu_kernel void @private_workgroup_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5566,7 +5542,6 @@ define amdgpu_kernel void @private_workgroup_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -5839,7 +5814,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6112,7 +6086,6 @@ define amdgpu_kernel void @private_workgroup_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6385,7 +6358,6 @@ define amdgpu_kernel void @private_workgroup_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6658,7 +6630,6 @@ define amdgpu_kernel void @private_workgroup_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -6931,7 +6902,6 @@ define amdgpu_kernel void @private_workgroup_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7204,7 +7174,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -7505,7 +7474,6 @@ define amdgpu_kernel void @private_workgroup_monotonic_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -7807,7 +7775,6 @@ define amdgpu_kernel void @private_workgroup_acquire_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8109,7 +8076,6 @@ define amdgpu_kernel void @private_workgroup_release_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8413,7 +8379,6 @@ define amdgpu_kernel void @private_workgroup_acq_rel_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -8717,7 +8682,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_monotonic_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9021,7 +8985,6 @@ define amdgpu_kernel void @private_workgroup_monotonic_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9323,7 +9286,6 @@ define amdgpu_kernel void @private_workgroup_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9625,7 +9587,6 @@ define amdgpu_kernel void @private_workgroup_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -9929,7 +9890,6 @@ define amdgpu_kernel void @private_workgroup_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10233,7 +10193,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10537,7 +10496,6 @@ define amdgpu_kernel void @private_workgroup_monotonic_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -10841,7 +10799,6 @@ define amdgpu_kernel void @private_workgroup_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11145,7 +11102,6 @@ define amdgpu_kernel void @private_workgroup_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11449,7 +11405,6 @@ define amdgpu_kernel void @private_workgroup_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11753,7 +11708,6 @@ define amdgpu_kernel void @private_workgroup_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -11962,7 +11916,6 @@ define amdgpu_kernel void @private_workgroup_one_as_unordered_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12162,7 +12115,6 @@ define amdgpu_kernel void @private_workgroup_one_as_monotonic_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12362,7 +12314,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acquire_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12562,7 +12513,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_load(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12744,7 +12694,6 @@ define amdgpu_kernel void @private_workgroup_one_as_unordered_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -12923,7 +12872,6 @@ define amdgpu_kernel void @private_workgroup_one_as_monotonic_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13102,7 +13050,6 @@ define amdgpu_kernel void @private_workgroup_one_as_release_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13283,7 +13230,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_store(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13464,7 +13410,6 @@ define amdgpu_kernel void @private_workgroup_one_as_monotonic_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13643,7 +13588,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acquire_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -13823,7 +13767,6 @@ define amdgpu_kernel void @private_workgroup_one_as_release_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14004,7 +13947,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acq_rel_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14186,7 +14128,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s1, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s2
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -14422,7 +14363,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acquire_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14658,7 +14598,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acq_rel_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -14896,7 +14835,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_ret_atomicrmw(
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[2:3], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[2:3]
@@ -15167,7 +15105,6 @@ define amdgpu_kernel void @private_workgroup_one_as_monotonic_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15437,7 +15374,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acquire_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15708,7 +15644,6 @@ define amdgpu_kernel void @private_workgroup_one_as_release_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -15980,7 +15915,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acq_rel_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16253,7 +16187,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_monotonic_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16526,7 +16459,6 @@ define amdgpu_kernel void @private_workgroup_one_as_monotonic_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -16797,7 +16729,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acquire_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17068,7 +16999,6 @@ define amdgpu_kernel void @private_workgroup_one_as_release_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17341,7 +17271,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acq_rel_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17614,7 +17543,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_acquire_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -17887,7 +17815,6 @@ define amdgpu_kernel void @private_workgroup_one_as_monotonic_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18160,7 +18087,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acquire_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18433,7 +18359,6 @@ define amdgpu_kernel void @private_workgroup_one_as_release_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18706,7 +18631,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acq_rel_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -18979,7 +18903,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_seq_cst_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s2, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s2, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s3
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[4:5], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[4:5]
@@ -19280,7 +19203,6 @@ define amdgpu_kernel void @private_workgroup_one_as_monotonic_monotonic_ret_cmpx
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19582,7 +19504,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acquire_monotonic_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -19884,7 +19805,6 @@ define amdgpu_kernel void @private_workgroup_one_as_release_monotonic_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20188,7 +20108,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acq_rel_monotonic_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20492,7 +20411,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_monotonic_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -20796,7 +20714,6 @@ define amdgpu_kernel void @private_workgroup_one_as_monotonic_acquire_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21098,7 +21015,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acquire_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21400,7 +21316,6 @@ define amdgpu_kernel void @private_workgroup_one_as_release_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -21704,7 +21619,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acq_rel_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22008,7 +21922,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_acquire_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22312,7 +22225,6 @@ define amdgpu_kernel void @private_workgroup_one_as_monotonic_seq_cst_ret_cmpxch
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22616,7 +22528,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acquire_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -22920,7 +22831,6 @@ define amdgpu_kernel void @private_workgroup_one_as_release_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23224,7 +23134,6 @@ define amdgpu_kernel void @private_workgroup_one_as_acq_rel_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]
@@ -23528,7 +23437,6 @@ define amdgpu_kernel void @private_workgroup_one_as_seq_cst_seq_cst_ret_cmpxchg(
 ; GFX1250-NEXT:    s_mov_b32 s3, 20
 ; GFX1250-NEXT:    v_lshlrev_b32_e64 v2, s3, v0
 ; GFX1250-NEXT:    v_mov_b32_e32 v0, s4
-; GFX1250-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
 ; GFX1250-NEXT:    v_mov_b32_e32 v1, v2
 ; GFX1250-NEXT:    s_mov_b64 s[6:7], src_flat_scratch_base_lo
 ; GFX1250-NEXT:    v_add_nc_u64_e64 v[0:1], v[0:1], s[6:7]

--- a/llvm/test/CodeGen/AMDGPU/mfma-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/mfma-loop.ll
@@ -101,41 +101,42 @@ define amdgpu_kernel void @test_mfma_loop_zeroinit(ptr addrspace(1) %arg) #0 {
 ;
 ; GFX90A-LABEL: test_mfma_loop_zeroinit:
 ; GFX90A:       ; %bb.0: ; %entry
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    s_mov_b32 s0, 16
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX90A-NEXT:  .LBB0_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_nop 1
@@ -160,41 +161,42 @@ define amdgpu_kernel void @test_mfma_loop_zeroinit(ptr addrspace(1) %arg) #0 {
 ;
 ; GFX942-LABEL: test_mfma_loop_zeroinit:
 ; GFX942:       ; %bb.0: ; %entry
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    s_mov_b32 s0, 16
-; GFX942-NEXT:    v_accvgpr_write_b32 a0, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX942-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX942-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX942-NEXT:  .LBB0_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX942-NEXT:    s_nop 1
@@ -332,42 +334,42 @@ define amdgpu_kernel void @test_mfma_loop_unfoldable_splat(ptr addrspace(1) %arg
 ;
 ; GFX90A-LABEL: test_mfma_loop_unfoldable_splat:
 ; GFX90A:       ; %bb.0: ; %entry
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x42f60000
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0x42f60000
 ; GFX90A-NEXT:    s_mov_b32 s0, 16
-; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX90A-NEXT:  .LBB1_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_nop 1
@@ -392,42 +394,42 @@ define amdgpu_kernel void @test_mfma_loop_unfoldable_splat(ptr addrspace(1) %arg
 ;
 ; GFX942-LABEL: test_mfma_loop_unfoldable_splat:
 ; GFX942:       ; %bb.0: ; %entry
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x42f60000
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0x42f60000
 ; GFX942-NEXT:    s_mov_b32 s0, 16
-; GFX942-NEXT:    v_accvgpr_write_b32 a31, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX942-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX942-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX942-NEXT:  .LBB1_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX942-NEXT:    s_nop 1
@@ -559,41 +561,42 @@ define amdgpu_kernel void @test_mfma_loop_non_splat(ptr addrspace(1) %arg) #0 {
 ;
 ; GFX90A-LABEL: test_mfma_loop_non_splat:
 ; GFX90A:       ; %bb.0: ; %entry
-; GFX90A-NEXT:    s_mov_b32 s0, 16
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, 1.0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 1.0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
+; GFX90A-NEXT:    s_mov_b32 s0, 16
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, 2.0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX90A-NEXT:  .LBB2_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_nop 1
@@ -618,41 +621,42 @@ define amdgpu_kernel void @test_mfma_loop_non_splat(ptr addrspace(1) %arg) #0 {
 ;
 ; GFX942-LABEL: test_mfma_loop_non_splat:
 ; GFX942:       ; %bb.0: ; %entry
-; GFX942-NEXT:    s_mov_b32 s0, 16
-; GFX942-NEXT:    v_accvgpr_write_b32 a0, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, 1.0
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 1.0
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
+; GFX942-NEXT:    s_mov_b32 s0, 16
 ; GFX942-NEXT:    v_mov_b32_e32 v1, 2.0
+; GFX942-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a1, v0
+; GFX942-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX942-NEXT:  .LBB2_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX942-NEXT:    s_nop 1
@@ -821,77 +825,77 @@ define amdgpu_kernel void @test_mfma_loop_unfoldable_seq(ptr addrspace(1) %arg) 
 ;
 ; GFX90A-LABEL: test_mfma_loop_unfoldable_seq:
 ; GFX90A:       ; %bb.0: ; %entry
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x42f60000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x42f80000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x42fa0000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x42fc0000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x42fe0000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43000000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43010000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43020000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43030000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43040000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43050000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43060000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43070000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43080000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43090000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x430a0000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x430b0000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x430c0000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x430d0000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x430e0000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x430f0000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43100000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43110000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43120000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43130000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43140000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43150000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43160000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43170000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43180000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x43190000
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 0x431a0000
+; GFX90A-NEXT:    v_mov_b32_e32 v1, 0x43190000
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0x43180000
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0x43170000
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0x43160000
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0x43150000
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0x43140000
+; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x43130000
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0x43120000
+; GFX90A-NEXT:    v_mov_b32_e32 v9, 0x43110000
+; GFX90A-NEXT:    v_mov_b32_e32 v10, 0x43100000
+; GFX90A-NEXT:    v_mov_b32_e32 v11, 0x430f0000
+; GFX90A-NEXT:    v_mov_b32_e32 v12, 0x430e0000
+; GFX90A-NEXT:    v_mov_b32_e32 v13, 0x430d0000
+; GFX90A-NEXT:    v_mov_b32_e32 v14, 0x430c0000
+; GFX90A-NEXT:    v_mov_b32_e32 v15, 0x430b0000
+; GFX90A-NEXT:    v_mov_b32_e32 v16, 0x430a0000
+; GFX90A-NEXT:    v_mov_b32_e32 v17, 0x43090000
+; GFX90A-NEXT:    v_mov_b32_e32 v18, 0x43080000
+; GFX90A-NEXT:    v_mov_b32_e32 v19, 0x43070000
+; GFX90A-NEXT:    v_mov_b32_e32 v20, 0x43060000
+; GFX90A-NEXT:    v_mov_b32_e32 v21, 0x43050000
+; GFX90A-NEXT:    v_mov_b32_e32 v22, 0x43040000
+; GFX90A-NEXT:    v_mov_b32_e32 v23, 0x43030000
+; GFX90A-NEXT:    v_mov_b32_e32 v24, 0x43020000
+; GFX90A-NEXT:    v_mov_b32_e32 v25, 0x43010000
+; GFX90A-NEXT:    v_mov_b32_e32 v26, 0x43000000
+; GFX90A-NEXT:    v_mov_b32_e32 v27, 0x42fe0000
+; GFX90A-NEXT:    v_mov_b32_e32 v28, 0x42fc0000
+; GFX90A-NEXT:    v_mov_b32_e32 v29, 0x42fa0000
+; GFX90A-NEXT:    v_mov_b32_e32 v30, 0x42f80000
+; GFX90A-NEXT:    v_mov_b32_e32 v31, 0x42f60000
 ; GFX90A-NEXT:    s_mov_b32 s0, 16
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v31
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v30
+; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v29
+; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v28
+; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v27
+; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v26
+; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v25
+; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v24
+; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v23
+; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v22
+; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v21
+; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v20
+; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v19
+; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v18
+; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v17
+; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v16
+; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v15
+; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v14
+; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v13
+; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v12
+; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v11
+; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v10
+; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v9
+; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v8
+; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v7
+; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v6
+; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v5
+; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v4
+; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v1
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 2.0
-; GFX90A-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX90A-NEXT:    v_mov_b32_e32 v0, 1.0
+; GFX90A-NEXT:    v_mov_b32_e32 v1, 2.0
 ; GFX90A-NEXT:  .LBB3_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_nop 1
-; GFX90A-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v1, v0, a[0:31]
+; GFX90A-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[0:31]
 ; GFX90A-NEXT:    s_add_i32 s0, s0, -1
 ; GFX90A-NEXT:    s_cmp_lg_u32 s0, 0
 ; GFX90A-NEXT:    s_cbranch_scc1 .LBB3_1
@@ -912,77 +916,77 @@ define amdgpu_kernel void @test_mfma_loop_unfoldable_seq(ptr addrspace(1) %arg) 
 ;
 ; GFX942-LABEL: test_mfma_loop_unfoldable_seq:
 ; GFX942:       ; %bb.0: ; %entry
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x42f60000
-; GFX942-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x42f80000
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x42fa0000
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x42fc0000
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x42fe0000
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43000000
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43010000
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43020000
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43030000
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43040000
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43050000
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43060000
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43070000
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43080000
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43090000
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x430a0000
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x430b0000
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x430c0000
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x430d0000
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x430e0000
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x430f0000
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43100000
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43110000
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43120000
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43130000
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43140000
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43150000
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43160000
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43170000
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43180000
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 0x43190000
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 0x431a0000
+; GFX942-NEXT:    v_mov_b32_e32 v1, 0x43190000
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0x43180000
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0x43170000
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0x43160000
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0x43150000
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0x43140000
+; GFX942-NEXT:    v_mov_b32_e32 v7, 0x43130000
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0x43120000
+; GFX942-NEXT:    v_mov_b32_e32 v9, 0x43110000
+; GFX942-NEXT:    v_mov_b32_e32 v10, 0x43100000
+; GFX942-NEXT:    v_mov_b32_e32 v11, 0x430f0000
+; GFX942-NEXT:    v_mov_b32_e32 v12, 0x430e0000
+; GFX942-NEXT:    v_mov_b32_e32 v13, 0x430d0000
+; GFX942-NEXT:    v_mov_b32_e32 v14, 0x430c0000
+; GFX942-NEXT:    v_mov_b32_e32 v15, 0x430b0000
+; GFX942-NEXT:    v_mov_b32_e32 v16, 0x430a0000
+; GFX942-NEXT:    v_mov_b32_e32 v17, 0x43090000
+; GFX942-NEXT:    v_mov_b32_e32 v18, 0x43080000
+; GFX942-NEXT:    v_mov_b32_e32 v19, 0x43070000
+; GFX942-NEXT:    v_mov_b32_e32 v20, 0x43060000
+; GFX942-NEXT:    v_mov_b32_e32 v21, 0x43050000
+; GFX942-NEXT:    v_mov_b32_e32 v22, 0x43040000
+; GFX942-NEXT:    v_mov_b32_e32 v23, 0x43030000
+; GFX942-NEXT:    v_mov_b32_e32 v24, 0x43020000
+; GFX942-NEXT:    v_mov_b32_e32 v25, 0x43010000
+; GFX942-NEXT:    v_mov_b32_e32 v26, 0x43000000
+; GFX942-NEXT:    v_mov_b32_e32 v27, 0x42fe0000
+; GFX942-NEXT:    v_mov_b32_e32 v28, 0x42fc0000
+; GFX942-NEXT:    v_mov_b32_e32 v29, 0x42fa0000
+; GFX942-NEXT:    v_mov_b32_e32 v30, 0x42f80000
+; GFX942-NEXT:    v_mov_b32_e32 v31, 0x42f60000
 ; GFX942-NEXT:    s_mov_b32 s0, 16
+; GFX942-NEXT:    v_accvgpr_write_b32 a0, v31
+; GFX942-NEXT:    v_accvgpr_write_b32 a1, v30
+; GFX942-NEXT:    v_accvgpr_write_b32 a2, v29
+; GFX942-NEXT:    v_accvgpr_write_b32 a3, v28
+; GFX942-NEXT:    v_accvgpr_write_b32 a4, v27
+; GFX942-NEXT:    v_accvgpr_write_b32 a5, v26
+; GFX942-NEXT:    v_accvgpr_write_b32 a6, v25
+; GFX942-NEXT:    v_accvgpr_write_b32 a7, v24
+; GFX942-NEXT:    v_accvgpr_write_b32 a8, v23
+; GFX942-NEXT:    v_accvgpr_write_b32 a9, v22
+; GFX942-NEXT:    v_accvgpr_write_b32 a10, v21
+; GFX942-NEXT:    v_accvgpr_write_b32 a11, v20
+; GFX942-NEXT:    v_accvgpr_write_b32 a12, v19
+; GFX942-NEXT:    v_accvgpr_write_b32 a13, v18
+; GFX942-NEXT:    v_accvgpr_write_b32 a14, v17
+; GFX942-NEXT:    v_accvgpr_write_b32 a15, v16
+; GFX942-NEXT:    v_accvgpr_write_b32 a16, v15
+; GFX942-NEXT:    v_accvgpr_write_b32 a17, v14
+; GFX942-NEXT:    v_accvgpr_write_b32 a18, v13
+; GFX942-NEXT:    v_accvgpr_write_b32 a19, v12
+; GFX942-NEXT:    v_accvgpr_write_b32 a20, v11
+; GFX942-NEXT:    v_accvgpr_write_b32 a21, v10
+; GFX942-NEXT:    v_accvgpr_write_b32 a22, v9
+; GFX942-NEXT:    v_accvgpr_write_b32 a23, v8
+; GFX942-NEXT:    v_accvgpr_write_b32 a24, v7
+; GFX942-NEXT:    v_accvgpr_write_b32 a25, v6
+; GFX942-NEXT:    v_accvgpr_write_b32 a26, v5
+; GFX942-NEXT:    v_accvgpr_write_b32 a27, v4
+; GFX942-NEXT:    v_accvgpr_write_b32 a28, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a30, v1
 ; GFX942-NEXT:    v_accvgpr_write_b32 a31, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 2.0
-; GFX942-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX942-NEXT:    v_mov_b32_e32 v0, 1.0
+; GFX942-NEXT:    v_mov_b32_e32 v1, 2.0
 ; GFX942-NEXT:  .LBB3_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX942-NEXT:    s_nop 1
-; GFX942-NEXT:    v_mfma_f32_32x32x1_2b_f32 a[0:31], v1, v0, a[0:31]
+; GFX942-NEXT:    v_mfma_f32_32x32x1_2b_f32 a[0:31], v0, v1, a[0:31]
 ; GFX942-NEXT:    s_add_i32 s0, s0, -1
 ; GFX942-NEXT:    s_cmp_lg_u32 s0, 0
 ; GFX942-NEXT:    s_cbranch_scc1 .LBB3_1
@@ -1110,42 +1114,42 @@ define amdgpu_kernel void @test_mfma_loop_vgpr_init(ptr addrspace(1) %arg) #0 {
 ;
 ; GFX90A-LABEL: test_mfma_loop_vgpr_init:
 ; GFX90A:       ; %bb.0: ; %entry
-; GFX90A-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX90A-NEXT:    v_and_b32_e32 v2, 0x3ff, v0
 ; GFX90A-NEXT:    s_mov_b32 s0, 16
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX90A-NEXT:  .LBB4_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_nop 1
@@ -1170,42 +1174,42 @@ define amdgpu_kernel void @test_mfma_loop_vgpr_init(ptr addrspace(1) %arg) #0 {
 ;
 ; GFX942-LABEL: test_mfma_loop_vgpr_init:
 ; GFX942:       ; %bb.0: ; %entry
-; GFX942-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX942-NEXT:    v_and_b32_e32 v2, 0x3ff, v0
 ; GFX942-NEXT:    s_mov_b32 s0, 16
-; GFX942-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a31, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX942-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX942-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX942-NEXT:  .LBB4_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX942-NEXT:    s_nop 1
@@ -1378,42 +1382,41 @@ define amdgpu_kernel void @test_mfma_loop_sgpr_init(ptr addrspace(1) %arg, float
 ; GFX90A:       ; %bb.0: ; %entry
 ; GFX90A-NEXT:    s_load_dword s1, s[4:5], 0x2c
 ; GFX90A-NEXT:    s_mov_b32 s0, 16
+; GFX90A-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, 1.0
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v0, s1
-; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, 2.0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a2, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a3, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a4, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a5, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a6, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a7, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a8, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a9, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a10, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a11, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a12, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a13, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a14, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a15, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a16, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a17, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a18, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a19, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a20, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a21, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a22, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a23, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a24, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a25, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a26, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a27, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a28, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a29, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a30, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a31, s1
 ; GFX90A-NEXT:  .LBB5_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_nop 1
@@ -1440,42 +1443,41 @@ define amdgpu_kernel void @test_mfma_loop_sgpr_init(ptr addrspace(1) %arg, float
 ; GFX942:       ; %bb.0: ; %entry
 ; GFX942-NEXT:    s_load_dword s1, s[4:5], 0x2c
 ; GFX942-NEXT:    s_mov_b32 s0, 16
+; GFX942-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX942-NEXT:    v_mov_b32_e32 v1, 1.0
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v0, s1
-; GFX942-NEXT:    v_accvgpr_write_b32 a31, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX942-NEXT:    v_mov_b32_e32 v0, 2.0
+; GFX942-NEXT:    v_accvgpr_write_b32 a0, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a1, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a2, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a3, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a4, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a5, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a6, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a7, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a8, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a9, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a10, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a11, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a12, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a13, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a14, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a15, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a16, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a17, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a18, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a19, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a20, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a21, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a22, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a23, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a24, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a25, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a26, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a27, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a28, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a29, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a30, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a31, s1
 ; GFX942-NEXT:  .LBB5_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX942-NEXT:    s_nop 1
@@ -1644,44 +1646,44 @@ define amdgpu_kernel void @test_mfma_loop_mixed_init(ptr addrspace(1) %arg, floa
 ; GFX90A-LABEL: test_mfma_loop_mixed_init:
 ; GFX90A:       ; %bb.0: ; %entry
 ; GFX90A-NEXT:    s_load_dword s1, s[4:5], 0x2c
-; GFX90A-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX90A-NEXT:    v_and_b32_e32 v2, 0x3ff, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    s_mov_b32 s0, 16
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v0, s1
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, s1
+; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v3
+; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v3
 ; GFX90A-NEXT:  .LBB6_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_nop 1
@@ -1707,44 +1709,44 @@ define amdgpu_kernel void @test_mfma_loop_mixed_init(ptr addrspace(1) %arg, floa
 ; GFX942-LABEL: test_mfma_loop_mixed_init:
 ; GFX942:       ; %bb.0: ; %entry
 ; GFX942-NEXT:    s_load_dword s1, s[4:5], 0x2c
-; GFX942-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX942-NEXT:    v_and_b32_e32 v2, 0x3ff, v0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    s_mov_b32 s0, 16
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v0, s1
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, v0
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX942-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX942-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX942-NEXT:    v_accvgpr_write_b32 a1, s1
+; GFX942-NEXT:    v_accvgpr_write_b32 a2, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a3, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a4, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a5, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a6, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a7, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a8, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a9, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a10, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a11, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a12, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a13, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a14, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a15, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a16, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a17, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a18, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a19, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a20, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a21, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a22, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a23, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a24, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a25, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a26, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a27, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a28, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a29, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a30, v3
+; GFX942-NEXT:    v_accvgpr_write_b32 a31, v3
 ; GFX942-NEXT:  .LBB6_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX942-NEXT:    s_nop 1
@@ -2094,152 +2096,57 @@ define amdgpu_kernel void @test_mfma_loop_agpr_init(ptr addrspace(1) %arg) #0 {
 ; GFX90A-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v0, v1, 0
 ; GFX90A-NEXT:    s_nop 15
 ; GFX90A-NEXT:    s_nop 2
-; GFX90A-NEXT:    v_accvgpr_read_b32 v2, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v3, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v4, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v5, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v7, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v8, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v9, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v10, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v11, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v12, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v13, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v14, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v15, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v16, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v17, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v18, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v19, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v20, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v21, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v22, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v23, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v24, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v25, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v26, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v27, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v28, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v29, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v30, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v31, a0
-; GFX90A-NEXT:    v_accvgpr_read_b32 v32, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a1, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a2, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a3, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a4, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a5, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a6, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a7, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a8, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a9, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a10, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a11, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a12, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a13, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a14, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a15, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a16, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a17, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a18, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a19, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a20, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a21, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a22, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a23, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a24, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a25, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a26, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a27, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a28, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a29, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a30, a0
+; GFX90A-NEXT:    v_accvgpr_mov_b32 a31, a0
 ; GFX90A-NEXT:  .LBB8_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v32
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v31
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v30
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v29
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v28
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v27
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v26
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v25
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v24
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v23
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v22
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v21
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v20
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v19
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v18
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v17
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v16
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v15
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v14
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v13
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v12
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v11
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v10
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v9
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v8
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v7
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v6
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v5
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v4
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v3
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a33, a31
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a32, a30
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a31, a29
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a30, a28
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a29, a27
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a28, a26
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a27, a25
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a26, a24
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a25, a23
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a24, a22
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a23, a21
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a22, a20
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a21, a19
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a20, a18
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a19, a17
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a18, a16
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a17, a15
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a16, a14
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a15, a13
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a14, a12
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a13, a11
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a12, a10
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a11, a9
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a10, a8
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a9, a7
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a8, a6
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a7, a5
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a6, a4
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a5, a3
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a4, a2
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a3, a1
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a2, a0
+; GFX90A-NEXT:    s_nop 1
+; GFX90A-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v0, v1, a[0:31]
 ; GFX90A-NEXT:    s_add_i32 s0, s0, -1
 ; GFX90A-NEXT:    s_cmp_lg_u32 s0, 0
-; GFX90A-NEXT:    v_mfma_f32_32x32x1f32 a[2:33], v0, v1, a[2:33]
-; GFX90A-NEXT:    s_nop 15
-; GFX90A-NEXT:    s_nop 2
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a0, a2
-; GFX90A-NEXT:    v_accvgpr_read_b32 v2, a3
-; GFX90A-NEXT:    v_accvgpr_read_b32 v3, a4
-; GFX90A-NEXT:    v_accvgpr_read_b32 v4, a5
-; GFX90A-NEXT:    v_accvgpr_read_b32 v5, a6
-; GFX90A-NEXT:    v_accvgpr_read_b32 v6, a7
-; GFX90A-NEXT:    v_accvgpr_read_b32 v7, a8
-; GFX90A-NEXT:    v_accvgpr_read_b32 v8, a9
-; GFX90A-NEXT:    v_accvgpr_read_b32 v9, a10
-; GFX90A-NEXT:    v_accvgpr_read_b32 v10, a11
-; GFX90A-NEXT:    v_accvgpr_read_b32 v11, a12
-; GFX90A-NEXT:    v_accvgpr_read_b32 v12, a13
-; GFX90A-NEXT:    v_accvgpr_read_b32 v13, a14
-; GFX90A-NEXT:    v_accvgpr_read_b32 v14, a15
-; GFX90A-NEXT:    v_accvgpr_read_b32 v15, a16
-; GFX90A-NEXT:    v_accvgpr_read_b32 v16, a17
-; GFX90A-NEXT:    v_accvgpr_read_b32 v17, a18
-; GFX90A-NEXT:    v_accvgpr_read_b32 v18, a19
-; GFX90A-NEXT:    v_accvgpr_read_b32 v19, a20
-; GFX90A-NEXT:    v_accvgpr_read_b32 v20, a21
-; GFX90A-NEXT:    v_accvgpr_read_b32 v21, a22
-; GFX90A-NEXT:    v_accvgpr_read_b32 v22, a23
-; GFX90A-NEXT:    v_accvgpr_read_b32 v23, a24
-; GFX90A-NEXT:    v_accvgpr_read_b32 v24, a25
-; GFX90A-NEXT:    v_accvgpr_read_b32 v25, a26
-; GFX90A-NEXT:    v_accvgpr_read_b32 v26, a27
-; GFX90A-NEXT:    v_accvgpr_read_b32 v27, a28
-; GFX90A-NEXT:    v_accvgpr_read_b32 v28, a29
-; GFX90A-NEXT:    v_accvgpr_read_b32 v29, a30
-; GFX90A-NEXT:    v_accvgpr_read_b32 v30, a31
-; GFX90A-NEXT:    v_accvgpr_read_b32 v31, a32
-; GFX90A-NEXT:    v_accvgpr_read_b32 v32, a33
 ; GFX90A-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX90A-NEXT:  ; %bb.2: ; %exit
 ; GFX90A-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    global_store_dwordx4 v0, a[30:33], s[0:1] offset:112
-; GFX90A-NEXT:    global_store_dwordx4 v0, a[26:29], s[0:1] offset:96
-; GFX90A-NEXT:    global_store_dwordx4 v0, a[22:25], s[0:1] offset:80
-; GFX90A-NEXT:    global_store_dwordx4 v0, a[18:21], s[0:1] offset:64
-; GFX90A-NEXT:    global_store_dwordx4 v0, a[14:17], s[0:1] offset:48
-; GFX90A-NEXT:    global_store_dwordx4 v0, a[10:13], s[0:1] offset:32
-; GFX90A-NEXT:    global_store_dwordx4 v0, a[6:9], s[0:1] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v0, a[2:5], s[0:1]
+; GFX90A-NEXT:    s_nop 12
+; GFX90A-NEXT:    global_store_dwordx4 v0, a[28:31], s[0:1] offset:112
+; GFX90A-NEXT:    global_store_dwordx4 v0, a[24:27], s[0:1] offset:96
+; GFX90A-NEXT:    global_store_dwordx4 v0, a[20:23], s[0:1] offset:80
+; GFX90A-NEXT:    global_store_dwordx4 v0, a[16:19], s[0:1] offset:64
+; GFX90A-NEXT:    global_store_dwordx4 v0, a[12:15], s[0:1] offset:48
+; GFX90A-NEXT:    global_store_dwordx4 v0, a[8:11], s[0:1] offset:32
+; GFX90A-NEXT:    global_store_dwordx4 v0, a[4:7], s[0:1] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v0, a[0:3], s[0:1]
 ; GFX90A-NEXT:    s_endpgm
 ;
 ; GFX942-LABEL: test_mfma_loop_agpr_init:
@@ -2251,152 +2158,57 @@ define amdgpu_kernel void @test_mfma_loop_agpr_init(ptr addrspace(1) %arg) #0 {
 ; GFX942-NEXT:    v_mfma_f32_32x32x1_2b_f32 a[0:31], v0, v1, 0
 ; GFX942-NEXT:    s_nop 15
 ; GFX942-NEXT:    s_nop 1
-; GFX942-NEXT:    v_accvgpr_read_b32 v2, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v3, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v4, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v5, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v7, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v8, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v9, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v10, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v11, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v12, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v13, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v14, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v15, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v16, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v17, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v18, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v19, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v20, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v21, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v22, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v23, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v24, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v25, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v26, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v27, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v28, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v29, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v30, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v31, a0
-; GFX942-NEXT:    v_accvgpr_read_b32 v32, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a1, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a2, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a3, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a4, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a5, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a6, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a7, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a8, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a9, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a10, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a11, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a12, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a13, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a14, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a15, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a16, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a17, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a18, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a19, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a20, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a21, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a22, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a23, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a24, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a25, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a26, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a27, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a28, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a29, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a30, a0
+; GFX942-NEXT:    v_accvgpr_mov_b32 a31, a0
 ; GFX942-NEXT:  .LBB8_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX942-NEXT:    v_accvgpr_write_b32 a31, v32
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, v31
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, v30
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, v29
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, v28
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, v27
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, v26
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, v25
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, v24
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, v23
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, v22
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, v21
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, v20
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, v19
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, v18
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, v17
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, v16
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, v15
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, v14
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, v13
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, v12
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, v11
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, v10
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, v9
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, v8
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, v7
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, v6
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, v5
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, v4
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, v3
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, v2
-; GFX942-NEXT:    v_accvgpr_mov_b32 a33, a31
-; GFX942-NEXT:    v_accvgpr_mov_b32 a32, a30
-; GFX942-NEXT:    v_accvgpr_mov_b32 a31, a29
-; GFX942-NEXT:    v_accvgpr_mov_b32 a30, a28
-; GFX942-NEXT:    v_accvgpr_mov_b32 a29, a27
-; GFX942-NEXT:    v_accvgpr_mov_b32 a28, a26
-; GFX942-NEXT:    v_accvgpr_mov_b32 a27, a25
-; GFX942-NEXT:    v_accvgpr_mov_b32 a26, a24
-; GFX942-NEXT:    v_accvgpr_mov_b32 a25, a23
-; GFX942-NEXT:    v_accvgpr_mov_b32 a24, a22
-; GFX942-NEXT:    v_accvgpr_mov_b32 a23, a21
-; GFX942-NEXT:    v_accvgpr_mov_b32 a22, a20
-; GFX942-NEXT:    v_accvgpr_mov_b32 a21, a19
-; GFX942-NEXT:    v_accvgpr_mov_b32 a20, a18
-; GFX942-NEXT:    v_accvgpr_mov_b32 a19, a17
-; GFX942-NEXT:    v_accvgpr_mov_b32 a18, a16
-; GFX942-NEXT:    v_accvgpr_mov_b32 a17, a15
-; GFX942-NEXT:    v_accvgpr_mov_b32 a16, a14
-; GFX942-NEXT:    v_accvgpr_mov_b32 a15, a13
-; GFX942-NEXT:    v_accvgpr_mov_b32 a14, a12
-; GFX942-NEXT:    v_accvgpr_mov_b32 a13, a11
-; GFX942-NEXT:    v_accvgpr_mov_b32 a12, a10
-; GFX942-NEXT:    v_accvgpr_mov_b32 a11, a9
-; GFX942-NEXT:    v_accvgpr_mov_b32 a10, a8
-; GFX942-NEXT:    v_accvgpr_mov_b32 a9, a7
-; GFX942-NEXT:    v_accvgpr_mov_b32 a8, a6
-; GFX942-NEXT:    v_accvgpr_mov_b32 a7, a5
-; GFX942-NEXT:    v_accvgpr_mov_b32 a6, a4
-; GFX942-NEXT:    v_accvgpr_mov_b32 a5, a3
-; GFX942-NEXT:    v_accvgpr_mov_b32 a4, a2
-; GFX942-NEXT:    v_accvgpr_mov_b32 a3, a1
-; GFX942-NEXT:    v_accvgpr_mov_b32 a2, a0
+; GFX942-NEXT:    s_nop 1
+; GFX942-NEXT:    v_mfma_f32_32x32x1_2b_f32 a[0:31], v0, v1, a[0:31]
 ; GFX942-NEXT:    s_add_i32 s0, s0, -1
 ; GFX942-NEXT:    s_cmp_lg_u32 s0, 0
-; GFX942-NEXT:    v_mfma_f32_32x32x1_2b_f32 a[2:33], v0, v1, a[2:33]
-; GFX942-NEXT:    s_nop 15
-; GFX942-NEXT:    s_nop 1
-; GFX942-NEXT:    v_accvgpr_mov_b32 a0, a2
-; GFX942-NEXT:    v_accvgpr_read_b32 v2, a3
-; GFX942-NEXT:    v_accvgpr_read_b32 v3, a4
-; GFX942-NEXT:    v_accvgpr_read_b32 v4, a5
-; GFX942-NEXT:    v_accvgpr_read_b32 v5, a6
-; GFX942-NEXT:    v_accvgpr_read_b32 v6, a7
-; GFX942-NEXT:    v_accvgpr_read_b32 v7, a8
-; GFX942-NEXT:    v_accvgpr_read_b32 v8, a9
-; GFX942-NEXT:    v_accvgpr_read_b32 v9, a10
-; GFX942-NEXT:    v_accvgpr_read_b32 v10, a11
-; GFX942-NEXT:    v_accvgpr_read_b32 v11, a12
-; GFX942-NEXT:    v_accvgpr_read_b32 v12, a13
-; GFX942-NEXT:    v_accvgpr_read_b32 v13, a14
-; GFX942-NEXT:    v_accvgpr_read_b32 v14, a15
-; GFX942-NEXT:    v_accvgpr_read_b32 v15, a16
-; GFX942-NEXT:    v_accvgpr_read_b32 v16, a17
-; GFX942-NEXT:    v_accvgpr_read_b32 v17, a18
-; GFX942-NEXT:    v_accvgpr_read_b32 v18, a19
-; GFX942-NEXT:    v_accvgpr_read_b32 v19, a20
-; GFX942-NEXT:    v_accvgpr_read_b32 v20, a21
-; GFX942-NEXT:    v_accvgpr_read_b32 v21, a22
-; GFX942-NEXT:    v_accvgpr_read_b32 v22, a23
-; GFX942-NEXT:    v_accvgpr_read_b32 v23, a24
-; GFX942-NEXT:    v_accvgpr_read_b32 v24, a25
-; GFX942-NEXT:    v_accvgpr_read_b32 v25, a26
-; GFX942-NEXT:    v_accvgpr_read_b32 v26, a27
-; GFX942-NEXT:    v_accvgpr_read_b32 v27, a28
-; GFX942-NEXT:    v_accvgpr_read_b32 v28, a29
-; GFX942-NEXT:    v_accvgpr_read_b32 v29, a30
-; GFX942-NEXT:    v_accvgpr_read_b32 v30, a31
-; GFX942-NEXT:    v_accvgpr_read_b32 v31, a32
-; GFX942-NEXT:    v_accvgpr_read_b32 v32, a33
 ; GFX942-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX942-NEXT:  ; %bb.2: ; %exit
 ; GFX942-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:    global_store_dwordx4 v0, a[30:33], s[0:1] offset:112
-; GFX942-NEXT:    global_store_dwordx4 v0, a[26:29], s[0:1] offset:96
-; GFX942-NEXT:    global_store_dwordx4 v0, a[22:25], s[0:1] offset:80
-; GFX942-NEXT:    global_store_dwordx4 v0, a[18:21], s[0:1] offset:64
-; GFX942-NEXT:    global_store_dwordx4 v0, a[14:17], s[0:1] offset:48
-; GFX942-NEXT:    global_store_dwordx4 v0, a[10:13], s[0:1] offset:32
-; GFX942-NEXT:    global_store_dwordx4 v0, a[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v0, a[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 11
+; GFX942-NEXT:    global_store_dwordx4 v0, a[28:31], s[0:1] offset:112
+; GFX942-NEXT:    global_store_dwordx4 v0, a[24:27], s[0:1] offset:96
+; GFX942-NEXT:    global_store_dwordx4 v0, a[20:23], s[0:1] offset:80
+; GFX942-NEXT:    global_store_dwordx4 v0, a[16:19], s[0:1] offset:64
+; GFX942-NEXT:    global_store_dwordx4 v0, a[12:15], s[0:1] offset:48
+; GFX942-NEXT:    global_store_dwordx4 v0, a[8:11], s[0:1] offset:32
+; GFX942-NEXT:    global_store_dwordx4 v0, a[4:7], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v0, a[0:3], s[0:1]
 ; GFX942-NEXT:    s_endpgm
 entry:
   %mai.0 = tail call <32 x float> @llvm.amdgcn.mfma.f32.32x32x1f32(float 1.0, float 2.0, <32 x float> zeroinitializer, i32 0, i32 0, i32 0)
@@ -2803,41 +2615,42 @@ define <32 x float> @test_mfma_loop_zeroinit_ret_use() #0 {
 ; GFX90A-LABEL: test_mfma_loop_zeroinit_ret_use:
 ; GFX90A:       ; %bb.0: ; %entry
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    s_mov_b32 s4, 16
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX90A-NEXT:  .LBB10_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_nop 1
@@ -2884,41 +2697,42 @@ define <32 x float> @test_mfma_loop_zeroinit_ret_use() #0 {
 ; GFX942-LABEL: test_mfma_loop_zeroinit_ret_use:
 ; GFX942:       ; %bb.0: ; %entry
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    s_mov_b32 s0, 16
-; GFX942-NEXT:    v_accvgpr_write_b32 a0, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 2.0
 ; GFX942-NEXT:    v_mov_b32_e32 v1, 1.0
+; GFX942-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a1, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX942-NEXT:  .LBB10_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX942-NEXT:    s_nop 1
@@ -3061,41 +2875,42 @@ define <32 x float> @test_mfma_loop_non_splat_ret_use() #0 {
 ; GFX90A-LABEL: test_mfma_loop_non_splat_ret_use:
 ; GFX90A:       ; %bb.0: ; %entry
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    s_mov_b32 s4, 16
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, 1.0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, 1.0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
+; GFX90A-NEXT:    s_mov_b32 s4, 16
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, 2.0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v0
+; GFX90A-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX90A-NEXT:  .LBB11_1: ; %for.cond.preheader
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_nop 1
@@ -3142,41 +2957,42 @@ define <32 x float> @test_mfma_loop_non_splat_ret_use() #0 {
 ; GFX942-LABEL: test_mfma_loop_non_splat_ret_use:
 ; GFX942:       ; %bb.0: ; %entry
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    s_mov_b32 s0, 16
-; GFX942-NEXT:    v_accvgpr_write_b32 a0, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a1, 1.0
-; GFX942-NEXT:    v_accvgpr_write_b32 a2, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a3, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a4, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a5, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a6, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a7, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a8, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a9, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a10, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a11, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a12, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a13, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a14, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a15, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a16, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a17, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a18, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a19, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a20, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a21, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a22, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a23, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a24, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a25, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a26, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a27, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a28, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a29, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a30, 0
-; GFX942-NEXT:    v_accvgpr_write_b32 a31, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 1.0
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
+; GFX942-NEXT:    s_mov_b32 s0, 16
 ; GFX942-NEXT:    v_mov_b32_e32 v1, 2.0
+; GFX942-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a1, v0
+; GFX942-NEXT:    v_accvgpr_write_b32 a2, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a3, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a4, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a5, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a6, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a7, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a8, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a9, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a10, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a11, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a12, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a13, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a14, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a15, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a16, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a17, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a18, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a19, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a20, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a21, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a22, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a23, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a24, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a25, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a26, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a27, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a28, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a29, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a30, v2
+; GFX942-NEXT:    v_accvgpr_write_b32 a31, v2
 ; GFX942-NEXT:  .LBB11_1: ; %for.cond.preheader
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX942-NEXT:    s_nop 1

--- a/llvm/test/CodeGen/AMDGPU/mfma-no-register-aliasing.ll
+++ b/llvm/test/CodeGen/AMDGPU/mfma-no-register-aliasing.ll
@@ -499,105 +499,73 @@ define amdgpu_kernel void @test_mfma_f32_32x32x1f32(ptr addrspace(1) %arg) #0 {
 ; FAST90A-NEXT:    s_load_dwordx16 s[36:51], s[0:1], 0x0
 ; FAST90A-NEXT:    s_load_dwordx16 s[4:19], s[0:1], 0x40
 ; FAST90A-NEXT:    s_waitcnt lgkmcnt(0)
-; FAST90A-NEXT:    v_accvgpr_write_b32 a32, s36
-; FAST90A-NEXT:    v_accvgpr_write_b32 a33, s37
-; FAST90A-NEXT:    v_accvgpr_write_b32 a34, s38
-; FAST90A-NEXT:    v_accvgpr_write_b32 a35, s39
-; FAST90A-NEXT:    v_accvgpr_write_b32 a36, s40
-; FAST90A-NEXT:    v_accvgpr_write_b32 a37, s41
-; FAST90A-NEXT:    v_accvgpr_write_b32 a38, s42
-; FAST90A-NEXT:    v_accvgpr_write_b32 a39, s43
-; FAST90A-NEXT:    v_accvgpr_write_b32 a40, s44
-; FAST90A-NEXT:    v_accvgpr_write_b32 a41, s45
-; FAST90A-NEXT:    v_accvgpr_write_b32 a42, s46
-; FAST90A-NEXT:    v_accvgpr_write_b32 a43, s47
-; FAST90A-NEXT:    v_accvgpr_write_b32 a44, s48
-; FAST90A-NEXT:    v_accvgpr_write_b32 a45, s49
-; FAST90A-NEXT:    v_accvgpr_write_b32 a46, s50
-; FAST90A-NEXT:    v_accvgpr_write_b32 a47, s51
-; FAST90A-NEXT:    v_accvgpr_write_b32 a48, s4
-; FAST90A-NEXT:    v_accvgpr_write_b32 a49, s5
-; FAST90A-NEXT:    v_accvgpr_write_b32 a50, s6
-; FAST90A-NEXT:    v_accvgpr_write_b32 a51, s7
-; FAST90A-NEXT:    v_accvgpr_write_b32 a52, s8
-; FAST90A-NEXT:    v_accvgpr_write_b32 a53, s9
-; FAST90A-NEXT:    v_accvgpr_write_b32 a54, s10
-; FAST90A-NEXT:    v_accvgpr_write_b32 a55, s11
-; FAST90A-NEXT:    v_accvgpr_write_b32 a56, s12
-; FAST90A-NEXT:    v_accvgpr_write_b32 a57, s13
-; FAST90A-NEXT:    v_accvgpr_write_b32 a58, s14
-; FAST90A-NEXT:    v_accvgpr_write_b32 a59, s15
-; FAST90A-NEXT:    v_accvgpr_write_b32 a60, s16
-; FAST90A-NEXT:    v_accvgpr_write_b32 a61, s17
-; FAST90A-NEXT:    v_accvgpr_write_b32 a62, s18
-; FAST90A-NEXT:    v_accvgpr_write_b32 a63, s19
+; FAST90A-NEXT:    v_accvgpr_write_b32 a0, s36
+; FAST90A-NEXT:    v_accvgpr_write_b32 a1, s37
+; FAST90A-NEXT:    v_accvgpr_write_b32 a2, s38
+; FAST90A-NEXT:    v_accvgpr_write_b32 a3, s39
+; FAST90A-NEXT:    v_accvgpr_write_b32 a4, s40
+; FAST90A-NEXT:    v_accvgpr_write_b32 a5, s41
+; FAST90A-NEXT:    v_accvgpr_write_b32 a6, s42
+; FAST90A-NEXT:    v_accvgpr_write_b32 a7, s43
+; FAST90A-NEXT:    v_accvgpr_write_b32 a8, s44
+; FAST90A-NEXT:    v_accvgpr_write_b32 a9, s45
+; FAST90A-NEXT:    v_accvgpr_write_b32 a10, s46
+; FAST90A-NEXT:    v_accvgpr_write_b32 a11, s47
+; FAST90A-NEXT:    v_accvgpr_write_b32 a12, s48
+; FAST90A-NEXT:    v_accvgpr_write_b32 a13, s49
+; FAST90A-NEXT:    v_accvgpr_write_b32 a14, s50
+; FAST90A-NEXT:    v_accvgpr_write_b32 a15, s51
+; FAST90A-NEXT:    v_accvgpr_write_b32 a16, s4
+; FAST90A-NEXT:    v_accvgpr_write_b32 a17, s5
+; FAST90A-NEXT:    v_accvgpr_write_b32 a18, s6
+; FAST90A-NEXT:    v_accvgpr_write_b32 a19, s7
+; FAST90A-NEXT:    v_accvgpr_write_b32 a20, s8
+; FAST90A-NEXT:    v_accvgpr_write_b32 a21, s9
+; FAST90A-NEXT:    v_accvgpr_write_b32 a22, s10
+; FAST90A-NEXT:    v_accvgpr_write_b32 a23, s11
+; FAST90A-NEXT:    v_accvgpr_write_b32 a24, s12
+; FAST90A-NEXT:    v_accvgpr_write_b32 a25, s13
+; FAST90A-NEXT:    v_accvgpr_write_b32 a26, s14
+; FAST90A-NEXT:    v_accvgpr_write_b32 a27, s15
+; FAST90A-NEXT:    v_accvgpr_write_b32 a28, s16
+; FAST90A-NEXT:    v_accvgpr_write_b32 a29, s17
+; FAST90A-NEXT:    v_accvgpr_write_b32 a30, s18
+; FAST90A-NEXT:    v_accvgpr_write_b32 a31, s19
 ; FAST90A-NEXT:    s_nop 1
-; FAST90A-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v1, v2, a[32:63]
-; FAST90A-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v1, v2, a[32:63]
+; FAST90A-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v1, v2, a[0:31]
+; FAST90A-NEXT:    v_mfma_f32_32x32x1f32 a[32:63], v1, v2, a[0:31]
 ; FAST90A-NEXT:    s_nop 15
 ; FAST90A-NEXT:    s_nop 2
-; FAST90A-NEXT:    v_accvgpr_read_b32 v3, a29
-; FAST90A-NEXT:    v_accvgpr_read_b32 v4, a28
-; FAST90A-NEXT:    v_accvgpr_read_b32 v5, a27
-; FAST90A-NEXT:    v_accvgpr_read_b32 v6, a26
-; FAST90A-NEXT:    v_accvgpr_read_b32 v7, a25
-; FAST90A-NEXT:    v_accvgpr_read_b32 v8, a24
-; FAST90A-NEXT:    v_accvgpr_read_b32 v9, a23
-; FAST90A-NEXT:    v_accvgpr_read_b32 v10, a22
-; FAST90A-NEXT:    v_accvgpr_read_b32 v11, a21
-; FAST90A-NEXT:    v_accvgpr_read_b32 v12, a20
-; FAST90A-NEXT:    v_accvgpr_read_b32 v13, a19
-; FAST90A-NEXT:    v_accvgpr_read_b32 v14, a18
-; FAST90A-NEXT:    v_accvgpr_read_b32 v15, a17
-; FAST90A-NEXT:    v_accvgpr_read_b32 v16, a16
-; FAST90A-NEXT:    v_accvgpr_read_b32 v17, a15
-; FAST90A-NEXT:    v_accvgpr_read_b32 v18, a14
-; FAST90A-NEXT:    v_accvgpr_read_b32 v19, a13
-; FAST90A-NEXT:    v_accvgpr_read_b32 v20, a12
-; FAST90A-NEXT:    v_accvgpr_read_b32 v21, a11
-; FAST90A-NEXT:    v_accvgpr_read_b32 v22, a10
-; FAST90A-NEXT:    v_accvgpr_read_b32 v23, a9
-; FAST90A-NEXT:    v_accvgpr_read_b32 v24, a8
-; FAST90A-NEXT:    v_accvgpr_read_b32 v25, a7
-; FAST90A-NEXT:    v_accvgpr_read_b32 v26, a6
-; FAST90A-NEXT:    v_accvgpr_read_b32 v27, a5
-; FAST90A-NEXT:    v_accvgpr_read_b32 v28, a4
-; FAST90A-NEXT:    v_accvgpr_read_b32 v29, a3
-; FAST90A-NEXT:    v_accvgpr_read_b32 v30, a2
-; FAST90A-NEXT:    v_accvgpr_read_b32 v31, a1
-; FAST90A-NEXT:    v_accvgpr_read_b32 v32, a0
-; FAST90A-NEXT:    v_accvgpr_mov_b32 a0, a32
-; FAST90A-NEXT:    v_accvgpr_mov_b32 a1, a33
-; FAST90A-NEXT:    v_accvgpr_write_b32 a2, v32
-; FAST90A-NEXT:    v_accvgpr_write_b32 a3, v31
-; FAST90A-NEXT:    v_accvgpr_write_b32 a4, v30
-; FAST90A-NEXT:    v_accvgpr_write_b32 a5, v29
-; FAST90A-NEXT:    v_accvgpr_write_b32 a6, v28
-; FAST90A-NEXT:    v_accvgpr_write_b32 a7, v27
-; FAST90A-NEXT:    v_accvgpr_write_b32 a8, v26
-; FAST90A-NEXT:    v_accvgpr_write_b32 a9, v25
-; FAST90A-NEXT:    v_accvgpr_write_b32 a10, v24
-; FAST90A-NEXT:    v_accvgpr_write_b32 a11, v23
-; FAST90A-NEXT:    v_accvgpr_write_b32 a12, v22
-; FAST90A-NEXT:    v_accvgpr_write_b32 a13, v21
-; FAST90A-NEXT:    v_accvgpr_write_b32 a14, v20
-; FAST90A-NEXT:    v_accvgpr_write_b32 a15, v19
-; FAST90A-NEXT:    v_accvgpr_write_b32 a16, v18
-; FAST90A-NEXT:    v_accvgpr_write_b32 a17, v17
-; FAST90A-NEXT:    v_accvgpr_write_b32 a18, v16
-; FAST90A-NEXT:    v_accvgpr_write_b32 a19, v15
-; FAST90A-NEXT:    v_accvgpr_write_b32 a20, v14
-; FAST90A-NEXT:    v_accvgpr_write_b32 a21, v13
-; FAST90A-NEXT:    v_accvgpr_write_b32 a22, v12
-; FAST90A-NEXT:    v_accvgpr_write_b32 a23, v11
-; FAST90A-NEXT:    v_accvgpr_write_b32 a24, v10
-; FAST90A-NEXT:    v_accvgpr_write_b32 a25, v9
-; FAST90A-NEXT:    v_accvgpr_write_b32 a26, v8
-; FAST90A-NEXT:    v_accvgpr_write_b32 a27, v7
-; FAST90A-NEXT:    v_accvgpr_write_b32 a28, v6
-; FAST90A-NEXT:    v_accvgpr_write_b32 a29, v5
-; FAST90A-NEXT:    v_accvgpr_write_b32 a30, v4
-; FAST90A-NEXT:    v_accvgpr_write_b32 a31, v3
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a2, a32
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a3, a33
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a4, a34
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a5, a35
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a6, a36
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a7, a37
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a8, a38
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a9, a39
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a10, a40
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a11, a41
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a12, a42
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a13, a43
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a14, a44
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a15, a45
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a16, a46
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a17, a47
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a18, a48
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a19, a49
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a20, a50
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a21, a51
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a22, a52
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a23, a53
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a24, a54
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a25, a55
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a26, a56
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a27, a57
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a28, a58
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a29, a59
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a30, a60
+; FAST90A-NEXT:    v_accvgpr_mov_b32 a31, a61
 ; FAST90A-NEXT:    s_nop 1
 ; FAST90A-NEXT:    v_mfma_f32_32x32x1f32 a[0:31], v1, v2, a[0:31]
 ; FAST90A-NEXT:    s_nop 15
@@ -709,39 +677,51 @@ define amdgpu_kernel void @test_mfma_f32_16x16x1f32(ptr addrspace(1) %arg) #0 {
 ; GREEDY90A-NEXT:    s_load_dwordx2 s[16:17], s[4:5], 0x24
 ; GREEDY90A-NEXT:    v_mov_b32_e32 v0, 1.0
 ; GREEDY90A-NEXT:    v_mov_b32_e32 v1, 2.0
-; GREEDY90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GREEDY90A-NEXT:    s_waitcnt lgkmcnt(0)
 ; GREEDY90A-NEXT:    s_load_dwordx16 s[0:15], s[16:17], 0x0
 ; GREEDY90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a33, s15
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a32, s14
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a31, s13
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a30, s12
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a29, s11
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a28, s10
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a27, s9
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a26, s8
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a25, s7
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a24, s6
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a23, s5
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a22, s4
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a21, s3
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a20, s2
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a19, s1
-; GREEDY90A-NEXT:    v_accvgpr_write_b32 a18, s0
-; GREEDY90A-NEXT:    s_nop 1
-; GREEDY90A-NEXT:    v_mfma_f32_16x16x1f32 a[18:33], v0, v1, a[18:33]
-; GREEDY90A-NEXT:    v_mfma_f32_16x16x1f32 a[2:17], v0, v1, a[18:33]
-; GREEDY90A-NEXT:    s_nop 9
-; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a0, a18
-; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a1, a19
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a0, s0
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a1, s1
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a2, s2
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a3, s3
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a4, s4
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a5, s5
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a6, s6
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a7, s7
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a8, s8
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a9, s9
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a10, s10
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a11, s11
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a12, s12
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a13, s13
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a14, s14
+; GREEDY90A-NEXT:    v_accvgpr_write_b32 a15, s15
 ; GREEDY90A-NEXT:    s_nop 1
 ; GREEDY90A-NEXT:    v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[0:15]
+; GREEDY90A-NEXT:    v_mfma_f32_16x16x1f32 a[16:31], v0, v1, a[0:15]
 ; GREEDY90A-NEXT:    s_nop 10
-; GREEDY90A-NEXT:    global_store_dwordx4 v2, a[12:15], s[16:17] offset:48
-; GREEDY90A-NEXT:    global_store_dwordx4 v2, a[8:11], s[16:17] offset:32
-; GREEDY90A-NEXT:    global_store_dwordx4 v2, a[4:7], s[16:17] offset:16
-; GREEDY90A-NEXT:    global_store_dwordx4 v2, a[0:3], s[16:17]
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a2, a16
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a3, a17
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a4, a18
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a5, a19
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a6, a20
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a7, a21
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a8, a22
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a9, a23
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a10, a24
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a11, a25
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a12, a26
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a13, a27
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a14, a28
+; GREEDY90A-NEXT:    v_accvgpr_mov_b32 a15, a29
+; GREEDY90A-NEXT:    s_nop 1
+; GREEDY90A-NEXT:    v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[0:15]
+; GREEDY90A-NEXT:    v_mov_b32_e32 v0, 0
+; GREEDY90A-NEXT:    s_nop 9
+; GREEDY90A-NEXT:    global_store_dwordx4 v0, a[12:15], s[16:17] offset:48
+; GREEDY90A-NEXT:    global_store_dwordx4 v0, a[8:11], s[16:17] offset:32
+; GREEDY90A-NEXT:    global_store_dwordx4 v0, a[4:7], s[16:17] offset:16
+; GREEDY90A-NEXT:    global_store_dwordx4 v0, a[0:3], s[16:17]
 ; GREEDY90A-NEXT:    s_endpgm
 ;
 ; GREEDY942-LABEL: test_mfma_f32_16x16x1f32:
@@ -749,39 +729,51 @@ define amdgpu_kernel void @test_mfma_f32_16x16x1f32(ptr addrspace(1) %arg) #0 {
 ; GREEDY942-NEXT:    s_load_dwordx2 s[16:17], s[4:5], 0x24
 ; GREEDY942-NEXT:    v_mov_b32_e32 v0, 1.0
 ; GREEDY942-NEXT:    v_mov_b32_e32 v1, 2.0
-; GREEDY942-NEXT:    v_mov_b32_e32 v2, 0
 ; GREEDY942-NEXT:    s_waitcnt lgkmcnt(0)
 ; GREEDY942-NEXT:    s_load_dwordx16 s[0:15], s[16:17], 0x0
 ; GREEDY942-NEXT:    s_waitcnt lgkmcnt(0)
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a33, s15
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a32, s14
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a31, s13
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a30, s12
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a29, s11
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a28, s10
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a27, s9
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a26, s8
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a25, s7
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a24, s6
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a23, s5
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a22, s4
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a21, s3
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a20, s2
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a19, s1
-; GREEDY942-NEXT:    v_accvgpr_write_b32 a18, s0
-; GREEDY942-NEXT:    s_nop 1
-; GREEDY942-NEXT:    v_mfma_f32_16x16x1_4b_f32 a[18:33], v0, v1, a[18:33]
-; GREEDY942-NEXT:    v_mfma_f32_16x16x1_4b_f32 a[2:17], v0, v1, a[18:33]
-; GREEDY942-NEXT:    s_nop 8
-; GREEDY942-NEXT:    v_accvgpr_mov_b32 a0, a18
-; GREEDY942-NEXT:    v_accvgpr_mov_b32 a1, a19
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a0, s0
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a1, s1
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a2, s2
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a3, s3
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a4, s4
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a5, s5
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a6, s6
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a7, s7
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a8, s8
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a9, s9
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a10, s10
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a11, s11
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a12, s12
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a13, s13
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a14, s14
+; GREEDY942-NEXT:    v_accvgpr_write_b32 a15, s15
 ; GREEDY942-NEXT:    s_nop 1
 ; GREEDY942-NEXT:    v_mfma_f32_16x16x1_4b_f32 a[0:15], v0, v1, a[0:15]
+; GREEDY942-NEXT:    v_mfma_f32_16x16x1_4b_f32 a[16:31], v0, v1, a[0:15]
 ; GREEDY942-NEXT:    s_nop 9
-; GREEDY942-NEXT:    global_store_dwordx4 v2, a[12:15], s[16:17] offset:48
-; GREEDY942-NEXT:    global_store_dwordx4 v2, a[8:11], s[16:17] offset:32
-; GREEDY942-NEXT:    global_store_dwordx4 v2, a[4:7], s[16:17] offset:16
-; GREEDY942-NEXT:    global_store_dwordx4 v2, a[0:3], s[16:17]
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a2, a16
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a3, a17
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a4, a18
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a5, a19
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a6, a20
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a7, a21
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a8, a22
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a9, a23
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a10, a24
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a11, a25
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a12, a26
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a13, a27
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a14, a28
+; GREEDY942-NEXT:    v_accvgpr_mov_b32 a15, a29
+; GREEDY942-NEXT:    s_nop 1
+; GREEDY942-NEXT:    v_mfma_f32_16x16x1_4b_f32 a[0:15], v0, v1, a[0:15]
+; GREEDY942-NEXT:    v_mov_b32_e32 v0, 0
+; GREEDY942-NEXT:    s_nop 8
+; GREEDY942-NEXT:    global_store_dwordx4 v0, a[12:15], s[16:17] offset:48
+; GREEDY942-NEXT:    global_store_dwordx4 v0, a[8:11], s[16:17] offset:32
+; GREEDY942-NEXT:    global_store_dwordx4 v0, a[4:7], s[16:17] offset:16
+; GREEDY942-NEXT:    global_store_dwordx4 v0, a[0:3], s[16:17]
 ; GREEDY942-NEXT:    s_endpgm
 ;
 ; GREEDY90A-GISEL-LABEL: test_mfma_f32_16x16x1f32:
@@ -839,9 +831,8 @@ define amdgpu_kernel void @test_mfma_f32_16x16x1f32(ptr addrspace(1) %arg) #0 {
 ; FAST90A-LABEL: test_mfma_f32_16x16x1f32:
 ; FAST90A:       ; %bb.0: ; %bb
 ; FAST90A-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
-; FAST90A-NEXT:    v_mov_b32_e32 v1, 1.0
-; FAST90A-NEXT:    v_mov_b32_e32 v2, 2.0
-; FAST90A-NEXT:    v_mov_b32_e32 v0, 0
+; FAST90A-NEXT:    v_mov_b32_e32 v0, 1.0
+; FAST90A-NEXT:    v_mov_b32_e32 v1, 2.0
 ; FAST90A-NEXT:    s_waitcnt lgkmcnt(0)
 ; FAST90A-NEXT:    s_load_dwordx16 s[4:19], s[0:1], 0x0
 ; FAST90A-NEXT:    s_waitcnt lgkmcnt(0)
@@ -862,8 +853,8 @@ define amdgpu_kernel void @test_mfma_f32_16x16x1f32(ptr addrspace(1) %arg) #0 {
 ; FAST90A-NEXT:    v_accvgpr_write_b32 a14, s18
 ; FAST90A-NEXT:    v_accvgpr_write_b32 a15, s19
 ; FAST90A-NEXT:    s_nop 1
-; FAST90A-NEXT:    v_mfma_f32_16x16x1f32 a[0:15], v1, v2, a[0:15]
-; FAST90A-NEXT:    v_mfma_f32_16x16x1f32 a[16:31], v1, v2, a[0:15]
+; FAST90A-NEXT:    v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[0:15]
+; FAST90A-NEXT:    v_mfma_f32_16x16x1f32 a[16:31], v0, v1, a[0:15]
 ; FAST90A-NEXT:    s_nop 10
 ; FAST90A-NEXT:    v_accvgpr_mov_b32 a2, a16
 ; FAST90A-NEXT:    v_accvgpr_mov_b32 a3, a17
@@ -880,8 +871,9 @@ define amdgpu_kernel void @test_mfma_f32_16x16x1f32(ptr addrspace(1) %arg) #0 {
 ; FAST90A-NEXT:    v_accvgpr_mov_b32 a14, a28
 ; FAST90A-NEXT:    v_accvgpr_mov_b32 a15, a29
 ; FAST90A-NEXT:    s_nop 1
-; FAST90A-NEXT:    v_mfma_f32_16x16x1f32 a[0:15], v1, v2, a[0:15]
-; FAST90A-NEXT:    s_nop 10
+; FAST90A-NEXT:    v_mfma_f32_16x16x1f32 a[0:15], v0, v1, a[0:15]
+; FAST90A-NEXT:    v_mov_b32_e32 v0, 0
+; FAST90A-NEXT:    s_nop 9
 ; FAST90A-NEXT:    global_store_dwordx4 v0, a[12:15], s[0:1] offset:48
 ; FAST90A-NEXT:    global_store_dwordx4 v0, a[8:11], s[0:1] offset:32
 ; FAST90A-NEXT:    global_store_dwordx4 v0, a[4:7], s[0:1] offset:16

--- a/llvm/test/CodeGen/AMDGPU/mmra.ll
+++ b/llvm/test/CodeGen/AMDGPU/mmra.ll
@@ -12,12 +12,12 @@ define void @fence_loads(ptr %ptr) {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; CHECK-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]], %subreg.sub0, [[COPY]], %subreg.sub1
-  ; CHECK-NEXT:   ATOMIC_FENCE 5, 1,  mmra !0
-  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]],  mmra !1
-  ; CHECK-NEXT:   [[FLAT_LOAD_UBYTE:%[0-9]+]]:vgpr_32 = FLAT_LOAD_UBYTE [[COPY2]], 0, 0, implicit $exec, implicit $flat_scr,  mmra !1 :: (load acquire (s8) from %ir.ptr, align 4)
+  ; CHECK-NEXT:   ATOMIC_FENCE 5, 1, mmra !0
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]], mmra !1
+  ; CHECK-NEXT:   [[FLAT_LOAD_UBYTE:%[0-9]+]]:vgpr_32 = FLAT_LOAD_UBYTE [[COPY2]], 0, 0, implicit $exec, implicit $flat_scr, mmra !1 :: (load acquire (s8) from %ir.ptr, align 4)
   ; CHECK-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 1, implicit $exec
-  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]],  mmra !2
-  ; CHECK-NEXT:   FLAT_STORE_BYTE [[COPY3]], killed [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr,  mmra !2 :: (store release (s8) into %ir.ptr, align 4)
+  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]], mmra !2
+  ; CHECK-NEXT:   FLAT_STORE_BYTE [[COPY3]], killed [[V_MOV_B32_e32_]], 0, 0, implicit $exec, implicit $flat_scr, mmra !2 :: (store release (s8) into %ir.ptr, align 4)
   ; CHECK-NEXT:   SI_RETURN
   fence release,                                        !mmra !0
   %ld = load atomic i8, ptr %ptr acquire, align 4,      !mmra !2
@@ -33,8 +33,8 @@ define void @atomicrmw_acq(ptr %ptr) {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; CHECK-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[COPY1]], %subreg.sub0, [[COPY]], %subreg.sub1
-  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]],  mmra !1
-  ; CHECK-NEXT:   [[FLAT_LOAD_UBYTE:%[0-9]+]]:vgpr_32 = FLAT_LOAD_UBYTE killed [[COPY2]], 0, 0, implicit $exec, implicit $flat_scr,  mmra !1 :: (load acquire (s8) from %ir.ptr)
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]], mmra !1
+  ; CHECK-NEXT:   [[FLAT_LOAD_UBYTE:%[0-9]+]]:vgpr_32 = FLAT_LOAD_UBYTE killed [[COPY2]], 0, 0, implicit $exec, implicit $flat_scr, mmra !1 :: (load acquire (s8) from %ir.ptr)
   ; CHECK-NEXT:   SI_RETURN
   %old.2 = atomicrmw add ptr %ptr, i8 0 acquire,        !mmra !2
   ret void
@@ -53,7 +53,7 @@ define void @atomicrmw_rel(ptr %ptr) {
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE]].sub0
   ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 -4
   ; CHECK-NEXT:   [[V_AND_B32_e64_:%[0-9]+]]:vgpr_32 = V_AND_B32_e64 [[COPY3]], killed [[S_MOV_B32_]], implicit $exec
-  ; CHECK-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_AND_B32_e64_]], %subreg.sub0, [[COPY2]], %subreg.sub1
+  ; CHECK-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_AND_B32_e64_]], %subreg.sub0, killed [[COPY2]], %subreg.sub1
   ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; CHECK-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 3
   ; CHECK-NEXT:   [[V_AND_B32_e64_1:%[0-9]+]]:vgpr_32 = V_AND_B32_e64 [[COPY3]], [[S_MOV_B32_1]], implicit $exec
@@ -61,8 +61,7 @@ define void @atomicrmw_rel(ptr %ptr) {
   ; CHECK-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 255
   ; CHECK-NEXT:   [[V_LSHLREV_B32_e64_1:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 killed [[V_LSHLREV_B32_e64_]], killed [[S_MOV_B32_2]], implicit $exec
   ; CHECK-NEXT:   [[V_NOT_B32_e32_:%[0-9]+]]:vgpr_32 = V_NOT_B32_e32 [[V_LSHLREV_B32_e64_1]], implicit $exec
-  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]],  mmra !2
-  ; CHECK-NEXT:   [[FLAT_LOAD_DWORD:%[0-9]+]]:vgpr_32 = FLAT_LOAD_DWORD [[COPY5]], 0, 0, implicit $exec, implicit $flat_scr,  mmra !2 :: (load (s32) from %ir.AlignedAddr)
+  ; CHECK-NEXT:   [[FLAT_LOAD_DWORD:%[0-9]+]]:vgpr_32 = FLAT_LOAD_DWORD [[REG_SEQUENCE1]], 0, 0, implicit $exec, implicit $flat_scr, mmra !2 :: (load (s32) from %ir.AlignedAddr)
   ; CHECK-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64 = S_MOV_B64 0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1.atomicrmw.start:
@@ -72,10 +71,9 @@ define void @atomicrmw_rel(ptr %ptr) {
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:vgpr_32 = PHI [[FLAT_LOAD_DWORD]], %bb.0, %6, %bb.1
   ; CHECK-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 [[V_NOT_B32_e32_]], [[V_LSHLREV_B32_e64_1]], implicit $exec
   ; CHECK-NEXT:   [[V_AND_B32_e64_2:%[0-9]+]]:vgpr_32 = V_AND_B32_e64 [[PHI1]], killed [[V_OR_B32_e64_]], implicit $exec
-  ; CHECK-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_AND_B32_e64_2]], %subreg.sub0, [[PHI1]], %subreg.sub1
-  ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]],  mmra !2
-  ; CHECK-NEXT:   [[FLAT_ATOMIC_CMPSWAP_RTN:%[0-9]+]]:vgpr_32 = FLAT_ATOMIC_CMPSWAP_RTN [[COPY4]], killed [[COPY6]], 0, 1, implicit $exec, implicit $flat_scr,  mmra !2 :: (load store release monotonic (s32) on %ir.AlignedAddr)
-  ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_64 = V_CMP_EQ_U32_e64 [[FLAT_ATOMIC_CMPSWAP_RTN]], [[PHI1]], implicit $exec,  mmra !2
+  ; CHECK-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_AND_B32_e64_2]], %subreg.sub0, [[PHI1]], %subreg.sub1
+  ; CHECK-NEXT:   [[FLAT_ATOMIC_CMPSWAP_RTN:%[0-9]+]]:vgpr_32 = FLAT_ATOMIC_CMPSWAP_RTN [[COPY4]], killed [[REG_SEQUENCE2]], 0, 1, implicit $exec, implicit $flat_scr, mmra !2 :: (load store release monotonic (s32) on %ir.AlignedAddr)
+  ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_64 = V_CMP_EQ_U32_e64 [[FLAT_ATOMIC_CMPSWAP_RTN]], [[PHI1]], implicit $exec, mmra !2
   ; CHECK-NEXT:   [[SI_IF_BREAK:%[0-9]+]]:sreg_64 = SI_IF_BREAK killed [[V_CMP_EQ_U32_e64_]], [[PHI]], implicit-def dead $scc
   ; CHECK-NEXT:   SI_LOOP [[SI_IF_BREAK]], %bb.1, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
@@ -101,7 +99,7 @@ define void @cmpxchg(ptr %ptr) {
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE]].sub0
   ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 -4
   ; CHECK-NEXT:   [[V_AND_B32_e64_:%[0-9]+]]:vgpr_32 = V_AND_B32_e64 [[COPY3]], killed [[S_MOV_B32_]], implicit $exec
-  ; CHECK-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_AND_B32_e64_]], %subreg.sub0, [[COPY2]], %subreg.sub1
+  ; CHECK-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_AND_B32_e64_]], %subreg.sub0, killed [[COPY2]], %subreg.sub1
   ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; CHECK-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 3
   ; CHECK-NEXT:   [[V_AND_B32_e64_1:%[0-9]+]]:vgpr_32 = V_AND_B32_e64 [[COPY3]], [[S_MOV_B32_1]], implicit $exec
@@ -111,8 +109,7 @@ define void @cmpxchg(ptr %ptr) {
   ; CHECK-NEXT:   [[V_NOT_B32_e32_:%[0-9]+]]:vgpr_32 = V_NOT_B32_e32 killed [[V_LSHLREV_B32_e64_1]], implicit $exec
   ; CHECK-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 1
   ; CHECK-NEXT:   [[V_LSHLREV_B32_e64_2:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 [[V_LSHLREV_B32_e64_]], killed [[S_MOV_B32_3]], implicit $exec
-  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]],  mmra !1
-  ; CHECK-NEXT:   [[FLAT_LOAD_DWORD:%[0-9]+]]:vgpr_32 = FLAT_LOAD_DWORD [[COPY5]], 0, 0, implicit $exec, implicit $flat_scr,  mmra !1 :: (load (s32) from %ir.AlignedAddr)
+  ; CHECK-NEXT:   [[FLAT_LOAD_DWORD:%[0-9]+]]:vgpr_32 = FLAT_LOAD_DWORD [[REG_SEQUENCE1]], 0, 0, implicit $exec, implicit $flat_scr, mmra !1 :: (load (s32) from %ir.AlignedAddr)
   ; CHECK-NEXT:   [[V_AND_B32_e64_2:%[0-9]+]]:vgpr_32 = V_AND_B32_e64 killed [[FLAT_LOAD_DWORD]], [[V_NOT_B32_e32_]], implicit $exec
   ; CHECK-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64 = S_MOV_B64 0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:sreg_64 = IMPLICIT_DEF
@@ -124,9 +121,8 @@ define void @cmpxchg(ptr %ptr) {
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:sreg_64 = PHI [[S_MOV_B64_]], %bb.0, %13, %bb.3
   ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:vgpr_32 = PHI [[V_AND_B32_e64_2]], %bb.0, %11, %bb.3
   ; CHECK-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 [[PHI2]], [[V_LSHLREV_B32_e64_2]], implicit $exec
-  ; CHECK-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_OR_B32_e64_]], %subreg.sub0, [[PHI2]], %subreg.sub1
-  ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]],  mmra !1
-  ; CHECK-NEXT:   [[FLAT_ATOMIC_CMPSWAP_RTN:%[0-9]+]]:vgpr_32 = FLAT_ATOMIC_CMPSWAP_RTN [[COPY4]], killed [[COPY6]], 0, 1, implicit $exec, implicit $flat_scr,  mmra !1 :: (load store acquire acquire (s32) on %ir.AlignedAddr)
+  ; CHECK-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_OR_B32_e64_]], %subreg.sub0, [[PHI2]], %subreg.sub1
+  ; CHECK-NEXT:   [[FLAT_ATOMIC_CMPSWAP_RTN:%[0-9]+]]:vgpr_32 = FLAT_ATOMIC_CMPSWAP_RTN [[COPY4]], killed [[REG_SEQUENCE2]], 0, 1, implicit $exec, implicit $flat_scr, mmra !1 :: (load store acquire acquire (s32) on %ir.AlignedAddr)
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_64 = V_CMP_NE_U32_e64 [[FLAT_ATOMIC_CMPSWAP_RTN]], [[PHI2]], implicit $exec
   ; CHECK-NEXT:   [[S_MOV_B64_1:%[0-9]+]]:sreg_64 = S_MOV_B64 -1
   ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
@@ -149,8 +145,8 @@ define void @cmpxchg(ptr %ptr) {
   ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:sreg_64 = PHI [[S_OR_B64_]], %bb.1, [[S_OR_B64_1]], %bb.2
   ; CHECK-NEXT:   [[PHI4:%[0-9]+]]:vgpr_32 = PHI [[DEF1]], %bb.1, [[V_AND_B32_e64_3]], %bb.2
   ; CHECK-NEXT:   SI_END_CF [[SI_IF]], implicit-def dead $exec, implicit-def dead $scc, implicit $exec
-  ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:sreg_64 = COPY [[PHI3]]
-  ; CHECK-NEXT:   [[SI_IF_BREAK:%[0-9]+]]:sreg_64 = SI_IF_BREAK [[COPY7]], [[PHI1]], implicit-def dead $scc
+  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:sreg_64 = COPY [[PHI3]]
+  ; CHECK-NEXT:   [[SI_IF_BREAK:%[0-9]+]]:sreg_64 = SI_IF_BREAK [[COPY5]], [[PHI1]], implicit-def dead $scc
   ; CHECK-NEXT:   SI_LOOP [[SI_IF_BREAK]], %bb.1, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.4
   ; CHECK-NEXT: {{  $}}
@@ -220,7 +216,7 @@ define void @atomicrmw_rel_deepcopy(ptr %ptr) {
   ; CHECK-NEXT:   [[COPY29:%[0-9]+]]:vgpr_32 = COPY [[REG_SEQUENCE]].sub0
   ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 -4
   ; CHECK-NEXT:   [[V_AND_B32_e64_:%[0-9]+]]:vgpr_32 = V_AND_B32_e64 [[COPY29]], killed [[S_MOV_B32_]], implicit $exec
-  ; CHECK-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_AND_B32_e64_]], %subreg.sub0, [[COPY11]], %subreg.sub1
+  ; CHECK-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_AND_B32_e64_]], %subreg.sub0, killed [[COPY11]], %subreg.sub1
   ; CHECK-NEXT:   [[COPY30:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
   ; CHECK-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 3
   ; CHECK-NEXT:   [[V_AND_B32_e64_1:%[0-9]+]]:vgpr_32 = V_AND_B32_e64 [[COPY29]], [[S_MOV_B32_1]], implicit $exec
@@ -228,8 +224,7 @@ define void @atomicrmw_rel_deepcopy(ptr %ptr) {
   ; CHECK-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 255
   ; CHECK-NEXT:   [[V_LSHLREV_B32_e64_1:%[0-9]+]]:vgpr_32 = V_LSHLREV_B32_e64 killed [[V_LSHLREV_B32_e64_]], killed [[S_MOV_B32_2]], implicit $exec
   ; CHECK-NEXT:   [[V_NOT_B32_e32_:%[0-9]+]]:vgpr_32 = V_NOT_B32_e32 [[V_LSHLREV_B32_e64_1]], implicit $exec
-  ; CHECK-NEXT:   [[COPY31:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]],  mmra !0
-  ; CHECK-NEXT:   [[FLAT_LOAD_DWORD:%[0-9]+]]:vgpr_32 = FLAT_LOAD_DWORD [[COPY31]], 0, 0, implicit $exec, implicit $flat_scr,  mmra !0 :: (load (s32) from %ir.AlignedAddr)
+  ; CHECK-NEXT:   [[FLAT_LOAD_DWORD:%[0-9]+]]:vgpr_32 = FLAT_LOAD_DWORD [[REG_SEQUENCE1]], 0, 0, implicit $exec, implicit $flat_scr, mmra !0 :: (load (s32) from %ir.AlignedAddr)
   ; CHECK-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64 = S_MOV_B64 0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1.atomicrmw.start:
@@ -239,10 +234,9 @@ define void @atomicrmw_rel_deepcopy(ptr %ptr) {
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:vgpr_32 = PHI [[FLAT_LOAD_DWORD]], %bb.0, %6, %bb.1
   ; CHECK-NEXT:   [[V_OR_B32_e64_:%[0-9]+]]:vgpr_32 = V_OR_B32_e64 [[V_NOT_B32_e32_]], [[V_LSHLREV_B32_e64_1]], implicit $exec
   ; CHECK-NEXT:   [[V_AND_B32_e64_2:%[0-9]+]]:vgpr_32 = V_AND_B32_e64 [[PHI1]], killed [[V_OR_B32_e64_]], implicit $exec
-  ; CHECK-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_AND_B32_e64_2]], %subreg.sub0, [[PHI1]], %subreg.sub1
-  ; CHECK-NEXT:   [[COPY32:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE2]],  mmra !0
-  ; CHECK-NEXT:   [[FLAT_ATOMIC_CMPSWAP_RTN:%[0-9]+]]:vgpr_32 = FLAT_ATOMIC_CMPSWAP_RTN [[COPY30]], killed [[COPY32]], 0, 1, implicit $exec, implicit $flat_scr,  mmra !0 :: (load store release monotonic (s32) on %ir.AlignedAddr)
-  ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_64 = V_CMP_EQ_U32_e64 [[FLAT_ATOMIC_CMPSWAP_RTN]], [[PHI1]], implicit $exec,  mmra !0
+  ; CHECK-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_AND_B32_e64_2]], %subreg.sub0, [[PHI1]], %subreg.sub1
+  ; CHECK-NEXT:   [[FLAT_ATOMIC_CMPSWAP_RTN:%[0-9]+]]:vgpr_32 = FLAT_ATOMIC_CMPSWAP_RTN [[COPY30]], killed [[REG_SEQUENCE2]], 0, 1, implicit $exec, implicit $flat_scr, mmra !0 :: (load store release monotonic (s32) on %ir.AlignedAddr)
+  ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_64 = V_CMP_EQ_U32_e64 [[FLAT_ATOMIC_CMPSWAP_RTN]], [[PHI1]], implicit $exec, mmra !0
   ; CHECK-NEXT:   [[SI_IF_BREAK:%[0-9]+]]:sreg_64 = SI_IF_BREAK killed [[V_CMP_EQ_U32_e64_]], [[PHI]], implicit-def dead $scc
   ; CHECK-NEXT:   SI_LOOP [[SI_IF_BREAK]], %bb.1, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2

--- a/llvm/test/CodeGen/AMDGPU/mubuf-legalize-operands-non-ptr-intrinsics.ll
+++ b/llvm/test/CodeGen/AMDGPU/mubuf-legalize-operands-non-ptr-intrinsics.ll
@@ -484,66 +484,69 @@ define void @mubuf_vgpr_adjacent_in_block(<4 x i32> %i, <4 x i32> %j, i32 %c, pt
 ; W64-O0:       ; %bb.0: ; %entry
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; W64-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
-; W64-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
-; W64-O0-NEXT:    v_mov_b32_e32 v13, v4
-; W64-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; W64-O0-NEXT:    v_mov_b32_e32 v6, v3
+; W64-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v12, v9
+; W64-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; W64-O0-NEXT:    s_nop 0
+; W64-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v12, v8
+; W64-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; W64-O0-NEXT:    s_nop 0
+; W64-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v12, v3
 ; W64-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
-; W64-O0-NEXT:    v_mov_b32_e32 v7, v2
-; W64-O0-NEXT:    v_mov_b32_e32 v8, v1
-; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
-; W64-O0-NEXT:    v_mov_b32_e32 v2, v0
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
-; W64-O0-NEXT:    ; kill: def $vgpr13 killed $vgpr13 def $vgpr13_vgpr14_vgpr15_vgpr16 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v14, v5
-; W64-O0-NEXT:    s_waitcnt vmcnt(3)
-; W64-O0-NEXT:    v_mov_b32_e32 v15, v4
+; W64-O0-NEXT:    v_mov_b32_e32 v13, v2
+; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; W64-O0-NEXT:    v_mov_b32_e32 v14, v1
+; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; W64-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr4 def $vgpr4_vgpr5_vgpr6_vgpr7 killed $exec
 ; W64-O0-NEXT:    s_waitcnt vmcnt(2)
-; W64-O0-NEXT:    v_mov_b32_e32 v16, v3
-; W64-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v5, v3
+; W64-O0-NEXT:    s_waitcnt vmcnt(1)
+; W64-O0-NEXT:    v_mov_b32_e32 v6, v2
+; W64-O0-NEXT:    s_waitcnt vmcnt(0)
+; W64-O0-NEXT:    v_mov_b32_e32 v7, v1
+; W64-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v14, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v16, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
-; W64-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr2 def $vgpr2_vgpr3_vgpr4_vgpr5 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v3, v8
-; W64-O0-NEXT:    v_mov_b32_e32 v4, v7
-; W64-O0-NEXT:    v_mov_b32_e32 v5, v6
-; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; W64-O0-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1_vgpr2_vgpr3 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v1, v14
+; W64-O0-NEXT:    v_mov_b32_e32 v2, v13
+; W64-O0-NEXT:    v_mov_b32_e32 v3, v12
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
-; W64-O0-NEXT:    ; kill: def $vgpr1 killed $vgpr1 def $vgpr1_vgpr2 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v2, v12
-; W64-O0-NEXT:    s_waitcnt vmcnt(9)
-; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    ; kill: def $vgpr11 killed $vgpr11 def $vgpr11_vgpr12 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v12, v9
+; W64-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; W64-O0-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v1, v10
-; W64-O0-NEXT:    s_waitcnt vmcnt(10)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v12, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; W64-O0-NEXT:    ; kill: def $vgpr8 killed $vgpr8 def $vgpr8_vgpr9 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v9, v10
+; W64-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:4 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b32 s4, 0
-; W64-O0-NEXT:    ; implicit-def: $vgpr17 : SGPR spill to VGPR lane
-; W64-O0-NEXT:    v_writelane_b32 v17, s4, 0
+; W64-O0-NEXT:    ; implicit-def: $vgpr15 : SGPR spill to VGPR lane
+; W64-O0-NEXT:    v_writelane_b32 v15, s4, 0
 ; W64-O0-NEXT:    s_mov_b64 s[4:5], exec
-; W64-O0-NEXT:    v_writelane_b32 v17, s4, 1
-; W64-O0-NEXT:    v_writelane_b32 v17, s5, 2
+; W64-O0-NEXT:    v_writelane_b32 v15, s4, 1
+; W64-O0-NEXT:    v_writelane_b32 v15, s5, 2
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:20 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
@@ -568,53 +571,53 @@ define void @mubuf_vgpr_adjacent_in_block(<4 x i32> %i, <4 x i32> %j, i32 %c, pt
 ; W64-O0-NEXT:    s_mov_b32 s9, s12
 ; W64-O0-NEXT:    s_mov_b32 s10, s7
 ; W64-O0-NEXT:    s_mov_b32 s11, s6
-; W64-O0-NEXT:    v_writelane_b32 v17, s8, 3
-; W64-O0-NEXT:    v_writelane_b32 v17, s9, 4
-; W64-O0-NEXT:    v_writelane_b32 v17, s10, 5
-; W64-O0-NEXT:    v_writelane_b32 v17, s11, 6
+; W64-O0-NEXT:    v_writelane_b32 v15, s8, 3
+; W64-O0-NEXT:    v_writelane_b32 v15, s9, 4
+; W64-O0-NEXT:    v_writelane_b32 v15, s10, 5
+; W64-O0-NEXT:    v_writelane_b32 v15, s11, 6
 ; W64-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
-; W64-O0-NEXT:    v_writelane_b32 v17, s4, 7
-; W64-O0-NEXT:    v_writelane_b32 v17, s5, 8
+; W64-O0-NEXT:    v_writelane_b32 v15, s4, 7
+; W64-O0-NEXT:    v_writelane_b32 v15, s5, 8
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:  ; %bb.2: ; in Loop: Header=BB1_1 Depth=1
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_readlane_b32 s4, v17, 7
-; W64-O0-NEXT:    v_readlane_b32 s5, v17, 8
-; W64-O0-NEXT:    v_readlane_b32 s8, v17, 3
-; W64-O0-NEXT:    v_readlane_b32 s9, v17, 4
-; W64-O0-NEXT:    v_readlane_b32 s10, v17, 5
-; W64-O0-NEXT:    v_readlane_b32 s11, v17, 6
-; W64-O0-NEXT:    v_readlane_b32 s6, v17, 0
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; W64-O0-NEXT:    v_readlane_b32 s4, v15, 7
+; W64-O0-NEXT:    v_readlane_b32 s5, v15, 8
+; W64-O0-NEXT:    v_readlane_b32 s8, v15, 3
+; W64-O0-NEXT:    v_readlane_b32 s9, v15, 4
+; W64-O0-NEXT:    v_readlane_b32 s10, v15, 5
+; W64-O0-NEXT:    v_readlane_b32 s11, v15, 6
+; W64-O0-NEXT:    v_readlane_b32 s6, v15, 0
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_nop 2
 ; W64-O0-NEXT:    buffer_load_format_x v0, v0, s[8:11], s6 idxen
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    s_cbranch_execnz .LBB1_1
 ; W64-O0-NEXT:  ; %bb.3:
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_readlane_b32 s4, v17, 1
-; W64-O0-NEXT:    v_readlane_b32 s5, v17, 2
+; W64-O0-NEXT:    v_readlane_b32 s4, v15, 1
+; W64-O0-NEXT:    v_readlane_b32 s5, v15, 2
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; W64-O0-NEXT:    s_mov_b64 s[4:5], exec
-; W64-O0-NEXT:    v_writelane_b32 v17, s4, 9
-; W64-O0-NEXT:    v_writelane_b32 v17, s5, 10
+; W64-O0-NEXT:    v_writelane_b32 v15, s4, 9
+; W64-O0-NEXT:    v_writelane_b32 v15, s5, 10
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:  .LBB1_4: ; =>This Inner Loop Header: Depth=1
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
@@ -639,48 +642,48 @@ define void @mubuf_vgpr_adjacent_in_block(<4 x i32> %i, <4 x i32> %j, i32 %c, pt
 ; W64-O0-NEXT:    s_mov_b32 s9, s12
 ; W64-O0-NEXT:    s_mov_b32 s10, s7
 ; W64-O0-NEXT:    s_mov_b32 s11, s6
-; W64-O0-NEXT:    v_writelane_b32 v17, s8, 11
-; W64-O0-NEXT:    v_writelane_b32 v17, s9, 12
-; W64-O0-NEXT:    v_writelane_b32 v17, s10, 13
-; W64-O0-NEXT:    v_writelane_b32 v17, s11, 14
+; W64-O0-NEXT:    v_writelane_b32 v15, s8, 11
+; W64-O0-NEXT:    v_writelane_b32 v15, s9, 12
+; W64-O0-NEXT:    v_writelane_b32 v15, s10, 13
+; W64-O0-NEXT:    v_writelane_b32 v15, s11, 14
 ; W64-O0-NEXT:    s_and_saveexec_b64 s[4:5], s[4:5]
-; W64-O0-NEXT:    v_writelane_b32 v17, s4, 15
-; W64-O0-NEXT:    v_writelane_b32 v17, s5, 16
+; W64-O0-NEXT:    v_writelane_b32 v15, s4, 15
+; W64-O0-NEXT:    v_writelane_b32 v15, s5, 16
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_store_dword v17, off, s[0:3], s32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v15, off, s[0:3], s32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:  ; %bb.5: ; in Loop: Header=BB1_4 Depth=1
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_readlane_b32 s4, v17, 15
-; W64-O0-NEXT:    v_readlane_b32 s5, v17, 16
-; W64-O0-NEXT:    v_readlane_b32 s8, v17, 11
-; W64-O0-NEXT:    v_readlane_b32 s9, v17, 12
-; W64-O0-NEXT:    v_readlane_b32 s10, v17, 13
-; W64-O0-NEXT:    v_readlane_b32 s11, v17, 14
-; W64-O0-NEXT:    v_readlane_b32 s6, v17, 0
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; W64-O0-NEXT:    v_readlane_b32 s4, v15, 15
+; W64-O0-NEXT:    v_readlane_b32 s5, v15, 16
+; W64-O0-NEXT:    v_readlane_b32 s8, v15, 11
+; W64-O0-NEXT:    v_readlane_b32 s9, v15, 12
+; W64-O0-NEXT:    v_readlane_b32 s10, v15, 13
+; W64-O0-NEXT:    v_readlane_b32 s11, v15, 14
+; W64-O0-NEXT:    v_readlane_b32 s6, v15, 0
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_nop 2
 ; W64-O0-NEXT:    buffer_load_format_x v0, v0, s[8:11], s6 idxen
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    s_cbranch_execnz .LBB1_4
 ; W64-O0-NEXT:  ; %bb.6:
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
-; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    v_readlane_b32 s4, v17, 9
-; W64-O0-NEXT:    v_readlane_b32 s5, v17, 10
+; W64-O0-NEXT:    v_readlane_b32 s4, v15, 9
+; W64-O0-NEXT:    v_readlane_b32 s5, v15, 10
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
-; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:12 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:16 ; 4-byte Folded Reload
-; W64-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
@@ -689,7 +692,7 @@ define void @mubuf_vgpr_adjacent_in_block(<4 x i32> %i, <4 x i32> %j, i32 %c, pt
 ; W64-O0-NEXT:    global_store_dword v[0:1], v2, off
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; W64-O0-NEXT:    buffer_load_dword v17, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v15, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_setpc_b64 s[30:31]
@@ -997,45 +1000,45 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0:       ; %bb.0: ; %entry
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; W64-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; W64-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v13, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
-; W64-O0-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v11, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
-; W64-O0-NEXT:    v_mov_b32_e32 v8, v5
-; W64-O0-NEXT:    v_mov_b32_e32 v5, v4
-; W64-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
-; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v31, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v8, v11
+; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    v_mov_b32_e32 v9, v3
+; W64-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    v_mov_b32_e32 v10, v2
+; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    v_mov_b32_e32 v11, v1
-; W64-O0-NEXT:    v_mov_b32_e32 v5, v0
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; W64-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr4 def $vgpr4_vgpr5_vgpr6_vgpr7 killed $exec
+; W64-O0-NEXT:    s_waitcnt vmcnt(2)
+; W64-O0-NEXT:    v_mov_b32_e32 v5, v3
+; W64-O0-NEXT:    s_waitcnt vmcnt(1)
+; W64-O0-NEXT:    v_mov_b32_e32 v6, v2
+; W64-O0-NEXT:    s_waitcnt vmcnt(0)
+; W64-O0-NEXT:    v_mov_b32_e32 v7, v1
 ; W64-O0-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1_vgpr2_vgpr3 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v1, v8
-; W64-O0-NEXT:    v_mov_b32_e32 v2, v6
-; W64-O0-NEXT:    v_mov_b32_e32 v3, v7
-; W64-O0-NEXT:    ; kill: def $vgpr5 killed $vgpr5 def $vgpr5_vgpr6_vgpr7_vgpr8 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v6, v11
-; W64-O0-NEXT:    v_mov_b32_e32 v7, v10
-; W64-O0-NEXT:    v_mov_b32_e32 v8, v9
-; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; W64-O0-NEXT:    v_mov_b32_e32 v1, v11
+; W64-O0-NEXT:    v_mov_b32_e32 v2, v10
+; W64-O0-NEXT:    v_mov_b32_e32 v3, v9
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; W64-O0-NEXT:    ; kill: def $vgpr4 killed $vgpr4 def $vgpr4_vgpr5 killed $exec
-; W64-O0-NEXT:    v_mov_b32_e32 v5, v12
-; W64-O0-NEXT:    s_waitcnt vmcnt(6)
-; W64-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; W64-O0-NEXT:    ; kill: def $vgpr8 killed $vgpr8 def $vgpr8_vgpr9 killed $exec
+; W64-O0-NEXT:    v_mov_b32_e32 v9, v12
+; W64-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; W64-O0-NEXT:    s_waitcnt vmcnt(6)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:8 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_nop 0
-; W64-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
-; W64-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:12 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:16 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:20 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    ;;#ASMSTART
 ; W64-O0-NEXT:    s_mov_b32 s4, 17
 ; W64-O0-NEXT:    ;;#ASMEND
@@ -1106,7 +1109,7 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    s_nop 2
 ; W64-O0-NEXT:    buffer_load_format_x v0, v0, s[8:11], s6 idxen
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    s_cbranch_execnz .LBB2_1
 ; W64-O0-NEXT:  ; %bb.3:
@@ -1118,13 +1121,13 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    v_readlane_b32 s7, v13, 3
 ; W64-O0-NEXT:    s_mov_b64 exec, s[6:7]
 ; W64-O0-NEXT:    v_readlane_b32 s4, v13, 1
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
-; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b32 s5, 0x3ff
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    v_and_b32_e64 v1, v1, s5
 ; W64-O0-NEXT:    v_cmp_eq_u32_e64 s[6:7], v1, s4
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 s[4:5], exec
 ; W64-O0-NEXT:    v_writelane_b32 v13, s4, 10
 ; W64-O0-NEXT:    v_writelane_b32 v13, s5, 11
@@ -1143,7 +1146,7 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    s_mov_b32 s5, 0
 ; W64-O0-NEXT:    v_writelane_b32 v13, s5, 12
 ; W64-O0-NEXT:    v_mov_b32_e32 v0, s4
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_mov_b64 s[4:5], exec
 ; W64-O0-NEXT:    v_writelane_b32 v13, s4, 13
 ; W64-O0-NEXT:    v_writelane_b32 v13, s5, 14
@@ -1199,12 +1202,12 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    v_readlane_b32 s10, v13, 17
 ; W64-O0-NEXT:    v_readlane_b32 s11, v13, 18
 ; W64-O0-NEXT:    v_readlane_b32 s6, v13, 12
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_nop 2
 ; W64-O0-NEXT:    buffer_load_format_x v0, v0, s[8:11], s6 idxen
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
 ; W64-O0-NEXT:    s_xor_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    s_cbranch_execnz .LBB2_5
 ; W64-O0-NEXT:  ; %bb.7:
@@ -1215,9 +1218,9 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    v_readlane_b32 s4, v13, 13
 ; W64-O0-NEXT:    v_readlane_b32 s5, v13, 14
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
-; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
-; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; W64-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
 ; W64-O0-NEXT:  .LBB2_8: ; %bb2
 ; W64-O0-NEXT:    s_or_saveexec_b64 s[16:17], -1
 ; W64-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 ; 4-byte Folded Reload
@@ -1228,12 +1231,12 @@ define void @mubuf_vgpr_outside_entry(<4 x i32> %i, <4 x i32> %j, i32 %c, ptr ad
 ; W64-O0-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; W64-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
-; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    global_store_dword v[0:1], v2, off
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_xor_saveexec_b64 s[4:5], -1
-; W64-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; W64-O0-NEXT:    buffer_load_dword v13, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
 ; W64-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; W64-O0-NEXT:    s_waitcnt vmcnt(0)
 ; W64-O0-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/no-fold-accvgpr-mov.ll
+++ b/llvm/test/CodeGen/AMDGPU/no-fold-accvgpr-mov.ll
@@ -6,8 +6,8 @@ define amdgpu_kernel void @matmul_kernel(i32 %a0, i32 %a1) {
 ; GFX942-LABEL: matmul_kernel:
 ; GFX942:       ; %bb.0: ; %entry
 ; GFX942-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x0
-; GFX942-NEXT:    s_mov_b32 s2, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v0, 0
+; GFX942-NEXT:    s_mov_b32 s2, 0
 ; GFX942-NEXT:    v_accvgpr_write_b32 a1, 0
 ; GFX942-NEXT:    s_mov_b32 s3, 0
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/rem_i128.ll
+++ b/llvm/test/CodeGen/AMDGPU/rem_i128.ll
@@ -388,8 +388,7 @@ define i128 @v_srem_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v14, v9
 ; GFX9-O0-NEXT:    v_cmp_eq_u64_e64 s[8:9], v[13:14], s[6:7]
 ; GFX9-O0-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
-; GFX9-O0-NEXT:    s_mov_b64 s[8:9], s[6:7]
-; GFX9-O0-NEXT:    v_cmp_ne_u64_e64 s[8:9], v[11:12], s[8:9]
+; GFX9-O0-NEXT:    v_cmp_ne_u64_e64 s[8:9], v[11:12], s[6:7]
 ; GFX9-O0-NEXT:    v_ffbh_u32_e64 v4, v4
 ; GFX9-O0-NEXT:    s_mov_b32 s12, 32
 ; GFX9-O0-NEXT:    v_add_u32_e64 v4, v4, s12
@@ -422,8 +421,7 @@ define i128 @v_srem_i128_vv(i128 %lhs, i128 %rhs) {
 ; GFX9-O0-NEXT:    v_cndmask_b32_e64 v8, v8, v9, s[8:9]
 ; GFX9-O0-NEXT:    ; kill: def $vgpr8 killed $vgpr8 def $vgpr8_vgpr9 killed $exec
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v9, v7
-; GFX9-O0-NEXT:    s_mov_b64 s[8:9], s[6:7]
-; GFX9-O0-NEXT:    v_cmp_ne_u64_e64 s[8:9], v[5:6], s[8:9]
+; GFX9-O0-NEXT:    v_cmp_ne_u64_e64 s[8:9], v[5:6], s[6:7]
 ; GFX9-O0-NEXT:    v_ffbh_u32_e64 v5, v0
 ; GFX9-O0-NEXT:    v_add_u32_e64 v5, v5, s12
 ; GFX9-O0-NEXT:    v_ffbh_u32_e64 v6, v1

--- a/llvm/test/CodeGen/AMDGPU/rewrite-vgpr-mfma-to-agpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/rewrite-vgpr-mfma-to-agpr.ll
@@ -767,32 +767,32 @@ define amdgpu_kernel void @test_rewrite_mfma_direct_copy_from_agpr_class_subreg_
 ; CHECK-NEXT:    ; def a[0:31]
 ; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    v_mov_b32_e32 v18, 4.0
-; CHECK-NEXT:    v_accvgpr_mov_b32 a17, a16
-; CHECK-NEXT:    v_accvgpr_mov_b32 a16, a15
-; CHECK-NEXT:    v_accvgpr_mov_b32 a15, a14
-; CHECK-NEXT:    v_accvgpr_mov_b32 a14, a13
-; CHECK-NEXT:    v_accvgpr_mov_b32 a13, a12
-; CHECK-NEXT:    v_accvgpr_mov_b32 a12, a11
-; CHECK-NEXT:    v_accvgpr_mov_b32 a11, a10
-; CHECK-NEXT:    v_accvgpr_mov_b32 a10, a9
-; CHECK-NEXT:    v_accvgpr_mov_b32 a9, a8
-; CHECK-NEXT:    v_accvgpr_mov_b32 a8, a7
-; CHECK-NEXT:    v_accvgpr_mov_b32 a7, a6
-; CHECK-NEXT:    v_accvgpr_mov_b32 a6, a5
-; CHECK-NEXT:    v_accvgpr_mov_b32 a5, a4
-; CHECK-NEXT:    v_accvgpr_mov_b32 a4, a3
-; CHECK-NEXT:    v_accvgpr_mov_b32 a3, a2
-; CHECK-NEXT:    v_accvgpr_mov_b32 a2, a1
+; CHECK-NEXT:    v_accvgpr_mov_b32 a0, a1
+; CHECK-NEXT:    v_accvgpr_mov_b32 a1, a2
+; CHECK-NEXT:    v_accvgpr_mov_b32 a2, a3
+; CHECK-NEXT:    v_accvgpr_mov_b32 a3, a4
+; CHECK-NEXT:    v_accvgpr_mov_b32 a4, a5
+; CHECK-NEXT:    v_accvgpr_mov_b32 a5, a6
+; CHECK-NEXT:    v_accvgpr_mov_b32 a6, a7
+; CHECK-NEXT:    v_accvgpr_mov_b32 a7, a8
+; CHECK-NEXT:    v_accvgpr_mov_b32 a8, a9
+; CHECK-NEXT:    v_accvgpr_mov_b32 a9, a10
+; CHECK-NEXT:    v_accvgpr_mov_b32 a10, a11
+; CHECK-NEXT:    v_accvgpr_mov_b32 a11, a12
+; CHECK-NEXT:    v_accvgpr_mov_b32 a12, a13
+; CHECK-NEXT:    v_accvgpr_mov_b32 a13, a14
+; CHECK-NEXT:    v_accvgpr_mov_b32 a14, a15
+; CHECK-NEXT:    v_accvgpr_mov_b32 a15, a16
 ; CHECK-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x0
 ; CHECK-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; CHECK-NEXT:    v_mfma_f32_16x16x1_4b_f32 a[2:17], v1, v18, a[2:17]
+; CHECK-NEXT:    v_mfma_f32_16x16x1_4b_f32 a[0:15], v1, v18, a[0:15]
 ; CHECK-NEXT:    v_lshlrev_b32_e32 v0, 6, v0
 ; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
 ; CHECK-NEXT:    s_nop 7
-; CHECK-NEXT:    global_store_dwordx4 v0, a[14:17], s[0:1] offset:48
-; CHECK-NEXT:    global_store_dwordx4 v0, a[10:13], s[0:1] offset:32
-; CHECK-NEXT:    global_store_dwordx4 v0, a[6:9], s[0:1] offset:16
-; CHECK-NEXT:    global_store_dwordx4 v0, a[2:5], s[0:1]
+; CHECK-NEXT:    global_store_dwordx4 v0, a[12:15], s[0:1] offset:48
+; CHECK-NEXT:    global_store_dwordx4 v0, a[8:11], s[0:1] offset:32
+; CHECK-NEXT:    global_store_dwordx4 v0, a[4:7], s[0:1] offset:16
+; CHECK-NEXT:    global_store_dwordx4 v0, a[0:3], s[0:1]
 ; CHECK-NEXT:    s_endpgm
   %def = call <32 x float> asm sideeffect "; def $0", "=a"()
   %src2 = shufflevector <32 x float> %def, <32 x float> poison, <16 x i32> <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16>

--- a/llvm/test/CodeGen/AMDGPU/scalar_to_vector.gfx11plus.ll
+++ b/llvm/test/CodeGen/AMDGPU/scalar_to_vector.gfx11plus.ll
@@ -26,9 +26,8 @@ define amdgpu_kernel void @scalar_to_vector_i32 (ptr addrspace(1) %a, ptr addrsp
   ; GFX11-REAL16-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[GLOBAL_LOAD_DWORD_SADDR]]
   ; GFX11-REAL16-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[COPY3]]
   ; GFX11-REAL16-NEXT:   [[S_PACK_HL_B32_B16_:%[0-9]+]]:sreg_32 = S_PACK_HL_B32_B16 [[COPY4]], killed [[COPY5]]
-  ; GFX11-REAL16-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[S_PACK_HL_B32_B16_]], %subreg.sub0, [[S_PACK_HL_B32_B16_]], %subreg.sub1
-  ; GFX11-REAL16-NEXT:   [[COPY6:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE1]]
-  ; GFX11-REAL16-NEXT:   GLOBAL_STORE_DWORDX2_SADDR killed [[V_MOV_B32_e32_]], killed [[COPY6]], killed [[S_LOAD_DWORDX2_IMM1]], 0, 0, implicit $exec :: (store (s64) into %ir.out.load, addrspace 1)
+  ; GFX11-REAL16-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[S_PACK_HL_B32_B16_]], %subreg.sub0, [[S_PACK_HL_B32_B16_]], %subreg.sub1
+  ; GFX11-REAL16-NEXT:   GLOBAL_STORE_DWORDX2_SADDR killed [[V_MOV_B32_e32_]], killed [[REG_SEQUENCE1]], killed [[S_LOAD_DWORDX2_IMM1]], 0, 0, implicit $exec :: (store (s64) into %ir.out.load, addrspace 1)
   ; GFX11-REAL16-NEXT:   S_ENDPGM 0
   ;
   ; GFX11-FAKE16-LABEL: name: scalar_to_vector_i32
@@ -47,9 +46,8 @@ define amdgpu_kernel void @scalar_to_vector_i32 (ptr addrspace(1) %a, ptr addrsp
   ; GFX11-FAKE16-NEXT:   [[GLOBAL_LOAD_DWORD_SADDR:%[0-9]+]]:vgpr_32 = GLOBAL_LOAD_DWORD_SADDR killed [[S_LOAD_DWORDX2_IMM]], killed [[V_LSHLREV_B32_e64_]], 0, 0, implicit $exec :: (load (s32) from %ir.in.gep1, addrspace 1)
   ; GFX11-FAKE16-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 117834498
   ; GFX11-FAKE16-NEXT:   [[V_PERM_B32_e64_:%[0-9]+]]:vgpr_32 = V_PERM_B32_e64 [[GLOBAL_LOAD_DWORD_SADDR]], [[GLOBAL_LOAD_DWORD_SADDR]], killed [[S_MOV_B32_2]], implicit $exec
-  ; GFX11-FAKE16-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[V_PERM_B32_e64_]], %subreg.sub0, [[V_PERM_B32_e64_]], %subreg.sub1
-  ; GFX11-FAKE16-NEXT:   [[COPY2:%[0-9]+]]:vreg_64 = COPY [[REG_SEQUENCE]]
-  ; GFX11-FAKE16-NEXT:   GLOBAL_STORE_DWORDX2_SADDR killed [[V_MOV_B32_e32_]], killed [[COPY2]], killed [[S_LOAD_DWORDX2_IMM1]], 0, 0, implicit $exec :: (store (s64) into %ir.out.load, addrspace 1)
+  ; GFX11-FAKE16-NEXT:   [[REG_SEQUENCE:%[0-9]+]]:vreg_64 = REG_SEQUENCE [[V_PERM_B32_e64_]], %subreg.sub0, [[V_PERM_B32_e64_]], %subreg.sub1
+  ; GFX11-FAKE16-NEXT:   GLOBAL_STORE_DWORDX2_SADDR killed [[V_MOV_B32_e32_]], killed [[REG_SEQUENCE]], killed [[S_LOAD_DWORDX2_IMM1]], 0, 0, implicit $exec :: (store (s64) into %ir.out.load, addrspace 1)
   ; GFX11-FAKE16-NEXT:   S_ENDPGM 0
 entry:
   %tid = call i32 @llvm.amdgcn.workitem.id.x()

--- a/llvm/test/CodeGen/AMDGPU/schedule-amdgpu-trackers.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-amdgpu-trackers.ll
@@ -75,7 +75,7 @@ define amdgpu_kernel void @constant_zextload_v64i16_to_v64i32(ptr addrspace(1) %
 ; CHECK-LABEL: {{^}}excess_soft_clause_reg_pressure:
 ; GFX908:    NumSgprs: 64
 ; GFX908-GCNTRACKERS:    NumSgprs: 64
-; GFX908:    NumVgprs: 43
+; GFX908:    NumVgprs: 41
 ; GFX908-GCNTRACKERS:    NumVgprs: 39
 ; GFX908:    Occupancy: 5
 ; GFX908-GCNTRACKERS:    Occupancy: 6

--- a/llvm/test/CodeGen/AMDGPU/sdiv64.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdiv64.ll
@@ -1458,8 +1458,7 @@ define i64 @v_test_sdiv_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
 ; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
-; GCN-IR-NEXT:    s_movk_i32 s6, 0xffc5
-; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, s6, v8
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffc5, v8
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
@@ -1650,8 +1649,7 @@ define i64 @v_test_sdiv_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
 ; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
-; GCN-IR-NEXT:    s_movk_i32 s6, 0xffd0
-; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, s6, v8
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffd0, v8
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]

--- a/llvm/test/CodeGen/AMDGPU/sgpr-to-vreg1-copy.ll
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-to-vreg1-copy.ll
@@ -5,25 +5,27 @@ define amdgpu_kernel void @copy_to_vreg_1(i32 %0) {
 ; GCN-LABEL: copy_to_vreg_1:
 ; GCN:       ; %bb.0: ; %._crit_edge
 ; GCN-NEXT:    s_load_dword s4, s[4:5], 0x0
+; GCN-NEXT:    s_mov_b32 s5, 0
 ; GCN-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GCN-NEXT:    v_mov_b64_e32 v[2:3], 0
+; GCN-NEXT:    v_mov_b32_e32 v2, 0
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_sub_i32 s5, 1, s4
+; GCN-NEXT:    s_sub_i32 s6, 1, s4
 ; GCN-NEXT:    s_cmp_lt_u32 s4, 2
 ; GCN-NEXT:    s_cselect_b64 s[0:1], -1, 0
 ; GCN-NEXT:    s_and_b64 s[2:3], s[0:1], exec
-; GCN-NEXT:    s_cselect_b32 s3, s5, 1
+; GCN-NEXT:    s_cselect_b32 s2, s6, 1
 ; GCN-NEXT:    s_cmp_lg_u64 s[0:1], 0
 ; GCN-NEXT:    v_cndmask_b32_e64 v1, 0, 1, s[0:1]
 ; GCN-NEXT:    s_addc_u32 s0, 1, 0
-; GCN-NEXT:    v_readfirstlane_b32 s2, v1
-; GCN-NEXT:    s_cmp_ge_u32 s3, s4
-; GCN-NEXT:    s_cselect_b32 s4, s0, s2
-; GCN-NEXT:    v_mov_b32_e32 v1, 0
+; GCN-NEXT:    s_cmp_ge_u32 s2, s4
+; GCN-NEXT:    v_readfirstlane_b32 s1, v1
+; GCN-NEXT:    s_cselect_b32 s4, s0, s1
+; GCN-NEXT:    v_mov_b32_e32 v1, s5
 ; GCN-NEXT:    s_cmp_lg_u64 0, 0
 ; GCN-NEXT:    s_mov_b64 s[0:1], 0
 ; GCN-NEXT:    v_cmp_ne_u64_e32 vcc, 0, v[0:1]
 ; GCN-NEXT:    s_cselect_b64 s[2:3], -1, 0
+; GCN-NEXT:    v_mov_b64_e32 v[0:1], 0
 ; GCN-NEXT:    s_branch .LBB0_3
 ; GCN-NEXT:  .LBB0_1: ; %Flow
 ; GCN-NEXT:    ; in Loop: Header=BB0_3 Depth=1
@@ -48,7 +50,7 @@ define amdgpu_kernel void @copy_to_vreg_1(i32 %0) {
 ; GCN-NEXT:  ; %bb.4: ; %pred.store.if
 ; GCN-NEXT:    ; in Loop: Header=BB0_3 Depth=1
 ; GCN-NEXT:    s_or_b64 s[6:7], s[6:7], exec
-; GCN-NEXT:    global_store_byte v[2:3], v1, off
+; GCN-NEXT:    global_store_byte v[0:1], v2, off
 ; GCN-NEXT:  .LBB0_5: ; %Flow2
 ; GCN-NEXT:    ; in Loop: Header=BB0_3 Depth=1
 ; GCN-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -62,7 +64,7 @@ define amdgpu_kernel void @copy_to_vreg_1(i32 %0) {
 ; GCN-NEXT:    s_cbranch_execz .LBB0_1
 ; GCN-NEXT:  ; %bb.7: ; %pred.store.if41
 ; GCN-NEXT:    ; in Loop: Header=BB0_3 Depth=1
-; GCN-NEXT:    global_store_byte v[2:3], v1, off
+; GCN-NEXT:    global_store_byte v[0:1], v2, off
 ; GCN-NEXT:    s_branch .LBB0_1
 ; GCN-NEXT:  .LBB0_8: ; %DummyReturnBlock
 ; GCN-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/shufflevector-physreg-copy.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector-physreg-copy.ll
@@ -576,9 +576,9 @@ define void @shufflevector_v2i32_10_physreg_even_agpr_pair_copy(ptr addrspace(1)
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def a4, a5
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a1, a4
-; GFX90A-NEXT:    v_accvgpr_mov_b32 a0, a5
-; GFX90A-NEXT:    global_store_dwordx2 v0, a[0:1], s[16:17]
+; GFX90A-NEXT:    v_accvgpr_read_b32 v2, a5
+; GFX90A-NEXT:    v_accvgpr_read_b32 v3, a4
+; GFX90A-NEXT:    global_store_dwordx2 v0, v[2:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -590,9 +590,9 @@ define void @shufflevector_v2i32_10_physreg_even_agpr_pair_copy(ptr addrspace(1)
 ; GFX940-NEXT:    ; def a4, a5
 ; GFX940-NEXT:    ;;#ASMEND
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_accvgpr_mov_b32 a1, a4
-; GFX940-NEXT:    v_accvgpr_mov_b32 a0, a5
-; GFX940-NEXT:    global_store_dwordx2 v0, a[0:1], s[0:1]
+; GFX940-NEXT:    v_accvgpr_read_b32 v2, a5
+; GFX940-NEXT:    v_accvgpr_read_b32 v3, a4
+; GFX940-NEXT:    global_store_dwordx2 v0, v[2:3], s[0:1]
 ; GFX940-NEXT:    s_waitcnt vmcnt(0)
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
   %asm = call { i32, i32 } asm "; def $0, $1", "={a4},={a5}"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v2i64.v2i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v2i64.v2i64.ll
@@ -291,27 +291,31 @@ define void @v_shuffle_v2i64_v2i64__3_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v2i64_v2i64__3_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v2i64_v2i64__3_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -474,27 +478,31 @@ define void @v_shuffle_v2i64_v2i64__1_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v2i64_v2i64__1_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v2i64_v2i64__1_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v2p0.v2p0.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v2p0.v2p0.ll
@@ -291,27 +291,31 @@ define void @v_shuffle_v2p0_v2p0__3_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v2p0_v2p0__3_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v2p0_v2p0__3_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -474,27 +478,31 @@ define void @v_shuffle_v2p0_v2p0__1_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v2p0_v2p0__1_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v2p0_v2p0__1_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3f32.v2f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3f32.v2f32.ll
@@ -167,15 +167,15 @@ define void @v_shuffle_v3f32_v2f32__3_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:1]
+; GFX90A-NEXT:    ; def v[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[2:4], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -183,15 +183,15 @@ define void @v_shuffle_v3f32_v2f32__3_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:1]
+; GFX942-NEXT:    ; def v[2:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v1
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v2, v3
+; GFX942-NEXT:    v_mov_b32_e32 v3, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[2:4], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x float> asm "; def $0", "=v"()
@@ -269,27 +269,27 @@ define void @v_shuffle_v3f32_v2f32__3_2_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v2f32__3_2_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx3 v2, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v2f32__3_2_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx3 v2, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x float> asm "; def $0", "=v"()
@@ -1232,34 +1232,35 @@ define void @v_shuffle_v3f32_v2f32__3_0_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v2f32__3_0_1:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
-; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v2f32__3_0_1:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
-; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v1
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x float> asm "; def $0", "=v"()
@@ -1288,34 +1289,35 @@ define void @v_shuffle_v3f32_v2f32__3_2_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v2f32__3_2_1:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:1]
+; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:5]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx3 v6, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v2f32__3_2_1:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:1]
+; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:5]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v0, v5
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx3 v6, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x float> asm "; def $0", "=v"()
@@ -1838,26 +1840,27 @@ define void @v_shuffle_v3f32_v2f32__3_u_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v2f32__3_u_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    global_store_dwordx3 v3, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx3 v2, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v2f32__3_u_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v1
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    global_store_dwordx3 v3, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx3 v2, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x float> asm "; def $0", "=v"()
@@ -1886,34 +1889,35 @@ define void @v_shuffle_v3f32_v2f32__3_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v2f32__3_0_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:1]
+; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:5]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    global_store_dwordx3 v6, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v2f32__3_0_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:1]
+; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:5]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v5
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    global_store_dwordx3 v6, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x float> asm "; def $0", "=v"()
@@ -1994,28 +1998,29 @@ define void @v_shuffle_v3f32_v2f32__3_2_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v2f32__3_2_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx3 v2, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v2f32__3_2_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx3 v2, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x float> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3f32.v3f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3f32.v3f32.ll
@@ -411,25 +411,27 @@ define void @v_shuffle_v3f32_v3f32__5_3_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v3f32__5_3_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v3f32__5_3_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    global_store_dwordx3 v4, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -946,28 +948,29 @@ define void @v_shuffle_v3f32_v3f32__1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v3f32__1_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v3f32__1_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -993,27 +996,29 @@ define void @v_shuffle_v3f32_v3f32__2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v3f32__2_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v3f32__2_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1376,13 +1381,14 @@ define void @v_shuffle_v3f32_v3f32__5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1392,13 +1398,14 @@ define void @v_shuffle_v3f32_v3f32__5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1983,13 +1990,14 @@ define void @v_shuffle_v3f32_v3f32__5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1999,13 +2007,14 @@ define void @v_shuffle_v3f32_v3f32__5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2830,28 +2839,29 @@ define void @v_shuffle_v3f32_v3f32__4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v3f32__4_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v3f32__4_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2878,27 +2888,29 @@ define void @v_shuffle_v3f32_v3f32__5_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v3f32__5_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v3f32__5_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2975,13 +2987,14 @@ define void @v_shuffle_v3f32_v3f32__5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2991,13 +3004,14 @@ define void @v_shuffle_v3f32_v3f32__5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -3133,27 +3147,29 @@ define void @v_shuffle_v3f32_v3f32__5_4_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v3f32__5_4_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v3f32__5_4_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -3574,13 +3590,14 @@ define void @v_shuffle_v3f32_v3f32__5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3590,13 +3607,14 @@ define void @v_shuffle_v3f32_v3f32__5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -3735,27 +3753,29 @@ define void @v_shuffle_v3f32_v3f32__5_3_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v3f32__5_3_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v3f32__5_3_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3f32.v4f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3f32.v4f32.ll
@@ -965,26 +965,29 @@ define void @v_shuffle_v3f32_v4f32__7_7_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_7_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_7_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -1011,26 +1014,29 @@ define void @v_shuffle_v3f32_v4f32__7_7_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_7_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_7_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -1241,28 +1247,29 @@ define void @v_shuffle_v3f32_v4f32__1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__1_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__1_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -1289,26 +1296,29 @@ define void @v_shuffle_v3f32_v4f32__2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__2_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__2_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -1335,28 +1345,29 @@ define void @v_shuffle_v3f32_v4f32__3_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__3_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__3_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -1838,14 +1849,14 @@ define void @v_shuffle_v3f32_v4f32__7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1855,14 +1866,14 @@ define void @v_shuffle_v3f32_v4f32__7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -2667,14 +2678,14 @@ define void @v_shuffle_v3f32_v4f32__7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v1
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2684,14 +2695,14 @@ define void @v_shuffle_v3f32_v4f32__7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -4664,28 +4675,29 @@ define void @v_shuffle_v3f32_v4f32__5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__5_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__5_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -4713,26 +4725,29 @@ define void @v_shuffle_v3f32_v4f32__6_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__6_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__6_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -4760,28 +4775,29 @@ define void @v_shuffle_v3f32_v4f32__7_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -4808,26 +4824,27 @@ define void @v_shuffle_v3f32_v4f32__7_u_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_u_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_u_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -4861,14 +4878,14 @@ define void @v_shuffle_v3f32_v4f32__7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4878,15 +4895,14 @@ define void @v_shuffle_v3f32_v4f32__7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -5081,28 +5097,29 @@ define void @v_shuffle_v3f32_v4f32__7_5_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_5_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_5_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -5129,29 +5146,29 @@ define void @v_shuffle_v3f32_v4f32__7_6_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_6_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_6_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -5675,14 +5692,14 @@ define void @v_shuffle_v3f32_v4f32__7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v3
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5692,15 +5709,14 @@ define void @v_shuffle_v3f32_v4f32__7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v3
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -5899,28 +5915,29 @@ define void @v_shuffle_v3f32_v4f32__7_4_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_4_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_4_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -5947,29 +5964,29 @@ define void @v_shuffle_v3f32_v4f32__7_6_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_6_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_6_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -6706,29 +6723,29 @@ define void @v_shuffle_v3f32_v4f32__7_4_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_4_6:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_4_6:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -7484,29 +7501,29 @@ define void @v_shuffle_v3f32_v4f32__7_4_7(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3f32_v4f32__7_4_7:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3f32_v4f32__7_4_7:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3i32.v2i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3i32.v2i32.ll
@@ -167,15 +167,15 @@ define void @v_shuffle_v3i32_v2i32__3_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:1]
+; GFX90A-NEXT:    ; def v[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[2:4], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -183,15 +183,15 @@ define void @v_shuffle_v3i32_v2i32__3_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:1]
+; GFX942-NEXT:    ; def v[2:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v1
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v2, v3
+; GFX942-NEXT:    v_mov_b32_e32 v3, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[2:4], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i32> asm "; def $0", "=v"()
@@ -269,27 +269,27 @@ define void @v_shuffle_v3i32_v2i32__3_2_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v2i32__3_2_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx3 v2, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v2i32__3_2_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx3 v2, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i32> asm "; def $0", "=v"()
@@ -1232,34 +1232,35 @@ define void @v_shuffle_v3i32_v2i32__3_0_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v2i32__3_0_1:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
-; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v2i32__3_0_1:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
-; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v1
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i32> asm "; def $0", "=v"()
@@ -1288,34 +1289,35 @@ define void @v_shuffle_v3i32_v2i32__3_2_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v2i32__3_2_1:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:1]
+; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:5]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx3 v6, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v2i32__3_2_1:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:1]
+; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:5]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v0, v5
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx3 v6, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i32> asm "; def $0", "=v"()
@@ -1838,26 +1840,27 @@ define void @v_shuffle_v3i32_v2i32__3_u_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v2i32__3_u_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    global_store_dwordx3 v3, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx3 v2, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v2i32__3_u_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v1
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    global_store_dwordx3 v3, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx3 v2, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i32> asm "; def $0", "=v"()
@@ -1886,34 +1889,35 @@ define void @v_shuffle_v3i32_v2i32__3_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v2i32__3_0_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:1]
+; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:5]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    global_store_dwordx3 v6, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v2i32__3_0_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:1]
+; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:5]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v5
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    global_store_dwordx3 v6, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i32> asm "; def $0", "=v"()
@@ -1994,28 +1998,29 @@ define void @v_shuffle_v3i32_v2i32__3_2_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v2i32__3_2_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx3 v2, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v2i32__3_2_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx3 v2, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i32> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3i32.v3i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3i32.v3i32.ll
@@ -411,25 +411,27 @@ define void @v_shuffle_v3i32_v3i32__5_3_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v3i32__5_3_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v3i32__5_3_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    global_store_dwordx3 v4, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -946,28 +948,29 @@ define void @v_shuffle_v3i32_v3i32__1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v3i32__1_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v3i32__1_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -993,27 +996,29 @@ define void @v_shuffle_v3i32_v3i32__2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v3i32__2_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v3i32__2_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1376,13 +1381,14 @@ define void @v_shuffle_v3i32_v3i32__5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1392,13 +1398,14 @@ define void @v_shuffle_v3i32_v3i32__5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1983,13 +1990,14 @@ define void @v_shuffle_v3i32_v3i32__5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1999,13 +2007,14 @@ define void @v_shuffle_v3i32_v3i32__5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2830,28 +2839,29 @@ define void @v_shuffle_v3i32_v3i32__4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v3i32__4_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v3i32__4_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2878,27 +2888,29 @@ define void @v_shuffle_v3i32_v3i32__5_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v3i32__5_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v3i32__5_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2975,13 +2987,14 @@ define void @v_shuffle_v3i32_v3i32__5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2991,13 +3004,14 @@ define void @v_shuffle_v3i32_v3i32__5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -3133,27 +3147,29 @@ define void @v_shuffle_v3i32_v3i32__5_4_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v3i32__5_4_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v3i32__5_4_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -3574,13 +3590,14 @@ define void @v_shuffle_v3i32_v3i32__5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3590,13 +3607,14 @@ define void @v_shuffle_v3i32_v3i32__5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -3735,27 +3753,29 @@ define void @v_shuffle_v3i32_v3i32__5_3_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v3i32__5_3_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v3i32__5_3_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3i32.v4i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3i32.v4i32.ll
@@ -965,26 +965,29 @@ define void @v_shuffle_v3i32_v4i32__7_7_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_7_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_7_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -1011,26 +1014,29 @@ define void @v_shuffle_v3i32_v4i32__7_7_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_7_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_7_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -1241,28 +1247,29 @@ define void @v_shuffle_v3i32_v4i32__1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__1_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__1_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -1289,26 +1296,29 @@ define void @v_shuffle_v3i32_v4i32__2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__2_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__2_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -1335,28 +1345,29 @@ define void @v_shuffle_v3i32_v4i32__3_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__3_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__3_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -1838,14 +1849,14 @@ define void @v_shuffle_v3i32_v4i32__7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1855,14 +1866,14 @@ define void @v_shuffle_v3i32_v4i32__7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -2667,14 +2678,14 @@ define void @v_shuffle_v3i32_v4i32__7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v1
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2684,14 +2695,14 @@ define void @v_shuffle_v3i32_v4i32__7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -4664,28 +4675,29 @@ define void @v_shuffle_v3i32_v4i32__5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__5_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__5_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -4713,26 +4725,29 @@ define void @v_shuffle_v3i32_v4i32__6_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__6_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__6_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -4760,28 +4775,29 @@ define void @v_shuffle_v3i32_v4i32__7_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -4808,26 +4824,27 @@ define void @v_shuffle_v3i32_v4i32__7_u_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_u_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_u_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -4861,14 +4878,14 @@ define void @v_shuffle_v3i32_v4i32__7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4878,15 +4895,14 @@ define void @v_shuffle_v3i32_v4i32__7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -5081,28 +5097,29 @@ define void @v_shuffle_v3i32_v4i32__7_5_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_5_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_5_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -5129,29 +5146,29 @@ define void @v_shuffle_v3i32_v4i32__7_6_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_6_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_6_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -5675,14 +5692,14 @@ define void @v_shuffle_v3i32_v4i32__7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v3
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5692,15 +5709,14 @@ define void @v_shuffle_v3i32_v4i32__7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v3
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -5899,28 +5915,29 @@ define void @v_shuffle_v3i32_v4i32__7_4_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_4_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_4_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -5947,29 +5964,29 @@ define void @v_shuffle_v3i32_v4i32__7_6_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_6_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_6_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -6706,29 +6723,29 @@ define void @v_shuffle_v3i32_v4i32__7_4_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_4_6:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_4_6:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -7484,29 +7501,29 @@ define void @v_shuffle_v3i32_v4i32__7_4_7(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i32_v4i32__7_4_7:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i32_v4i32__7_4_7:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3i64.v2i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3i64.v2i64.ll
@@ -291,27 +291,31 @@ define void @v_shuffle_v3i64_v2i64__3_2_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i64_v2i64__3_2_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i64_v2i64__3_2_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -695,28 +699,32 @@ define void @v_shuffle_v3i64_v2i64__1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i64_v2i64__1_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx2 v6, v[0:1], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx2 v4, v[0:1], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i64_v2i64__1_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    global_store_dwordx2 v6, v[0:1], s[0:1] offset:16
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx2 v4, v[0:1], s[0:1] offset:16
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -1555,28 +1563,32 @@ define void @v_shuffle_v3i64_v2i64__3_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i64_v2i64__3_2_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx2 v6, v[0:1], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx2 v4, v[0:1], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i64_v2i64__3_2_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    global_store_dwordx2 v6, v[0:1], s[0:1] offset:16
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx2 v4, v[0:1], s[0:1] offset:16
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -2148,28 +2160,32 @@ define void @v_shuffle_v3i64_v2i64__3_2_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3i64_v2i64__3_2_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx2 v6, v[2:3], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx2 v4, v[2:3], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3i64_v2i64__3_2_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    global_store_dwordx2 v6, v[2:3], s[0:1] offset:16
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx2 v4, v[2:3], s[0:1] offset:16
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3p0.v2p0.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3p0.v2p0.ll
@@ -291,27 +291,31 @@ define void @v_shuffle_v3p0_v2p0__3_2_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p0_v2p0__3_2_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p0_v2p0__3_2_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -695,28 +699,32 @@ define void @v_shuffle_v3p0_v2p0__1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p0_v2p0__1_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx2 v6, v[0:1], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx2 v4, v[0:1], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p0_v2p0__1_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    global_store_dwordx2 v6, v[0:1], s[0:1] offset:16
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx2 v4, v[0:1], s[0:1] offset:16
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -1555,28 +1563,32 @@ define void @v_shuffle_v3p0_v2p0__3_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p0_v2p0__3_2_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx2 v6, v[0:1], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx2 v4, v[0:1], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p0_v2p0__3_2_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    global_store_dwordx2 v6, v[0:1], s[0:1] offset:16
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx2 v4, v[0:1], s[0:1] offset:16
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -2148,28 +2160,32 @@ define void @v_shuffle_v3p0_v2p0__3_2_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p0_v2p0__3_2_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx2 v6, v[2:3], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx2 v4, v[2:3], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p0_v2p0__3_2_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    global_store_dwordx2 v6, v[2:3], s[0:1] offset:16
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx2 v4, v[2:3], s[0:1] offset:16
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3p3.v2p3.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3p3.v2p3.ll
@@ -167,15 +167,15 @@ define void @v_shuffle_v3p3_v2p3__3_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:1]
+; GFX90A-NEXT:    ; def v[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[2:4], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -183,15 +183,15 @@ define void @v_shuffle_v3p3_v2p3__3_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:1]
+; GFX942-NEXT:    ; def v[2:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v1
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v2, v3
+; GFX942-NEXT:    v_mov_b32_e32 v3, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[2:4], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -269,27 +269,27 @@ define void @v_shuffle_v3p3_v2p3__3_2_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v2p3__3_2_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx3 v2, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v2p3__3_2_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx3 v2, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1232,34 +1232,35 @@ define void @v_shuffle_v3p3_v2p3__3_0_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v2p3__3_0_1:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
-; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v2p3__3_0_1:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
-; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v1
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1288,34 +1289,35 @@ define void @v_shuffle_v3p3_v2p3__3_2_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v2p3__3_2_1:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:1]
+; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:5]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx3 v6, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v2p3__3_2_1:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:1]
+; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:5]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v0, v5
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx3 v6, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1838,26 +1840,27 @@ define void @v_shuffle_v3p3_v2p3__3_u_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v2p3__3_u_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    global_store_dwordx3 v3, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx3 v2, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v2p3__3_u_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v1
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    global_store_dwordx3 v3, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx3 v2, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1886,34 +1889,35 @@ define void @v_shuffle_v3p3_v2p3__3_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v2p3__3_0_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:1]
+; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:5]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    global_store_dwordx3 v6, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v2p3__3_0_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:1]
+; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:5]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v5
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    global_store_dwordx3 v6, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1994,28 +1998,29 @@ define void @v_shuffle_v3p3_v2p3__3_2_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v2p3__3_2_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[0:2], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx3 v2, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v2p3__3_2_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx3 v4, v[0:2], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx3 v2, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr addrspace(3)> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3p3.v3p3.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3p3.v3p3.ll
@@ -411,25 +411,27 @@ define void @v_shuffle_v3p3_v3p3__5_3_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v3p3__5_3_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    global_store_dwordx3 v4, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v3p3__5_3_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    global_store_dwordx3 v4, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -946,28 +948,29 @@ define void @v_shuffle_v3p3_v3p3__1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v3p3__1_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v3p3__1_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -993,27 +996,29 @@ define void @v_shuffle_v3p3_v3p3__2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v3p3__2_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v3p3__2_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1376,13 +1381,14 @@ define void @v_shuffle_v3p3_v3p3__5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1392,13 +1398,14 @@ define void @v_shuffle_v3p3_v3p3__5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1983,13 +1990,14 @@ define void @v_shuffle_v3p3_v3p3__5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1999,13 +2007,14 @@ define void @v_shuffle_v3p3_v3p3__5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2830,28 +2839,29 @@ define void @v_shuffle_v3p3_v3p3__4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v3p3__4_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v3p3__4_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2878,27 +2888,29 @@ define void @v_shuffle_v3p3_v3p3__5_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v3p3__5_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v3p3__5_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2975,13 +2987,14 @@ define void @v_shuffle_v3p3_v3p3__5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2991,13 +3004,14 @@ define void @v_shuffle_v3p3_v3p3__5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -3133,27 +3147,29 @@ define void @v_shuffle_v3p3_v3p3__5_4_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v3p3__5_4_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v3p3__5_4_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -3574,13 +3590,14 @@ define void @v_shuffle_v3p3_v3p3__5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    global_store_dwordx3 v5, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3590,13 +3607,14 @@ define void @v_shuffle_v3p3_v3p3__5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx3 v5, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -3735,27 +3753,29 @@ define void @v_shuffle_v3p3_v3p3__5_3_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v3p3__5_3_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx3 v3, v[4:6], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v3p3__5_3_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx3 v3, v[4:6], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v3p3.v4p3.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v3p3.v4p3.ll
@@ -965,26 +965,29 @@ define void @v_shuffle_v3p3_v4p3__7_7_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_7_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_7_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1011,26 +1014,29 @@ define void @v_shuffle_v3p3_v4p3__7_7_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_7_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_7_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1241,28 +1247,29 @@ define void @v_shuffle_v3p3_v4p3__1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__1_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__1_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1289,26 +1296,29 @@ define void @v_shuffle_v3p3_v4p3__2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__2_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__2_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1335,28 +1345,29 @@ define void @v_shuffle_v3p3_v4p3__3_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__3_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__3_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1838,14 +1849,14 @@ define void @v_shuffle_v3p3_v4p3__7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1855,14 +1866,14 @@ define void @v_shuffle_v3p3_v4p3__7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2667,14 +2678,14 @@ define void @v_shuffle_v3p3_v4p3__7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v1
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2684,14 +2695,14 @@ define void @v_shuffle_v3p3_v4p3__7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4664,28 +4675,29 @@ define void @v_shuffle_v3p3_v4p3__5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__5_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__5_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4713,26 +4725,29 @@ define void @v_shuffle_v3p3_v4p3__6_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__6_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__6_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4760,28 +4775,29 @@ define void @v_shuffle_v3p3_v4p3__7_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4808,26 +4824,27 @@ define void @v_shuffle_v3p3_v4p3__7_u_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_u_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_u_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4861,14 +4878,14 @@ define void @v_shuffle_v3p3_v4p3__7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4878,15 +4895,14 @@ define void @v_shuffle_v3p3_v4p3__7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5081,28 +5097,29 @@ define void @v_shuffle_v3p3_v4p3__7_5_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_5_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_5_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5129,29 +5146,29 @@ define void @v_shuffle_v3p3_v4p3__7_6_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_6_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_6_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5675,14 +5692,14 @@ define void @v_shuffle_v3p3_v4p3__7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v3
+; GFX90A-NEXT:    global_store_dwordx3 v6, v[8:10], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5692,15 +5709,14 @@ define void @v_shuffle_v3p3_v4p3__7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v3
+; GFX942-NEXT:    global_store_dwordx3 v6, v[8:10], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5899,28 +5915,29 @@ define void @v_shuffle_v3p3_v4p3__7_4_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_4_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx3 v5, v[2:4], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_4_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx3 v5, v[2:4], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5947,29 +5964,29 @@ define void @v_shuffle_v3p3_v4p3__7_6_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_6_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_6_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v2
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -6706,29 +6723,29 @@ define void @v_shuffle_v3p3_v4p3__7_4_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_4_6:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_4_6:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -7484,29 +7501,29 @@ define void @v_shuffle_v3p3_v4p3__7_4_7(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v3p3_v4p3__7_4_7:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    global_store_dwordx3 v7, v[4:6], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    global_store_dwordx3 v4, v[6:8], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v3p3_v4p3__7_4_7:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx3 v7, v[4:6], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx3 v4, v[6:8], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4f32.v2f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4f32.v2f32.ll
@@ -272,27 +272,27 @@ define void @v_shuffle_v4f32_v2f32__3_2_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v2f32__3_2_u_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx4 v2, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v2f32__3_2_u_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx4 v2, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x float> asm "; def $0", "=v"()
@@ -2380,28 +2380,29 @@ define void @v_shuffle_v4f32_v2f32__3_3_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v2f32__3_3_u_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v2, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v2f32__3_3_u_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v2, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x float> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4f32.v3f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4f32.v3f32.ll
@@ -255,15 +255,15 @@ define void @v_shuffle_v4f32_v3f32__5_0_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -271,15 +271,16 @@ define void @v_shuffle_v4f32_v3f32__5_0_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v2, v4
+; GFX942-NEXT:    v_mov_b32_e32 v3, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -413,27 +414,27 @@ define void @v_shuffle_v4f32_v3f32__5_3_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_3_u_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_3_u_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -553,15 +554,16 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -569,16 +571,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v2, v4
+; GFX942-NEXT:    v_mov_b32_e32 v3, v4
+; GFX942-NEXT:    v_mov_b32_e32 v4, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -609,16 +612,16 @@ define void @v_shuffle_v4f32_v3f32__5_5_1_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -626,17 +629,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_1_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v2, v4
+; GFX942-NEXT:    v_mov_b32_e32 v3, v4
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -719,27 +722,29 @@ define void @v_shuffle_v4f32_v3f32__5_5_3_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_3_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_3_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -766,28 +771,29 @@ define void @v_shuffle_v4f32_v3f32__5_5_4_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_4_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_4_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1031,31 +1037,31 @@ define void @v_shuffle_v4f32_v3f32__5_5_5_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_5_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_5_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1083,28 +1089,31 @@ define void @v_shuffle_v4f32_v3f32__5_5_5_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_5_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_5_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1180,28 +1189,29 @@ define void @v_shuffle_v4f32_v3f32__u_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__u_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__u_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v1, v0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1325,31 +1335,31 @@ define void @v_shuffle_v4f32_v3f32__2_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__2_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__2_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1375,28 +1385,29 @@ define void @v_shuffle_v4f32_v3f32__3_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__3_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__3_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v1, v0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1488,15 +1499,15 @@ define void @v_shuffle_v4f32_v3f32__5_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1506,15 +1517,15 @@ define void @v_shuffle_v4f32_v3f32__5_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1545,34 +1556,33 @@ define void @v_shuffle_v4f32_v3f32__5_u_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_u_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_u_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v5, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1606,15 +1616,15 @@ define void @v_shuffle_v4f32_v3f32__5_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1624,15 +1634,15 @@ define void @v_shuffle_v4f32_v3f32__5_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1664,17 +1674,17 @@ define void @v_shuffle_v4f32_v3f32__5_2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:2]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1682,17 +1692,17 @@ define void @v_shuffle_v4f32_v3f32__5_2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1724,17 +1734,17 @@ define void @v_shuffle_v4f32_v3f32__5_3_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v9, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v9, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1742,17 +1752,17 @@ define void @v_shuffle_v4f32_v3f32__5_3_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v9, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v9, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1843,15 +1853,15 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1861,15 +1871,15 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -1901,16 +1911,16 @@ define void @v_shuffle_v4f32_v3f32__5_5_u_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1918,16 +1928,16 @@ define void @v_shuffle_v4f32_v3f32__5_5_u_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2018,17 +2028,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:2]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2036,17 +2046,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2078,17 +2088,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v9, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v9, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2096,17 +2106,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v9, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v8
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    global_store_dwordx4 v9, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2603,16 +2613,17 @@ define void @v_shuffle_v4f32_v3f32__5_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2620,16 +2631,17 @@ define void @v_shuffle_v4f32_v3f32__5_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2661,16 +2673,17 @@ define void @v_shuffle_v4f32_v3f32__5_2_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2678,17 +2691,17 @@ define void @v_shuffle_v4f32_v3f32__5_2_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2720,16 +2733,17 @@ define void @v_shuffle_v4f32_v3f32__5_3_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2737,16 +2751,17 @@ define void @v_shuffle_v4f32_v3f32__5_3_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2834,16 +2849,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2851,17 +2867,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2893,15 +2909,16 @@ define void @v_shuffle_v4f32_v3f32__5_5_u_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2909,16 +2926,16 @@ define void @v_shuffle_v4f32_v3f32__5_5_u_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -2949,15 +2966,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2965,16 +2984,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -3006,16 +3026,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_2_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3023,17 +3044,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_2_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -3065,16 +3086,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3082,17 +3104,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -3124,16 +3146,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3141,17 +3164,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -3581,17 +3604,17 @@ define void @v_shuffle_v4f32_v3f32__5_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3599,17 +3622,17 @@ define void @v_shuffle_v4f32_v3f32__5_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -3868,16 +3891,16 @@ define void @v_shuffle_v4f32_v3f32__5_5_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:2]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3885,16 +3908,16 @@ define void @v_shuffle_v4f32_v3f32__5_5_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -3926,16 +3949,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3943,16 +3967,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v8
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -4040,36 +4065,37 @@ define void @v_shuffle_v4f32_v3f32__5_5_3_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_3_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_3_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v8
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v6
+; GFX942-NEXT:    v_mov_b32_e32 v9, v6
+; GFX942-NEXT:    v_mov_b32_e32 v10, v4
+; GFX942-NEXT:    v_mov_b32_e32 v11, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -4351,31 +4377,31 @@ define void @v_shuffle_v4f32_v3f32__5_3_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_3_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_3_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -4403,29 +4429,27 @@ define void @v_shuffle_v4f32_v3f32__5_u_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_u_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v1, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v1, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_u_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v1, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v1, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v0
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -4456,17 +4480,17 @@ define void @v_shuffle_v4f32_v3f32__5_0_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4474,17 +4498,17 @@ define void @v_shuffle_v4f32_v3f32__5_0_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -4573,36 +4597,35 @@ define void @v_shuffle_v4f32_v3f32__5_2_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_2_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v4
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_2_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v4
+; GFX942-NEXT:    global_store_dwordx4 v3, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -4630,31 +4653,31 @@ define void @v_shuffle_v4f32_v3f32__5_4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_4_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_4_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -4682,31 +4705,31 @@ define void @v_shuffle_v4f32_v3f32__5_5_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -4734,28 +4757,29 @@ define void @v_shuffle_v4f32_v3f32__5_5_u_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_u_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_u_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -4786,16 +4810,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4803,17 +4828,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -5369,28 +5394,27 @@ define void @v_shuffle_v4f32_v3f32__5_u_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_u_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_u_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -5421,17 +5445,17 @@ define void @v_shuffle_v4f32_v3f32__5_0_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5439,17 +5463,17 @@ define void @v_shuffle_v4f32_v3f32__5_0_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -5536,36 +5560,35 @@ define void @v_shuffle_v4f32_v3f32__5_2_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_2_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_2_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    global_store_dwordx4 v3, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -5592,28 +5615,31 @@ define void @v_shuffle_v4f32_v3f32__5_3_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_3_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_3_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -5641,28 +5667,31 @@ define void @v_shuffle_v4f32_v3f32__5_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -5690,27 +5719,29 @@ define void @v_shuffle_v4f32_v3f32__5_5_u_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_u_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_u_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -5742,16 +5773,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5759,17 +5791,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -5801,17 +5833,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_1_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5819,17 +5851,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_1_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -5915,27 +5947,31 @@ define void @v_shuffle_v4f32_v3f32__5_5_3_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_3_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_3_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -6497,30 +6533,31 @@ define void @v_shuffle_v4f32_v3f32__5_3_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_3_5_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_3_5_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -6593,28 +6630,29 @@ define void @v_shuffle_v4f32_v3f32__5_5_u_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_u_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_u_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -6646,16 +6684,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v6
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v4
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -6663,17 +6702,17 @@ define void @v_shuffle_v4f32_v3f32__5_5_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v4
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()
@@ -6819,28 +6858,31 @@ define void @v_shuffle_v4f32_v3f32__5_5_3_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v3f32__5_5_3_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v3f32__5_5_3_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x float> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4f32.v4f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4f32.v4f32.ll
@@ -963,26 +963,29 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_4_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_4_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -1009,26 +1012,29 @@ define void @v_shuffle_v4f32_v4f32__7_7_5_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_5_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_5_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -1440,31 +1446,31 @@ define void @v_shuffle_v4f32_v4f32__7_7_7_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_7_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_7_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -1734,28 +1740,31 @@ define void @v_shuffle_v4f32_v4f32__2_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__2_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__2_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -2785,14 +2794,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v0
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2802,14 +2812,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v11, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -4138,14 +4149,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4155,14 +4167,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -4196,14 +4209,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_5_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4213,14 +4227,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_5_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v3
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -5448,34 +5463,37 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_4_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:7]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v7
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[4:7]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v7
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v7
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v2
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_4_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:7]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v7
-; GFX942-NEXT:    v_mov_b32_e32 v8, v4
-; GFX942-NEXT:    v_mov_b32_e32 v9, v2
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1]
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[4:7]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v10, v7
+; GFX942-NEXT:    v_mov_b32_e32 v11, v7
+; GFX942-NEXT:    v_mov_b32_e32 v12, v4
+; GFX942-NEXT:    v_mov_b32_e32 v13, v2
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -7172,28 +7190,31 @@ define void @v_shuffle_v4f32_v4f32__6_4_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__6_4_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__6_4_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -7271,28 +7292,29 @@ define void @v_shuffle_v4f32_v4f32__7_u_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_u_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_u_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -7559,30 +7581,31 @@ define void @v_shuffle_v4f32_v4f32__7_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_5_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_5_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -7660,28 +7683,31 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -7763,14 +7789,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v2
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7780,14 +7807,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v2
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -8041,31 +8069,31 @@ define void @v_shuffle_v4f32_v4f32__7_7_6_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_6_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_6_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v0
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -8946,28 +8974,31 @@ define void @v_shuffle_v4f32_v4f32__7_7_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_5_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_5_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -9047,14 +9078,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -9064,14 +9096,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -9105,14 +9138,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_1_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -9122,14 +9156,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_1_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -9277,28 +9312,31 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_4_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_4_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -9327,31 +9365,31 @@ define void @v_shuffle_v4f32_v4f32__7_7_6_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_6_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_6_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -10319,15 +10357,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_0_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v4
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v4
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -10337,15 +10375,15 @@ define void @v_shuffle_v4f32_v4f32__7_7_0_6(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
-; GFX942-NEXT:    v_mov_b32_e32 v9, v4
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v4
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -10553,31 +10591,31 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_4_6:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_4_6:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -11777,31 +11815,31 @@ define void @v_shuffle_v4f32_v4f32__7_7_4_7(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_4_7:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_4_7:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()
@@ -11830,31 +11868,31 @@ define void @v_shuffle_v4f32_v4f32__7_7_5_7(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4f32_v4f32__7_7_5_7:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4f32_v4f32__7_7_5_7:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x float> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4i32.v2i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4i32.v2i32.ll
@@ -272,27 +272,27 @@ define void @v_shuffle_v4i32_v2i32__3_2_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v2i32__3_2_u_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx4 v2, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v2i32__3_2_u_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx4 v2, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i32> asm "; def $0", "=v"()
@@ -2386,28 +2386,29 @@ define void @v_shuffle_v4i32_v2i32__3_3_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v2i32__3_3_u_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v2, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v2i32__3_3_u_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v2, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i32> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4i32.v3i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4i32.v3i32.ll
@@ -255,15 +255,15 @@ define void @v_shuffle_v4i32_v3i32__5_0_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -271,15 +271,16 @@ define void @v_shuffle_v4i32_v3i32__5_0_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v2, v4
+; GFX942-NEXT:    v_mov_b32_e32 v3, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -413,27 +414,27 @@ define void @v_shuffle_v4i32_v3i32__5_3_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_3_u_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_3_u_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -553,15 +554,16 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -569,16 +571,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v2, v4
+; GFX942-NEXT:    v_mov_b32_e32 v3, v4
+; GFX942-NEXT:    v_mov_b32_e32 v4, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -609,16 +612,16 @@ define void @v_shuffle_v4i32_v3i32__5_5_1_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -626,17 +629,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_1_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v2, v4
+; GFX942-NEXT:    v_mov_b32_e32 v3, v4
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -719,27 +722,29 @@ define void @v_shuffle_v4i32_v3i32__5_5_3_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_3_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_3_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -766,28 +771,29 @@ define void @v_shuffle_v4i32_v3i32__5_5_4_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_4_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_4_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1031,31 +1037,31 @@ define void @v_shuffle_v4i32_v3i32__5_5_5_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_5_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_5_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1083,28 +1089,31 @@ define void @v_shuffle_v4i32_v3i32__5_5_5_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_5_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_5_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1180,28 +1189,29 @@ define void @v_shuffle_v4i32_v3i32__u_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__u_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__u_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v1, v0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1325,31 +1335,31 @@ define void @v_shuffle_v4i32_v3i32__2_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__2_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__2_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1375,28 +1385,29 @@ define void @v_shuffle_v4i32_v3i32__3_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__3_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__3_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v1, v0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1488,15 +1499,15 @@ define void @v_shuffle_v4i32_v3i32__5_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1506,15 +1517,15 @@ define void @v_shuffle_v4i32_v3i32__5_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1545,34 +1556,33 @@ define void @v_shuffle_v4i32_v3i32__5_u_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_u_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_u_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v5, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1606,15 +1616,15 @@ define void @v_shuffle_v4i32_v3i32__5_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1624,15 +1634,15 @@ define void @v_shuffle_v4i32_v3i32__5_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1664,17 +1674,17 @@ define void @v_shuffle_v4i32_v3i32__5_2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:2]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1682,17 +1692,17 @@ define void @v_shuffle_v4i32_v3i32__5_2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1724,17 +1734,17 @@ define void @v_shuffle_v4i32_v3i32__5_3_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v9, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v9, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1742,17 +1752,17 @@ define void @v_shuffle_v4i32_v3i32__5_3_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v9, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v9, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1843,15 +1853,15 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1861,15 +1871,15 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -1901,16 +1911,16 @@ define void @v_shuffle_v4i32_v3i32__5_5_u_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1918,16 +1928,16 @@ define void @v_shuffle_v4i32_v3i32__5_5_u_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2018,17 +2028,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:2]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2036,17 +2046,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2078,17 +2088,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v9, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v9, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2096,17 +2106,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v9, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v8
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    global_store_dwordx4 v9, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2603,16 +2613,17 @@ define void @v_shuffle_v4i32_v3i32__5_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2620,16 +2631,17 @@ define void @v_shuffle_v4i32_v3i32__5_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2661,16 +2673,17 @@ define void @v_shuffle_v4i32_v3i32__5_2_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2678,17 +2691,17 @@ define void @v_shuffle_v4i32_v3i32__5_2_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2720,16 +2733,17 @@ define void @v_shuffle_v4i32_v3i32__5_3_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2737,16 +2751,17 @@ define void @v_shuffle_v4i32_v3i32__5_3_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2834,16 +2849,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2851,17 +2867,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2893,15 +2909,16 @@ define void @v_shuffle_v4i32_v3i32__5_5_u_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2909,16 +2926,16 @@ define void @v_shuffle_v4i32_v3i32__5_5_u_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -2949,15 +2966,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2965,16 +2984,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -3006,16 +3026,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_2_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3023,17 +3044,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_2_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -3065,16 +3086,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3082,17 +3104,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -3124,16 +3146,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3141,17 +3164,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -3581,17 +3604,17 @@ define void @v_shuffle_v4i32_v3i32__5_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3599,17 +3622,17 @@ define void @v_shuffle_v4i32_v3i32__5_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -3868,16 +3891,16 @@ define void @v_shuffle_v4i32_v3i32__5_5_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:2]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3885,16 +3908,16 @@ define void @v_shuffle_v4i32_v3i32__5_5_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -3926,16 +3949,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3943,16 +3967,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v8
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -4040,36 +4065,37 @@ define void @v_shuffle_v4i32_v3i32__5_5_3_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_3_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_3_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v8
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v6
+; GFX942-NEXT:    v_mov_b32_e32 v9, v6
+; GFX942-NEXT:    v_mov_b32_e32 v10, v4
+; GFX942-NEXT:    v_mov_b32_e32 v11, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -4351,31 +4377,31 @@ define void @v_shuffle_v4i32_v3i32__5_3_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_3_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_3_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -4403,29 +4429,27 @@ define void @v_shuffle_v4i32_v3i32__5_u_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_u_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v1, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v1, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_u_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v1, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v1, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v0
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -4456,17 +4480,17 @@ define void @v_shuffle_v4i32_v3i32__5_0_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4474,17 +4498,17 @@ define void @v_shuffle_v4i32_v3i32__5_0_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -4573,36 +4597,35 @@ define void @v_shuffle_v4i32_v3i32__5_2_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_2_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v4
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_2_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v4
+; GFX942-NEXT:    global_store_dwordx4 v3, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -4630,31 +4653,31 @@ define void @v_shuffle_v4i32_v3i32__5_4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_4_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_4_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -4682,31 +4705,31 @@ define void @v_shuffle_v4i32_v3i32__5_5_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -4734,28 +4757,29 @@ define void @v_shuffle_v4i32_v3i32__5_5_u_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_u_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_u_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -4786,16 +4810,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4803,17 +4828,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -5369,28 +5394,27 @@ define void @v_shuffle_v4i32_v3i32__5_u_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_u_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_u_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -5421,17 +5445,17 @@ define void @v_shuffle_v4i32_v3i32__5_0_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5439,17 +5463,17 @@ define void @v_shuffle_v4i32_v3i32__5_0_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -5536,36 +5560,35 @@ define void @v_shuffle_v4i32_v3i32__5_2_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_2_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_2_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    global_store_dwordx4 v3, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -5592,28 +5615,31 @@ define void @v_shuffle_v4i32_v3i32__5_3_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_3_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_3_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -5641,28 +5667,31 @@ define void @v_shuffle_v4i32_v3i32__5_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -5690,27 +5719,29 @@ define void @v_shuffle_v4i32_v3i32__5_5_u_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_u_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_u_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -5742,16 +5773,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5759,17 +5791,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -5801,17 +5833,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_1_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5819,17 +5851,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_1_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -5915,27 +5947,31 @@ define void @v_shuffle_v4i32_v3i32__5_5_3_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_3_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_3_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -6497,30 +6533,31 @@ define void @v_shuffle_v4i32_v3i32__5_3_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_3_5_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_3_5_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -6593,28 +6630,29 @@ define void @v_shuffle_v4i32_v3i32__5_5_u_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_u_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_u_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -6646,16 +6684,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v6
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v4
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -6663,17 +6702,17 @@ define void @v_shuffle_v4i32_v3i32__5_5_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v4
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()
@@ -6819,28 +6858,31 @@ define void @v_shuffle_v4i32_v3i32__5_5_3_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v3i32__5_5_3_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v3i32__5_5_3_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i32> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4i32.v4i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4i32.v4i32.ll
@@ -963,26 +963,29 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_4_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_4_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -1009,26 +1012,29 @@ define void @v_shuffle_v4i32_v4i32__7_7_5_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_5_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_5_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -1440,31 +1446,31 @@ define void @v_shuffle_v4i32_v4i32__7_7_7_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_7_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_7_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -1734,28 +1740,31 @@ define void @v_shuffle_v4i32_v4i32__2_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__2_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__2_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -2785,14 +2794,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v0
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2802,14 +2812,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v11, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -4138,14 +4149,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4155,14 +4167,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -4196,14 +4209,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_5_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4213,14 +4227,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_5_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v3
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -5448,34 +5463,37 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_4_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:7]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v7
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[4:7]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v7
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v7
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v2
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_4_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:7]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v7
-; GFX942-NEXT:    v_mov_b32_e32 v8, v4
-; GFX942-NEXT:    v_mov_b32_e32 v9, v2
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1]
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[4:7]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v10, v7
+; GFX942-NEXT:    v_mov_b32_e32 v11, v7
+; GFX942-NEXT:    v_mov_b32_e32 v12, v4
+; GFX942-NEXT:    v_mov_b32_e32 v13, v2
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -7172,28 +7190,31 @@ define void @v_shuffle_v4i32_v4i32__6_4_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__6_4_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__6_4_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -7271,28 +7292,29 @@ define void @v_shuffle_v4i32_v4i32__7_u_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_u_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_u_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -7559,30 +7581,31 @@ define void @v_shuffle_v4i32_v4i32__7_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_5_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_5_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -7660,28 +7683,31 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -7763,14 +7789,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v2
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7780,14 +7807,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v2
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -8041,31 +8069,31 @@ define void @v_shuffle_v4i32_v4i32__7_7_6_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_6_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_6_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v0
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -8946,28 +8974,31 @@ define void @v_shuffle_v4i32_v4i32__7_7_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_5_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_5_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -9047,14 +9078,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -9064,14 +9096,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -9105,14 +9138,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_1_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -9122,14 +9156,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_1_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -9277,28 +9312,31 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_4_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_4_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -9327,31 +9365,31 @@ define void @v_shuffle_v4i32_v4i32__7_7_6_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_6_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_6_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -10319,15 +10357,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_0_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v4
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v4
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -10337,15 +10375,15 @@ define void @v_shuffle_v4i32_v4i32__7_7_0_6(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
-; GFX942-NEXT:    v_mov_b32_e32 v9, v4
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v4
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -10553,31 +10591,31 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_4_6:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_4_6:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -11777,31 +11815,31 @@ define void @v_shuffle_v4i32_v4i32__7_7_4_7(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_4_7:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_4_7:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()
@@ -11830,31 +11868,31 @@ define void @v_shuffle_v4i32_v4i32__7_7_5_7(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i32_v4i32__7_7_5_7:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i32_v4i32__7_7_5_7:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i32> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4i64.v2i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4i64.v2i64.ll
@@ -291,27 +291,31 @@ define void @v_shuffle_v4i64_v2i64__3_2_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i64_v2i64__3_2_u_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i64_v2i64__3_2_u_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -624,15 +628,15 @@ define void @v_shuffle_v4i64_v2i64__3_3_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -642,18 +646,18 @@ define void @v_shuffle_v4i64_v2i64__3_3_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -752,15 +756,15 @@ define void @v_shuffle_v4i64_v2i64__3_3_3_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -770,15 +774,15 @@ define void @v_shuffle_v4i64_v2i64__3_3_3_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v2
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -953,33 +957,39 @@ define void @v_shuffle_v4i64_v2i64__1_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i64_v2i64__1_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    s_nop 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i64_v2i64__1_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    s_nop 1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -1206,18 +1216,18 @@ define void @v_shuffle_v4i64_v2i64__3_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v7
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1227,18 +1237,18 @@ define void @v_shuffle_v4i64_v2i64__3_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:7]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v12, v0
+; GFX942-NEXT:    v_mov_b32_e32 v13, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v7
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -1556,15 +1566,15 @@ define void @v_shuffle_v4i64_v2i64__3_3_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1574,18 +1584,18 @@ define void @v_shuffle_v4i64_v2i64__3_3_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -1663,33 +1673,33 @@ define void @v_shuffle_v4i64_v2i64__0_1_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i64_v2i64__0_1_1_1:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i64_v2i64__0_1_1_1:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v2
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -1961,17 +1971,17 @@ define void @v_shuffle_v4i64_v2i64__3_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v7
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1984,17 +1994,17 @@ define void @v_shuffle_v4i64_v2i64__3_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:7]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
-; GFX942-NEXT:    v_mov_b32_e32 v8, v2
-; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v3
+; GFX942-NEXT:    v_mov_b32_e32 v12, v2
+; GFX942-NEXT:    v_mov_b32_e32 v13, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v7
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -2447,33 +2457,39 @@ define void @v_shuffle_v4i64_v2i64__3_2_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i64_v2i64__3_2_2_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    s_nop 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i64_v2i64__3_2_2_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    s_nop 1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -2508,15 +2524,15 @@ define void @v_shuffle_v4i64_v2i64__3_u_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2526,15 +2542,15 @@ define void @v_shuffle_v4i64_v2i64__3_u_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -2577,17 +2593,17 @@ define void @v_shuffle_v4i64_v2i64__3_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2597,21 +2613,21 @@ define void @v_shuffle_v4i64_v2i64__3_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -2649,18 +2665,18 @@ define void @v_shuffle_v4i64_v2i64__3_1_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v7
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2670,19 +2686,19 @@ define void @v_shuffle_v4i64_v2i64__3_1_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:7]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v8, v4
-; GFX942-NEXT:    v_mov_b32_e32 v9, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v5
+; GFX942-NEXT:    v_mov_b32_e32 v12, v4
+; GFX942-NEXT:    v_mov_b32_e32 v13, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v7
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -2717,15 +2733,15 @@ define void @v_shuffle_v4i64_v2i64__3_3_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2735,15 +2751,15 @@ define void @v_shuffle_v4i64_v2i64__3_3_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -2776,13 +2792,13 @@ define void @v_shuffle_v4i64_v2i64__3_3_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[4:7], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2792,13 +2808,13 @@ define void @v_shuffle_v4i64_v2i64__3_3_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v6, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v4, v[4:7], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -3134,33 +3150,33 @@ define void @v_shuffle_v4i64_v2i64__2_3_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i64_v2i64__2_3_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i64_v2i64__2_3_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v2
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()
@@ -3374,39 +3390,39 @@ define void @v_shuffle_v4i64_v2i64__3_2_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i64_v2i64__3_2_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
 ; GFX90A-NEXT:    s_nop 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i64_v2i64__3_2_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v2
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
 ; GFX942-NEXT:    s_nop 1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x i64> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4i64.v3i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4i64.v3i64.ll
@@ -1126,15 +1126,15 @@ define void @v_shuffle_v4i64_v3i64__5_5_5_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1144,15 +1144,15 @@ define void @v_shuffle_v4i64_v3i64__5_5_5_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i64> asm "; def $0", "=v"()
@@ -1388,13 +1388,15 @@ define void @v_shuffle_v4i64_v3i64__1_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1404,13 +1406,15 @@ define void @v_shuffle_v4i64_v3i64__1_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i64> asm "; def $0", "=v"()
@@ -3637,33 +3641,33 @@ define void @v_shuffle_v4i64_v3i64__1_2_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i64_v3i64__1_2_2_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i64_v3i64__1_2_2_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v4
+; GFX942-NEXT:    v_mov_b32_e32 v11, v5
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i64> asm "; def $0", "=v"()
@@ -4787,13 +4791,15 @@ define void @v_shuffle_v4i64_v3i64__4_3_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4803,13 +4809,15 @@ define void @v_shuffle_v4i64_v3i64__4_3_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i64> asm "; def $0", "=v"()
@@ -5169,15 +5177,15 @@ define void @v_shuffle_v4i64_v3i64__5_4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5187,15 +5195,15 @@ define void @v_shuffle_v4i64_v3i64__5_4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i64> asm "; def $0", "=v"()
@@ -5532,15 +5540,15 @@ define void @v_shuffle_v4i64_v3i64__5_5_4_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5550,15 +5558,15 @@ define void @v_shuffle_v4i64_v3i64__5_5_4_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i64> asm "; def $0", "=v"()
@@ -6255,17 +6263,17 @@ define void @v_shuffle_v4i64_v3i64__5_3_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -6275,17 +6283,17 @@ define void @v_shuffle_v4i64_v3i64__5_3_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i64> asm "; def $0", "=v"()
@@ -6970,33 +6978,33 @@ define void @v_shuffle_v4i64_v3i64__4_5_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4i64_v3i64__4_5_5_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4i64_v3i64__4_5_5_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v4
+; GFX942-NEXT:    v_mov_b32_e32 v11, v5
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i64> asm "; def $0", "=v"()
@@ -7344,15 +7352,15 @@ define void @v_shuffle_v4i64_v3i64__5_4_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7362,15 +7370,15 @@ define void @v_shuffle_v4i64_v3i64__5_4_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v4
+; GFX942-NEXT:    v_mov_b32_e32 v11, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x i64> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4i64.v4i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4i64.v4i64.ll
@@ -8328,15 +8328,15 @@ define void @v_shuffle_v4i64_v4i64__7_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v7
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -8346,15 +8346,15 @@ define void @v_shuffle_v4i64_v4i64__7_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:7]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v12, v0
+; GFX942-NEXT:    v_mov_b32_e32 v13, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v7
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i64> asm "; def $0", "=v"()
@@ -11254,15 +11254,15 @@ define void @v_shuffle_v4i64_v4i64__7_5_6_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v7
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -11272,15 +11272,15 @@ define void @v_shuffle_v4i64_v4i64__7_5_6_6(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:7]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
-; GFX942-NEXT:    v_mov_b32_e32 v8, v4
-; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v5
+; GFX942-NEXT:    v_mov_b32_e32 v12, v4
+; GFX942-NEXT:    v_mov_b32_e32 v13, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v7
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x i64> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4p0.v2p0.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4p0.v2p0.ll
@@ -291,27 +291,31 @@ define void @v_shuffle_v4p0_v2p0__3_2_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p0_v2p0__3_2_u_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p0_v2p0__3_2_u_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -624,15 +628,15 @@ define void @v_shuffle_v4p0_v2p0__3_3_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -642,18 +646,18 @@ define void @v_shuffle_v4p0_v2p0__3_3_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -752,15 +756,15 @@ define void @v_shuffle_v4p0_v2p0__3_3_3_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -770,15 +774,15 @@ define void @v_shuffle_v4p0_v2p0__3_3_3_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v2
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -953,33 +957,39 @@ define void @v_shuffle_v4p0_v2p0__1_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p0_v2p0__1_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    s_nop 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p0_v2p0__1_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    s_nop 1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -1206,18 +1216,18 @@ define void @v_shuffle_v4p0_v2p0__3_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v7
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1227,18 +1237,18 @@ define void @v_shuffle_v4p0_v2p0__3_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:7]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v12, v0
+; GFX942-NEXT:    v_mov_b32_e32 v13, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v7
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -1556,15 +1566,15 @@ define void @v_shuffle_v4p0_v2p0__3_3_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1574,18 +1584,18 @@ define void @v_shuffle_v4p0_v2p0__3_3_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -1663,33 +1673,33 @@ define void @v_shuffle_v4p0_v2p0__0_1_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p0_v2p0__0_1_1_1:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p0_v2p0__0_1_1_1:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v2
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -1961,17 +1971,17 @@ define void @v_shuffle_v4p0_v2p0__3_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v7
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1984,17 +1994,17 @@ define void @v_shuffle_v4p0_v2p0__3_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:7]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
-; GFX942-NEXT:    v_mov_b32_e32 v8, v2
-; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v3
+; GFX942-NEXT:    v_mov_b32_e32 v12, v2
+; GFX942-NEXT:    v_mov_b32_e32 v13, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v7
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -2447,33 +2457,39 @@ define void @v_shuffle_v4p0_v2p0__3_2_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p0_v2p0__3_2_2_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    s_nop 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p0_v2p0__3_2_2_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    s_nop 1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -2508,15 +2524,15 @@ define void @v_shuffle_v4p0_v2p0__3_u_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2526,15 +2542,15 @@ define void @v_shuffle_v4p0_v2p0__3_u_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -2577,17 +2593,17 @@ define void @v_shuffle_v4p0_v2p0__3_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2597,21 +2613,21 @@ define void @v_shuffle_v4p0_v2p0__3_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -2649,18 +2665,18 @@ define void @v_shuffle_v4p0_v2p0__3_1_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v7
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2670,19 +2686,19 @@ define void @v_shuffle_v4p0_v2p0__3_1_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:7]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v8, v4
-; GFX942-NEXT:    v_mov_b32_e32 v9, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v5
+; GFX942-NEXT:    v_mov_b32_e32 v12, v4
+; GFX942-NEXT:    v_mov_b32_e32 v13, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v7
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -2717,15 +2733,15 @@ define void @v_shuffle_v4p0_v2p0__3_3_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2735,15 +2751,15 @@ define void @v_shuffle_v4p0_v2p0__3_3_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -2776,13 +2792,13 @@ define void @v_shuffle_v4p0_v2p0__3_3_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[4:7], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2792,13 +2808,13 @@ define void @v_shuffle_v4p0_v2p0__3_3_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v6, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v4, v[4:7], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -3134,33 +3150,33 @@ define void @v_shuffle_v4p0_v2p0__2_3_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p0_v2p0__2_3_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p0_v2p0__2_3_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v2
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()
@@ -3374,39 +3390,39 @@ define void @v_shuffle_v4p0_v2p0__3_2_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p0_v2p0__3_2_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17] offset:16
 ; GFX90A-NEXT:    s_nop 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p0_v2p0__3_2_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v2
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1] offset:16
 ; GFX942-NEXT:    s_nop 1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4p0.v3p0.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4p0.v3p0.ll
@@ -1126,15 +1126,15 @@ define void @v_shuffle_v4p0_v3p0__5_5_5_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1144,15 +1144,15 @@ define void @v_shuffle_v4p0_v3p0__5_5_5_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr> asm "; def $0", "=v"()
@@ -1388,13 +1388,15 @@ define void @v_shuffle_v4p0_v3p0__1_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1404,13 +1406,15 @@ define void @v_shuffle_v4p0_v3p0__1_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr> asm "; def $0", "=v"()
@@ -3637,33 +3641,33 @@ define void @v_shuffle_v4p0_v3p0__1_2_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p0_v3p0__1_2_2_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p0_v3p0__1_2_2_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v4
+; GFX942-NEXT:    v_mov_b32_e32 v11, v5
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr> asm "; def $0", "=v"()
@@ -4787,13 +4791,15 @@ define void @v_shuffle_v4p0_v3p0__4_3_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4803,13 +4809,15 @@ define void @v_shuffle_v4p0_v3p0__4_3_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v8, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr> asm "; def $0", "=v"()
@@ -5169,15 +5177,15 @@ define void @v_shuffle_v4p0_v3p0__5_4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5187,15 +5195,15 @@ define void @v_shuffle_v4p0_v3p0__5_4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr> asm "; def $0", "=v"()
@@ -5532,15 +5540,15 @@ define void @v_shuffle_v4p0_v3p0__5_5_4_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5550,15 +5558,15 @@ define void @v_shuffle_v4p0_v3p0__5_5_4_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr> asm "; def $0", "=v"()
@@ -6255,17 +6263,17 @@ define void @v_shuffle_v4p0_v3p0__5_3_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -6275,17 +6283,17 @@ define void @v_shuffle_v4p0_v3p0__5_3_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v2
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v2, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v3, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v4, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr> asm "; def $0", "=v"()
@@ -6970,33 +6978,33 @@ define void @v_shuffle_v4p0_v3p0__4_5_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p0_v3p0__4_5_5_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p0_v3p0__4_5_5_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[2:5], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v4
+; GFX942-NEXT:    v_mov_b32_e32 v11, v5
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr> asm "; def $0", "=v"()
@@ -7344,15 +7352,15 @@ define void @v_shuffle_v4p0_v3p0__5_4_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7362,15 +7370,15 @@ define void @v_shuffle_v4p0_v3p0__5_4_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v4
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v8, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v4
+; GFX942-NEXT:    v_mov_b32_e32 v11, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v10, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v6, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4p0.v4p0.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4p0.v4p0.ll
@@ -8328,15 +8328,15 @@ define void @v_shuffle_v4p0_v4p0__7_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v1
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v7
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -8346,15 +8346,15 @@ define void @v_shuffle_v4p0_v4p0__7_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:7]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v0
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v12, v0
+; GFX942-NEXT:    v_mov_b32_e32 v13, v1
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v7
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr> asm "; def $0", "=v"()
@@ -11254,15 +11254,15 @@ define void @v_shuffle_v4p0_v4p0__7_5_6_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:7]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v12, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
 ; GFX90A-NEXT:    v_mov_b32_e32 v11, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v5
 ; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX90A-NEXT:    v_mov_b32_e32 v1, v7
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[8:11], s[16:17] offset:16
-; GFX90A-NEXT:    global_store_dwordx4 v12, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17] offset:16
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[0:3], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -11272,15 +11272,15 @@ define void @v_shuffle_v4p0_v4p0__7_5_6_6(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:7]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v12, 0
-; GFX942-NEXT:    v_mov_b32_e32 v8, v4
-; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    v_mov_b32_e32 v10, v4
 ; GFX942-NEXT:    v_mov_b32_e32 v11, v5
+; GFX942-NEXT:    v_mov_b32_e32 v12, v4
+; GFX942-NEXT:    v_mov_b32_e32 v13, v5
 ; GFX942-NEXT:    v_mov_b32_e32 v0, v6
 ; GFX942-NEXT:    v_mov_b32_e32 v1, v7
-; GFX942-NEXT:    global_store_dwordx4 v12, v[8:11], s[0:1] offset:16
-; GFX942-NEXT:    global_store_dwordx4 v12, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1] offset:16
+; GFX942-NEXT:    global_store_dwordx4 v8, v[0:3], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4p3.v2p3.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4p3.v2p3.ll
@@ -272,27 +272,27 @@ define void @v_shuffle_v4p3_v2p3__3_2_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v2p3__3_2_u_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx4 v2, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v2p3__3_2_u_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx4 v2, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2386,28 +2386,29 @@ define void @v_shuffle_v4p3_v2p3__3_3_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v2p3__3_3_u_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:3]
+; GFX90A-NEXT:    ; def v[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v2, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v2p3__3_3_u_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:3]
+; GFX942-NEXT:    ; def v[0:1]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v3
-; GFX942-NEXT:    v_mov_b32_e32 v1, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v2, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <2 x ptr addrspace(3)> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4p3.v3p3.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4p3.v3p3.ll
@@ -255,15 +255,15 @@ define void @v_shuffle_v4p3_v3p3__5_0_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -271,15 +271,16 @@ define void @v_shuffle_v4p3_v3p3__5_0_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v2, v4
+; GFX942-NEXT:    v_mov_b32_e32 v3, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -413,27 +414,27 @@ define void @v_shuffle_v4p3_v3p3__5_3_u_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_3_u_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_3_u_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -553,15 +554,16 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -569,16 +571,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v2, v4
+; GFX942-NEXT:    v_mov_b32_e32 v3, v4
+; GFX942-NEXT:    v_mov_b32_e32 v4, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -609,16 +612,16 @@ define void @v_shuffle_v4p3_v3p3__5_5_1_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -626,17 +629,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_1_u(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v2, v4
+; GFX942-NEXT:    v_mov_b32_e32 v3, v4
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -719,27 +722,29 @@ define void @v_shuffle_v4p3_v3p3__5_5_3_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_3_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_3_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -766,28 +771,29 @@ define void @v_shuffle_v4p3_v3p3__5_5_4_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_4_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_4_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1031,31 +1037,31 @@ define void @v_shuffle_v4p3_v3p3__5_5_5_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_5_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_5_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1083,28 +1089,31 @@ define void @v_shuffle_v4p3_v3p3__5_5_5_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_5_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_5_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1180,28 +1189,29 @@ define void @v_shuffle_v4p3_v3p3__u_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__u_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__u_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v1, v0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1325,31 +1335,31 @@ define void @v_shuffle_v4p3_v3p3__2_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__2_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__2_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1375,28 +1385,29 @@ define void @v_shuffle_v4p3_v3p3__3_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__3_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__3_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v1, v0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1488,15 +1499,15 @@ define void @v_shuffle_v4p3_v3p3__5_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1506,15 +1517,15 @@ define void @v_shuffle_v4p3_v3p3__5_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1545,34 +1556,33 @@ define void @v_shuffle_v4p3_v3p3__5_u_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_u_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_u_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    global_store_dwordx4 v5, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1606,15 +1616,15 @@ define void @v_shuffle_v4p3_v3p3__5_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1624,15 +1634,15 @@ define void @v_shuffle_v4p3_v3p3__5_1_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1664,17 +1674,17 @@ define void @v_shuffle_v4p3_v3p3__5_2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:2]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1682,17 +1692,17 @@ define void @v_shuffle_v4p3_v3p3__5_2_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1724,17 +1734,17 @@ define void @v_shuffle_v4p3_v3p3__5_3_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v9, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v9, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1742,17 +1752,17 @@ define void @v_shuffle_v4p3_v3p3__5_3_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v9, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v9, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1843,15 +1853,15 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1861,15 +1871,15 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1901,16 +1911,16 @@ define void @v_shuffle_v4p3_v3p3__5_5_u_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1918,16 +1928,16 @@ define void @v_shuffle_v4p3_v3p3__5_5_u_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2018,17 +2028,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:2]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2036,17 +2046,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_2_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2078,17 +2088,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v9, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v9, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2096,17 +2106,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_3_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v9, 0
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v8
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    global_store_dwordx4 v9, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2603,16 +2613,17 @@ define void @v_shuffle_v4p3_v3p3__5_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2620,16 +2631,17 @@ define void @v_shuffle_v4p3_v3p3__5_0_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2661,16 +2673,17 @@ define void @v_shuffle_v4p3_v3p3__5_2_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2678,17 +2691,17 @@ define void @v_shuffle_v4p3_v3p3__5_2_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2720,16 +2733,17 @@ define void @v_shuffle_v4p3_v3p3__5_3_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2737,16 +2751,17 @@ define void @v_shuffle_v4p3_v3p3__5_3_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2834,16 +2849,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2851,17 +2867,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_1_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2893,15 +2909,16 @@ define void @v_shuffle_v4p3_v3p3__5_5_u_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
 ; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2909,16 +2926,16 @@ define void @v_shuffle_v4p3_v3p3__5_5_u_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2949,15 +2966,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2965,16 +2984,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -3006,16 +3026,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_2_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3023,17 +3044,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_2_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -3065,16 +3086,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3082,17 +3104,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_3_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -3124,16 +3146,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3141,17 +3164,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -3581,17 +3604,17 @@ define void @v_shuffle_v4p3_v3p3__5_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3599,17 +3622,17 @@ define void @v_shuffle_v4p3_v3p3__5_0_2_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -3868,16 +3891,16 @@ define void @v_shuffle_v4p3_v3p3__5_5_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[0:2]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3885,16 +3908,16 @@ define void @v_shuffle_v4p3_v3p3__5_5_u_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[0:2]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -3926,16 +3949,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3943,16 +3967,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_2(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v8
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v6
+; GFX942-NEXT:    v_mov_b32_e32 v5, v6
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4040,36 +4065,37 @@ define void @v_shuffle_v4p3_v3p3__5_5_3_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_3_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[6:8]
+; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v8
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v6
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_3_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[6:8]
+; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    v_mov_b32_e32 v0, v8
-; GFX942-NEXT:    v_mov_b32_e32 v1, v8
-; GFX942-NEXT:    v_mov_b32_e32 v2, v6
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v6
+; GFX942-NEXT:    v_mov_b32_e32 v9, v6
+; GFX942-NEXT:    v_mov_b32_e32 v10, v4
+; GFX942-NEXT:    v_mov_b32_e32 v11, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4351,31 +4377,31 @@ define void @v_shuffle_v4p3_v3p3__5_3_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_3_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_3_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4403,29 +4429,27 @@ define void @v_shuffle_v4p3_v3p3__5_u_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_u_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v1, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v1, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_u_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v1, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v1, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v0
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4456,17 +4480,17 @@ define void @v_shuffle_v4p3_v3p3__5_0_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4474,17 +4498,17 @@ define void @v_shuffle_v4p3_v3p3__5_0_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4573,36 +4597,35 @@ define void @v_shuffle_v4p3_v3p3__5_2_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_2_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v4
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_2_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v4
+; GFX942-NEXT:    global_store_dwordx4 v3, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4630,31 +4653,31 @@ define void @v_shuffle_v4p3_v3p3__5_4_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_4_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_4_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v5
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4682,31 +4705,31 @@ define void @v_shuffle_v4p3_v3p3__5_5_3_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_3_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_3_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4734,28 +4757,29 @@ define void @v_shuffle_v4p3_v3p3__5_5_u_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_u_3:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_u_3:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4786,16 +4810,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4803,17 +4828,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_3(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5369,28 +5394,27 @@ define void @v_shuffle_v4p3_v3p3__5_u_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_u_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[2:5], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_u_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v1
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v1
+; GFX942-NEXT:    v_mov_b32_e32 v5, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[2:5], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5421,17 +5445,17 @@ define void @v_shuffle_v4p3_v3p3__5_0_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5439,17 +5463,17 @@ define void @v_shuffle_v4p3_v3p3__5_0_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5536,36 +5560,35 @@ define void @v_shuffle_v4p3_v3p3__5_2_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_2_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[4:6]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_2_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[4:6]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v2, v5
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    global_store_dwordx4 v3, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5592,28 +5615,31 @@ define void @v_shuffle_v4p3_v3p3__5_3_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_3_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_3_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5641,28 +5667,31 @@ define void @v_shuffle_v4p3_v3p3__5_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5690,27 +5719,29 @@ define void @v_shuffle_v4p3_v3p3__5_5_u_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_u_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_u_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5742,16 +5773,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5759,17 +5791,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5801,17 +5833,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_1_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v5
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -5819,17 +5851,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_1_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v5
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5915,27 +5947,31 @@ define void @v_shuffle_v4p3_v3p3__5_5_3_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_3_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_3_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -6497,30 +6533,31 @@ define void @v_shuffle_v4p3_v3p3__5_3_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_3_5_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_3_5_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -6593,28 +6630,29 @@ define void @v_shuffle_v4p3_v3p3__5_5_u_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_u_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v2
-; GFX90A-NEXT:    global_store_dwordx4 v4, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_u_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v4, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v1, v2
-; GFX942-NEXT:    v_mov_b32_e32 v3, v2
-; GFX942-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -6646,16 +6684,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[0:2]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
+; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:4]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v7, 0
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:6]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v6
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v6
-; GFX90A-NEXT:    global_store_dwordx4 v7, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v4
+; GFX90A-NEXT:    global_store_dwordx4 v5, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -6663,17 +6702,17 @@ define void @v_shuffle_v4p3_v3p3__5_5_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[0:2]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    v_mov_b32_e32 v5, 0
+; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:4]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, 0
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:6]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v6
-; GFX942-NEXT:    v_mov_b32_e32 v1, v6
-; GFX942-NEXT:    v_mov_b32_e32 v3, v6
-; GFX942-NEXT:    global_store_dwordx4 v7, v[0:3], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v4
+; GFX942-NEXT:    v_mov_b32_e32 v7, v4
+; GFX942-NEXT:    v_mov_b32_e32 v9, v4
+; GFX942-NEXT:    global_store_dwordx4 v5, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -6819,28 +6858,31 @@ define void @v_shuffle_v4p3_v3p3__5_5_3_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v3p3__5_5_3_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[2:4]
+; GFX90A-NEXT:    ; def v[0:2]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v0, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v1, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v4
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[0:3], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v4, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v5, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
+; GFX90A-NEXT:    global_store_dwordx4 v3, v[4:7], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v3p3__5_5_3_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v3, 0
 ; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[2:4]
+; GFX942-NEXT:    ; def v[0:2]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v0, v4
-; GFX942-NEXT:    v_mov_b32_e32 v1, v4
-; GFX942-NEXT:    v_mov_b32_e32 v3, v4
-; GFX942-NEXT:    global_store_dwordx4 v5, v[0:3], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, v2
+; GFX942-NEXT:    v_mov_b32_e32 v5, v2
+; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v7, v2
+; GFX942-NEXT:    global_store_dwordx4 v3, v[4:7], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <3 x ptr addrspace(3)> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/shufflevector.v4p3.v4p3.ll
+++ b/llvm/test/CodeGen/AMDGPU/shufflevector.v4p3.v4p3.ll
@@ -963,26 +963,29 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_4_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_4_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1009,26 +1012,29 @@ define void @v_shuffle_v4p3_v4p3__7_7_5_u(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_5_u:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v5, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    global_store_dwordx4 v5, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_5_u:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v5, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    global_store_dwordx4 v5, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1440,31 +1446,31 @@ define void @v_shuffle_v4p3_v4p3__7_7_7_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_7_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_7_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v3
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -1734,28 +1740,31 @@ define void @v_shuffle_v4p3_v4p3__2_0_0_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__2_0_0_0:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__2_0_0_0:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -2785,14 +2794,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v0
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2802,14 +2812,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_0(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v11, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4138,14 +4149,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4155,14 +4167,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v2
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -4196,14 +4209,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_5_1(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v1
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4213,14 +4227,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_5_1(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v6, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v11, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v10, v3
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -5448,34 +5463,37 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_2(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_4_2:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; def v[4:7]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v7
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v4
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17]
+; GFX90A-NEXT:    ;;#ASMSTART
+; GFX90A-NEXT:    ; def v[4:7]
+; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v7
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v7
+; GFX90A-NEXT:    v_mov_b32_e32 v12, v4
+; GFX90A-NEXT:    v_mov_b32_e32 v13, v2
+; GFX90A-NEXT:    global_store_dwordx4 v8, v[10:13], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_4_2:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    ;;#ASMSTART
-; GFX942-NEXT:    ; def v[4:7]
-; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v8, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v7
-; GFX942-NEXT:    v_mov_b32_e32 v8, v4
-; GFX942-NEXT:    v_mov_b32_e32 v9, v2
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1]
+; GFX942-NEXT:    ;;#ASMSTART
+; GFX942-NEXT:    ; def v[4:7]
+; GFX942-NEXT:    ;;#ASMEND
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v10, v7
+; GFX942-NEXT:    v_mov_b32_e32 v11, v7
+; GFX942-NEXT:    v_mov_b32_e32 v12, v4
+; GFX942-NEXT:    v_mov_b32_e32 v13, v2
+; GFX942-NEXT:    global_store_dwordx4 v8, v[10:13], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -7172,28 +7190,31 @@ define void @v_shuffle_v4p3_v4p3__6_4_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__6_4_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__6_4_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v3, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v2
+; GFX942-NEXT:    v_mov_b32_e32 v7, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -7271,28 +7292,29 @@ define void @v_shuffle_v4p3_v4p3__7_u_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_u_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_u_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -7559,30 +7581,31 @@ define void @v_shuffle_v4p3_v4p3__7_5_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_5_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v3, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_5_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v3, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -7660,28 +7683,31 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_4_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v0
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_4_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v0
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -7763,14 +7789,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v2
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7780,14 +7807,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_0_4(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v2
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -8041,31 +8069,31 @@ define void @v_shuffle_v4p3_v4p3__7_7_6_4(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_6_4:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v0
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v0
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_6_4:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v0
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v0
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -8946,28 +8974,31 @@ define void @v_shuffle_v4p3_v4p3__7_7_5_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_5_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_5_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v1
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -9047,14 +9078,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -9064,14 +9096,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_0_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -9105,14 +9138,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_1_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v3
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -9122,14 +9156,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_1_5(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
-; GFX942-NEXT:    v_mov_b32_e32 v4, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v1
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v3
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -9277,28 +9312,31 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_4_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v1
-; GFX90A-NEXT:    global_store_dwordx4 v6, v[2:5], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_4_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v6, 0
-; GFX942-NEXT:    v_mov_b32_e32 v2, v3
-; GFX942-NEXT:    v_mov_b32_e32 v4, v0
-; GFX942-NEXT:    v_mov_b32_e32 v5, v1
-; GFX942-NEXT:    global_store_dwordx4 v6, v[2:5], s[0:1]
+; GFX942-NEXT:    s_nop 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -9327,31 +9365,31 @@ define void @v_shuffle_v4p3_v4p3__7_7_6_5(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_6_5:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v1
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v2
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v1
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_6_5:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v2
-; GFX942-NEXT:    v_mov_b32_e32 v7, v1
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v2
+; GFX942-NEXT:    v_mov_b32_e32 v9, v1
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -10319,15 +10357,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_0_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v10, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[2:5]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v5
-; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v9, v4
-; GFX90A-NEXT:    global_store_dwordx4 v10, v[6:9], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v5
+; GFX90A-NEXT:    v_mov_b32_e32 v10, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v11, v4
+; GFX90A-NEXT:    global_store_dwordx4 v6, v[8:11], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -10337,15 +10375,15 @@ define void @v_shuffle_v4p3_v4p3__7_7_0_6(ptr addrspace(1) inreg %ptr) {
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v10, 0
+; GFX942-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[2:5]
 ; GFX942-NEXT:    ;;#ASMEND
-; GFX942-NEXT:    v_mov_b32_e32 v8, v0
-; GFX942-NEXT:    v_mov_b32_e32 v6, v5
-; GFX942-NEXT:    v_mov_b32_e32 v7, v5
-; GFX942-NEXT:    v_mov_b32_e32 v9, v4
-; GFX942-NEXT:    global_store_dwordx4 v10, v[6:9], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v10, v0
+; GFX942-NEXT:    v_mov_b32_e32 v8, v5
+; GFX942-NEXT:    v_mov_b32_e32 v9, v5
+; GFX942-NEXT:    v_mov_b32_e32 v11, v4
+; GFX942-NEXT:    global_store_dwordx4 v6, v[8:11], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -10553,31 +10591,31 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_6(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_4_6:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v7, v2
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v2
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_4_6:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
-; GFX942-NEXT:    v_mov_b32_e32 v7, v2
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
+; GFX942-NEXT:    v_mov_b32_e32 v7, v3
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v2
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -11777,31 +11815,31 @@ define void @v_shuffle_v4p3_v4p3__7_7_4_7(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_4_7:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_4_7:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v0
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v0
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()
@@ -11830,31 +11868,31 @@ define void @v_shuffle_v4p3_v4p3__7_7_5_7(ptr addrspace(1) inreg %ptr) {
 ; GFX90A-LABEL: v_shuffle_v4p3_v4p3__7_7_5_7:
 ; GFX90A:       ; %bb.0:
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX90A-NEXT:    v_mov_b32_e32 v8, 0
+; GFX90A-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[0:3]
 ; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    v_mov_b32_e32 v4, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v5, v3
-; GFX90A-NEXT:    v_mov_b32_e32 v6, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, v3
-; GFX90A-NEXT:    global_store_dwordx4 v8, v[4:7], s[16:17]
+; GFX90A-NEXT:    v_mov_b32_e32 v8, v1
+; GFX90A-NEXT:    v_mov_b32_e32 v9, v3
+; GFX90A-NEXT:    global_store_dwordx4 v4, v[6:9], s[16:17]
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX942-LABEL: v_shuffle_v4p3_v4p3__7_7_5_7:
 ; GFX942:       ; %bb.0:
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX942-NEXT:    v_mov_b32_e32 v8, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    ;;#ASMSTART
 ; GFX942-NEXT:    ; def v[0:3]
 ; GFX942-NEXT:    ;;#ASMEND
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_mov_b32_e32 v4, v3
-; GFX942-NEXT:    v_mov_b32_e32 v5, v3
-; GFX942-NEXT:    v_mov_b32_e32 v6, v1
+; GFX942-NEXT:    v_mov_b32_e32 v6, v3
 ; GFX942-NEXT:    v_mov_b32_e32 v7, v3
-; GFX942-NEXT:    global_store_dwordx4 v8, v[4:7], s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v8, v1
+; GFX942-NEXT:    v_mov_b32_e32 v9, v3
+; GFX942-NEXT:    global_store_dwordx4 v4, v[6:9], s[0:1]
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %vec0 = call <4 x ptr addrspace(3)> asm "; def $0", "=v"()

--- a/llvm/test/CodeGen/AMDGPU/sint_to_fp.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/sint_to_fp.f64.ll
@@ -401,11 +401,11 @@ define void @v_select_sint_to_fp_i1_vals_f64(ptr addrspace(1) %out, i32 %in) {
 ; GCN-LABEL: v_select_sint_to_fp_i1_vals_f64:
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_mov_b32_e32 v3, 0xbff00000
+; GCN-NEXT:    v_mov_b32_e32 v4, 0xbff00000
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GCN-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
-; GCN-NEXT:    v_mov_b32_e32 v2, 0
-; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[2:3]
+; GCN-NEXT:    v_mov_b32_e32 v3, 0
+; GCN-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[3:4]
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -414,10 +414,10 @@ define void @v_select_sint_to_fp_i1_vals_f64(ptr addrspace(1) %out, i32 %in) {
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    v_mov_b32_e32 v3, 0xbff00000
 ; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
-; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[2:3], off
+; GFX942-NEXT:    v_cndmask_b32_e32 v5, 0, v3, vcc
+; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[4:5], off
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %cmp = icmp eq i32 %in, 0
@@ -482,11 +482,11 @@ define void @v_select_sint_to_fp_i1_vals_i64(ptr addrspace(1) %out, i32 %in) {
 ; GCN-LABEL: v_select_sint_to_fp_i1_vals_i64:
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_mov_b32_e32 v3, 0xbff00000
+; GCN-NEXT:    v_mov_b32_e32 v4, 0xbff00000
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GCN-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
-; GCN-NEXT:    v_mov_b32_e32 v2, 0
-; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[2:3]
+; GCN-NEXT:    v_mov_b32_e32 v3, 0
+; GCN-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[3:4]
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -495,10 +495,10 @@ define void @v_select_sint_to_fp_i1_vals_i64(ptr addrspace(1) %out, i32 %in) {
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    v_mov_b32_e32 v3, 0xbff00000
 ; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
-; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[2:3], off
+; GFX942-NEXT:    v_cndmask_b32_e32 v5, 0, v3, vcc
+; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[4:5], off
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %cmp = icmp eq i32 %in, 0
@@ -512,11 +512,11 @@ define void @v_swap_select_sint_to_fp_i1_vals_f64(ptr addrspace(1) %out, i32 %in
 ; GCN-LABEL: v_swap_select_sint_to_fp_i1_vals_f64:
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_mov_b32_e32 v3, 0xbff00000
+; GCN-NEXT:    v_mov_b32_e32 v4, 0xbff00000
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GCN-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
-; GCN-NEXT:    v_mov_b32_e32 v2, 0
-; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[2:3]
+; GCN-NEXT:    v_mov_b32_e32 v3, 0
+; GCN-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
+; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[3:4]
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -525,10 +525,10 @@ define void @v_swap_select_sint_to_fp_i1_vals_f64(ptr addrspace(1) %out, i32 %in
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    v_mov_b32_e32 v3, 0xbff00000
 ; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
-; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[2:3], off
+; GFX942-NEXT:    v_cndmask_b32_e64 v5, v3, 0, vcc
+; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[4:5], off
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %cmp = icmp eq i32 %in, 0

--- a/llvm/test/CodeGen/AMDGPU/srem64.ll
+++ b/llvm/test/CodeGen/AMDGPU/srem64.ll
@@ -1608,8 +1608,7 @@ define i64 @v_test_srem_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
 ; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
-; GCN-IR-NEXT:    s_movk_i32 s6, 0xffc5
-; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, s6, v8
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffc5, v8
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
@@ -1798,8 +1797,7 @@ define i64 @v_test_srem_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
 ; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
-; GCN-IR-NEXT:    s_movk_i32 s6, 0xffd0
-; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, s6, v8
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffd0, v8
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]

--- a/llvm/test/CodeGen/AMDGPU/uint_to_fp.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/uint_to_fp.f64.ll
@@ -660,11 +660,11 @@ define void @v_select_uint_to_fp_i1_vals_f64(ptr addrspace(1) %out, i32 %in) {
 ; GCN-LABEL: v_select_uint_to_fp_i1_vals_f64:
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_mov_b32_e32 v3, 0x3ff00000
+; GCN-NEXT:    v_mov_b32_e32 v4, 0x3ff00000
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GCN-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
-; GCN-NEXT:    v_mov_b32_e32 v2, 0
-; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[2:3]
+; GCN-NEXT:    v_mov_b32_e32 v3, 0
+; GCN-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[3:4]
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -673,10 +673,10 @@ define void @v_select_uint_to_fp_i1_vals_f64(ptr addrspace(1) %out, i32 %in) {
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    v_mov_b32_e32 v3, 0x3ff00000
 ; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
-; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[2:3], off
+; GFX942-NEXT:    v_cndmask_b32_e32 v5, 0, v3, vcc
+; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[4:5], off
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %cmp = icmp eq i32 %in, 0
@@ -741,11 +741,11 @@ define void @v_select_uint_to_fp_i1_vals_i64(ptr addrspace(1) %out, i32 %in) {
 ; GCN-LABEL: v_select_uint_to_fp_i1_vals_i64:
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_mov_b32_e32 v3, 0x3ff00000
+; GCN-NEXT:    v_mov_b32_e32 v4, 0x3ff00000
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GCN-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
-; GCN-NEXT:    v_mov_b32_e32 v2, 0
-; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[2:3]
+; GCN-NEXT:    v_mov_b32_e32 v3, 0
+; GCN-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[3:4]
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -754,10 +754,10 @@ define void @v_select_uint_to_fp_i1_vals_i64(ptr addrspace(1) %out, i32 %in) {
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    v_mov_b32_e32 v3, 0x3ff00000
 ; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
-; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[2:3], off
+; GFX942-NEXT:    v_cndmask_b32_e32 v5, 0, v3, vcc
+; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[4:5], off
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %cmp = icmp eq i32 %in, 0
@@ -823,11 +823,11 @@ define void @v_swap_select_uint_to_fp_i1_vals_f64(ptr addrspace(1) %out, i32 %in
 ; GCN-LABEL: v_swap_select_uint_to_fp_i1_vals_f64:
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    v_mov_b32_e32 v3, 0x3ff00000
+; GCN-NEXT:    v_mov_b32_e32 v4, 0x3ff00000
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GCN-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
-; GCN-NEXT:    v_mov_b32_e32 v2, 0
-; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[2:3]
+; GCN-NEXT:    v_mov_b32_e32 v3, 0
+; GCN-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
+; GCN-NEXT:    flat_store_dwordx2 v[0:1], v[3:4]
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -836,10 +836,10 @@ define void @v_swap_select_uint_to_fp_i1_vals_f64(ptr addrspace(1) %out, i32 %in
 ; GFX942-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX942-NEXT:    v_mov_b32_e32 v3, 0x3ff00000
 ; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v2, 0
+; GFX942-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX942-NEXT:    s_nop 0
-; GFX942-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
-; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[2:3], off
+; GFX942-NEXT:    v_cndmask_b32_e64 v5, v3, 0, vcc
+; GFX942-NEXT:    global_store_dwordx2 v[0:1], v[4:5], off
 ; GFX942-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-NEXT:    s_setpc_b64 s[30:31]
   %cmp = icmp eq i32 %in, 0

--- a/llvm/test/CodeGen/AMDGPU/vector_range_metadata.ll
+++ b/llvm/test/CodeGen/AMDGPU/vector_range_metadata.ll
@@ -37,8 +37,8 @@ define <2 x i64> @test_add2x64(ptr %a_ptr, ptr %b_ptr) {
 ; CHECK-NEXT:    flat_load_dwordx4 v[4:7], v[0:1]
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    flat_load_dwordx4 v[6:9], v[2:3]
-; CHECK-NEXT:    ; kill: killed $vgpr2 killed $vgpr3
 ; CHECK-NEXT:    ; kill: killed $vgpr0 killed $vgpr1
+; CHECK-NEXT:    ; kill: killed $vgpr2 killed $vgpr3
 ; CHECK-NEXT:    v_mov_b32_e32 v2, 48
 ; CHECK-NEXT:    v_mov_b32_e32 v3, 0
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -91,8 +91,8 @@ define <3 x i64> @test_add3x64(ptr %a_ptr, ptr %b_ptr) {
 ; CHECK-NEXT:    flat_load_dwordx4 v[4:7], v[0:1]
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    flat_load_dwordx4 v[6:9], v[2:3]
-; CHECK-NEXT:    ; kill: killed $vgpr2 killed $vgpr3
 ; CHECK-NEXT:    ; kill: killed $vgpr0 killed $vgpr1
+; CHECK-NEXT:    ; kill: killed $vgpr2 killed $vgpr3
 ; CHECK-NEXT:    v_mov_b32_e32 v2, 48
 ; CHECK-NEXT:    v_mov_b32_e32 v3, 0
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/vgpr-large-tuple-alloc-error.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-large-tuple-alloc-error.ll
@@ -90,7 +90,8 @@ define i32 @test_tuple(<16 x i64> %0) {
 ; GFX900-NEXT:    v_mov_b32_e32 v28, v35
 ; GFX900-NEXT:    v_mov_b32_e32 v29, v34
 ; GFX900-NEXT:    v_mov_b32_e32 v30, v33
-; GFX900-NEXT:    ; kill: def $vgpr31 killed $vgpr32 killed $exec
+; GFX900-NEXT:    s_waitcnt vmcnt(0)
+; GFX900-NEXT:    v_mov_b32_e32 v31, v32
 ; GFX900-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX900-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GFX900-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
@@ -190,7 +191,8 @@ define i32 @test_tuple(<16 x i64> %0) {
 ; GFX906-NEXT:    v_mov_b32_e32 v28, v35
 ; GFX906-NEXT:    v_mov_b32_e32 v29, v34
 ; GFX906-NEXT:    v_mov_b32_e32 v30, v33
-; GFX906-NEXT:    ; kill: def $vgpr31 killed $vgpr32 killed $exec
+; GFX906-NEXT:    s_waitcnt vmcnt(0)
+; GFX906-NEXT:    v_mov_b32_e32 v31, v32
 ; GFX906-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX906-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:4 ; 4-byte Folded Reload
 ; GFX906-NEXT:    buffer_load_dword v61, off, s[0:3], s32 offset:8 ; 4-byte Folded Reload
@@ -290,7 +292,8 @@ define i32 @test_tuple(<16 x i64> %0) {
 ; GFX908-NEXT:    v_mov_b32_e32 v28, v35
 ; GFX908-NEXT:    v_mov_b32_e32 v29, v34
 ; GFX908-NEXT:    v_mov_b32_e32 v30, v33
-; GFX908-NEXT:    ; kill: def $vgpr31 killed $vgpr32 killed $exec
+; GFX908-NEXT:    s_waitcnt vmcnt(0)
+; GFX908-NEXT:    v_mov_b32_e32 v31, v32
 ; GFX908-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX908-NEXT:    v_accvgpr_read_b32 v62, a14 ; Reload Reuse
 ; GFX908-NEXT:    v_accvgpr_read_b32 v61, a13 ; Reload Reuse
@@ -307,7 +310,6 @@ define i32 @test_tuple(<16 x i64> %0) {
 ; GFX908-NEXT:    v_accvgpr_read_b32 v42, a2 ; Reload Reuse
 ; GFX908-NEXT:    v_accvgpr_read_b32 v41, a1 ; Reload Reuse
 ; GFX908-NEXT:    v_accvgpr_read_b32 v40, a0 ; Reload Reuse
-; GFX908-NEXT:    s_waitcnt vmcnt(0)
 ; GFX908-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX90a-LABEL: test_tuple:
@@ -390,7 +392,8 @@ define i32 @test_tuple(<16 x i64> %0) {
 ; GFX90a-NEXT:    v_mov_b32_e32 v28, v35
 ; GFX90a-NEXT:    v_mov_b32_e32 v29, v34
 ; GFX90a-NEXT:    v_mov_b32_e32 v30, v33
-; GFX90a-NEXT:    ; kill: def $vgpr31 killed $vgpr32 killed $exec
+; GFX90a-NEXT:    s_waitcnt vmcnt(0)
+; GFX90a-NEXT:    v_mov_b32_e32 v31, v32
 ; GFX90a-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX90a-NEXT:    v_accvgpr_read_b32 v62, a14 ; Reload Reuse
 ; GFX90a-NEXT:    v_accvgpr_read_b32 v61, a13 ; Reload Reuse
@@ -407,7 +410,6 @@ define i32 @test_tuple(<16 x i64> %0) {
 ; GFX90a-NEXT:    v_accvgpr_read_b32 v42, a2 ; Reload Reuse
 ; GFX90a-NEXT:    v_accvgpr_read_b32 v41, a1 ; Reload Reuse
 ; GFX90a-NEXT:    v_accvgpr_read_b32 v40, a0 ; Reload Reuse
-; GFX90a-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90a-NEXT:    s_setpc_b64 s[30:31]
   %2 = shufflevector <16 x i64> %0, <16 x i64> zeroinitializer, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   ret i32 0

--- a/llvm/test/CodeGen/AMDGPU/vgpr-liverange-ir.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-liverange-ir.ll
@@ -640,7 +640,7 @@ define protected amdgpu_kernel void @nested_waterfalls(ptr addrspace(1) %tex.coe
   ; SI-NEXT: {{  $}}
   ; SI-NEXT: bb.7:
   ; SI-NEXT:   $exec_lo = S_MOV_B32 killed [[S_MOV_B32_]]
-  ; SI-NEXT:   GLOBAL_STORE_DWORD undef %34:vreg_64, killed [[IMAGE_SAMPLE_V1_V2_nsa_gfx10_]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; SI-NEXT:   GLOBAL_STORE_DWORD undef %35:vreg_64, killed [[IMAGE_SAMPLE_V1_V2_nsa_gfx10_]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; SI-NEXT:   S_ENDPGM 0
 entry:
   %0 = tail call i32 @llvm.amdgcn.workitem.id.x()

--- a/llvm/test/CodeGen/AMDGPU/wwm-reserved-spill.ll
+++ b/llvm/test/CodeGen/AMDGPU/wwm-reserved-spill.ll
@@ -877,171 +877,91 @@ define amdgpu_gfx <32 x i32> @strict_wwm_callee_saves(<32 x i32> inreg %keep, pt
 ; GFX9-O0:       ; %bb.0:
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-O0-NEXT:    s_xor_saveexec_b64 s[34:35], -1
-; GFX9-O0-NEXT:    buffer_store_dword v32, off, s[0:3], s32 offset:172 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:176 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:180 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v32, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
 ; GFX9-O0-NEXT:    s_nop 0
-; GFX9-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:184 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
 ; GFX9-O0-NEXT:    s_mov_b64 exec, s[34:35]
-; GFX9-O0-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v41, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v42, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v43, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v44, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v45, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v46, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v47, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:96 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:20
+; GFX9-O0-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:24 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v10, off, s[0:3], s32 offset:44 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v9, off, s[0:3], s32 offset:36 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v8, off, s[0:3], s32 offset:52 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v7, off, s[0:3], s32 offset:40 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v6, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v5, off, s[0:3], s32 offset:48 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v4, off, s[0:3], s32 offset:68 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s32 offset:56 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v2, off, s[0:3], s32 offset:28 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:32 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:20
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:120 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:16
+; GFX9-O0-NEXT:    buffer_store_dword v35, off, s[0:3], s32 offset:92 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:16
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:116 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:12
+; GFX9-O0-NEXT:    buffer_store_dword v36, off, s[0:3], s32 offset:88 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:12
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:112 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:8
+; GFX9-O0-NEXT:    buffer_store_dword v37, off, s[0:3], s32 offset:84 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:8
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:108 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:4
+; GFX9-O0-NEXT:    buffer_store_dword v38, off, s[0:3], s32 offset:80 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v39, off, s[0:3], s32 offset:4
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:104 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32
+; GFX9-O0-NEXT:    buffer_store_dword v39, off, s[0:3], s32 offset:76 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_load_dword v40, off, s[0:3], s32
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s32 offset:100 ; 4-byte Folded Spill
+; GFX9-O0-NEXT:    buffer_store_dword v40, off, s[0:3], s32 offset:72 ; 4-byte Folded Spill
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v0, s4
-; GFX9-O0-NEXT:    v_mov_b32_e32 v35, s5
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s6
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:168 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s7
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:164 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s8
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:160 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s9
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:156 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s10
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:152 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s11
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:148 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s12
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:144 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s13
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:140 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s14
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:136 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s15
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:132 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s16
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:128 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v40, s17
-; GFX9-O0-NEXT:    v_mov_b32_e32 v39, s18
-; GFX9-O0-NEXT:    v_mov_b32_e32 v38, s19
-; GFX9-O0-NEXT:    v_mov_b32_e32 v37, s20
-; GFX9-O0-NEXT:    v_mov_b32_e32 v36, s21
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s22
-; GFX9-O0-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:124 ; 4-byte Folded Spill
-; GFX9-O0-NEXT:    v_mov_b32_e32 v47, s23
-; GFX9-O0-NEXT:    v_mov_b32_e32 v46, s24
-; GFX9-O0-NEXT:    v_mov_b32_e32 v45, s25
-; GFX9-O0-NEXT:    v_mov_b32_e32 v44, s26
-; GFX9-O0-NEXT:    v_mov_b32_e32 v43, s27
-; GFX9-O0-NEXT:    v_mov_b32_e32 v42, s28
-; GFX9-O0-NEXT:    v_mov_b32_e32 v41, s29
-; GFX9-O0-NEXT:    ; kill: def $vgpr0 killed $vgpr0 def $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23_vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31 killed $exec
-; GFX9-O0-NEXT:    v_mov_b32_e32 v1, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:168 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v2, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:164 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v3, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:160 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v4, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:156 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v5, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:152 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v6, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:148 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v7, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:144 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v8, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:140 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v9, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:136 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v10, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:132 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v11, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:128 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v12, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:124 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    v_mov_b32_e32 v13, v40
-; GFX9-O0-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    v_mov_b32_e32 v14, v39
-; GFX9-O0-NEXT:    buffer_load_dword v39, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    v_mov_b32_e32 v15, v38
-; GFX9-O0-NEXT:    buffer_load_dword v38, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    v_mov_b32_e32 v16, v37
-; GFX9-O0-NEXT:    buffer_load_dword v37, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    v_mov_b32_e32 v17, v36
-; GFX9-O0-NEXT:    buffer_load_dword v36, off, s[0:3], s32 offset:116 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(5)
-; GFX9-O0-NEXT:    v_mov_b32_e32 v18, v35
-; GFX9-O0-NEXT:    buffer_load_dword v35, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    v_mov_b32_e32 v19, v47
-; GFX9-O0-NEXT:    v_mov_b32_e32 v20, v46
-; GFX9-O0-NEXT:    v_mov_b32_e32 v21, v45
-; GFX9-O0-NEXT:    v_mov_b32_e32 v22, v44
-; GFX9-O0-NEXT:    v_mov_b32_e32 v23, v43
-; GFX9-O0-NEXT:    v_mov_b32_e32 v24, v42
-; GFX9-O0-NEXT:    v_mov_b32_e32 v25, v41
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(5)
+; GFX9-O0-NEXT:    v_mov_b32_e32 v1, s5
+; GFX9-O0-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9-O0-NEXT:    v_mov_b32_e32 v3, s7
+; GFX9-O0-NEXT:    v_mov_b32_e32 v4, s8
+; GFX9-O0-NEXT:    v_mov_b32_e32 v5, s9
+; GFX9-O0-NEXT:    v_mov_b32_e32 v6, s10
+; GFX9-O0-NEXT:    v_mov_b32_e32 v7, s11
+; GFX9-O0-NEXT:    v_mov_b32_e32 v8, s12
+; GFX9-O0-NEXT:    v_mov_b32_e32 v9, s13
+; GFX9-O0-NEXT:    v_mov_b32_e32 v10, s14
+; GFX9-O0-NEXT:    v_mov_b32_e32 v11, s15
+; GFX9-O0-NEXT:    v_mov_b32_e32 v12, s16
+; GFX9-O0-NEXT:    v_mov_b32_e32 v13, s17
+; GFX9-O0-NEXT:    v_mov_b32_e32 v14, s18
+; GFX9-O0-NEXT:    v_mov_b32_e32 v15, s19
+; GFX9-O0-NEXT:    v_mov_b32_e32 v16, s20
+; GFX9-O0-NEXT:    v_mov_b32_e32 v17, s21
+; GFX9-O0-NEXT:    v_mov_b32_e32 v18, s22
+; GFX9-O0-NEXT:    v_mov_b32_e32 v19, s23
+; GFX9-O0-NEXT:    v_mov_b32_e32 v20, s24
+; GFX9-O0-NEXT:    v_mov_b32_e32 v21, s25
+; GFX9-O0-NEXT:    v_mov_b32_e32 v22, s26
+; GFX9-O0-NEXT:    v_mov_b32_e32 v23, s27
+; GFX9-O0-NEXT:    v_mov_b32_e32 v24, s28
+; GFX9-O0-NEXT:    v_mov_b32_e32 v25, s29
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v26, v40
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(4)
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v27, v39
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(3)
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v28, v38
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(2)
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v29, v37
-; GFX9-O0-NEXT:    s_waitcnt vmcnt(1)
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v30, v36
 ; GFX9-O0-NEXT:    ; kill: def $vgpr31 killed $vgpr35 killed $exec
-; GFX9-O0-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v30, off, s[0:3], s32 offset:116 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v31, off, s[0:3], s32 offset:92 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v30, off, s[0:3], s32 offset:88 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:84 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:80 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v27, off, s[0:3], s32 offset:76 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v26, off, s[0:3], s32 offset:72 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v11, off, s[0:3], s32 offset:68 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v10, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v9, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v8, off, s[0:3], s32 offset:56 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v7, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v6, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v5, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v4, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v2, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v1, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
 ; GFX9-O0-NEXT:    ; kill: def $vgpr2 killed $vgpr2 def $vgpr2_vgpr3 killed $exec
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(4)
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v3, v5
@@ -1178,19 +1098,12 @@ define amdgpu_gfx <32 x i32> @strict_wwm_callee_saves(<32 x i32> inreg %keep, pt
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v23, s27
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v24, s28
 ; GFX9-O0-NEXT:    v_mov_b32_e32 v25, s29
-; GFX9-O0-NEXT:    buffer_load_dword v47, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v46, off, s[0:3], s32 offset:28 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v45, off, s[0:3], s32 offset:32 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:36 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:40 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v42, off, s[0:3], s32 offset:44 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v41, off, s[0:3], s32 offset:48 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:52 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v40, off, s[0:3], s32 offset:24 ; 4-byte Folded Reload
 ; GFX9-O0-NEXT:    s_xor_saveexec_b64 s[34:35], -1
-; GFX9-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:172 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:176 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:180 ; 4-byte Folded Reload
-; GFX9-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:184 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v32, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v33, off, s[0:3], s32 offset:104 ; 4-byte Folded Reload
+; GFX9-O0-NEXT:    buffer_load_dword v34, off, s[0:3], s32 offset:108 ; 4-byte Folded Reload
 ; GFX9-O0-NEXT:    s_mov_b64 exec, s[34:35]
 ; GFX9-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-O0-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/amdgpu_isel.ll.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/amdgpu_isel.ll.expected
@@ -3,15 +3,15 @@
 
 define i64 @i64_test(i64 %i) nounwind readnone {
 ; CHECK-LABEL: i64_test:
-; CHECK:       SelectionDAG has 25 nodes:
+; CHECK:       SelectionDAG has 26 nodes:
 ; CHECK-NEXT:    t0: ch,glue = EntryToken
 ; CHECK-NEXT:    t2: i32,ch = CopyFromReg # D:1 t0, Register:i32 %8
 ; CHECK-NEXT:    t4: i32,ch = CopyFromReg # D:1 t0, Register:i32 %9
-; CHECK-NEXT:    t50: i64 = REG_SEQUENCE # D:1 TargetConstant:i32<66>, t2, TargetConstant:i32<3>, t4, TargetConstant:i32<11>
+; CHECK-NEXT:    t51: i64 = REG_SEQUENCE # D:1 TargetConstant:i32<66>, t2, TargetConstant:i32<3>, t4, TargetConstant:i32<11>
 ; CHECK-NEXT:    t27: i32,ch = BUFFER_LOAD_DWORD_OFFEN<Mem:(dereferenceable load (s32) from %ir.loc, align 8, addrspace 5)> TargetFrameIndex:i32<0>, Register:v4i32 $sgpr0_sgpr1_sgpr2_sgpr3, TargetConstant:i32<0>, TargetConstant:i32<0>, TargetConstant:i32<0>, TargetConstant:i1<0>, t0
 ; CHECK-NEXT:    t30: i32,ch = BUFFER_LOAD_DWORD_OFFEN<Mem:(dereferenceable load (s32) from %ir.loc + 4, basealign 8, addrspace 5)> TargetFrameIndex:i32<0>, Register:v4i32 $sgpr0_sgpr1_sgpr2_sgpr3, TargetConstant:i32<0>, TargetConstant:i32<4>, TargetConstant:i32<0>, TargetConstant:i1<0>, t0
-; CHECK-NEXT:    t33: v2i32 = REG_SEQUENCE # D:1 TargetConstant:i32<66>, t27, TargetConstant:i32<3>, t30, TargetConstant:i32<11>
-; CHECK-NEXT:    t10: i64 = V_ADD_U64_PSEUDO # D:1 t50, t33
+; CHECK-NEXT:    t33: v2i32 = REG_SEQUENCE # D:1 TargetConstant:i32<42>, t27, TargetConstant:i32<3>, t30, TargetConstant:i32<11>
+; CHECK-NEXT:    t10: i64 = V_ADD_U64_PSEUDO # D:1 t51, t33
 ; CHECK-NEXT:    t24: i32 = EXTRACT_SUBREG # D:1 t10, TargetConstant:i32<3>
 ; CHECK-NEXT:    t17: ch,glue = CopyToReg # D:1 t0, Register:i32 $vgpr0, t24
 ; CHECK-NEXT:    t39: i32 = EXTRACT_SUBREG # D:1 t10, TargetConstant:i32<11>


### PR DESCRIPTION
The main improvement is to the mfma tests. There are some
mild regressions scattered around, and a few major ones.
The worst regressions are in some of the bitcast tests;
these are cases where the SGPR argument list runs out
and uses VGPRs, and the copies-from-VGPR are misidentified
as divergent. Most of the shufflevector tests are also
regressions. These end up with cleaner MIR, but then get poor
regalloc decisions.