### PR TITLE
[JITLink][MachO] Endianness fix for relocation bit-field handling.

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/MachOLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/MachOLinkGraphBuilder.h
@@ -163,6 +163,7 @@ protected:
   static bool isDebugSection(const NormalizedSection &NSec);
   static bool isZeroFillSection(const NormalizedSection &NSec);
 
+  template <endianness ObjE>
   MachO::relocation_info
   getRelocationInfo(const object::relocation_iterator RelItr) {
     MachO::any_relocation_info ARI =
@@ -170,10 +171,17 @@ protected:
     MachO::relocation_info RI;
     RI.r_address = ARI.r_word0;
     RI.r_symbolnum = ARI.r_word1 & 0xffffff;
-    RI.r_pcrel = (ARI.r_word1 >> 24) & 1;
-    RI.r_length = (ARI.r_word1 >> 25) & 3;
-    RI.r_extern = (ARI.r_word1 >> 27) & 1;
-    RI.r_type = (ARI.r_word1 >> 28);
+    if (ObjE == endianness::native) {
+      RI.r_pcrel = (ARI.r_word1 >> 24) & 1;
+      RI.r_length = (ARI.r_word1 >> 25) & 3;
+      RI.r_extern = (ARI.r_word1 >> 27) & 1;
+      RI.r_type = (ARI.r_word1 >> 28);
+    } else {
+      RI.r_pcrel = (ARI.r_word1 >> 28) & 0x1;
+      RI.r_length = (ARI.r_word1 >> 26) & 0x3;
+      RI.r_extern = (ARI.r_word1 >> 25) & 0x1;
+      RI.r_type = (ARI.r_word1 >> 24) & 0xf;
+    }
     return RI;
   }
 

--- a/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
@@ -165,7 +165,7 @@ private:
       return make_error<JITLinkError>("arm64 SUBTRACTOR without paired "
                                       "UNSIGNED relocation");
 
-    auto UnsignedRI = getRelocationInfo(UnsignedRelItr);
+    auto UnsignedRI = getRelocationInfo<endianness::little>(UnsignedRelItr);
 
     if (SubRI.r_address != UnsignedRI.r_address)
       return make_error<JITLinkError>("arm64 SUBTRACTOR and paired UNSIGNED "
@@ -288,7 +288,8 @@ private:
       for (auto RelItr = S.relocation_begin(), RelEnd = S.relocation_end();
            RelItr != RelEnd; ++RelItr) {
 
-        MachO::relocation_info RI = getRelocationInfo(RelItr);
+        MachO::relocation_info RI =
+            getRelocationInfo<endianness::little>(RelItr);
 
         // Validate the relocation kind.
         auto MachORelocKind = getRelocationKind(RI);
@@ -337,7 +338,7 @@ private:
           if (RelItr == RelEnd)
             return make_error<JITLinkError>("Unpaired Addend reloc at " +
                                             formatv("{0:x16}", FixupAddress));
-          RI = getRelocationInfo(RelItr);
+          RI = getRelocationInfo<endianness::little>(RelItr);
 
           MachORelocKind = getRelocationKind(RI);
           if (!MachORelocKind)

--- a/llvm/lib/ExecutionEngine/JITLink/MachO_x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachO_x86_64.cpp
@@ -140,7 +140,7 @@ private:
       return make_error<JITLinkError>("x86_64 SUBTRACTOR without paired "
                                       "UNSIGNED relocation");
 
-    auto UnsignedRI = getRelocationInfo(UnsignedRelItr);
+    auto UnsignedRI = getRelocationInfo<endianness::little>(UnsignedRelItr);
 
     if (SubRI.r_address != UnsignedRI.r_address)
       return make_error<JITLinkError>("x86_64 SUBTRACTOR and paired UNSIGNED "
@@ -264,7 +264,8 @@ private:
       for (auto RelItr = S.relocation_begin(), RelEnd = S.relocation_end();
            RelItr != RelEnd; ++RelItr) {
 
-        MachO::relocation_info RI = getRelocationInfo(RelItr);
+        MachO::relocation_info RI =
+            getRelocationInfo<endianness::little>(RelItr);
 
         // Find the address of the value to fix up.
         auto FixupAddress = SectionAddress + (uint32_t)RI.r_address;


### PR DESCRIPTION
When reading r_pcrel, r_length, r_extern and r_type fields of any_relocation_info we need to take endianness into account.

This is an alternative fix the issue described in
for https://github.com/llvm/llvm-project/pull/167902. This fix avoids external calls and further dependence on MachOObject file.