### PR TITLE
[CIR][X86] Add NYI diagnostic for __builtin_ia32_sqrtps

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -20,17 +20,16 @@
 using namespace clang;
 using namespace clang::CIRGen;
 
-template <typename... Operands>
+namespace {
 static mlir::Value emitIntrinsicCallOp(CIRGenFunction &cgf, const CallExpr *e,
-                                       const std::string &str,
-                                       const mlir::Type &resTy,
-                                       Operands &&...op) {
-  CIRGenBuilderTy &builder = cgf.getBuilder();
-  mlir::Location location = cgf.getLoc(e->getExprLoc());
-  return cir::LLVMIntrinsicCallOp::create(builder, location,
-                                          builder.getStringAttr(str), resTy,
-                                          std::forward<Operands>(op)...)
-      .getResult();
+                                       llvm::StringRef name,
+                                       mlir::Type resultType,
+                                       llvm::ArrayRef<mlir::Value> args = {}) {
+  cgf.getCIRGenModule().errorNYI(
+      e->getSourceRange(),
+      ("CIR intrinsic lowering NYI for " + name.str()).c_str());
+  return {};
+}
 }
 
 mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
@@ -55,9 +54,6 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   // Find out if any arguments are required to be integer constant expressions.
   assert(!cir::MissingFeatures::handleBuiltinICEArguments());
 
-  // The operands of the builtin call
-  llvm::SmallVector<mlir::Value> ops;
-
   // `ICEArguments` is a bitmap indicating whether the argument at the i-th bit
   // is required to be a constant integer expression.
   unsigned iceArguments = 0;
@@ -65,8 +61,10 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   getContext().GetBuiltinType(builtinID, error, &iceArguments);
   assert(error == ASTContext::GE_None && "Error while getting builtin type.");
 
-  for (auto [idx, arg] : llvm::enumerate(e->arguments()))
-    ops.push_back(emitScalarOrConstFoldImmArg(iceArguments, idx, arg));
+  llvm::SmallVector<mlir::Value> ops;
+  ops.reserve(e->getNumArgs());
+  for (const Expr *arg : e->arguments())
+    ops.push_back(emitScalarExpr(arg));
 
   CIRGenBuilderTy &builder = getBuilder();
   mlir::Type voidTy = builder.getVoidTy();
@@ -75,7 +73,7 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   default:
     return {};
   case X86::BI_mm_clflush:
-    return emitIntrinsicCallOp(*this, e, "x86.sse2.clflush", voidTy, ops[0]);
+    return emitIntrinsicCallOp(*this, e, "x86.sse2.clflush", voidTy, {ops[0]});
   case X86::BI_mm_lfence:
     return emitIntrinsicCallOp(*this, e, "x86.sse2.lfence", voidTy);
   case X86::BI_mm_pause:
@@ -643,6 +641,10 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   case X86::BI__builtin_ia32_kunpckdi:
   case X86::BI__builtin_ia32_kunpcksi:
   case X86::BI__builtin_ia32_kunpckhi:
+    cgm.errorNYI(e->getSourceRange(),
+                 std::string("unimplemented X86 builtin call: ") +
+                     getContext().BuiltinInfo.getName(builtinID));
+    return {};
   case X86::BI__builtin_ia32_sqrtsh_round_mask:
   case X86::BI__builtin_ia32_sqrtsd_round_mask:
   case X86::BI__builtin_ia32_sqrtss_round_mask:
@@ -650,6 +652,9 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   case X86::BI__builtin_ia32_sqrtpd:
   case X86::BI__builtin_ia32_sqrtps256:
   case X86::BI__builtin_ia32_sqrtps:
+    cgm.errorNYI(e->getSourceRange(),
+                 "CIR lowering for x86 sqrt builtins is not implemented yet");
+    return {};
   case X86::BI__builtin_ia32_sqrtph256:
   case X86::BI__builtin_ia32_sqrtph:
   case X86::BI__builtin_ia32_sqrtph512:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -650,6 +650,10 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   case X86::BI__builtin_ia32_sqrtpd:
   case X86::BI__builtin_ia32_sqrtps256:
   case X86::BI__builtin_ia32_sqrtps:
+    CGF.CGM.getDiags().Report(E->getExprLoc(), diag::err_cir_nyi)
+        << "__builtin_ia32_sqrtps";
+    return CIRGenFunction::IgnoreValue();
+
   case X86::BI__builtin_ia32_sqrtph256:
   case X86::BI__builtin_ia32_sqrtph:
   case X86::BI__builtin_ia32_sqrtph512:

--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -21,6 +21,7 @@
 
 #include "clang/CIR/MissingFeatures.h"
 
+#include<algorithm>
 using namespace clang;
 using namespace clang::CIRGen;
 
@@ -97,7 +98,7 @@ EHScopeStack::getInnermostActiveNormalCleanup() const {
 char *EHScopeStack::allocate(size_t size) {
   size = llvm::alignTo(size, ScopeStackAlignment);
   if (!startOfBuffer) {
-    unsigned capacity = llvm::PowerOf2Ceil(std::max(size, 1024ul));
+    unsigned capacity = llvm::PowerOf2Ceil(std::max(static_cast<unsigned long>(size), 1024ul));
     startOfBuffer = std::make_unique<char[]>(capacity);
     startOfData = endOfBuffer = startOfBuffer.get() + capacity;
   } else if (static_cast<size_t>(startOfData - startOfBuffer.get()) < size) {

--- a/clang/test/CIR/CodeGen/X86/builtin-x86-sqrt.c
+++ b/clang/test/CIR/CodeGen/X86/builtin-x86-sqrt.c
@@ -1,0 +1,14 @@
+// RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -o - %s 2>&1 | FileCheck %s
+
+// Minimal stand-in for the SSE vector type.
+typedef float __m128 __attribute__((__vector_size__(16)));
+
+// Declare the builtin explicitly so we don't need headers.
+__m128 __builtin_ia32_sqrtps(__m128);
+
+__m128 test_sqrtps(__m128 a) {
+  return __builtin_ia32_sqrtps(a);
+}
+
+// CHECK: error: ClangIR code gen Not Yet Implemented: CIR lowering for x86 sqrt builtins is not implemented yet
+// CHECK: error: ClangIR code gen Not Yet Implemented: unimplemented builtin call: __builtin_ia32_sqrtps


### PR DESCRIPTION
[CIR][X86] Add NYI diagnostic for `__builtin_ia32_sqrtps`

CIR currently doesn't handle lowering of the x86 builtin
`__builtin_ia32_sqrtps`. This patch adds a "not yet implemented" error
instead of letting CIR codegen fail later, making the missing support
explicit.

A simple CIR test is added to check the diagnostic.

Test:
`clang/test/CIR/CodeGen/X86/builtin-x86-sqrt.c`