### PR TITLE
[MLIR] Fix empty optional access in DialectConversion

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2766,7 +2766,7 @@ LogicalResult OperationLegalizer::legalizeWithPattern(Operation *op) {
       rewriterImpl.patternMaterializations.clear();
 #if MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS
       // Expensive pattern check that can detect API violations.
-      if (checkOp) {
+      if (checkOp && topLevelFingerPrint) {
         OperationFingerPrint fingerPrintAfterPattern(checkOp);
         if (fingerPrintAfterPattern != *topLevelFingerPrint)
           llvm::report_fatal_error("pattern '" + pattern.getDebugName() +


### PR DESCRIPTION
When both `MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS` and MLIR multithreading are enabled, `topLevelFingerPrint` is empty but its value is accessed. This adds a `has_value()` check before dereferencing the optional.