### PR TITLE
Update Clang Maintainers

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -147,7 +147,6 @@ Clang static analyzer
 
 | Balázs Benics
 | benicsbalazs\@gmail.com (email), steakhal (Phabricator), steakhal (GitHub)
-| balazs.benics\@sonarsource.com (email), balazs-benics-sonarsource (GitHub)
 
 Compiler options
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I've left Sonar by the end of October. For my upcoming contributions, I'll simply use my personal (this) account.
I'll remain a Clang Static Analyser maintainer, but I'll likely spend less time on that part as in my new job this falls out of my key responsibilities.
From now on, I'm part of the Apple org, but for accessibility, I'll keep using my personal email address for open-source contributions and for the build bots.