### PR TITLE
[libc++][Windows] Enable thread::hardware_concurrency to support more than 64 processors

### DIFF
--- a/libcxx/src/thread.cpp
+++ b/libcxx/src/thread.cpp
@@ -74,9 +74,7 @@ unsigned thread::hardware_concurrency() noexcept {
     return 0;
   return static_cast<unsigned>(result);
 #elif defined(_LIBCPP_WIN32API)
-  SYSTEM_INFO info;
-  GetSystemInfo(&info);
-  return info.dwNumberOfProcessors;
+  return static_cast<unsigned>(GetActiveProcessorCount(ALL_PROCESSOR_GROUPS));
 #else // defined(CTL_HW) && defined(HW_NCPU)
   // TODO: grovel through /proc or check cpuid on x86 and similar
   // instructions on other architectures.


### PR DESCRIPTION
Starting with Windows 11, processes can utilize more than 64 processors by default, but GetSystemInfo can only report a maximum of 64. Starting with Windows Vista, GetActiveProcessorCount accurately retrieves the total number of processors on the current system. I’ve implemented similar improvements to Microsoft STL. The following links contain additional background information: https://github.com/microsoft/STL/issues/5453, https://github.com/microsoft/STL/pull/5459 (note: Reason STL uses the more complex GetLogicalProcessorInformationEx: https://github.com/microsoft/STL/pull/5459#discussion_r2072242241.).