### PR TITLE
[Object] Add getRISCVVendorRelocationTypeName to render RISCV vendor-specific relocations to strings.

### DIFF
--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -72,6 +72,8 @@ struct VersionEntry {
 };
 
 LLVM_ABI StringRef getELFRelocationTypeName(uint32_t Machine, uint32_t Type);
+LLVM_ABI StringRef getRISCVVendorRelocationTypeName(uint32_t Type,
+                                                    StringRef Vendor);
 LLVM_ABI uint32_t getELFRelativeRelocationType(uint32_t Machine);
 LLVM_ABI StringRef getELFSectionTypeName(uint32_t Machine, uint32_t Type);
 

--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -191,17 +191,18 @@ StringRef llvm::object::getELFRelocationTypeName(uint32_t Machine,
 
 #undef ELF_RELOC
 
+StringRef llvm::object::getRISCVVendorRelocationTypeName(uint32_t Type,
+                                                         StringRef Vendor) {
 #define ELF_RISCV_NONSTANDARD_RELOC(vendor, name, number)                      \
   if (Vendor == #vendor && Type == number)                                     \
     return #name;
 
-StringRef llvm::object::getRISCVVendorRelocationTypeName(uint32_t Type,
-                                                         StringRef Vendor) {
 #include "llvm/BinaryFormat/ELFRelocs/RISCV_nonstandard.def"
-  return "Unknown";
-}
 
 #undef ELF_RISCV_NONSTANDARD_RELOC
+
+  return "Unknown";
+}
 
 uint32_t llvm::object::getELFRelativeRelocationType(uint32_t Machine) {
   switch (Machine) {

--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -191,6 +191,18 @@ StringRef llvm::object::getELFRelocationTypeName(uint32_t Machine,
 
 #undef ELF_RELOC
 
+#define ELF_RISCV_NONSTANDARD_RELOC(vendor, name, number)                      \
+  if (Vendor == #vendor && Type == number)                                     \
+    return #name;
+
+StringRef llvm::object::getRISCVVendorRelocationTypeName(uint32_t Type,
+                                                         StringRef Vendor) {
+#include "llvm/BinaryFormat/ELFRelocs/RISCV_nonstandard.def"
+  return "Unknown";
+}
+
+#undef ELF_RISCV_NONSTANDARD_RELOC
+
 uint32_t llvm::object::getELFRelativeRelocationType(uint32_t Machine) {
   switch (Machine) {
   case ELF::EM_X86_64:

--- a/llvm/unittests/Object/ELFTest.cpp
+++ b/llvm/unittests/Object/ELFTest.cpp
@@ -255,6 +255,20 @@ TEST(ELFTest, getELFRelocationTypeNameForLoongArch) {
             getELFRelocationTypeName(EM_LOONGARCH, R_LARCH_CALL36));
 }
 
+TEST(ELFTest, getRISCVVendorRelocationTypeName) {
+  EXPECT_EQ("R_RISCV_QC_ABS20_U",
+            getRISCVVendorRelocationTypeName(R_RISCV_CUSTOM192, "QUALCOMM"));
+  EXPECT_EQ("R_RISCV_QC_E_BRANCH",
+            getRISCVVendorRelocationTypeName(R_RISCV_CUSTOM193, "QUALCOMM"));
+  EXPECT_EQ("R_RISCV_QC_E_32",
+            getRISCVVendorRelocationTypeName(R_RISCV_CUSTOM194, "QUALCOMM"));
+  EXPECT_EQ("R_RISCV_QC_E_CALL_PLT",
+            getRISCVVendorRelocationTypeName(R_RISCV_CUSTOM195, "QUALCOMM"));
+
+  EXPECT_EQ("R_RISCV_NDS_BRANCH_10",
+            getRISCVVendorRelocationTypeName(R_RISCV_CUSTOM241, "ANDES"));
+}
+
 TEST(ELFTest, getELFRelativeRelocationType) {
   EXPECT_EQ(ELF::R_VE_RELATIVE, getELFRelativeRelocationType(EM_VE));
   EXPECT_EQ(ELF::R_LARCH_RELATIVE, getELFRelativeRelocationType(EM_LOONGARCH));


### PR DESCRIPTION
This will be used in places like LLD to render them for error messages.
