### PR TITLE
[CAS] Remove a redundant cast (NFC)

### DIFF
--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -938,8 +938,7 @@ Error OnDiskGraphDB::validate(bool Deep, HashingFuncT Hasher) const {
       // Check offset is a postive value, and large enough to hold the
       // header for the data record.
       if (D.Offset.get() <= 0 ||
-          (uint64_t)D.Offset.get() + sizeof(DataRecordHandle::Header) >=
-              DataPool.size())
+          D.Offset.get() + sizeof(DataRecordHandle::Header) >= DataPool.size())
         return formatError("datapool record out of bound");
       break;
     case TrieRecord::StorageKind::Standalone:


### PR DESCRIPTION
D.Offset.get() already returns uint64_t.

Identified with readability-redundant-casting.
