### PR TITLE
[MC] Remove a redundant cast (NFC)

### DIFF
--- a/llvm/lib/MC/MCELFStreamer.cpp
+++ b/llvm/lib/MC/MCELFStreamer.cpp
@@ -271,8 +271,7 @@ void MCELFStreamer::emitCommonSymbol(MCSymbol *S, uint64_t Size,
                          " redeclared as different type");
   }
 
-  static_cast<MCSymbolELF *>(Symbol)->setSize(
-      MCConstantExpr::create(Size, getContext()));
+  Symbol->setSize(MCConstantExpr::create(Size, getContext()));
 }
 
 void MCELFStreamer::emitELFSize(MCSymbol *Symbol, const MCExpr *Value) {


### PR DESCRIPTION
Symbol is already of type MCSymbolELF *.

Identified with readability-redundant-casting.
