### PR TITLE
[JITLink][MachO][AArch64] Specify endianness, fix name of testcase.

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_ptrauth_noalloc_sections.yaml
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/MachO_ptrauth_noalloc_sections.yaml
@@ -16,6 +16,7 @@
 # CHECK: llvm-jitlink error: {{.*}} unsupported edge kind Pointer64Authenticated
 
 --- !mach-o
+IsLittleEndian: true
 FileHeader:
   magic:           0xFEEDFACF
   cputype:         0x100000C


### PR DESCRIPTION
The "MachO_ptrauth_noolloc_sections.yaml" testcase had a typo in the name, and didn't explicitly specify its endianness. This was causing it to fail when enabled on big endian platforms.

See conversation in https://github.com/llvm/llvm-project/pull/167902