### PR TITLE
[libc++][test] re-enable the inference test for clang

### DIFF
--- a/libcxx/test/std/language.support/support.dynamic/hardware_inference_size.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/hardware_inference_size.compile.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// UNSUPPORTED: (clang || apple-clang) && stdlib=libc++
 
 #include <new>
 


### PR DESCRIPTION
Fixes #168210