### PR TITLE
[GlobalMerge] add a command to force global merge

### DIFF
--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -111,6 +111,12 @@ EnableGlobalMerge("enable-global-merge", cl::Hidden,
                   cl::desc("Enable the global merge pass"),
                   cl::init(true));
 
+static cl::opt<bool> ForceEnableGlobalMerge(
+    "force-enable-global-merge", cl::Hidden,
+    cl::desc(
+        "Force enable the global merge, regardless of the optimization level"),
+    cl::init(false));
+
 static cl::opt<unsigned>
 GlobalMergeMaxOffset("global-merge-max-offset", cl::Hidden,
                      cl::desc("Set maximum offset for global merge pass"),
@@ -374,7 +380,9 @@ bool GlobalMergeImpl::doMerge(SmallVectorImpl<GlobalVariable *> &Globals,
         Function *ParentFn = I->getParent()->getParent();
 
         // If we're only optimizing for size, ignore non-minsize functions.
-        if (Opt.SizeOnly && !ParentFn->hasMinSize())
+        // And add a config to force global merge
+        if (!ForceEnableGlobalMerge &&
+            (Opt.SizeOnly && !ParentFn->hasMinSize()))
           continue;
 
         size_t UGSIdx = GlobalUsesByFunction[ParentFn];

--- a/llvm/test/CodeGen/ARM/force-global-merge.ll
+++ b/llvm/test/CodeGen/ARM/force-global-merge.ll
@@ -1,0 +1,23 @@
+; RUN: llc -mtriple=arm-eabi -force-enable-global-merge %s -o - | FileCheck %s
+
+@g_value1 = dso_local local_unnamed_addr global i32 0, align 4
+@g_value2 = dso_local local_unnamed_addr global i32 0, align 4
+@g_value3 = dso_local local_unnamed_addr global i32 0, align 4
+@g_value4 = dso_local local_unnamed_addr global i32 0, align 4
+
+define dso_local i32 @foo1() local_unnamed_addr {
+entry:
+  %0 = load i32, ptr @g_value1, align 4
+  %1 = load i32, ptr @g_value2, align 4
+  %2 = load i32, ptr @g_value3, align 4
+  %3 = load i32, ptr @g_value4, align 4
+  %call = tail call i32 @foo(i32 %0, i32 %1, i32 %2, i32 %3)
+  ret i32 %call
+}
+
+declare i32 @foo(i32, i32, i32, i32)
+
+; CHECK:      ldr     [[BASE:r[0-9]+]], .LCPI0_0
+; CHECK:      ldm     [[BASE]], {[[R0:r[0-9]+]], [[R1:r[0-9]+]], [[R2:r[0-9]+]], [[R3:r[0-9]+]]}
+; CHECK:      .LCPI0_0:
+; CHECK-NEXT: .long   .L_MergedGlobals


### PR DESCRIPTION
I've found that in certain performance scenarios, particularly with the -O2  this PR can significantly enhance the efficiency of loading global variables.