### PR TITLE
[CI] Skip Running Premerge Advisor on AArch64

### DIFF
--- a/.ci/premerge_advisor_explain.py
+++ b/.ci/premerge_advisor_explain.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
 
     # Skip looking for results on AArch64 for now because the premerge advisor
     # service is not available on AWS currently.
-    if platform.machine() == "arm64" or platform.machine == "aarch64":
+    if platform.machine() == "arm64" or platform.machine() == "aarch64":
         sys.exit(0)
 
     main(

--- a/.ci/premerge_advisor_explain.py
+++ b/.ci/premerge_advisor_explain.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
 
     # Skip looking for results on AArch64 for now because the premerge advisor
     # service is not available on AWS currently.
-    if platform.machine() == "arm64":
+    if platform.machine() == "arm64" or platform.machine == "aarch64":
         sys.exit(0)
 
     main(

--- a/.ci/premerge_advisor_upload.py
+++ b/.ci/premerge_advisor_upload.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     # Skip uploading results on AArch64 for now because the premerge advisor
     # service is not available on AWS currently.
-    if platform.machine() == "arm64":
+    if platform.machine() == "arm64" or platform.machine() == "aarch64":
         sys.exit(0)
 
     main(args.commit_sha, args.workflow_run_number, args.build_log_files)


### PR DESCRIPTION
They were still running because the conditional was not correct. This patch fixes that so they do not interefere with the results of the job.