### PR TITLE
[MLIR][Transform][Python] Expose applying named_sequences as a method

### DIFF
--- a/mlir/test/python/dialects/transform_interpreter.py
+++ b/mlir/test/python/dialects/transform_interpreter.py
@@ -30,10 +30,14 @@ def print_self():
 # CHECK: transform.print
 # CHECK: transform.yield
 
+
 @test_in_context
 def print_self_via_apply_method():
-    m = ir.Module.parse(print_root_module.replace("from interpreter", "print_self_via_apply_method"))
+    m = ir.Module.parse(
+        print_root_module.replace("from interpreter", "print_self_via_apply_method")
+    )
     m.body.operations[0].apply(m)
+
 
 # CHECK-LABEL: print_self_via_apply_method
 # CHECK: transform.named_sequence @__transform_main

--- a/mlir/test/python/dialects/transform_interpreter.py
+++ b/mlir/test/python/dialects/transform_interpreter.py
@@ -30,6 +30,16 @@ def print_self():
 # CHECK: transform.print
 # CHECK: transform.yield
 
+@test_in_context
+def print_self_via_apply_method():
+    m = ir.Module.parse(print_root_module.replace("from interpreter", "print_self_via_apply_method"))
+    m.body.operations[0].apply(m)
+
+# CHECK-LABEL: print_self_via_apply_method
+# CHECK: transform.named_sequence @__transform_main
+# CHECK: transform.print
+# CHECK: transform.yield
+
 
 @test_in_context
 def print_other():


### PR DESCRIPTION
Makes it so that a NamedSequenceOp can be directly applied to a Module, via a method `apply(...)`.