### PR TITLE
[clang] Add break/continue stmts with missing lable to the AST

### DIFF
--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2313,10 +2313,8 @@ StmtResult Parser::ParseBreakOrContinueStatement(bool IsContinue) {
       // TODO: Make this a compatibility/extension warning instead once the
       // syntax of this feature is finalised.
       Diag(LabelLoc, diag::err_c2y_labeled_break_continue) << IsContinue;
-    if (!Target) {
+    if (!Target)
       Diag(LabelLoc, diag::err_break_continue_label_not_found) << IsContinue;
-      return StmtError();
-    }
   }
 
   if (IsContinue)

--- a/clang/test/SemaCXX/labeled-break-continue-constexpr.cpp
+++ b/clang/test/SemaCXX/labeled-break-continue-constexpr.cpp
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -fnamed-loops -std=c++23 -fsyntax-only -verify %s
 // RUN: %clang_cc1 -fnamed-loops -std=c++23 -fsyntax-only -verify %s -fexperimental-new-constant-interpreter
-// expected-no-diagnostics
 
 struct Tracker {
   bool& destroyed;
@@ -168,3 +167,12 @@ constexpr T f12() {
 }
 static_assert(f12<int>() == 93);
 static_assert(f12<unsigned>() == 93u);
+
+
+constexpr int labelNotFound() {
+  a: for (;;) {
+    break azzz; // expected-error {{'break' label does not name an enclosing loop or 'switch'}}
+  }
+  return 1;
+}
+static_assert(labelNotFound() == 1);


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/156801

We can't return a `RecoveryExpr` here since the functions returns a `StmtResult`. Just add those statements to the AST without the target.

I'm not entirely sure if we should do the same thing in `Sema::ActOnBreakStmt`, but I think so.