### PR TITLE
[libc] Fix wrapper headers if std=c99 is set

### DIFF
--- a/clang/lib/Headers/llvm_libc_wrappers/stdio.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/stdio.h
@@ -67,13 +67,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern FILE * stderr;
+extern FILE *stderr;
 __LIBC_ATTRS;
 
-extern FILE * stdin;
+extern FILE *stdin;
 __LIBC_ATTRS;
 
-extern FILE * stdout;
+extern FILE *stdout;
 __LIBC_ATTRS;
 
 #ifdef __cplusplus

--- a/clang/lib/Headers/llvm_libc_wrappers/stdio.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/stdio.h
@@ -67,11 +67,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern FILE * stderr; __LIBC_ATTRS;
+extern FILE * stderr;
+__LIBC_ATTRS;
 
-extern FILE * stdin; __LIBC_ATTRS;
+extern FILE * stdin;
+__LIBC_ATTRS;
 
-extern FILE * stdout; __LIBC_ATTRS;
+extern FILE * stdout;
+__LIBC_ATTRS;
 
 #ifdef __cplusplus
 }

--- a/clang/lib/Headers/llvm_libc_wrappers/stdio.h
+++ b/clang/lib/Headers/llvm_libc_wrappers/stdio.h
@@ -60,7 +60,22 @@
 
 #pragma omp begin declare target
 
-#include <llvm-libc-decls/stdio.h>
+#ifndef __LIBC_ATTRS
+#define __LIBC_ATTRS
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern FILE * stderr; __LIBC_ATTRS;
+
+extern FILE * stdin; __LIBC_ATTRS;
+
+extern FILE * stdout; __LIBC_ATTRS;
+
+#ifdef __cplusplus
+}
+#endif
 
 #pragma omp end declare target
 


### PR DESCRIPTION
Declarations of stdio functions can be skipped for wrapper headers. Previous declarations of stdio functions caused compilation errors when the -std=c99 option is set.