### PR TITLE
Improve error response message parsing for DAP evaluate requests.

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -335,6 +335,7 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
         self._proc.stdin.flush()
         return self.seq
 
+    @staticmethod
     def _handle_message(
         message: dict, debugger_state: DAPDebuggerState, logger: Logger
     ):
@@ -419,6 +420,7 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
             request_seq = message["request_seq"]
             debugger_state.set_response(request_seq, message)
 
+    @staticmethod
     def _colorize_dap_message(message: dict) -> dict:
         colorized_message = copy.deepcopy(message)
         if colorized_message["type"] == "event":
@@ -432,6 +434,7 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
             colorized_message["command"] = f"<y>{colorized_message['command']}</>"
         return colorized_message
 
+    @staticmethod
     def _read_dap_output(
         proc: subprocess.Popen,
         debugger_state: DAPDebuggerState,
@@ -454,6 +457,7 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
                 DAP._handle_message(message, debugger_state, logger)
                 buffer = rest[content_length:]
 
+    @staticmethod
     def _read_dap_err(proc: subprocess.Popen, logger: Logger):
         while True:
             err: bytes = proc.stderr.readline()
@@ -930,10 +934,16 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
             )
         )
         eval_response = self._await_response(eval_req_id)
+        result: str = ""
         if not eval_response["success"]:
-            result: str = eval_response["message"]
+            if eval_response["body"].get("error", None):
+                result = eval_response["body"]["error"]["format"]
+            elif eval_response["message"]:
+                result = eval_response["message"]
+            else:
+                result = "<unable to evaluate expression>"
         else:
-            result: str = eval_response["body"]["result"]
+            result = eval_response["body"]["result"]
         type_str = eval_response["body"].get("type")
 
         return self._evaluate_result_value(expression, result, type_str)


### PR DESCRIPTION
Updated the evaluate handler to check for DAP ErrorResponse bodies, which are used to display user errors if a request fails. This was updated in PR https://github.com/llvm/llvm-project/pull/167720

This should fix https://lab.llvm.org/buildbot/#/builders/163 