### PR TITLE
[ORC] Move DebugObjectManagerPlugin into Debugging/ELFDebugObjectPlugin (NFC)

### DIFF
--- a/clang/lib/Interpreter/IncrementalExecutor.cpp
+++ b/clang/lib/Interpreter/IncrementalExecutor.cpp
@@ -18,7 +18,6 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
-#include "llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h"
 #include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h"
 #include "llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h"
 #include "llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h"

--- a/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/RemoteJITUtils.cpp
+++ b/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/RemoteJITUtils.cpp
@@ -9,8 +9,7 @@
 #include "RemoteJITUtils.h"
 
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h"
-#include "llvm/ExecutionEngine/Orc/EPCDebugObjectRegistrar.h"
+#include "llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h"
 #include "llvm/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.h"
 #include "llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.h"

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h
@@ -24,7 +24,7 @@ namespace orc {
 /// For each object containing debug info, installs JITLink passes to synthesize
 /// a debug object and then register it via the GDB JIT-registration interface.
 ///
-/// Currently MachO only. For ELF use DebugObjectManagerPlugin. These two
+/// Currently MachO only. For ELF use ELFDebugObjectPlugin. These two
 /// plugins will be merged in the near future.
 class LLVM_ABI GDBJITDebugInfoRegistrationPlugin
     : public ObjectLinkingLayer::Plugin {

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h
@@ -1,4 +1,4 @@
-//===---- DebugObjectManagerPlugin.h - JITLink debug objects ---*- C++ -*-===//
+//===---- ELFDebugObjectPlugin.h - JITLink debug objects ---*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_EXECUTIONENGINE_ORC_DEBUGOBJECTMANAGERPLUGIN_H
-#define LLVM_EXECUTIONENGINE_ORC_DEBUGOBJECTMANAGERPLUGIN_H
+#ifndef LLVM_EXECUTIONENGINE_ORC_ELFDEBUGOBJECTPLUGIN_H
+#define LLVM_EXECUTIONENGINE_ORC_ELFDEBUGOBJECTPLUGIN_H
 
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
@@ -46,7 +46,7 @@ class DebugObject;
 /// DebugObjectRegistrar is notified. Ownership of DebugObjects remains with the
 /// plugin.
 ///
-class LLVM_ABI DebugObjectManagerPlugin : public ObjectLinkingLayer::Plugin {
+class LLVM_ABI ELFDebugObjectPlugin : public ObjectLinkingLayer::Plugin {
 public:
   /// Create the plugin to submit DebugObjects for JITLink artifacts. For all
   /// options the recommended setting is true.
@@ -63,9 +63,9 @@ public:
   ///   sequence. When turning this off, the user has to issue the call to
   ///   __jit_debug_register_code() on the executor side manually.
   ///
-  DebugObjectManagerPlugin(ExecutionSession &ES, bool RequireDebugSections,
-                           bool AutoRegisterCode, Error &Err);
-  ~DebugObjectManagerPlugin() override;
+  ELFDebugObjectPlugin(ExecutionSession &ES, bool RequireDebugSections,
+                       bool AutoRegisterCode, Error &Err);
+  ~ELFDebugObjectPlugin() override;
 
   void notifyMaterializing(MaterializationResponsibility &MR,
                            jitlink::LinkGraph &G, jitlink::JITLinkContext &Ctx,
@@ -99,4 +99,4 @@ private:
 } // namespace orc
 } // namespace llvm
 
-#endif // LLVM_EXECUTIONENGINE_ORC_DEBUGOBJECTMANAGERPLUGIN_H
+#endif // LLVM_EXECUTIONENGINE_ORC_ELFDEBUGOBJECTPLUGIN_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h
@@ -1,4 +1,4 @@
-//===---- ELFDebugObjectPlugin.h - JITLink debug objects ---*- C++ -*-===//
+//===------ ELFDebugObjectPlugin.h - JITLink debug objects ------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/lib/ExecutionEngine/Orc/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/CMakeLists.txt
@@ -14,7 +14,6 @@ add_llvm_component_library(LLVMOrcJIT
   CompileOnDemandLayer.cpp
   CompileUtils.cpp
   Core.cpp
-  DebugObjectManagerPlugin.cpp
   DebugUtils.cpp
   EHFrameRegistrationPlugin.cpp
   EPCDynamicLibrarySearchGenerator.cpp

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_component_library(LLVMOrcDebugging
   DebugInfoSupport.cpp
   DebuggerSupport.cpp
   DebuggerSupportPlugin.cpp
+  ELFDebugObjectPlugin.cpp
   LLJITUtilsCBindings.cpp
   PerfSupportPlugin.cpp
   VTuneSupportPlugin.cpp

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/DebuggerSupport.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h"
-#include "llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h"
 #include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h"
+#include "llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 
 #define DEBUG_TYPE "orc"
@@ -36,8 +36,8 @@ Error enableDebuggerSupport(LLJIT &J) {
   switch (TT.getObjectFormat()) {
   case Triple::ELF: {
     Error TargetSymErr = Error::success();
-    ObjLinkingLayer->addPlugin(std::make_unique<DebugObjectManagerPlugin>(
-        ES, false, true, TargetSymErr));
+    ObjLinkingLayer->addPlugin(
+        std::make_unique<ELFDebugObjectPlugin>(ES, false, true, TargetSymErr));
     return TargetSymErr;
   }
   case Triple::MachO: {

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp
@@ -1,4 +1,4 @@
-//===------- DebugObjectManagerPlugin.cpp - JITLink debug objects ---------===//
+//===------- ELFDebugObjectPlugin.cpp - JITLink debug objects ---------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h"
+#include "llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringMap.h"
@@ -406,10 +406,9 @@ createDebugObjectFromBuffer(ExecutionSession &ES, LinkGraph &G,
   }
 }
 
-DebugObjectManagerPlugin::DebugObjectManagerPlugin(ExecutionSession &ES,
-                                                   bool RequireDebugSections,
-                                                   bool AutoRegisterCode,
-                                                   Error &Err)
+ELFDebugObjectPlugin::ELFDebugObjectPlugin(ExecutionSession &ES,
+                                           bool RequireDebugSections,
+                                           bool AutoRegisterCode, Error &Err)
     : ES(ES), RequireDebugSections(RequireDebugSections),
       AutoRegisterCode(AutoRegisterCode) {
   // Pass bootstrap symbol for registration function to enable debugging
@@ -418,9 +417,9 @@ DebugObjectManagerPlugin::DebugObjectManagerPlugin(ExecutionSession &ES,
       {{RegistrationAction, rt::RegisterJITLoaderGDBAllocActionName}});
 }
 
-DebugObjectManagerPlugin::~DebugObjectManagerPlugin() = default;
+ELFDebugObjectPlugin::~ELFDebugObjectPlugin() = default;
 
-void DebugObjectManagerPlugin::notifyMaterializing(
+void ELFDebugObjectPlugin::notifyMaterializing(
     MaterializationResponsibility &MR, LinkGraph &G, JITLinkContext &Ctx,
     MemoryBufferRef ObjBuffer) {
   std::lock_guard<std::mutex> Lock(PendingObjsLock);
@@ -443,9 +442,9 @@ void DebugObjectManagerPlugin::notifyMaterializing(
   }
 }
 
-void DebugObjectManagerPlugin::modifyPassConfig(
-    MaterializationResponsibility &MR, LinkGraph &G,
-    PassConfiguration &PassConfig) {
+void ELFDebugObjectPlugin::modifyPassConfig(MaterializationResponsibility &MR,
+                                            LinkGraph &G,
+                                            PassConfiguration &PassConfig) {
   // Not all link artifacts have associated debug objects.
   std::lock_guard<std::mutex> Lock(PendingObjsLock);
   auto It = PendingObjs.find(&MR);
@@ -507,16 +506,15 @@ void DebugObjectManagerPlugin::modifyPassConfig(
   }
 }
 
-Error DebugObjectManagerPlugin::notifyFailed(
-    MaterializationResponsibility &MR) {
+Error ELFDebugObjectPlugin::notifyFailed(MaterializationResponsibility &MR) {
   std::lock_guard<std::mutex> Lock(PendingObjsLock);
   PendingObjs.erase(&MR);
   return Error::success();
 }
 
-void DebugObjectManagerPlugin::notifyTransferringResources(JITDylib &JD,
-                                                           ResourceKey DstKey,
-                                                           ResourceKey SrcKey) {
+void ELFDebugObjectPlugin::notifyTransferringResources(JITDylib &JD,
+                                                       ResourceKey DstKey,
+                                                       ResourceKey SrcKey) {
   // Debug objects are stored by ResourceKey only after registration.
   // Thus, pending objects don't need to be updated here.
   std::lock_guard<std::mutex> Lock(RegisteredObjsLock);
@@ -530,8 +528,8 @@ void DebugObjectManagerPlugin::notifyTransferringResources(JITDylib &JD,
   }
 }
 
-Error DebugObjectManagerPlugin::notifyRemovingResources(JITDylib &JD,
-                                                        ResourceKey Key) {
+Error ELFDebugObjectPlugin::notifyRemovingResources(JITDylib &JD,
+                                                    ResourceKey Key) {
   // Removing the resource for a pending object fails materialization, so they
   // get cleaned up in the notifyFailed() handler.
   std::lock_guard<std::mutex> Lock(RegisteredObjsLock);

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -17,9 +17,9 @@
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX, LLVM_ENABLE_THREADS
 #include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
 #include "llvm/ExecutionEngine/Orc/COFFPlatform.h"
-#include "llvm/ExecutionEngine/Orc/DebugObjectManagerPlugin.h"
 #include "llvm/ExecutionEngine/Orc/Debugging/DebugInfoSupport.h"
 #include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupportPlugin.h"
+#include "llvm/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.h"
 #include "llvm/ExecutionEngine/Orc/Debugging/PerfSupportPlugin.h"
 #include "llvm/ExecutionEngine/Orc/Debugging/VTuneSupportPlugin.h"
 #include "llvm/ExecutionEngine/Orc/EHFrameRegistrationPlugin.h"
@@ -1299,8 +1299,8 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
       ObjLayer.addPlugin(ExitOnErr(EHFrameRegistrationPlugin::Create(ES)));
     if (DebuggerSupport) {
       Error TargetSymErr = Error::success();
-      auto Plugin = std::make_unique<DebugObjectManagerPlugin>(ES, true, true,
-                                                               TargetSymErr);
+      auto Plugin =
+          std::make_unique<ELFDebugObjectPlugin>(ES, true, true, TargetSymErr);
       if (!TargetSymErr)
         ObjLayer.addPlugin(std::move(Plugin));
       else

--- a/llvm/utils/gn/secondary/llvm/lib/ExecutionEngine/Orc/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/ExecutionEngine/Orc/BUILD.gn
@@ -22,7 +22,7 @@ static_library("Orc") {
     "CompileOnDemandLayer.cpp",
     "CompileUtils.cpp",
     "Core.cpp",
-    "DebugObjectManagerPlugin.cpp",
+    "ELFDebugObjectPlugin.cpp",
     "DebugUtils.cpp",
     "EHFrameRegistrationPlugin.cpp",
     "ELFNixPlatform.cpp",


### PR DESCRIPTION
In 4 years the plugin wasn't adapted to other object formats. This patch makes it specific for ELF, which will allow to remove some abstractions down the line. It also moves the plugin from LLVMOrcJIT into LLVMOrcDebugging, which didn't exist back then.