### PR TITLE
[libc] Add `IN6_IS_ADDR_{LINK, SITE}LOCAL`

### DIFF
--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -33,4 +33,12 @@
 #define INET_ADDRSTRLEN 16
 #define INET6_ADDRSTRLEN 46
 
+#define IN6_IS_ADDR_LINKLOCAL(a)                                               \
+  ((__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[0]) == 0xfe &&            \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xc0) == 0x80)
+
+#define IN6_IS_ADDR_SITELOCAL(a)                                               \
+  ((__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[0]) == 0xfe &&            \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xc0) == 0xc0)
+
 #endif // LLVM_LIBC_MACROS_NETINET_IN_MACROS_H

--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -33,6 +33,10 @@
 #define INET_ADDRSTRLEN 16
 #define INET6_ADDRSTRLEN 46
 
+// The following macros test for special IPv6 addresses. Each macro is of type
+// int and takes a single argument of type const struct in6_addr *:
+// https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/netinet_in.h.html
+
 #define IN6_IS_ADDR_LINKLOCAL(a)                                               \
   ((__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[0]) == 0xfe &&            \
    (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xc0) == 0x80)

--- a/libc/test/include/netinet_in_test.cpp
+++ b/libc/test/include/netinet_in_test.cpp
@@ -9,21 +9,20 @@
 #include "include/llvm-libc-macros/netinet-in-macros.h"
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcNetinetInTest, IPPROTOMacro) {
-  EXPECT_EQ(IPPROTO_IP, 0);
-  EXPECT_EQ(IPPROTO_ICMP, 1);
-  EXPECT_EQ(IPPROTO_TCP, 6);
-  EXPECT_EQ(IPPROTO_UDP, 17);
-  EXPECT_EQ(IPPROTO_IPV6, 41);
-  EXPECT_EQ(IPPROTO_RAW, 255);
-}
+TEST(LlvmLibcNetinetInTest, IN6Macro) {
+  char buff[16] = {};
 
-TEST(LlvmLibcNetinetInTest, IPV6Macro) {
-  EXPECT_EQ(IPV6_UNICAST_HOPS, 16);
-  EXPECT_EQ(IPV6_MULTICAST_IF, 17);
-  EXPECT_EQ(IPV6_MULTICAST_HOPS, 18);
-  EXPECT_EQ(IPV6_MULTICAST_LOOP, 19);
-  EXPECT_EQ(IPV6_JOIN_GROUP, 20);
-  EXPECT_EQ(IPV6_LEAVE_GROUP, 21);
-  EXPECT_EQ(IPV6_V6ONLY, 26);
+  buff[0] = 0xfe;
+  buff[1] = 0x80;
+  EXPECT_TRUE(IN6_IS_ADDR_LINKLOCAL(buff));
+  buff[0] = 0xff;
+  buff[1] = 0x80;
+  EXPECT_FALSE(IN6_IS_ADDR_LINKLOCAL(buff));
+
+  buff[0] = 0xfe;
+  buff[1] = 0xc0;
+  EXPECT_TRUE(IN6_IS_ADDR_SITELOCAL(buff));
+  buff[0] = 0xff;
+  buff[1] = 0x80;
+  EXPECT_FALSE(IN6_IS_ADDR_SITELOCAL(buff));
 }


### PR DESCRIPTION
This patch introduces two macros in `netinet/in.h`. The redundant tests for macro values in the testcases have been removed.