### PR TITLE
[LLVM][Unittest] disable plugin tests for `LLVM_BUILD_LLVM_DYLIB` on WIN32

### DIFF
--- a/llvm/unittests/Analysis/InlineAdvisorPlugin/CMakeLists.txt
+++ b/llvm/unittests/Analysis/InlineAdvisorPlugin/CMakeLists.txt
@@ -2,7 +2,7 @@
 # libraries, but expects them to exist in the process loading the plugin. This 
 # doesn't work with DLLs on Windows (where a shared library can't have undefined
 # references), so just skip this testcase on Windows.
-if ((NOT WIN32 AND NOT CYGWIN) OR LLVM_BUILD_LLVM_DYLIB)
+if ((NOT WIN32 AND NOT CYGWIN) OR LLVM_LINK_LLVM_DYLIB)
   unset(LLVM_LINK_COMPONENTS)
   add_llvm_library(InlineAdvisorPlugin MODULE BUILDTREE_ONLY
     InlineAdvisorPlugin.cpp

--- a/llvm/unittests/Analysis/InlineOrderPlugin/CMakeLists.txt
+++ b/llvm/unittests/Analysis/InlineOrderPlugin/CMakeLists.txt
@@ -2,7 +2,7 @@
 # libraries, but expects them to exist in the process loading the plugin. This 
 # doesn't work with DLLs on Windows (where a shared library can't have undefined
 # references), so just skip this testcase on Windows.
-if ((NOT WIN32 AND NOT CYGWIN) OR LLVM_BUILD_LLVM_DYLIB)
+if ((NOT WIN32 AND NOT CYGWIN) OR LLVM_LINK_LLVM_DYLIB)
   unset(LLVM_LINK_COMPONENTS)
   add_llvm_library(InlineOrderPlugin MODULE BUILDTREE_ONLY
     InlineOrderPlugin.cpp


### PR DESCRIPTION
Building these plugins require `LLVM_LINK_LLVM_DYLIB` but not `LLVM_BUILD_LLVM_DYLIB`.