### PR TITLE
[clang-tidy] Add `IgnoredFilesList` option to `readability-duplicate-include`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
@@ -69,9 +69,8 @@ private:
 DuplicateIncludeCheck::DuplicateIncludeCheck(StringRef Name,
                                              ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      IgnoredFilesList(
-          llvm::ArrayRef<llvm::StringRef>(utils::options::parseStringList(
-              Options.get("IgnoredFilesList", "")))) {}
+      IgnoredFilesList(utils::options::parseStringList(
+          Options.get("IgnoredFilesList", ""))) {}
 
 DuplicateIncludeCallbacks::DuplicateIncludeCallbacks(
     DuplicateIncludeCheck &Check, const SourceManager &SM,

--- a/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
@@ -94,14 +94,6 @@ bool DuplicateIncludeCallbacks::isAllowedDuplicate(
         return R.match(FileName);
       }))
     return true;
-
-  if (File) {
-    const StringRef Resolved = File->getName();
-    return llvm::any_of(AllowedRegexes, [&Resolved](const llvm::Regex &R) {
-      return R.match(Resolved);
-    });
-  }
-
   return false;
 }
 

--- a/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
@@ -61,7 +61,7 @@ private:
   SmallVector<FileList> Files;
   DuplicateIncludeCheck &Check;
   const SourceManager &SM;
-  std::vector<llvm::Regex> AllowedRegexes;
+  SmallVector<llvm::Regex> AllowedRegexes;
 };
 
 } // namespace

--- a/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
@@ -36,7 +36,7 @@ class DuplicateIncludeCallbacks : public PPCallbacks {
 public:
   DuplicateIncludeCallbacks(DuplicateIncludeCheck &Check,
                             const SourceManager &SM,
-                            const std::vector<StringRef> &IgnoredList);
+                            llvm::ArrayRef<StringRef> IgnoredList);
 
   void FileChanged(SourceLocation Loc, FileChangeReason Reason,
                    SrcMgr::CharacteristicKind FileType,
@@ -70,12 +70,13 @@ private:
 DuplicateIncludeCheck::DuplicateIncludeCheck(StringRef Name,
                                              ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      IgnoredFilesList(utils::options::parseStringList(
-          Options.get("IgnoredFilesList", ""))) {}
+      IgnoredFilesList(
+          llvm::ArrayRef<llvm::StringRef>(utils::options::parseStringList(
+              Options.get("IgnoredFilesList", "")))) {}
 
 DuplicateIncludeCallbacks::DuplicateIncludeCallbacks(
     DuplicateIncludeCheck &Check, const SourceManager &SM,
-    const std::vector<StringRef> &IgnoredList)
+    llvm::ArrayRef<StringRef> IgnoredList)
     : Check(Check), SM(SM) {
   // The main file doesn't participate in the FileChanged notification.
   Files.emplace_back();

--- a/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.h
@@ -28,7 +28,7 @@ public:
 private:
   // Semicolon-separated list of regexes or file names to ignore from duplicate
   // warnings.
-  const llvm::SmallVector<StringRef, 0> IgnoredFilesList;
+  const std::vector<StringRef> IgnoredFilesList;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_READABILITY_DUPLICATEINCLUDECHECK_H
 
 #include "../ClangTidyCheck.h"
+#include <vector>
 
 namespace clang::tidy::readability {
 
@@ -19,11 +20,16 @@ namespace clang::tidy::readability {
 /// directives between them are analyzed.
 class DuplicateIncludeCheck : public ClangTidyCheck {
 public:
-  DuplicateIncludeCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  DuplicateIncludeCheck(StringRef Name, ClangTidyContext *Context);
 
   void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                            Preprocessor *ModuleExpanderPP) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+
+private:
+  // Semicolon-separated list of regexes or file names to ignore from duplicate
+  // warnings.
+  const std::vector<StringRef> IgnoredFilesList;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.h
@@ -10,7 +10,6 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_READABILITY_DUPLICATEINCLUDECHECK_H
 
 #include "../ClangTidyCheck.h"
-#include <vector>
 
 namespace clang::tidy::readability {
 
@@ -29,7 +28,7 @@ public:
 private:
   // Semicolon-separated list of regexes or file names to ignore from duplicate
   // warnings.
-  const std::vector<StringRef> IgnoredFilesList;
+  const llvm::SmallVector<StringRef, 0> IgnoredFilesList;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -316,7 +316,7 @@ Changes in existing checks
   exceptions from captures are now diagnosed, exceptions in the bodies of
   lambdas that aren't actually invoked are not. Additionally, fixed an issue
   where the check wouldn't diagnose throws in arguments to functions or
-  constructors. Added fine-grained configuration via options 
+  constructors. Added fine-grained configuration via options
   `CheckDestructors`, `CheckMoveMemberFunctions`, `CheckMain`,
   `CheckedSwapFunctions`, and `CheckNothrowFunctions`.
 
@@ -504,6 +504,11 @@ Changes in existing checks
   generating fix-it hints when size method is called from implicit ``this``,
   ignoring default constructors with user provided arguments and adding
   detection in container's method except ``empty``.
+
+- Improved :doc:`readability-duplicate-include
+  <clang-tidy/checks/readability/duplicate-include>` check by adding
+  the ``IgnoredFilesList`` option (semicolon-separated list of regexes or
+  filenames) to allow intentional duplicates.
 
 - Improved :doc:`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check by ignoring

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/duplicate-include.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/duplicate-include.rst
@@ -7,6 +7,17 @@ Looks for duplicate includes and removes them.  The check maintains a list of
 included files and looks for duplicates.  If a macro is defined or undefined
 then the list of included files is cleared.
 
+Options
+-------
+
+.. option:: IgnoredFilesList
+
+  A semicolon-separated list of regular expressions or filenames that are
+  allowed to be included multiple times without diagnostics. Matching is
+  performed against the textual include name. If the header can be
+  resolved, its full path is also matched against the patterns.
+  Default is empty.
+
 Examples:
 
 .. code-block:: c++

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/duplicate-include.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/duplicate-include.rst
@@ -7,17 +7,6 @@ Looks for duplicate includes and removes them.  The check maintains a list of
 included files and looks for duplicates.  If a macro is defined or undefined
 then the list of included files is cleared.
 
-Options
--------
-
-.. option:: IgnoredFilesList
-
-  A semicolon-separated list of regular expressions or filenames that are
-  allowed to be included multiple times without diagnostics. Matching is
-  performed against the textual include name. If the header can be
-  resolved, its full path is also matched against the patterns.
-  Default is empty.
-
 Examples:
 
 .. code-block:: c++
@@ -44,3 +33,12 @@ Because of the intervening macro definitions, this code remains unchanged:
   #define NDEBUG
   #include "assertion.h"
   // ...code with assertions disabled
+
+Options
+-------
+
+.. option:: IgnoredFilesList
+
+  A semicolon-separated list of regular expressions or filenames that are
+  allowed to be included multiple times without diagnostics. Matching is
+  performed against the textual include name. Default is an empty string.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/Inputs/duplicate-include/pack_begin.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/Inputs/duplicate-include/pack_begin.h
@@ -1,0 +1,1 @@
+// Intentionally unguarded begin-pack header used in tests

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/Inputs/duplicate-include/pack_end.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/Inputs/duplicate-include/pack_end.h
@@ -1,0 +1,1 @@
+// Intentionally unguarded end-pack header used in tests

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include-ignored-files.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include-ignored-files.cpp
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s readability-duplicate-include %t -- \
-// RUN:   -config="{CheckOptions: {readability-duplicate-include.IgnoredFilesList: 'pack_.*\\.h'}}" -header-filter='' \
-// RUN:   -- -I %S/Inputs/duplicate-include
+// RUN:   -config="{CheckOptions: {readability-duplicate-include.IgnoredFilesList: 'pack_.*\\.h'}}" \
+// RUN:   -header-filter='' -- -I %S/Inputs/duplicate-include
 
 int g;
 #include "duplicate-include.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include-ignored-files.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include-ignored-files.cpp
@@ -1,9 +1,24 @@
 // RUN: %check_clang_tidy %s readability-duplicate-include %t -- \
-// RUN:   -config="{CheckOptions: {readability-duplicate-include.IgnoredFilesList: 'pack_.*\\.h'}}" \
+// RUN:   -config="{CheckOptions: {readability-duplicate-include.IgnoredFilesList: 'pack_.*\\.h'}}" -header-filter='' \
 // RUN:   -- -I %S/Inputs/duplicate-include
+
+int g;
+#include "duplicate-include.h"
+int h;
+#include "duplicate-include.h"
+int i;
+// CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include [readability-duplicate-include]
+// CHECK-FIXES:      int g;
+// CHECK-FIXES-NEXT: #include "duplicate-include.h"
+// CHECK-FIXES-NEXT: int h;
+// CHECK-FIXES-NEXT: int i;
 
 #include "pack_begin.h"
 struct A { int x; };
 #include "pack_end.h"
 
-// no warning
+#include "pack_begin.h"
+struct B { int x; };
+#include "pack_end.h"
+
+// No warning here.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include-ignored-files.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include-ignored-files.cpp
@@ -1,0 +1,9 @@
+// RUN: %check_clang_tidy %s readability-duplicate-include %t -- \
+// RUN:   -config="{CheckOptions: {readability-duplicate-include.IgnoredFilesList: 'pack_.*\\.h'}}" \
+// RUN:   -- -I %S/Inputs/duplicate-include
+
+#include "pack_begin.h"
+struct A { int x; };
+#include "pack_end.h"
+
+// no warning


### PR DESCRIPTION
Closes [#166938](https://github.com/llvm/llvm-project/issues/166938)