### PR TITLE
[TableGen] Strip directories from filename prefixes.

### DIFF
--- a/llvm/lib/TableGen/Main.cpp
+++ b/llvm/lib/TableGen/Main.cpp
@@ -167,8 +167,7 @@ int llvm::TableGenMain(const char *argv0,
 
   // Write output to memory.
   Timer.startBackendTimer("Backend overall");
-  SmallString<128> FilenamePrefix(OutputFilename);
-  sys::path::replace_extension(FilenamePrefix, "");
+  SmallString<128> FilenamePrefix(sys::path::stem(OutputFilename));
   TableGenOutputFiles OutFiles;
   unsigned status = 0;
   // ApplyCallback will return true if it did not apply any callback. In that


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/pull/167700 to support
builds where TableGen's output file is specified as full path
rather than just filename.