### PR TITLE
AMDGPU: Don't duplicate implicit operands in 3-address conversion

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -4187,7 +4187,7 @@ SIInstrInfo::convertToThreeAddressImpl(MachineInstr &MI,
   if (NewMFMAOpc != -1) {
     MachineInstrBuilder MIB =
         BuildMI(MBB, MI, MI.getDebugLoc(), get(NewMFMAOpc));
-    for (unsigned I = 0, E = MI.getNumOperands(); I != E; ++I)
+    for (unsigned I = 0, E = MI.getNumExplicitOperands(); I != E; ++I)
       MIB.add(MI.getOperand(I));
     return MIB;
   }
@@ -4196,7 +4196,7 @@ SIInstrInfo::convertToThreeAddressImpl(MachineInstr &MI,
     unsigned NewOpc = AMDGPU::mapWMMA2AddrTo3AddrOpcode(MI.getOpcode());
     MachineInstrBuilder MIB = BuildMI(MBB, MI, MI.getDebugLoc(), get(NewOpc))
                                   .setMIFlags(MI.getFlags());
-    for (unsigned I = 0, E = MI.getNumOperands(); I != E; ++I)
+    for (unsigned I = 0, E = MI.getNumExplicitOperands(); I != E; ++I)
       MIB->addOperand(MI.getOperand(I));
     return MIB;
   }

--- a/llvm/test/CodeGen/AMDGPU/twoaddr-wmma.mir
+++ b/llvm/test/CodeGen/AMDGPU/twoaddr-wmma.mir
@@ -2,7 +2,7 @@
 # RUN: llc -mtriple=amdgcn -mcpu=gfx1100 %s --passes=two-address-instruction -verify-each -o - | FileCheck -check-prefix=GCN %s
 
 # GCN-LABEL: name: test_v_wmma_f32_16x16x16_f16_twoaddr_w32
-# GCN: early-clobber %2:vreg_256 = V_WMMA_F32_16X16X16_F16_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_256 = V_WMMA_F32_16X16X16_F16_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_f32_16x16x16_f16_twoaddr_w32
@@ -20,7 +20,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_f32_16x16x16_bf16_twoaddr_w32
-# GCN: early-clobber %2:vreg_256 = V_WMMA_F32_16X16X16_BF16_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_256 = V_WMMA_F32_16X16X16_BF16_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_f32_16x16x16_bf16_twoaddr_w32
@@ -38,7 +38,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_f16_16x16x16_f16_twoaddr_w32
-# GCN: early-clobber %2:vreg_256 = V_WMMA_F16_16X16X16_F16_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_256 = V_WMMA_F16_16X16X16_F16_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_f16_16x16x16_f16_twoaddr_w32
@@ -56,7 +56,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_bf16_16x16x16_bf16_twoaddr_w32
-# GCN: early-clobber %2:vreg_256 = V_WMMA_BF16_16X16X16_BF16_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_256 = V_WMMA_BF16_16X16X16_BF16_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_bf16_16x16x16_bf16_twoaddr_w32
@@ -74,7 +74,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_i32_16x16x16_iu8_twoaddr_w32
-# GCN: early-clobber %2:vreg_256 = V_WMMA_I32_16X16X16_IU8_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_256 = V_WMMA_I32_16X16X16_IU8_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_i32_16x16x16_iu8_twoaddr_w32
@@ -92,7 +92,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_i32_16x16x16_iu4_twoaddr_w32
-# GCN: early-clobber %2:vreg_256 = V_WMMA_I32_16X16X16_IU4_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_256 = V_WMMA_I32_16X16X16_IU4_threeaddr_w32 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_i32_16x16x16_iu4_twoaddr_w32
@@ -110,7 +110,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_f32_16x16x16_f16_twoaddr_w64
-# GCN: early-clobber %2:vreg_128 = V_WMMA_F32_16X16X16_F16_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_128 = V_WMMA_F32_16X16X16_F16_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_f32_16x16x16_f16_twoaddr_w64
@@ -128,7 +128,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_f32_16x16x16_bf16_twoaddr_w64
-# GCN: early-clobber %2:vreg_128 = V_WMMA_F32_16X16X16_BF16_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_128 = V_WMMA_F32_16X16X16_BF16_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_f32_16x16x16_bf16_twoaddr_w64
@@ -146,7 +146,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_f16_16x16x16_f16_twoaddr_w64
-# GCN: early-clobber %2:vreg_128 = V_WMMA_F16_16X16X16_F16_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_128 = V_WMMA_F16_16X16X16_F16_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_f16_16x16x16_f16_twoaddr_w64
@@ -164,7 +164,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_bf16_16x16x16_bf16_twoaddr_w64
-# GCN: early-clobber %2:vreg_128 = V_WMMA_BF16_16X16X16_BF16_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_128 = V_WMMA_BF16_16X16X16_BF16_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_bf16_16x16x16_bf16_twoaddr_w64
@@ -182,7 +182,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_i32_16x16x16_iu8_twoaddr_w64
-# GCN: early-clobber %2:vreg_128 = V_WMMA_I32_16X16X16_IU8_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_128 = V_WMMA_I32_16X16X16_IU8_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_i32_16x16x16_iu8_twoaddr_w64
@@ -200,7 +200,7 @@ body:             |
 ...
 
 # GCN-LABEL: name: test_v_wmma_i32_16x16x16_iu4_twoaddr_w64
-# GCN: early-clobber %2:vreg_128 = V_WMMA_I32_16X16X16_IU4_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, implicit $exec
+# GCN: early-clobber %2:vreg_128 = V_WMMA_I32_16X16X16_IU4_threeaddr_w64 8, killed %1, 8, killed %1, 8, %0, 0, 0, 0, implicit $exec{{$}}
 
 ---
 name:            test_v_wmma_i32_16x16x16_iu4_twoaddr_w64


### PR DESCRIPTION
We previously got a duplicate implicit $exec operand. It didn't really
hurt anything (other than being a slight drag on compile-time
performance). Still, let's keep things clean.