### PR TITLE
[libcxx] Install ninja in CI container from system repo

### DIFF
--- a/libcxx/utils/ci/docker/linux-builder-base.dockerfile
+++ b/libcxx/utils/ci/docker/linux-builder-base.dockerfile
@@ -70,6 +70,7 @@ RUN sudo apt-get update \
         libxml2-dev \
         lsb-release \
         make \
+        ninja-build \
         python3 \
         python3-dev \
         python3-packaging \
@@ -82,14 +83,6 @@ RUN sudo apt-get update \
         wget \
         xz-utils \
     && sudo rm -rf /var/lib/apt/lists/*
-
-RUN <<EOF
-  set -e
-  wget -qO /tmp/ninja.gz https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip
-  gunzip /tmp/ninja.gz
-  chmod a+x /tmp/ninja
-  sudo mv /tmp/ninja /usr/local/bin/ninja
-EOF
 
 # These two locales are not enabled by default so generate them
 RUN <<EOF


### PR DESCRIPTION
To fix the TODO now that the ninja version available in the Ubuntu repositories (1.11) is new enough.