### PR TITLE
Reapply "[compiler-rt] Default to Lit's Internal Shell"

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -113,6 +113,9 @@ def push_dynamic_library_lookup_path(config, new_path):
         config.environment[dynamic_library_lookup_var] = new_ld_library_path_64
 
 
+# TODO: Consolidate the logic for turning on the internal shell by default for all LLVM test suites.
+# See https://github.com/llvm/llvm-project/issues/106636 for more details.
+#
 # Choose between lit's internal shell pipeline runner and a real shell.  If
 # LIT_USE_INTERNAL_SHELL is in the environment, we use that as an override.
 use_lit_shell = os.environ.get("LIT_USE_INTERNAL_SHELL")
@@ -120,9 +123,8 @@ if use_lit_shell:
     # 0 is external, "" is default, and everything else is internal.
     execute_external = use_lit_shell == "0"
 else:
-    # Otherwise we default to internal on Windows and external elsewhere, as
-    # bash on Windows is usually very slow.
-    execute_external = not sys.platform in ["win32"]
+    # Otherwise we default to internal everywhere.
+    execute_external = False
 
 # Allow expanding substitutions that are based on other substitutions
 config.recursiveExpansionLimit = 10


### PR DESCRIPTION
This reverts commit 8cc49fb99a4798f67b6b70fabfd584095d022e92.

This was causing failures on two specific buildbots that have since been fixed.