### PR TITLE
Revert "[clang][SourceManager] Use `getFileLoc` when computing `getPresumedLoc`"

### DIFF
--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -1464,9 +1464,8 @@ public:
   /// directives.  This provides a view on the data that a user should see
   /// in diagnostics, for example.
   ///
-  /// If \p Loc is a macro expansion location, the presumed location
-  /// computation uses the spelling location for macro arguments and the
-  /// expansion location for other macro expansions.
+  /// Note that a presumed location is always given as the expansion point of
+  /// an expansion location, not at the spelling location.
   ///
   /// \returns The presumed location of the specified SourceLocation. If the
   /// presumed location cannot be calculated (e.g., because \p Loc is invalid

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -1435,7 +1435,7 @@ PresumedLoc SourceManager::getPresumedLoc(SourceLocation Loc,
   if (Loc.isInvalid()) return PresumedLoc();
 
   // Presumed locations are always for expansion points.
-  FileIDAndOffset LocInfo = getDecomposedLoc(getFileLoc(Loc));
+  FileIDAndOffset LocInfo = getDecomposedExpansionLoc(Loc);
 
   bool Invalid = false;
   const SLocEntry &Entry = getSLocEntry(LocInfo.first, &Invalid);

--- a/clang/test/Analysis/plist-macros-with-expansion.cpp
+++ b/clang/test/Analysis/plist-macros-with-expansion.cpp
@@ -405,14 +405,14 @@ void commaInBracketsTest() {
   code
 
 void commaInBracesTest() {
-  PASTE_CODE({
+  PASTE_CODE({ // expected-warning{{Dereference of null pointer}}
     // NOTE: If we were to add a new variable here after a comma, we'd get a
     // compilation error, so this test is mainly here to show that this was also
     // investigated.
     //
     // int *ptr = nullptr, a;
     int *ptr = nullptr;
-    *ptr = 5; // expected-warning{{Dereference of null pointer}}
+    *ptr = 5;
   })
 }
 
@@ -425,14 +425,14 @@ void commaInBracesTest() {
 // CHECK-NEXT:      <key>col</key><integer>3</integer>
 // CHECK-NEXT:      <key>file</key><integer>0</integer>
 // CHECK-NEXT:     </dict>
-// CHECK-NEXT:     <key>name</key><string>PASTE_CODE({
+// CHECK-NEXT:     <key>name</key><string>PASTE_CODE({ // expected-
 // CHECK-NEXT:    // NOTE: If we were to add a new variable here after a comma, we&apos;d get a
 // CHECK-NEXT:    // compilation error, so this test is mainly here to show that this was also
 // CHECK-NEXT:    // investigated.
 // CHECK-NEXT:    //
 // CHECK-NEXT:    // int *ptr = nullptr, a;
 // CHECK-NEXT:    int *ptr = nullptr;
-// CHECK-NEXT:    *ptr = 5; // expected-
+// CHECK-NEXT:    *ptr = 5;
 // CHECK-NEXT:  })</string>
 // CHECK-NEXT:     <key>expansion</key><string>{int *ptr =nullptr ;*ptr =5;}</string>
 // CHECK-NEXT:    </dict>

--- a/clang/test/C/C23/n2350.c
+++ b/clang/test/C/C23/n2350.c
@@ -47,10 +47,11 @@ int struct_in_second_param(void) {
 
 int macro(void) {
   return offsetof(struct A // cpp-error {{'A' cannot be defined in a type specifier}} \
-                              expected-warning {{defining a type within 'offsetof' is a C23 extension}}
+                              expected-warning 2 {{defining a type within 'offsetof' is a C23 extension}}
   {
     int a;
-    struct B // expected-warning {{defining a type within 'offsetof' is a C23 extension}}
+    struct B // verifier seems to think the error is emitted by the macro
+             // In fact the location of the error is "B" on the line above
     {
       int c;
       int d;

--- a/clang/test/ExtractAPI/macro_undefined.c
+++ b/clang/test/ExtractAPI/macro_undefined.c
@@ -89,7 +89,7 @@ FUNC_GEN(bar, const int *, unsigned);
       },
       "location": {
         "position": {
-          "character": 9,
+          "character": 0,
           "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
@@ -241,7 +241,7 @@ FUNC_GEN(bar, const int *, unsigned);
       },
       "location": {
         "position": {
-          "character": 9,
+          "character": 0,
           "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"

--- a/clang/test/FixIt/format.cpp
+++ b/clang/test/FixIt/format.cpp
@@ -56,9 +56,9 @@ void a(N::E NEVal, S *SPtr, S &SRef) {
   // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:7-[[@LINE-2]]:7}:"static_cast<int>("
   // CHECK: fix-it:"{{.*}}":{[[@LINE-3]]:17-[[@LINE-3]]:17}:")"
 
-  LOG(
+  LOG( // expected-warning{{format specifies type 'int' but the argument has type 'N::E'}}
       "%d",
-      SPtr->Type // expected-warning{{format specifies type 'int' but the argument has type 'N::E'}}
+      SPtr->Type
   );
   // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:7-[[@LINE-2]]:7}:"static_cast<int>("
   // CHECK: fix-it:"{{.*}}":{[[@LINE-3]]:17-[[@LINE-3]]:17}:")"
@@ -68,8 +68,8 @@ void a(N::E NEVal, S *SPtr, S &SRef) {
   // CHECK: fix-it:"{{.*}}":{[[@LINE-1]]:7-[[@LINE-1]]:7}:"static_cast<int>("
   // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:16-[[@LINE-2]]:16}:")"
 
-  LOG("%d",
-      SRef.Type); // expected-warning{{format specifies type 'int' but the argument has type 'N::E'}}
+  LOG("%d", // expected-warning{{format specifies type 'int' but the argument has type 'N::E'}}
+      SRef.Type);
   // CHECK: fix-it:"{{.*}}":{[[@LINE-1]]:7-[[@LINE-1]]:7}:"static_cast<int>("
   // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:16-[[@LINE-2]]:16}:")"
 

--- a/clang/test/Preprocessor/macro_arg_directive.c
+++ b/clang/test/Preprocessor/macro_arg_directive.c
@@ -18,7 +18,7 @@ void fail(const char *);
  ({ int result = 0; __VA_ARGS__; if (!result) { fail(#__VA_ARGS__); }; result })
 
 static inline int f(int k) {
-  return MUNCH( // expected-note {{to match this '('}} expected-error {{returning 'void'}} expected-note {{expansion of macro 'MUNCH' requested here}}
+  return MUNCH( // expected-error {{expected ')'}} expected-note {{to match this '('}} expected-error {{returning 'void'}} expected-note {{expansion of macro 'MUNCH' requested here}}
     if (k < 3)
       result = 24;
     else if (k > 4)
@@ -27,6 +27,6 @@ static inline int f(int k) {
 
 #include "macro_arg_directive.h" // expected-error {{embedding a #include directive within macro arguments is not supported}}
 
-int g(int k) { // expected-error {{expected ')'}}
+int g(int k) {
   return f(k) + f(k-1));
 }

--- a/clang/test/Preprocessor/print_line_track.c
+++ b/clang/test/Preprocessor/print_line_track.c
@@ -1,9 +1,9 @@
-/* RUN: %clang_cc1 -E %s | grep -z 'a.3'
- * RUN: %clang_cc1 -E %s | grep -z 'b.16'
- * RUN: %clang_cc1 -E -P %s | grep -z 'a.3'
- * RUN: %clang_cc1 -E -P %s | grep -z 'b.16'
+/* RUN: %clang_cc1 -E %s | grep 'a 3'
+ * RUN: %clang_cc1 -E %s | grep 'b 16'
+ * RUN: %clang_cc1 -E -P %s | grep 'a 3'
+ * RUN: %clang_cc1 -E -P %s | grep 'b 16'
  * RUN: %clang_cc1 -E %s | not grep '# 0 '
- * RUN: %clang_cc1 -E -P %s | count 4
+ * RUN: %clang_cc1 -E -P %s | count 2
  * PR1848 PR3437 PR7360
 */
 
@@ -14,3 +14,4 @@ t(a
 
 t(b
 __LINE__)
+


### PR DESCRIPTION
Reverts llvm/llvm-project#166255

It broke bots:
https://lab.llvm.org/buildbot/#/builders/190/builds/31102