### PR TITLE
[MLIR] Fix affine SSA id parser for values with numbers

### DIFF
--- a/mlir/lib/AsmParser/AffineParser.cpp
+++ b/mlir/lib/AsmParser/AffineParser.cpp
@@ -311,13 +311,6 @@ AffineExpr AffineParser::parseSSAIdExpr(bool isSymbol) {
   if (getToken().isNot(Token::percent_identifier))
     return emitWrongTokenError("expected ssa identifier"), nullptr;
   auto name = getTokenSpelling();
-  // Check if we already parsed this SSA id.
-  for (auto entry : dimsAndSymbols) {
-    if (entry.first == name) {
-      consumeToken(Token::percent_identifier);
-      return entry.second;
-    }
-  }
   // Parse the SSA id and add an AffineDim/SymbolExpr to represent it.
   if (parseElement(isSymbol))
     return nullptr;

--- a/mlir/test/Dialect/Affine/load-store.mlir
+++ b/mlir/test/Dialect/Affine/load-store.mlir
@@ -198,6 +198,20 @@ func.func @test_prefetch(%arg0 : index, %arg1 : index) {
 
 // -----
 
+// Test with load affine map with same SSA name. 
+func.func @test_load_same_ssa_name() {
+  %0 = memref.alloc() : memref<10x10xf32>
+  affine.for %i0 = 0 to 100 {
+    %i2:2 = affine.delinearize_index %i0 into (10, 10) : index, index
+    %1 = affine.load %0[%i2#0, %i2#1] : memref<10x10xf32>
+    // CHECK: %{{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<10x10xf32>
+    affine.store %1, %0[%i2#0, %i2#1] : memref<10x10xf32>
+  }
+  return
+}
+
+// -----
+
 // Test with just loop IVs.
 func.func @vector_load_vector_store_iv() {
   %0 = memref.alloc() : memref<100x100xf32>


### PR DESCRIPTION
```
module {
  func.func @main(%arg17: memref<1000xf32, strided<[?], offset: ?>>) -> memref<1x1000xf32> {
    %alloc_342 = memref.alloc() {alignment = 64 : i64} : memref<1x1x1000xf32>
    %alloc_343 = memref.alloc() {alignment = 64 : i64} : memref<1x1000xf32>
    affine.for %arg89 = 0 to 1 {
      affine.for %arg90 = 0 to 1000 {
        %0:2 = affine.delinearize_index %arg89 into (1, 1) : index, index
        %1 = affine.load %alloc_342[%0#0, %0#1, %arg90] : memref<1x1x1000xf32>
        %2 = affine.linearize_index disjoint [%arg89, %arg90] by (1, 1000) : index
        %3 = affine.load %arg17[%2] : memref<1000xf32, strided<[?], offset: ?>>
        %4 = arith.addf %1, %3 : f32
        affine.store %4, %alloc_343[%arg89, %arg90] : memref<1x1000xf32>
      }
    }
    return %alloc_343 : memref<1x1000xf32>
  }
}
```

```
mlir-opt test.mlir
error: expected ']' in affine map
        %1 = affine.load %alloc_342[%0#0, %0#1, %arg90] : memref<1x1x1000xf32>
```

It seems that there is a bug in `affine.load` operation's affine map of SSA ids handling where its values are numbered. (%0#0, %0#1, ...) `dimsAndSymbols` in AffineParser only takes the name of the value %0, but not #0, and thinks %0 is already parsed when checking redundancy for %0#1. I am not sure if checking for redundancy is necessary here, but removing the check works. 
