### PR TITLE
[XRay] Run tests inside bootstrapping build

### DIFF
--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -16,6 +16,13 @@ pythonize_bool(COMPILER_RT_HAS_AARCH64_SME)
 
 pythonize_bool(COMPILER_RT_HAS_NO_DEFAULT_CONFIG_FLAG)
 
+if(LLVM_TREE_AVAILABLE OR NOT COMPILER_RT_STANDALONE_BUILD)
+  set(COMPILER_RT_BUILT_WITH_LLVM TRUE)
+else()
+  set(COMPILER_RT_BUILT_WITH_LLVM FALSE)
+endif()
+pythonize_bool(COMPILER_RT_BUILT_WITH_LLVM)
+
 configure_compiler_rt_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.common.configured.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.common.configured)

--- a/compiler-rt/test/xray/lit.site.cfg.py.in
+++ b/compiler-rt/test/xray/lit.site.cfg.py.in
@@ -5,7 +5,7 @@ config.name_suffix = "@XRAY_TEST_CONFIG_SUFFIX@"
 config.xray_lit_source_dir = "@XRAY_LIT_SOURCE_DIR@"
 config.target_cflags = "@XRAY_TEST_TARGET_CFLAGS@"
 config.target_arch = "@XRAY_TEST_TARGET_ARCH@"
-config.built_with_llvm = ("@COMPILER_RT_STANDALONE_BUILD@" != "TRUE")
+config.built_with_llvm = ("@COMPILER_RT_STANDALONE_BUILD AND NOT LLVM_TREE_AVAILABLE@" != "TRUE")
 
 # TODO: Look into whether we can run a capability test on the standalone build to
 # see whether it can run 'llvm-xray convert' instead of turning off tests for a

--- a/compiler-rt/test/xray/lit.site.cfg.py.in
+++ b/compiler-rt/test/xray/lit.site.cfg.py.in
@@ -5,7 +5,7 @@ config.name_suffix = "@XRAY_TEST_CONFIG_SUFFIX@"
 config.xray_lit_source_dir = "@XRAY_LIT_SOURCE_DIR@"
 config.target_cflags = "@XRAY_TEST_TARGET_CFLAGS@"
 config.target_arch = "@XRAY_TEST_TARGET_ARCH@"
-config.built_with_llvm = ("@COMPILER_RT_STANDALONE_BUILD AND NOT LLVM_TREE_AVAILABLE@" != "TRUE")
+config.built_with_llvm = "@COMPILER_RT_BUILT_WITH_LLVM@"
 
 # TODO: Look into whether we can run a capability test on the standalone build to
 # see whether it can run 'llvm-xray convert' instead of turning off tests for a


### PR DESCRIPTION
COMPILER_RT_STANDALONE_BUILD is set when doing a bootstrapping build through LLVM_ENABLE_RUNTIMES with the CMake source directory being in llvm/. This patch changes the XRay tests to also detect that we have LLVM sources and the llvm-xray tool if we are in a bootstrapping build through the use of the LLVM_TREE_AVAILABLE variable which is set in runtimes/CMakeLists.txt.