### PR TITLE
[llvm][docs] Correct the list of the available -fveclib= options to match with the reality

### DIFF
--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -349,7 +349,7 @@ Many of these math functions are only vectorizable if the file has been built
 with a specified target vector library that provides a vector implementation
 of that math function. Using clang, this is handled by the "-fveclib" command
 line option with one of the following vector libraries:
-"accelerate,libmvec,massv,svml,sleef,darwin_libsystem_m,armpl,amdlibm"
+"Accelerate,libmvec,MASSV,SVML,SLEEF,Darwin_libsystem_m,ArmPL,AMDLIBM"
 
 .. code-block:: console
 


### PR DESCRIPTION
The command line reality is this:

$ clang -c prog.c -fveclib=accelerate
error: invalid value 'accelerate' in '-fveclib=accelerate'

$ clang -c prog.c -fveclib=Accelerate
prog.c:1:2: warning: This is only a test [-W#warnings]
    1 | #warning This is only a test
      |  ^
1 warning generated.

$ clang -c prog.c -fveclib=libmvec
prog.c:1:2: warning: This is only a test [-W#warnings]
    1 | #warning This is only a test
      |  ^
1 warning generated.

$ clang -c prog.c -fveclib=LIBMVEC
error: invalid value 'LIBMVEC' in '-fveclib=LIBMVEC'

$ clang -c prog.c -fveclib=massv
error: invalid value 'massv' in '-fveclib=massv'

$ clang -c prog.c -fveclib=MASSV
prog.c:1:2: warning: This is only a test [-W#warnings]
    1 | #warning This is only a test
      |  ^
1 warning generated.

$ clang -c prog.c -fveclib=sleef
error: invalid value 'sleef' in '-fveclib=sleef'

$ clang -c prog.c -fveclib=sleefgnuabi
error: invalid value 'sleefgnuabi' in '-fveclib=sleefgnuabi'

$ clang -c prog.c -fveclib=SLEEF
prog.c:1:2: warning: This is only a test [-W#warnings]
    1 | #warning This is only a test
      |  ^
1 warning generated.

$ clang -c prog.c -fveclib=darwin_libsystem_m
error: invalid value 'darwin' in '-fveclib=darwin_libsystem_m'

$ clang -c prog.c -fveclib=Darwin_libsystem_m
prog.c:1:2: warning: This is only a test [-W#warnings]
    1 | #warning This is only a test
      |  ^
1 warning generated.

$ clang -c prog.c -fveclib=armpl
error: invalid value 'armpl' in '-fveclib=armpl'

$ clang -c prog.c -fveclib=ARMPL
error: invalid value 'ARMPL' in '-fveclib=ARMPL'

$ clang -c prog.c -fveclib=ArmPL
prog.c:1:2: warning: This is only a test [-W#warnings]
    1 | #warning This is only a test
      |  ^
1 warning generated.

$ clang -c prog.c -fveclib=amdlibm
error: invalid value 'amdlibm' in '-fveclib=amdlibm'

$ clang -c prog.c -fveclib=AMDLIBM
clang: error: unsupported option 'AMDLIBM' for target 'aarch64'