### PR TITLE
[CI] Fix typo in CI Best Practices for the release branch names push filter

### DIFF
--- a/llvm/docs/CIBestPractices.rst
+++ b/llvm/docs/CIBestPractices.rst
@@ -135,7 +135,7 @@ branches as follows:
   push:
     branches:
       - main
-      - releases/*
+      - release/*
 
 Container Best Practices
 ========================


### PR DESCRIPTION
The CIBestPractices.rst document uses `releases/*` as the branch name filter for push events. The actual release branch names match the pattern `release/*`.