### PR TITLE
[ObjectYAML][CodeView] Include inline annotation data

### DIFF
--- a/llvm/lib/ObjectYAML/CodeViewYAMLSymbols.cpp
+++ b/llvm/lib/ObjectYAML/CodeViewYAMLSymbols.cpp
@@ -386,7 +386,7 @@ template <> void SymbolRecordImpl<InlineSiteSym>::map(IO &IO) {
   IO.mapOptional("PtrParent", Symbol.Parent, 0U);
   IO.mapOptional("PtrEnd", Symbol.End, 0U);
   IO.mapRequired("Inlinee", Symbol.Inlinee);
-  // TODO: The binary annotations
+  IO.mapOptional("AnnotationData", Symbol.AnnotationData);
 }
 
 template <> void SymbolRecordImpl<LocalSym>::map(IO &IO) {

--- a/llvm/test/tools/llvm-pdbutil/inline-annotations.test
+++ b/llvm/test/tools/llvm-pdbutil/inline-annotations.test
@@ -1,0 +1,39 @@
+# RUN: llvm-pdbutil yaml2pdb %s --pdb=%t.pdb
+# RUN: llvm-pdbutil dump --all %t.pdb | FileCheck --check-prefix=CHECK-YAML2PDB %s
+
+# RUN: llvm-pdbutil pdb2yaml --module-syms %t.pdb > %t.yaml
+# RUN: FileCheck --input-file=%t.yaml --check-prefix=CHECK-PDB2YAML %s
+
+# CHECK-YAML2PDB: 4 | S_INLINESITE [size = 24]
+# CHECK-YAML2PDB:     inlinee = 0x1000 (<unknown UDT>), parent = 268, end = 508
+# CHECK-YAML2PDB:       0602      line 1 (+1)
+# CHECK-YAML2PDB:       0315      code 0x15 (+0x15)
+# CHECK-YAML2PDB:       040B      code end 0x20 (+0xB)
+# CHECK-YAML2PDB:       0000
+
+# CHECK-PDB2YAML: Modi:
+# CHECK-PDB2YAML:   Records:
+# CHECK-PDB2YAML:     - Kind:            S_INLINESITE
+# CHECK-PDB2YAML:       InlineSiteSym:
+# CHECK-PDB2YAML:         PtrParent:       268
+# CHECK-PDB2YAML:         PtrEnd:          508
+# CHECK-PDB2YAML:         Inlinee:         4096
+# CHECK-PDB2YAML:         AnnotationData:  [ 6, 2, 3, 21, 4, 11, 0, 0 ]
+
+---
+DbiStream:
+  Modules:
+    - Module:          'C:\Users\johannes\AppData\Local\Temp\inline_sites_live-2a62f2.o'
+      Modi:
+        Records:
+          - Kind:            S_INLINESITE
+            InlineSiteSym:
+              PtrParent:       268
+              PtrEnd:          508
+              Inlinee:         4096
+              AnnotationData:  [ 6, 2, 3, 21, 4, 11, 0, 0 ]
+  SectionHeaders:
+    - Name:            .text
+    - Name:            .rdata
+    - Name:            .pdata
+...


### PR DESCRIPTION
The annotation data for `S_INLINESITE` symbols was missing in YAML. This caused PDBs with inline sites to have incorrect symbol offsets, because `S_INLINESITE` wouldn't have the same size after creating a PDB from YAML.

I kept the annotations as binary, because that's how they're represented in LLVM.