### PR TITLE
[ARM] Remove Subtarget from ARMAsmPrinter

### DIFF
--- a/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.cpp
@@ -679,14 +679,14 @@ void ARMAsmPrinter::emitAttributes() {
   if (isPositionIndependent()) {
     ATS.emitAttribute(ARMBuildAttrs::ABI_PCS_RW_data,
                       ARMBuildAttrs::AddressRWPCRel);
-  } else if (getTM().isRWPI()) {
+  } else if (STI.isRWPI()) {
     // RWPI specific attributes.
     ATS.emitAttribute(ARMBuildAttrs::ABI_PCS_RW_data,
                       ARMBuildAttrs::AddressRWSBRel);
   }
 
   // RO data addressing.
-  if (isPositionIndependent() || getTM().isROPI()) {
+  if (isPositionIndependent() || STI.isROPI()) {
     ATS.emitAttribute(ARMBuildAttrs::ABI_PCS_RO_data,
                       ARMBuildAttrs::AddressROPCRel);
   }
@@ -832,7 +832,7 @@ void ARMAsmPrinter::emitAttributes() {
   }
 
   // We currently do not support using R9 as the TLS pointer.
-  if (getTM().isRWPI())
+  if (STI.isRWPI())
     ATS.emitAttribute(ARMBuildAttrs::ABI_PCS_R9_use,
                       ARMBuildAttrs::R9IsSB);
   else if (STI.isR9Reserved())
@@ -1047,7 +1047,8 @@ void ARMAsmPrinter::emitJumpTableAddrs(const MachineInstr *MI) {
     //    .word (LBB1 - LJTI_0_0)
     const MCExpr *Expr = MCSymbolRefExpr::create(MBB->getSymbol(), OutContext);
 
-    if (isPositionIndependent() || getTM().isROPI())
+    const ARMSubtarget &STI = MF->getSubtarget<ARMSubtarget>();
+    if (isPositionIndependent() || STI.isROPI())
       Expr = MCBinaryExpr::createSub(Expr, MCSymbolRefExpr::create(JTISymbol,
                                                                    OutContext),
                                      OutContext);

--- a/llvm/lib/Target/ARM/ARMAsmPrinter.h
+++ b/llvm/lib/Target/ARM/ARMAsmPrinter.h
@@ -9,13 +9,13 @@
 #ifndef LLVM_LIB_TARGET_ARM_ARMASMPRINTER_H
 #define LLVM_LIB_TARGET_ARM_ARMASMPRINTER_H
 
-#include "ARMSubtarget.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/Target/TargetMachine.h"
 
 namespace llvm {
 
 class ARMFunctionInfo;
+class ARMBaseTargetMachine;
 class MCOperand;
 class MachineConstantPool;
 class MachineOperand;
@@ -33,10 +33,6 @@ public:
   static char ID;
 
 private:
-  /// Subtarget - Keep a pointer to the ARMSubtarget around so that we can
-  /// make the right decision when printing asm code for different targets.
-  const ARMSubtarget *Subtarget;
-
   /// AFI - Keep a pointer to ARMFunctionInfo for the current
   /// MachineFunction.
   ARMFunctionInfo *AFI;

--- a/llvm/lib/Target/ARM/ARMMCInstLower.cpp
+++ b/llvm/lib/Target/ARM/ARMMCInstLower.cpp
@@ -112,8 +112,8 @@ bool ARMAsmPrinter::lowerOperand(const MachineOperand &MO,
     MCOp = GetSymbolRef(MO, GetJTISymbol(MO.getIndex()));
     break;
   case MachineOperand::MO_ConstantPoolIndex:
-    if (Subtarget->genExecuteOnly())
-      llvm_unreachable("execute-only should not generate constant pools");
+    assert(!MF->getSubtarget<ARMSubtarget>().genExecuteOnly() &&
+           "execute-only should not generate constant pools");
     MCOp = GetSymbolRef(MO, GetCPISymbol(MO.getIndex()));
     break;
   case MachineOperand::MO_BlockAddress:

--- a/llvm/lib/Target/ARM/ARMSubtarget.cpp
+++ b/llvm/lib/Target/ARM/ARMSubtarget.cpp
@@ -308,8 +308,19 @@ void ARMSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
   }
 }
 
-bool ARMSubtarget::isROPI() const { return TM.isROPI(); }
-bool ARMSubtarget::isRWPI() const { return TM.isRWPI(); }
+bool ARMSubtarget::isROPI() const {
+  // FIXME: This should ideally come from a function attribute, to work
+  // correctly with LTO.
+  return TM.getRelocationModel() == Reloc::ROPI ||
+         TM.getRelocationModel() == Reloc::ROPI_RWPI;
+}
+
+bool ARMSubtarget::isRWPI() const {
+  // FIXME: This should ideally come from a function attribute, to work
+  // correctly with LTO.
+  return TM.getRelocationModel() == Reloc::RWPI ||
+         TM.getRelocationModel() == Reloc::ROPI_RWPI;
+}
 
 bool ARMSubtarget::isGVIndirectSymbol(const GlobalValue *GV) const {
   return TM.isGVIndirectSymbol(GV);

--- a/llvm/lib/Target/ARM/ARMSubtarget.cpp
+++ b/llvm/lib/Target/ARM/ARMSubtarget.cpp
@@ -308,14 +308,8 @@ void ARMSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
   }
 }
 
-bool ARMSubtarget::isROPI() const {
-  return TM.getRelocationModel() == Reloc::ROPI ||
-         TM.getRelocationModel() == Reloc::ROPI_RWPI;
-}
-bool ARMSubtarget::isRWPI() const {
-  return TM.getRelocationModel() == Reloc::RWPI ||
-         TM.getRelocationModel() == Reloc::ROPI_RWPI;
-}
+bool ARMSubtarget::isROPI() const { return TM.isROPI(); }
+bool ARMSubtarget::isRWPI() const { return TM.isRWPI(); }
 
 bool ARMSubtarget::isGVIndirectSymbol(const GlobalValue *GV) const {
   return TM.isGVIndirectSymbol(GV);

--- a/llvm/lib/Target/ARM/ARMTargetMachine.h
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.h
@@ -86,6 +86,15 @@ public:
            TargetTriple.isOSWindows() || TargetABI == ARM::ARM_ABI_AAPCS16;
   }
 
+  bool isROPI() const {
+    return getRelocationModel() == Reloc::ROPI ||
+           getRelocationModel() == Reloc::ROPI_RWPI;
+  }
+  bool isRWPI() const {
+    return getRelocationModel() == Reloc::RWPI ||
+           getRelocationModel() == Reloc::ROPI_RWPI;
+  }
+
   bool targetSchedulesPostRAScheduling() const override { return true; };
 
   MachineFunctionInfo *

--- a/llvm/lib/Target/ARM/ARMTargetMachine.h
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.h
@@ -86,15 +86,6 @@ public:
            TargetTriple.isOSWindows() || TargetABI == ARM::ARM_ABI_AAPCS16;
   }
 
-  bool isROPI() const {
-    return getRelocationModel() == Reloc::ROPI ||
-           getRelocationModel() == Reloc::ROPI_RWPI;
-  }
-  bool isRWPI() const {
-    return getRelocationModel() == Reloc::RWPI ||
-           getRelocationModel() == Reloc::ROPI_RWPI;
-  }
-
   bool targetSchedulesPostRAScheduling() const override { return true; };
 
   MachineFunctionInfo *


### PR DESCRIPTION
Remove Subtarget uses from ARMAsmPrinter, making use of TargetMachine where applicable and getting the Subtarget from the MF where not. Some of the `if() llvm_unreachable` have been replaced by `asserts`.