### PR TITLE
[flang][NFC] Strip trailing whitespace from tests (6 of N)

### DIFF
--- a/flang/test/Lower/PowerPC/ppc-vec-load-elem-order.f90
+++ b/flang/test/Lower/PowerPC/ppc-vec-load-elem-order.f90
@@ -394,7 +394,7 @@ subroutine vec_xl_testi8a(arg1, arg2, res)
   vector(integer(1)) :: res
   res = vec_xl(arg1, arg2)
 
-  
+
 ! LLVMIR: %[[arg1:.*]] = load i8, ptr %0, align 1
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %1, i8 %[[arg1]]
 ! LLVMIR: %[[ld:.*]] = load <16 x i8>, ptr %[[addr]], align 1
@@ -481,7 +481,7 @@ subroutine vec_xl_be_testi8a(arg1, arg2, res)
   vector(integer(1)) :: res
   res = vec_xl_be(arg1, arg2)
 
-  
+
 ! LLVMIR: %4 = load i8, ptr %0, align 1
 ! LLVMIR: %5 = getelementptr i8, ptr %1, i8 %4
 ! LLVMIR: %6 = load <16 x i8>, ptr %5, align 1

--- a/flang/test/Lower/PowerPC/ppc-vec-sel.f90
+++ b/flang/test/Lower/PowerPC/ppc-vec-sel.f90
@@ -136,7 +136,7 @@ subroutine vec_sel_testu8(arg1, arg2, arg3)
   vector(unsigned(8)) :: arg1, arg2, r
   vector(unsigned(8)) :: arg3
   r = vec_sel(arg1, arg2, arg3)
-  
+
 
 ! LLVMIR: %[[arg1:.*]] = load <2 x i64>, ptr %{{.*}}, align 16
 ! LLVMIR: %[[arg2:.*]] = load <2 x i64>, ptr %{{.*}}, align 16

--- a/flang/test/Lower/PowerPC/ppc-vec-store-elem-order.f90
+++ b/flang/test/Lower/PowerPC/ppc-vec-store-elem-order.f90
@@ -14,7 +14,7 @@ subroutine vec_st_test(arg1, arg2, arg3)
 ! LLVMIR: %[[arg1:.*]] = load <8 x i16>, ptr %0, align 16
 ! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %2, i32 %[[arg2]]
-! LLVMIR: %[[bc:.*]] = bitcast <8 x i16> %[[arg1]] to <4 x i32> 
+! LLVMIR: %[[bc:.*]] = bitcast <8 x i16> %[[arg1]] to <4 x i32>
 ! LLVMIR: %[[shf:.*]] = shufflevector <4 x i32> %[[bc]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR:  call void @llvm.ppc.altivec.stvx(<4 x i32> %[[shf]], ptr %[[addr]])
 end subroutine vec_st_test
@@ -28,7 +28,7 @@ subroutine vec_ste_test(arg1, arg2, arg3)
   integer(4) :: arg2
   real(4) :: arg3
   call vec_ste(arg1, arg2, arg3)
-  
+
 ! LLVMIR: %[[arg1:.*]] = load <4 x float>, ptr %0, align 16
 ! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[addr]] = getelementptr i8, ptr %2, i32 %[[arg2]]

--- a/flang/test/Lower/PowerPC/ppc-vec-store.f90
+++ b/flang/test/Lower/PowerPC/ppc-vec-store.f90
@@ -300,7 +300,7 @@ subroutine vec_xst_test_vr4i2r4(arg1, arg2, arg3)
   real(4) :: arg3
   call vec_xst(arg1, arg2, arg3)
 
-  
+
 ! LLVMIR: %[[arg1:.*]] = load <4 x float>, ptr %{{.*}}, align 16
 ! LLVMIR: %[[arg2:.*]] = load i16, ptr %{{.*}}, align 2
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %{{.*}}, i16 %[[arg2]]
@@ -432,7 +432,7 @@ subroutine vec_xst_be_test_vi4i4vai4(arg1, arg2, arg3, i)
 ! LLVMIR: %[[iadd:.*]] = add nsw i64 %[[imul2]], 0
 ! LLVMIR: %[[gep1:.*]] = getelementptr <4 x i32>, ptr %2, i64 %[[iadd]]
 ! LLVMIR: %[[arg1:.*]] = load <4 x i32>, ptr %0, align 16
-! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4 
+! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[gep2:.*]] = getelementptr i8, ptr %[[gep1]], i32 %[[arg2]]
 ! LLVMIR: %[[src:.*]] = shufflevector <4 x i32> %[[arg1]], <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
 ! LLVMIR: store <4 x i32> %[[src]], ptr %[[gep2]], align 16
@@ -449,7 +449,7 @@ subroutine vec_xstd2_test_vr4i2r4(arg1, arg2, arg3)
   real(4) :: arg3
   call vec_xstd2(arg1, arg2, arg3)
 
-  
+
 ! LLVMIR: %[[arg1:.*]] = load <4 x float>, ptr %{{.*}}, align 16
 ! LLVMIR: %[[arg2:.*]] = load i16, ptr %{{.*}}, align 2
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %{{.*}}, i16 %[[arg2]]
@@ -509,7 +509,7 @@ subroutine vec_xstd2_test_vi4i4vai4(arg1, arg2, arg3, i)
 ! LLVMIR: %[[iadd:.*]] = add nsw i64 %[[imul2]], 0
 ! LLVMIR: %[[gep1:.*]] = getelementptr <4 x i32>, ptr %2, i64 %[[iadd]]
 ! LLVMIR: %[[arg1:.*]] = load <4 x i32>, ptr %0, align 16
-! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4 
+! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[gep2:.*]] = getelementptr i8, ptr %[[gep1]], i32 %[[arg2]]
 ! LLVMIR: %[[src:.*]] = bitcast <4 x i32> %[[arg1]] to <2 x i64>
 ! LLVMIR: store <2 x i64> %[[src]], ptr %[[gep2]], align 16
@@ -526,7 +526,7 @@ subroutine vec_xstw4_test_vr4i2r4(arg1, arg2, arg3)
   real(4) :: arg3
   call vec_xstw4(arg1, arg2, arg3)
 
-  
+
 ! LLVMIR: %[[arg1:.*]] = load <4 x float>, ptr %{{.*}}, align 16
 ! LLVMIR: %[[arg2:.*]] = load i16, ptr %{{.*}}, align 2
 ! LLVMIR: %[[addr:.*]] = getelementptr i8, ptr %{{.*}}, i16 %[[arg2]]
@@ -584,7 +584,7 @@ subroutine vec_xstw4_test_vi4i4vai4(arg1, arg2, arg3, i)
 ! LLVMIR: %[[iadd:.*]] = add nsw i64 %[[imul2]], 0
 ! LLVMIR: %[[gep1:.*]] = getelementptr <4 x i32>, ptr %2, i64 %[[iadd]]
 ! LLVMIR: %[[arg1:.*]] = load <4 x i32>, ptr %0, align 16
-! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4 
+! LLVMIR: %[[arg2:.*]] = load i32, ptr %1, align 4
 ! LLVMIR: %[[gep2:.*]] = getelementptr i8, ptr %[[gep1]], i32 %[[arg2]]
 ! LLVMIR: store <4 x i32> %[[arg1]], ptr %[[gep2]], align 16
 end subroutine vec_xstw4_test_vi4i4vai4

--- a/flang/test/Lower/allocatable-assignment.f90
+++ b/flang/test/Lower/allocatable-assignment.f90
@@ -283,14 +283,14 @@ end subroutine
 ! CHECK:           hlfir.assign %[[VAL_8]]#0 to %[[VAL_14]]#0 realloc keep_lhs_len : !fir.box<!fir.array<20x!fir.char<1,?>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
 
 subroutine test_derived_with_init(x, y)
-  type t 
+  type t
     integer, allocatable :: a(:)
-  end type                                                                                     
-  type(t), allocatable :: x                                                                    
-  type(t) :: y                                                                                 
+  end type
+  type(t), allocatable :: x
+  type(t) :: y
   ! The allocatable component of `x` need to be initialized
   ! during the automatic allocation (setting its rank and allocation
-  ! status) before it is assigned with the component of `y` 
+  ! status) before it is assigned with the component of `y`
   x = y
 end subroutine
 ! CHECK-LABEL:   func.func @_QMalloc_assignPtest_derived_with_init(
@@ -357,7 +357,7 @@ end module
 !  real :: y(2, 3) = reshape([1,2,3,4,5,6], [2,3])
 !  real, allocatable :: x (:, :)
 !  allocate(x(2,2))
-!  call test_with_lbounds(x, y) 
+!  call test_with_lbounds(x, y)
 !  print *, x(10, 20)
 !  print *, x
 !end

--- a/flang/test/Lower/allocatable-globals.f90
+++ b/flang/test/Lower/allocatable-globals.f90
@@ -12,7 +12,7 @@
 module mod_allocatables
   character(10), allocatable :: c(:)
 end module
-  
+
 ! CHECK-LABEL: func @_QPtest_mod_allocatables()
 subroutine test_mod_allocatables()
   use mod_allocatables, only: c

--- a/flang/test/Lower/allocatable-polymorphic.f90
+++ b/flang/test/Lower/allocatable-polymorphic.f90
@@ -460,7 +460,7 @@ contains
 ! CHECK: %[[X_DECL:.*]]:2 = hlfir.declare %[[X]](%{{.*}}) {uniq_name = "_QMpolyFtest_allocate_with_moldEx"} : (!fir.ref<!fir.array<10x!fir.type<_QMpolyTp2{p1:!fir.type<_QMpolyTp1{a:i32,b:i32}>,c:i32}>>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10x!fir.type<_QMpolyTp2{p1:!fir.type<_QMpolyTp1{a:i32,b:i32}>,c:i32}>>>, !fir.ref<!fir.array<10x!fir.type<_QMpolyTp2{p1:!fir.type<_QMpolyTp1{a:i32,b:i32}>,c:i32}>>>)
 
 ! CHECK: %[[EMBOX_X:.*]] = fir.embox %[[X_DECL]]#0(%{{.*}}) : (!fir.ref<!fir.array<10x!fir.type<_QMpolyTp2{p1:!fir.type<_QMpolyTp1{a:i32,b:i32}>,c:i32}>>>, !fir.shape<1>) -> !fir.box<!fir.array<10x!fir.type<_QMpolyTp2{p1:!fir.type<_QMpolyTp1{a:i32,b:i32}>,c:i32}>>>
-! CHECK: %[[RANK:.*]] = arith.constant 1 : i32 
+! CHECK: %[[RANK:.*]] = arith.constant 1 : i32
 ! CHECK: %[[P_BOX_NONE:.*]] = fir.convert %[[P_DECL]]#0 : (!fir.ref<!fir.class<!fir.ptr<!fir.array<?x!fir.type<_QMpolyTp1{a:i32,b:i32}>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK: %[[X_BOX_NONE:.*]] = fir.convert %[[EMBOX_X]] : (!fir.box<!fir.array<10x!fir.type<_QMpolyTp2{p1:!fir.type<_QMpolyTp1{a:i32,b:i32}>,c:i32}>>>) -> !fir.box<none>
 ! CHECK: fir.call @_FortranAPointerApplyMold(%[[P_BOX_NONE]], %[[X_BOX_NONE]], %[[RANK]]) {{.*}} : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32) -> ()
@@ -614,10 +614,10 @@ end
 ! LLVM: %[[TYPE_CODE:.*]] = load i8, ptr %[[TYPE_CODE_GEP]]
 ! LLVM-NEXT: %[[EXT_TYPE_CODE:.*]] = sext i8 %[[TYPE_CODE]] to i32
 ! LLVM: %{{.*}} = insertvalue { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] } undef, i64 %[[ELEM_SIZE]], 1
-! LLVM: %[[TRUNC_TYPE_CODE:.*]] = trunc i32 %[[EXT_TYPE_CODE]] to i8 
+! LLVM: %[[TRUNC_TYPE_CODE:.*]] = trunc i32 %[[EXT_TYPE_CODE]] to i8
 ! LLVM: %{{.*}} = insertvalue { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] } %{{.*}}, i8 %[[TRUNC_TYPE_CODE]], 4
 ! LLVM: store { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] } %{{.*}}, ptr %[[TMP:.*]]
-! LLVM: call void %{{.*}}(ptr %{{.*}}) 
+! LLVM: call void %{{.*}}(ptr %{{.*}})
 
 ! LLVM: call void @llvm.memcpy.p0.p0.i32
 ! LLVM: %[[GEP_TDESC_C2:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] }, ptr %{{.*}}, i32 0, i32 7
@@ -628,7 +628,7 @@ end
 ! LLVM: %[[TYPE_CODE:.*]] = load i8, ptr %[[TYPE_CODE_GEP]]
 ! LLVM-NEXT: %[[EXT_TYPE_CODE:.*]] = sext i8 %[[TYPE_CODE]] to i32
 ! LLVM: %{{.*}} = insertvalue { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] } undef, i64 %[[ELEM_SIZE]], 1
-! LLVM: %[[TRUNC_TYPE_CODE:.*]] = trunc i32 %[[EXT_TYPE_CODE]] to i8 
+! LLVM: %[[TRUNC_TYPE_CODE:.*]] = trunc i32 %[[EXT_TYPE_CODE]] to i8
 ! LLVM: %{{.*}} = insertvalue { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] } %{{.*}}, i8 %[[TRUNC_TYPE_CODE]], 4
 ! LLVM: store { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] } %{{.*}}, ptr %{{.*}}
 ! LLVM: call void %{{.*}}(ptr %{{.*}})

--- a/flang/test/Lower/allocated.f90
+++ b/flang/test/Lower/allocated.f90
@@ -15,4 +15,3 @@ subroutine allocated_test(scalar, array)
     ! CHECK: cmpi ne, %[[addrToInt1]], %c0{{.*}}
     print *, allocated(array)
   end subroutine
-  

--- a/flang/test/Lower/array-elemental-calls-2.f90
+++ b/flang/test/Lower/array-elemental-calls-2.f90
@@ -172,7 +172,7 @@ end subroutine
 subroutine check_parentheses_derived(a)
   type t
     integer :: i
-  end type  
+  end type
   interface
     integer elemental function elem_func_derived(x)
       import :: t

--- a/flang/test/Lower/array-elemental-calls.f90
+++ b/flang/test/Lower/array-elemental-calls.f90
@@ -57,7 +57,7 @@ subroutine test_loop_order(i, j)
       integer, intent(in) :: j
     end function
   end interface
-  
+
   i = 42 + pure_func(j)
   i = 42 + impure_func(j)
 end subroutine

--- a/flang/test/Lower/array-expression-assumed-size.f90
+++ b/flang/test/Lower/array-expression-assumed-size.f90
@@ -16,8 +16,8 @@ end subroutine assumed_size_forall_test
 
 ! CHECK-LABEL: func @_QPassumed_size_test(
 ! CHECK-SAME:    %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>{{.*}}) {
-! CHECK:         %[[VAL_1A:.*]] = fir.convert %c10{{.*}} : (i64) -> index 
-! CHECK:         %[[VAL_1B:.*]] = arith.cmpi sgt, %[[VAL_1A]], %c0{{.*}} : index 
+! CHECK:         %[[VAL_1A:.*]] = fir.convert %c10{{.*}} : (i64) -> index
+! CHECK:         %[[VAL_1B:.*]] = arith.cmpi sgt, %[[VAL_1A]], %c0{{.*}} : index
 ! CHECK:         %[[VAL_1:.*]] = arith.select %[[VAL_1B]], %[[VAL_1A]], %c0{{.*}} : index
 ! CHECK:         %[[VAL_2:.*]] = fir.assumed_size_extent : index
 ! CHECK:         %[[VAL_3:.*]] = arith.constant 1 : index
@@ -79,8 +79,8 @@ end subroutine assumed_size_forall_test
 ! CHECK-LABEL: func @_QPassumed_size_forall_test(
 ! CHECK-SAME:       %[[VAL_0:.*]]: !fir.ref<!fir.array<10x?xi32>>{{.*}}) {
 ! CHECK:         %[[VAL_1:.*]] = fir.alloca i32 {adapt.valuebyref, bindc_name = "i"}
-! CHECK:         %[[VAL_2A:.*]] = fir.convert %c10{{.*}} : (i64) -> index 
-! CHECK:         %[[VAL_2B:.*]] = arith.cmpi sgt, %[[VAL_2A]], %c0{{.*}} : index 
+! CHECK:         %[[VAL_2A:.*]] = fir.convert %c10{{.*}} : (i64) -> index
+! CHECK:         %[[VAL_2B:.*]] = arith.cmpi sgt, %[[VAL_2A]], %c0{{.*}} : index
 ! CHECK:         %[[VAL_2:.*]] = arith.select %[[VAL_2B]], %[[VAL_2A]], %c0{{.*}} : index
 ! CHECK:         %[[VAL_3:.*]] = fir.assumed_size_extent : index
 ! CHECK:         %[[VAL_4:.*]] = arith.constant 2 : i32

--- a/flang/test/Lower/array-substring.f90
+++ b/flang/test/Lower/array-substring.f90
@@ -46,5 +46,5 @@ function test(C)
   logical :: test(1)
   character*12  C(1)
 
-  test = C(1:1)(1:8) == (/'ABCDabcd'/) 
+  test = C(1:1)(1:8) == (/'ABCDabcd'/)
 end function test

--- a/flang/test/Lower/array-wide-char.f90
+++ b/flang/test/Lower/array-wide-char.f90
@@ -2,7 +2,7 @@
 
 character(LEN=128, KIND=4), PARAMETER :: conarr(3) = &
      [ character(128,4) :: "now is the time", "for all good men to come", &
-     "to the aid of the country" ]       
+     "to the aid of the country" ]
 character(LEN=10, KIND=4) :: arr(3) = &
      [ character(10,4) :: "good buddy", "best buddy", " " ]
 call action_on_char4(conarr)

--- a/flang/test/Lower/array.f90
+++ b/flang/test/Lower/array.f90
@@ -93,7 +93,7 @@ subroutine s(i,j,k,ii,jj,kk,a1,a2,a3,a4,a5,a6,a7)
   ! CHECK: fir.coordinate_of %[[a7]], %[[t7]] :
   ! CHECK-LABEL: EndIoStatement
   print *, a7(kk, jj, ii)
-  
+
 end subroutine s
 
 ! CHECK-LABEL: range

--- a/flang/test/Lower/forall-pointer-assignment.f90
+++ b/flang/test/Lower/forall-pointer-assignment.f90
@@ -1,4 +1,4 @@
-! Test lower of FORALL pointer assignment 
+! Test lower of FORALL pointer assignment
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 
 

--- a/flang/test/Lower/forall/forall-2.f90
+++ b/flang/test/Lower/forall/forall-2.f90
@@ -16,7 +16,7 @@ subroutine implied_iters_allocatable(thing, a1)
   end type t
   type(t) :: thing(:)
   integer :: i
-  
+
   forall (i=5:13)
   ! commenting out this test for the moment (hits assert)
   !  thing(i)%arr = a1
@@ -32,7 +32,7 @@ subroutine conflicting_allocatable(thing, lo, hi)
   end type t
   type(t) :: thing(:)
   integer :: i
-  
+
   forall (i = lo:hi)
   ! commenting out this test for the moment (hits assert)
   !  thing(i)%arr = thing(hi-i)%arr

--- a/flang/test/Lower/forall/forall-ranked.f90
+++ b/flang/test/Lower/forall/forall-ranked.f90
@@ -68,7 +68,7 @@ subroutine test_forall_with_ranked_dimension
      integer :: arr(11)
   end type t
   type(t) :: a(10,10)
-  
+
   forall (i=1:5)
      a(i,:)%arr(i+4) = f(i)
   end forall

--- a/flang/test/Lower/forall/forall-where-2.f90
+++ b/flang/test/Lower/forall/forall-where-2.f90
@@ -6,7 +6,7 @@
 ! Test a FORALL construct with a nested WHERE construct where the mask
 ! contains temporary array expressions.
 
-subroutine test_nested_forall_where_with_temp_in_mask(a,b)  
+subroutine test_nested_forall_where_with_temp_in_mask(a,b)
   interface
     function temp_foo(i, j)
       integer :: i, j
@@ -28,10 +28,10 @@ end subroutine
 
 ! CHECK:  func @_QPtest_nested_forall_where_with_temp_in_mask({{.*}}) {
 ! CHECK:   %[[tempResultBox:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {bindc_name = ".result"}
-           ! Where condition pre-evaluation 
+           ! Where condition pre-evaluation
 ! CHECK:   fir.do_loop {{.*}} {
 ! CHECK:      fir.do_loop {{.*}} {
-                ! Evaluation of mask for iteration (i,j) into ragged array temp 
+                ! Evaluation of mask for iteration (i,j) into ragged array temp
 ! CHECK:        %[[tempResult:.*]] = fir.call @_QPtemp_foo
 ! CHECK:        fir.save_result %[[tempResult]] to %[[tempResultBox]] : !fir.box<!fir.heap<!fir.array<?xf32>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK:        fir.if {{.*}} {
@@ -52,7 +52,7 @@ end subroutine
 ! CHECK:      fir.do_loop {{.*}} {
                 ! Array assignment at iteration (i, j)
 ! CHECK:        fir.do_loop {{.*}} {
-! CHECK:          fir.if {{.*}} {  
+! CHECK:          fir.if {{.*}} {
 ! CHECK:            arith.divf
 ! CHECK:          } else {
 ! CHECK:          }
@@ -64,7 +64,7 @@ end subroutine
 ! CHECK:      fir.do_loop {{.*}} {
                 ! Array assignment at iteration (i, j)
 ! CHECK:        fir.do_loop {{.*}} {
-! CHECK:          fir.if {{.*}} {  
+! CHECK:          fir.if {{.*}} {
 ! CHECK:          } else {
 ! CHECK:            arith.negf
 ! CHECK:          }

--- a/flang/test/Lower/forall/forall-where.f90
+++ b/flang/test/Lower/forall/forall-where.f90
@@ -6,7 +6,7 @@
 !    This has both an explicit and implicit iteration space. The WHERE construct
 !    makes the assignments conditional and the where mask evaluation must happen
 !    prior to evaluating the array assignment statement.
-subroutine test_nested_forall_where(a,b)  
+subroutine test_nested_forall_where(a,b)
   type t
      real data(100)
   end type t


### PR DESCRIPTION
Only the fortran source files in flang/test/Lower/PowerPC and some in
flang/test/Lower have been modified. The other files in the directory will
be cleaned up in subsequent commits