### PR TITLE
[libc++] Remove is_signed<T> use from <limits>

### DIFF
--- a/libcxx/include/limits
+++ b/libcxx/include/limits
@@ -107,7 +107,6 @@ template<> class numeric_limits<cv long double>;
 #else
 #  include <__config>
 #  include <__type_traits/is_arithmetic.h>
-#  include <__type_traits/is_signed.h>
 
 #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #    pragma GCC system_header
@@ -217,7 +216,7 @@ protected:
 
   static _LIBCPP_CONSTEXPR const bool is_iec559  = false;
   static _LIBCPP_CONSTEXPR const bool is_bounded = true;
-  static _LIBCPP_CONSTEXPR const bool is_modulo  = !std::is_signed<_Tp>::value;
+  static _LIBCPP_CONSTEXPR const bool is_modulo  = !is_signed;
 
 #  if defined(__i386__) || defined(__x86_64__) || defined(__wasm__)
   static _LIBCPP_CONSTEXPR const bool traps = true;


### PR DESCRIPTION
`numeric_limits` already has a member that tells us whether a type is signed or not. There is no need to use the type trait for that.
