### PR TITLE
[Flang] - Enhance testing for strictly-nested teams in target regions.

### DIFF
--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -263,7 +263,7 @@ void OmpStructureChecker::Enter(const parser::OpenMPLoopConstruct &x) {
   }
 
   if (CurrentDirectiveIsNested() &&
-      llvm::omp::allTeamsSet.test(GetContext().directive) &&
+      llvm::omp::topTeamsSet.test(GetContext().directive) &&
       GetContextParent().directive == llvm::omp::Directive::OMPD_target &&
       !GetDirectiveNest(TargetBlockOnlyTeams)) {
     context_.Say(GetContextParent().directiveSource,

--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -262,6 +262,15 @@ void OmpStructureChecker::Enter(const parser::OpenMPLoopConstruct &x) {
     EnterDirectiveNest(SIMDNest);
   }
 
+  if (CurrentDirectiveIsNested() &&
+      llvm::omp::allTeamsSet.test(GetContext().directive) &&
+      GetContextParent().directive == llvm::omp::Directive::OMPD_target &&
+      !GetDirectiveNest(TargetBlockOnlyTeams)) {
+    context_.Say(GetContextParent().directiveSource,
+        "TARGET construct with nested TEAMS region contains statements or "
+        "directives outside of the TEAMS construct"_err_en_US);
+  }
+
   // Combined target loop constructs are target device constructs. Keep track of
   // whether any such construct has been visited to later check that REQUIRES
   // directives for target-related options don't appear after them.

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -5215,6 +5215,13 @@ bool OmpStructureChecker::CheckTargetBlockOnlyTeams(
         if (dirId == llvm::omp::Directive::OMPD_teams) {
           nestedTeams = true;
         }
+      } else if (const auto *ompLoopConstruct{
+                     std::get_if<parser::OpenMPLoopConstruct>(
+                         &ompConstruct->u)}) {
+        llvm::omp::Directive dirId{ompLoopConstruct->BeginDir().DirId()};
+        if (llvm::omp::allTeamsSet.test(dirId)) {
+          nestedTeams = true;
+        }
       }
     }
 

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -5219,7 +5219,7 @@ bool OmpStructureChecker::CheckTargetBlockOnlyTeams(
                      std::get_if<parser::OpenMPLoopConstruct>(
                          &ompConstruct->u)}) {
         llvm::omp::Directive dirId{ompLoopConstruct->BeginDir().DirId()};
-        if (llvm::omp::allTeamsSet.test(dirId)) {
+        if (llvm::omp::topTeamsSet.test(dirId)) {
           nestedTeams = true;
         }
       }

--- a/flang/test/Semantics/OpenMP/target-teams-nesting.f90
+++ b/flang/test/Semantics/OpenMP/target-teams-nesting.f90
@@ -1,0 +1,22 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+
+program main
+  implicit none
+  integer, parameter :: n = 100
+  integer, parameter :: expected = n+2
+  integer :: i
+  integer :: counter
+
+  counter = 0
+  !ERROR: TARGET construct with nested TEAMS region contains statements or directives outside of the TEAMS construct
+  !$omp target map(tofrom:counter)
+  counter = counter+1
+  !$omp teams distribute reduction(+:counter)
+  do i=1, n
+     counter = counter+1
+  end do
+  counter = counter+1
+  !$omp end target
+
+  print '("Result: "I0)', counter
+ end program

--- a/flang/test/Semantics/OpenMP/target-teams-nesting.f90
+++ b/flang/test/Semantics/OpenMP/target-teams-nesting.f90
@@ -17,6 +17,4 @@ program main
   end do
   counter = counter+1
   !$omp end target
-
-  print '("Result: "I0)', counter
  end program


### PR DESCRIPTION
This patch enhances the semantics test for checking that teams directives are strictly nested inside target directives.

Fixes https://github.com/llvm/llvm-project/issues/153173