### PR TITLE
[PowerPC ]convert `(setcc (and X, 1), 0, eq)`  to  `XORI (and X, 1), 1`

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -15790,7 +15790,7 @@ static bool canConvertSETCCToXori(SDNode *N) {
   // Check the `SDValue &V` is from `and` with `1`.
   auto IsAndWithOne = [](SDValue &V) {
     if (V.getOpcode() == ISD::AND) {
-      for (const SDValue &Op : V.getNode()->ops())
+      for (const SDValue &Op : V->ops())
         if (auto *C = dyn_cast<ConstantSDNode>(Op))
           if (C->isOne())
             return true;

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -15778,8 +15778,7 @@ SDValue convertTwoLoadsAndCmpToVCMPEQUB(SelectionDAG &DAG, SDNode *N,
 // Detect whether there is a pattern like (setcc (and X, 1), 0, eq).
 // If it is , return true; otherwise return false.
 static bool canConvertSETCCToXori(SDNode *N) {
-  if (N->getOpcode() != ISD::SETCC)
-    return false;
+  assert(N->getOpcode() == ISD::SETCC && "Should ibe SETCC SDNode here.");
 
   ISD::CondCode CC = cast<CondCodeSDNode>(N->getOperand(2))->get();
   if (CC != ISD::SETEQ)
@@ -15791,8 +15790,7 @@ static bool canConvertSETCCToXori(SDNode *N) {
   // Check the `SDValue &V` is from `and` with `1`.
   auto IsAndWithOne = [](SDValue &V) {
     if (V.getOpcode() == ISD::AND) {
-      SDNode *AndNode = V.getNode();
-      for (const SDValue &Op : AndNode->ops())
+      for (const SDValue &Op : V.getNode()->ops())
         if (auto *C = dyn_cast<ConstantSDNode>(Op))
           if (C->isOne())
             return true;
@@ -15817,7 +15815,7 @@ static bool canConvertSETCCToXori(SDNode *N) {
 // before calling the function; otherwise, it may produce incorrect results.
 static SDValue ConvertSETCCToXori(SDNode *N, SelectionDAG &DAG) {
 
-  assert(N->getOpcode() == ISD::SETCC && "Should SETCC SDNode here.");
+  assert(N->getOpcode() == ISD::SETCC && "Should ibe SETCC SDNode here.");
   SDValue LHS = N->getOperand(0);
   SDValue RHS = N->getOperand(1);
   SDLoc DL(N);

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -15778,7 +15778,7 @@ SDValue convertTwoLoadsAndCmpToVCMPEQUB(SelectionDAG &DAG, SDNode *N,
 // Detect whether there is a pattern like (setcc (and X, 1), 0, eq).
 // If it is , return true; otherwise return false.
 static bool canConvertSETCCToXori(SDNode *N) {
-  assert(N->getOpcode() == ISD::SETCC && "Should ibe SETCC SDNode here.");
+  assert(N->getOpcode() == ISD::SETCC && "Should be SETCC SDNode here.");
 
   ISD::CondCode CC = cast<CondCodeSDNode>(N->getOperand(2))->get();
   if (CC != ISD::SETEQ)
@@ -15815,7 +15815,7 @@ static bool canConvertSETCCToXori(SDNode *N) {
 // before calling the function; otherwise, it may produce incorrect results.
 static SDValue ConvertSETCCToXori(SDNode *N, SelectionDAG &DAG) {
 
-  assert(N->getOpcode() == ISD::SETCC && "Should ibe SETCC SDNode here.");
+  assert(N->getOpcode() == ISD::SETCC && "Should be SETCC SDNode here.");
   SDValue LHS = N->getOperand(0);
   SDValue RHS = N->getOperand(1);
   SDLoc DL(N);

--- a/llvm/test/CodeGen/PowerPC/memCmpUsedInZeroEqualityComparison.ll
+++ b/llvm/test/CodeGen/PowerPC/memCmpUsedInZeroEqualityComparison.ll
@@ -39,9 +39,8 @@ define signext i32 @zeroEqualityTest01(ptr %x, ptr %y) {
 ; CHECK-NEXT:    lxvd2x 35, 0, 3
 ; CHECK-NEXT:    vcmpequb. 2, 3, 2
 ; CHECK-NEXT:    mfocrf 3, 2
+; CHECK-NEXT:    not 3, 3
 ; CHECK-NEXT:    rlwinm 3, 3, 25, 31, 31
-; CHECK-NEXT:    cntlzw 3, 3
-; CHECK-NEXT:    srwi 3, 3, 5
 ; CHECK-NEXT:    blr
   %call = tail call signext i32 @memcmp(ptr %x, ptr %y, i64 16)
   %not.tobool = icmp ne i32 %call, 0


### PR DESCRIPTION
Based on the  discussion  in https://github.com/llvm/llvm-project/pull/158657#discussion_r2407761946, 
We can convert `(setcc (and X, 1), 0, eq)`   to  `XORI (and X, 1), 1` and save one instruction.