### PR TITLE
[CodeGen] Remove a redundant declaration (NFC)

### DIFF
--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -401,8 +401,6 @@ struct InsertedPass {
 
 namespace llvm {
 
-extern cl::opt<bool> EnableFSDiscriminator;
-
 class PassConfigImpl {
 public:
   // List of passes explicitly substituted by this target. Normally this is


### PR DESCRIPTION
EnableFSDiscriminator is declared in DebugInfoMetadata.h.

Identified with readability-redundant-declaration.
