### PR TITLE
[ADT] Add roundUpNumBuckets to DenseMap (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -556,8 +556,8 @@ private:
     return llvm::make_range(getBuckets(), getBucketsEnd());
   }
 
-  void grow(unsigned NumBuckets) {
-    NumBuckets = DerivedT::roundUpNumBuckets(NumBuckets);
+  void grow(unsigned MinNumBuckets) {
+    unsigned NumBuckets = DerivedT::roundUpNumBuckets(MinNumBuckets);
     derived().grow(NumBuckets);
   }
 


### PR DESCRIPTION
This patch adds computeNumBuckets, a helper function to compute the
number of buckets.

This is part of the effort outlined in #168255.  This makes it easier
to move the core logic of grow() to DenseMapBase::grow().
