### PR TITLE
Insert symbols for prefetch targets read from basic blocks section profile.

### DIFF
--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -71,6 +71,14 @@ struct CFGProfile {
   }
 };
 
+// The prefetch symbol is emitted immediately after the call of the given index,
+// in block `BBID` (First call has an index of 1). Zero callsite index means the
+// start of the block.
+struct CallsiteID {
+  UniqueBBID BBID;
+  unsigned CallsiteIndex;
+};
+
 // This struct represents the raw optimization profile for a function,
 // including CFG data (block and edge counts) and layout directives (clustering
 // and cloning paths).
@@ -83,6 +91,17 @@ struct FunctionOptimizationProfile {
   SmallVector<SmallVector<unsigned>> ClonePaths;
   // Cfg profile data (block and edge frequencies).
   CFGProfile CFG;
+  // Code prefetch targets, specified by the callsite ID. The target is the code
+  // immediately following this callsite.
+  SmallVector<CallsiteID> PrefetchTargets;
+  // Node counts for each basic block.
+  DenseMap<UniqueBBID, uint64_t> NodeCounts;
+  // Edge counts for each edge.
+  DenseMap<UniqueBBID, DenseMap<UniqueBBID, uint64_t>> EdgeCounts;
+  // Hash for each basic block. The Hashes are stored for every original block
+  // (not cloned blocks), hence the map key being unsigned instead of
+  // UniqueBBID.
+  DenseMap<unsigned, uint64_t> BBHashes;
 };
 
 class BasicBlockSectionsProfileReader {
@@ -117,6 +136,11 @@ public:
       return nullptr;
     return &It->second.CFG;
   }
+
+  // Returns the prefetch targets (identified by their containing callsite IDs)
+  // for function `FuncName`.
+  SmallVector<CallsiteID>
+  getPrefetchTargetsForFunction(StringRef FuncName) const;
 
 private:
   StringRef getAliasName(StringRef FuncName) const {
@@ -226,6 +250,9 @@ public:
 
   uint64_t getEdgeCount(StringRef FuncName, const UniqueBBID &SrcBBID,
                         const UniqueBBID &DestBBID) const;
+
+  SmallVector<CallsiteID>
+  getPrefetchTargetsForFunction(StringRef FuncName) const;
 
   // Initializes the FunctionNameToDIFilename map for the current module and
   // then reads the profile for the matching functions.

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -233,7 +233,7 @@ private:
 
   /// Contains the callsite indices in this block that are targets of code
   /// prefetching. The index `i` specifies the `i`th call, with zero
-  /// representing the beginning of the block and ` representing the first call.
+  /// representing the beginning of the block and 1 representing the first call.
   /// Must be in ascending order and without duplicates.
   SmallVector<unsigned> PrefetchTargetCallsiteIndexes;
 

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -231,6 +231,12 @@ private:
   /// is only computed once and is cached.
   mutable MCSymbol *CachedMCSymbol = nullptr;
 
+  /// Contains the callsite indices in this block that are targets of code
+  /// prefetching. The index `i` specifies the `i`th call, with zero
+  /// representing the beginning of the block and ` representing the first call.
+  /// Must be in ascending order and without duplicates.
+  SmallVector<unsigned> PrefetchTargetCallsiteIndexes;
+
   /// Cached MCSymbol for this block (used if IsEHContTarget).
   mutable MCSymbol *CachedEHContMCSymbol = nullptr;
 
@@ -711,6 +717,14 @@ public:
   void setIsEndSection(bool V = true) { IsEndSection = V; }
 
   std::optional<UniqueBBID> getBBID() const { return BBID; }
+
+  const SmallVector<unsigned> &getPrefetchTargetCallsiteIndexes() const {
+    return PrefetchTargetCallsiteIndexes;
+  }
+
+  void setPrefetchTargetCallsiteIndexes(const SmallVector<unsigned> &V) {
+    PrefetchTargetCallsiteIndexes = V;
+  }
 
   /// Returns the section ID of this basic block.
   MBBSectionID getSectionID() const { return SectionID; }

--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -73,6 +73,8 @@ LLVM_ABI MachineFunctionPass *createBasicBlockPathCloningPass();
 /// and inference when using propeller.
 LLVM_ABI MachineFunctionPass *createBasicBlockMatchingAndInferencePass();
 
+LLVM_ABI MachineFunctionPass *createInsertCodePrefetchPass();
+
 /// createMachineBlockHashInfoPass - This pass computes basic block hashes.
 LLVM_ABI MachineFunctionPass *createMachineBlockHashInfoPass();
 

--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -57,6 +57,7 @@ LLVM_ABI void initializeAssumptionCacheTrackerPass(PassRegistry &);
 LLVM_ABI void initializeAtomicExpandLegacyPass(PassRegistry &);
 LLVM_ABI void initializeBasicBlockMatchingAndInferencePass(PassRegistry &);
 LLVM_ABI void initializeBasicBlockPathCloningPass(PassRegistry &);
+LLVM_ABI void initializeInsertCodePrefetchPass(PassRegistry &);
 LLVM_ABI void
 initializeBasicBlockSectionsProfileReaderWrapperPassPass(PassRegistry &);
 LLVM_ABI void initializeBasicBlockSectionsPass(PassRegistry &);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2010,7 +2010,33 @@ void AsmPrinter::emitFunctionBody() {
     // Print a label for the basic block.
     emitBasicBlockStart(MBB);
     DenseMap<StringRef, unsigned> MnemonicCounts;
+
+    // Helper to emit a symbol for the prefetch target associated with the given
+    // callsite index in the current MBB.
+    auto EmitPrefetchTargetSymbol = [&](unsigned CallsiteIndex) {
+      MCSymbol *PrefetchTargetSymbol = OutContext.getOrCreateSymbol(
+          Twine("__llvm_prefetch_target_") + MF->getName() + Twine("_") +
+          utostr(MBB.getBBID()->BaseID) + Twine("_") +
+          utostr(static_cast<unsigned>(CallsiteIndex)));
+      // If the function is weak-linkage it may be replaced by a strong
+      // version, in which case the prefetch targets should also be replaced.
+      OutStreamer->emitSymbolAttribute(
+          PrefetchTargetSymbol,
+          MF->getFunction().isWeakForLinker() ? MCSA_Weak : MCSA_Global);
+      OutStreamer->emitLabel(PrefetchTargetSymbol);
+    };
+    SmallVector<unsigned> PrefetchTargets =
+        MBB.getPrefetchTargetCallsiteIndexes();
+    auto PrefetchTargetIt = PrefetchTargets.begin();
+    unsigned LastCallsiteIndex = 0;
+
     for (auto &MI : MBB) {
+      if (PrefetchTargetIt != PrefetchTargets.end() &&
+          *PrefetchTargetIt == LastCallsiteIndex) {
+        EmitPrefetchTargetSymbol(*PrefetchTargetIt);
+        ++PrefetchTargetIt;
+      }
+
       // Print the assembly for the instruction.
       if (!MI.isPosition() && !MI.isImplicitDef() && !MI.isKill() &&
           !MI.isDebugInstr()) {
@@ -2148,8 +2174,11 @@ void AsmPrinter::emitFunctionBody() {
         break;
       }
 
-      if (MI.isCall() && MF->getTarget().Options.BBAddrMap)
-        OutStreamer->emitLabel(createCallsiteEndSymbol(MBB));
+      if (MI.isCall()) {
+        if (MF->getTarget().Options.BBAddrMap)
+          OutStreamer->emitLabel(createCallsiteEndSymbol(MBB));
+        LastCallsiteIndex++;
+      }
 
       if (TM.Options.EmitCallGraphSection && MI.isCall())
         handleCallsiteForCallgraph(FuncCGInfo, CallSitesInfoMap, MI);
@@ -2160,6 +2189,12 @@ void AsmPrinter::emitFunctionBody() {
 
       for (auto &Handler : Handlers)
         Handler->endInstruction();
+    }
+    // Emit the last prefetch target in case the last instruction was a call.
+    if (PrefetchTargetIt != PrefetchTargets.end() &&
+        *PrefetchTargetIt == LastCallsiteIndex) {
+      EmitPrefetchTargetSymbol(*PrefetchTargetIt);
+      ++PrefetchTargetIt;
     }
 
     // We must emit temporary symbol for the end of this basic block, if either

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2016,8 +2016,8 @@ void AsmPrinter::emitFunctionBody() {
     auto EmitPrefetchTargetSymbol = [&](unsigned CallsiteIndex) {
       MCSymbol *PrefetchTargetSymbol = OutContext.getOrCreateSymbol(
           Twine("__llvm_prefetch_target_") + MF->getName() + Twine("_") +
-          utostr(MBB.getBBID()->BaseID) + Twine("_") +
-          utostr(static_cast<unsigned>(CallsiteIndex)));
+          Twine(MBB.getBBID()->BaseID) + Twine("_") +
+          Twine(static_cast<unsigned>(CallsiteIndex)));
       // If the function is weak-linkage it may be replaced by a strong
       // version, in which case the prefetch targets should also be replaced.
       OutStreamer->emitSymbolAttribute(

--- a/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
@@ -93,6 +93,13 @@ uint64_t BasicBlockSectionsProfileReader::getEdgeCount(
   return EdgeIt->second;
 }
 
+SmallVector<CallsiteID>
+BasicBlockSectionsProfileReader::getPrefetchTargetsForFunction(
+    StringRef FuncName) const {
+  return ProgramPathAndClusterInfo.lookup(getAliasName(FuncName))
+      .PrefetchTargets;
+}
+
 // Reads the version 1 basic block sections profile. Profile for each function
 // is encoded as follows:
 //   m <module_name>
@@ -148,6 +155,36 @@ uint64_t BasicBlockSectionsProfileReader::getEdgeCount(
 //                            +-->: 5 :
 //                                ....
 // ****************************************************************************
+// This profile can also specify prefetch targets (starting with 't') which
+// instruct the compiler to emit a prefetch symbol for the given target.
+// A prefetch target is specified by a pair "<bbid>,<subblock_index>" where
+// bbid specifies the target basic block and subblock_index is a zero-based
+// index. Subblock 0 refers to the region at the beginning of the block up to
+// the first callsite. Subblock `i > 0` refers to the region immediately after
+// the `i`-th callsite up to the `i+1`-th callsite (or the end of the block).
+// The prefetch target is always emitted at the beginning of the subblock.
+// This is the beginning of the basic block for `i = 0` and immediately after
+// the `i`-th call for every `i > 0`.
+//
+// Example: A basic block in function "foo" with BBID 10 and two call
+// instructions (call_A, call_B). This block is conceptually split into
+// subblocks, with the prefetch target symbol emitted at the beginning of each
+// subblock.
+//
+// +----------------------------------+
+// | __llvm_prefetch_target_foo_10_0: | <- Subblock 0 (before call_A)
+// |  Instruction 1                   |
+// |  Instruction 2                   |
+// |  call_A (Callsite 0)             |
+// | __llvm_prefetch_target_foo_10_1: | <--- Subblock 1 (after call_A,
+// |                                  |                  before call_B)
+// |  Instruction 3                   |
+// |  call_B (Callsite 1)             |
+// | __llvm_prefetch_target_foo_10_2: | <--- Subblock 2 (after call_B,
+// |                                  |                  before call_C)
+// |  Instruction 4                   |
+// +----------------------------------+
+//
 Error BasicBlockSectionsProfileReader::ReadV1Profile() {
   auto FI = ProgramOptimizationProfile.end();
 
@@ -306,6 +343,27 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
               "'");
         FI->second.CFG.BBHashes[BBID] = Hash;
       }
+      continue;
+    }
+    case 't': { // Callsite target specifier.
+      // Skip the profile when we the profile iterator (FI) refers to the
+      // past-the-end element.
+      if (FI == ProgramPathAndClusterInfo.end())
+        continue;
+      SmallVector<StringRef, 2> PrefetchTargetStr;
+      Values[0].split(PrefetchTargetStr, ',');
+      if (PrefetchTargetStr.size() != 2)
+        return createProfileParseError(Twine("Callsite target expected: ") +
+                                       Values[0]);
+      auto TargetBBID = parseUniqueBBID(PrefetchTargetStr[0]);
+      if (!TargetBBID)
+        return TargetBBID.takeError();
+      unsigned long long CallsiteIndex;
+      if (getAsUnsignedInteger(PrefetchTargetStr[1], 10, CallsiteIndex))
+        return createProfileParseError(Twine("signed integer expected: '") +
+                                       PrefetchTargetStr[1]);
+      FI->second.PrefetchTargets.push_back(
+          CallsiteID{*TargetBBID, static_cast<unsigned>(CallsiteIndex)});
       continue;
     }
     default:
@@ -518,6 +576,12 @@ uint64_t BasicBlockSectionsProfileReaderWrapperPass::getEdgeCount(
     StringRef FuncName, const UniqueBBID &SrcBBID,
     const UniqueBBID &SinkBBID) const {
   return BBSPR.getEdgeCount(FuncName, SrcBBID, SinkBBID);
+}
+
+SmallVector<CallsiteID>
+BasicBlockSectionsProfileReaderWrapperPass::getPrefetchTargetsForFunction(
+    StringRef FuncName) const {
+  return BBSPR.getPrefetchTargetsForFunction(FuncName);
 }
 
 BasicBlockSectionsProfileReader &

--- a/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
@@ -97,7 +97,8 @@ SmallVector<CallsiteID>
 BasicBlockSectionsProfileReader::getPrefetchTargetsForFunction(
     StringRef FuncName) const {
   auto R = ProgramOptimizationProfile.find(getAliasName(FuncName));
-  return R != ProgramOptimizationProfile.end() ? R->second.PrefetchTargets : SmallVector<CallsiteID>();
+  return R != ProgramOptimizationProfile.end() ? R->second.PrefetchTargets
+                                               : SmallVector<CallsiteID>();
 }
 
 // Reads the version 1 basic block sections profile. Profile for each function

--- a/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
+++ b/llvm/lib/CodeGen/BasicBlockSectionsProfileReader.cpp
@@ -96,8 +96,8 @@ uint64_t BasicBlockSectionsProfileReader::getEdgeCount(
 SmallVector<CallsiteID>
 BasicBlockSectionsProfileReader::getPrefetchTargetsForFunction(
     StringRef FuncName) const {
-  return ProgramPathAndClusterInfo.lookup(getAliasName(FuncName))
-      .PrefetchTargets;
+  auto R = ProgramOptimizationProfile.find(getAliasName(FuncName));
+  return R != ProgramOptimizationProfile.end() ? R->second.PrefetchTargets : SmallVector<CallsiteID>();
 }
 
 // Reads the version 1 basic block sections profile. Profile for each function
@@ -348,7 +348,7 @@ Error BasicBlockSectionsProfileReader::ReadV1Profile() {
     case 't': { // Callsite target specifier.
       // Skip the profile when we the profile iterator (FI) refers to the
       // past-the-end element.
-      if (FI == ProgramPathAndClusterInfo.end())
+      if (FI == ProgramOptimizationProfile.end())
         continue;
       SmallVector<StringRef, 2> PrefetchTargetStr;
       Values[0].split(PrefetchTargetStr, ',');

--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -79,6 +79,7 @@ add_llvm_component_library(LLVMCodeGen
   IndirectBrExpandPass.cpp
   InitUndef.cpp
   InlineSpiller.cpp
+  InsertCodePrefetch.cpp
   InterferenceCache.cpp
   InterleavedAccessPass.cpp
   InterleavedLoadCombinePass.cpp

--- a/llvm/lib/CodeGen/InsertCodePrefetch.cpp
+++ b/llvm/lib/CodeGen/InsertCodePrefetch.cpp
@@ -1,0 +1,101 @@
+//===-- InsertCodePrefetch.cpp ---=========--------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// Code Prefetch Insertion Pass.
+//===----------------------------------------------------------------------===//
+/// This pass inserts code prefetch instructions according to the prefetch
+/// directives in the basic block section profile. The target of a prefetch can
+/// be the beginning of any dynamic basic block, that is the beginning of a
+/// machine basic block, or immediately after a callsite. A global symbol is
+/// emitted at the position of the target so it can be addressed from the
+/// prefetch instruction from any module.
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/CodeGen/BasicBlockSectionUtils.h"
+#include "llvm/CodeGen/BasicBlockSectionsProfileReader.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/Passes.h"
+#include "llvm/InitializePasses.h"
+
+using namespace llvm;
+#define DEBUG_TYPE "insert-code-prefetch"
+
+namespace {
+class InsertCodePrefetch : public MachineFunctionPass {
+public:
+  static char ID;
+
+  InsertCodePrefetch() : MachineFunctionPass(ID) {
+    initializeInsertCodePrefetchPass(*PassRegistry::getPassRegistry());
+  }
+
+  StringRef getPassName() const override {
+    return "Code Prefetch Inserter Pass";
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+  // Sets prefetch targets based on the bb section profile.
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+//            Implementation
+//===----------------------------------------------------------------------===//
+
+char InsertCodePrefetch::ID = 0;
+INITIALIZE_PASS_BEGIN(InsertCodePrefetch, DEBUG_TYPE, "Code prefetch insertion",
+                      true, false)
+INITIALIZE_PASS_DEPENDENCY(BasicBlockSectionsProfileReaderWrapperPass)
+INITIALIZE_PASS_END(InsertCodePrefetch, DEBUG_TYPE, "Code prefetch insertion",
+                    true, false)
+
+bool InsertCodePrefetch::runOnMachineFunction(MachineFunction &MF) {
+  assert(MF.getTarget().getBBSectionsType() == BasicBlockSection::List &&
+         "BB Sections list not enabled!");
+  if (hasInstrProfHashMismatch(MF))
+    return false;
+  // Set each block's prefetch targets so AsmPrinter can emit a special symbol
+  // there.
+  SmallVector<CallsiteID> PrefetchTargets =
+      getAnalysis<BasicBlockSectionsProfileReaderWrapperPass>()
+          .getPrefetchTargetsForFunction(MF.getName());
+  DenseMap<UniqueBBID, SmallVector<unsigned>> PrefetchTargetsByBBID;
+  for (const auto &Target : PrefetchTargets)
+    PrefetchTargetsByBBID[Target.BBID].push_back(Target.CallsiteIndex);
+  // Sort and uniquify the callsite indices for every block.
+  for (auto &[K, V] : PrefetchTargetsByBBID) {
+    llvm::sort(V);
+    V.erase(llvm::unique(V), V.end());
+  }
+  for (auto &MBB : MF) {
+    auto R = PrefetchTargetsByBBID.find(*MBB.getBBID());
+    if (R == PrefetchTargetsByBBID.end())
+      continue;
+    MBB.setPrefetchTargetCallsiteIndexes(R->second);
+  }
+  return false;
+}
+
+void InsertCodePrefetch::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.setPreservesAll();
+  AU.addRequired<BasicBlockSectionsProfileReaderWrapperPass>();
+  MachineFunctionPass::getAnalysisUsage(AU);
+}
+
+MachineFunctionPass *llvm::createInsertCodePrefetchPass() {
+  return new InsertCodePrefetch();
+}

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -1298,8 +1298,10 @@ void TargetPassConfig::addMachinePasses() {
           TM->getBBSectionsFuncListBuf()));
       if (BasicBlockSectionMatchInfer)
         addPass(llvm::createBasicBlockMatchingAndInferencePass());
-      else
+      else {
         addPass(llvm::createBasicBlockPathCloningPass());
+        addPass(llvm::createInsertCodePrefetchPass());
+      }
     }
     addPass(llvm::createBasicBlockSectionsPass());
   }

--- a/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch-call-terminates-block.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch-call-terminates-block.ll
@@ -1,0 +1,29 @@
+;; Check prefetch directives properly handle a block terminating with a call.
+;;
+;; Specify the bb sections profile:
+; RUN: echo 'v1' > %t
+; RUN: echo 'f fred' >> %t
+; RUN: echo 't 0,1' >> %t
+;;
+; RUN: llc < %s -mtriple=x86_64-pc-linux -asm-verbose=false -function-sections -basic-block-sections=%t -O1 | FileCheck %s
+
+define i32 @fred() personality ptr @__gxx_personality_v0 {
+entry:
+  invoke void @explode()
+          to label %continue unwind label %cleanup
+; CHECK:      fred:
+; CHECK:        callq explode@PLT
+; CHECK-NEXT:   .globl __llvm_prefetch_target_fred_0_1
+; CHECK-NEXT: __llvm_prefetch_target_fred_0_1:
+
+continue:
+  ret i32 0
+
+cleanup:
+  %res = landingpad { i8*, i32 }
+          cleanup
+  resume { i8*, i32 } %res
+}
+
+declare void @__gxx_personality_v0()
+declare void @explode()

--- a/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
@@ -2,69 +2,69 @@
 ;;
 ;; Specify the bb sections profile:
 ; RUN: echo 'v1' > %t
-; RUN: echo 'f _Z3foob' >> %t
+; RUN: echo 'f foo' >> %t
 ; RUN: echo 't 0,0' >> %t
 ; RUN: echo 't 1,0' >> %t
 ; RUN: echo 't 1,1' >> %t
 ; RUN: echo 't 2,1' >> %t
 ; RUN: echo 't 3,0' >> %t
-; RUN: echo 'f _Z3barv' >> %t
+; RUN: echo 'f bar' >> %t
 ; RUN: echo 't 0,0' >> %t
 ; RUN: echo 't 21,1' >> %t
-; RUN: echo 'f _Z3quxv' >> %t
+; RUN: echo 'f qux' >> %t
 ; RUN: echo 't 0,0' >> %t
 ; RUN: echo 't 0,1' >> %t
 ;;
 ; RUN: llc < %s -mtriple=x86_64-pc-linux -asm-verbose=false -function-sections -basic-block-sections=%t -O0 | FileCheck %s
 
-define void @_Z3foob(i1 %arg) nounwind {
+define void @foo(i1 %arg) nounwind {
   br i1 %arg, label %cond.true, label %cond.false
-; CHECK:      _Z3foob:
-; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3foob_0_0
-; CHECK-NEXT: __llvm_prefetch_target__Z3foob_0_0:
+; CHECK:      foo:
+; CHECK-NEXT:   .globl __llvm_prefetch_target_foo_0_0
+; CHECK-NEXT: __llvm_prefetch_target_foo_0_0:
 
 cond.true:                                           ; preds = %1
-  call i32 @_Z3barv()
+  call i32 @bar()
   br label %end
-; CHECK:        .globl __llvm_prefetch_target__Z3foob_1_0
-; CHECK-NEXT: __llvm_prefetch_target__Z3foob_1_0:
-; CHECK-NEXT:   callq _Z3barv@PLT
-; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3foob_1_1
-; CHECK-NEXT: __llvm_prefetch_target__Z3foob_1_1:
+; CHECK:        .globl __llvm_prefetch_target_foo_1_0
+; CHECK-NEXT: __llvm_prefetch_target_foo_1_0:
+; CHECK-NEXT:   callq bar@PLT
+; CHECK-NEXT:   .globl __llvm_prefetch_target_foo_1_1
+; CHECK-NEXT: __llvm_prefetch_target_foo_1_1:
 
 cond.false:                                          ; preds = %1
-  call i32 @_Z3bazv()
+  call i32 @baz()
   br label %end
-; CHECK:        callq _Z3bazv@PLT
-; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3foob_2_1
-; CHECK-NEXT: __llvm_prefetch_target__Z3foob_2_1:
+; CHECK:        callq baz@PLT
+; CHECK-NEXT:   .globl __llvm_prefetch_target_foo_2_1
+; CHECK-NEXT: __llvm_prefetch_target_foo_2_1:
 
 end:                                             ; preds = %11, %9
   ret void
 ; CHECK:      .LBB0_3:
-; CHECK-NEXT:   .globl	__llvm_prefetch_target__Z3foob_3_0
-; CHECK-NEXT: __llvm_prefetch_target__Z3foob_3_0:
+; CHECK-NEXT:   .globl	__llvm_prefetch_target_foo_3_0
+; CHECK-NEXT: __llvm_prefetch_target_foo_3_0:
 }
 
-define weak i32 @_Z3barv() nounwind {
-  %call = call i32 @_Z3bazv()
+define weak i32 @bar() nounwind {
+  %call = call i32 @baz()
   ret i32 %call
-; CHECK:      _Z3barv:
-; CHECK-NEXT:   .weak __llvm_prefetch_target__Z3barv_0_0
-; CHECK-NEXT: __llvm_prefetch_target__Z3barv_0_0:
-; CHECK:        callq _Z3bazv@PLT
+; CHECK:      bar:
+; CHECK-NEXT:   .weak __llvm_prefetch_target_bar_0_0
+; CHECK-NEXT: __llvm_prefetch_target_bar_0_0:
+; CHECK:        callq baz@PLT
 }
 
-define internal i32 @_Z3quxv() nounwind {
-  %call = call i32 @_Z3bazv()
+define internal i32 @qux() nounwind {
+  %call = call i32 @baz()
   ret i32 %call
-; CHECK:      _Z3quxv:
-; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3quxv_0_0
-; CHECK-NEXT: __llvm_prefetch_target__Z3quxv_0_0:
-; CHECK:        callq _Z3bazv@PLT
-; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3quxv_0_1
-; CHECK-NEXT: __llvm_prefetch_target__Z3quxv_0_1:
+; CHECK:      qux:
+; CHECK-NEXT:   .globl __llvm_prefetch_target_qux_0_0
+; CHECK-NEXT: __llvm_prefetch_target_qux_0_0:
+; CHECK:        callq baz@PLT
+; CHECK-NEXT:   .globl __llvm_prefetch_target_qux_0_1
+; CHECK-NEXT: __llvm_prefetch_target_qux_0_1:
 }
 
-declare i32 @_Z3bazv() #1
-declare i32 @_Z3dummy() #2
+declare i32 @baz()
+declare i32 @dummy()

--- a/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
@@ -11,6 +11,9 @@
 ; RUN: echo 'f _Z3barv' >> %t
 ; RUN: echo 't 0,0' >> %t
 ; RUN: echo 't 21,1' >> %t
+; RUN: echo 'f _Z3quxv' >> %t
+; RUN: echo 't 0,0' >> %t
+; RUN: echo 't 0,1' >> %t
 ;;
 ; RUN: llc < %s -mtriple=x86_64-pc-linux -asm-verbose=false -function-sections -basic-block-sections=%t -O0 | FileCheck %s
 
@@ -60,6 +63,18 @@ define weak i32 @_Z3barv() nounwind {
 ; CHECK:      _Z3barv:
 ; CHECK-NEXT:   .weak __llvm_prefetch_target__Z3barv_0_0
 ; CHECK-NEXT: __llvm_prefetch_target__Z3barv_0_0:
+; CHECK:        callq _Z3bazv@PLT
+}
+
+define internal i32 @_Z3quxv() nounwind {
+  %1 = call i32 @_Z3bazv()
+  ret i32 %1
+; CHECK:      _Z3quxv:
+; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3quxv_0_0
+; CHECK-NEXT: __llvm_prefetch_target__Z3quxv_0_0:
+; CHECK:        callq _Z3bazv@PLT
+; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3quxv_0_1
+; CHECK-NEXT: __llvm_prefetch_target__Z3quxv_0_1:
 }
 
 declare i32 @_Z3bazv() #1

--- a/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
@@ -1,0 +1,65 @@
+;; Check prefetch directives in basic block section profiles.
+;;
+;; Specify the bb sections profile:
+; RUN: echo 'v1' > %t
+; RUN: echo 'f _Z3foob' >> %t
+; RUN: echo 't 0,0' >> %t
+; RUN: echo 't 1,0' >> %t
+; RUN: echo 't 1,1' >> %t
+; RUN: echo 't 2,1' >> %t
+; RUN: echo 't 3,0' >> %t
+; RUN: echo 'f _Z3barv' >> %t
+; RUN: echo 't 0,0' >> %t
+; RUN: echo 't 21,1' >> %t
+;;
+; RUN: llc < %s -mtriple=x86_64-pc-linux -asm-verbose=false -function-sections -basic-block-sections=%t -O0 | FileCheck %s
+
+define i32 @_Z3foob(i1 zeroext %0) nounwind {
+  %2 = alloca i32, align 4
+  %3 = alloca i8, align 1
+  %4 = zext i1 %0 to i8
+  store i8 %4, ptr %3, align 1
+  %5 = load i8, ptr %3, align 1
+  %6 = trunc i8 %5 to i1
+  %7 = zext i1 %6 to i32
+  %8 = icmp sgt i32 %7, 0
+  br i1 %8, label %9, label %11
+; CHECK:      _Z3foob:
+; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3foob_0_0
+; CHECK-NEXT: __llvm_prefetch_target__Z3foob_0_0:
+
+9:                                                ; preds = %1
+  %10 = call i32 @_Z3barv()
+  store i32 %10, ptr %2, align 4
+  br label %13
+; CHECK:        .globl __llvm_prefetch_target__Z3foob_1_0
+; CHECK-NEXT: __llvm_prefetch_target__Z3foob_1_0:
+; CHECK-NEXT:   callq _Z3barv@PLT
+; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3foob_1_1
+; CHECK-NEXT: __llvm_prefetch_target__Z3foob_1_1:
+
+11:                                               ; preds = %1
+  %12 = call i32 @_Z3bazv()
+  store i32 %12, ptr %2, align 4
+  br label %13
+; CHECK:        callq _Z3bazv@PLT
+; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3foob_2_1
+; CHECK-NEXT: __llvm_prefetch_target__Z3foob_2_1:
+
+13:                                               ; preds = %11, %9
+  %14 = load i32, ptr %2, align 4
+  ret i32 %14
+; CHECK:      .LBB0_3:
+; CHECK-NEXT:   .globl	__llvm_prefetch_target__Z3foob_3_0
+; CHECK-NEXT: __llvm_prefetch_target__Z3foob_3_0:
+}
+
+define weak i32 @_Z3barv() nounwind {
+  %1 = call i32 @_Z3bazv()
+  ret i32 %1
+; CHECK:      _Z3barv:
+; CHECK-NEXT:   .weak __llvm_prefetch_target__Z3barv_0_0
+; CHECK-NEXT: __llvm_prefetch_target__Z3barv_0_0:
+}
+
+declare i32 @_Z3bazv() #1

--- a/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
@@ -17,49 +17,38 @@
 ;;
 ; RUN: llc < %s -mtriple=x86_64-pc-linux -asm-verbose=false -function-sections -basic-block-sections=%t -O0 | FileCheck %s
 
-define i32 @_Z3foob(i1 zeroext %0) nounwind {
-  %2 = alloca i32, align 4
-  %3 = alloca i8, align 1
-  %4 = zext i1 %0 to i8
-  store i8 %4, ptr %3, align 1
-  %5 = load i8, ptr %3, align 1
-  %6 = trunc i8 %5 to i1
-  %7 = zext i1 %6 to i32
-  %8 = icmp sgt i32 %7, 0
-  br i1 %8, label %9, label %11
+define void @_Z3foob(i1 %arg) nounwind {
+  br i1 %arg, label %cond.true, label %cond.false
 ; CHECK:      _Z3foob:
 ; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3foob_0_0
 ; CHECK-NEXT: __llvm_prefetch_target__Z3foob_0_0:
 
-9:                                                ; preds = %1
-  %10 = call i32 @_Z3barv()
-  store i32 %10, ptr %2, align 4
-  br label %13
+cond.true:                                           ; preds = %1
+  call i32 @_Z3barv()
+  br label %end
 ; CHECK:        .globl __llvm_prefetch_target__Z3foob_1_0
 ; CHECK-NEXT: __llvm_prefetch_target__Z3foob_1_0:
 ; CHECK-NEXT:   callq _Z3barv@PLT
 ; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3foob_1_1
 ; CHECK-NEXT: __llvm_prefetch_target__Z3foob_1_1:
 
-11:                                               ; preds = %1
-  %12 = call i32 @_Z3bazv()
-  store i32 %12, ptr %2, align 4
-  br label %13
+cond.false:                                          ; preds = %1
+  call i32 @_Z3bazv()
+  br label %end
 ; CHECK:        callq _Z3bazv@PLT
 ; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3foob_2_1
 ; CHECK-NEXT: __llvm_prefetch_target__Z3foob_2_1:
 
-13:                                               ; preds = %11, %9
-  %14 = load i32, ptr %2, align 4
-  ret i32 %14
+end:                                             ; preds = %11, %9
+  ret void
 ; CHECK:      .LBB0_3:
 ; CHECK-NEXT:   .globl	__llvm_prefetch_target__Z3foob_3_0
 ; CHECK-NEXT: __llvm_prefetch_target__Z3foob_3_0:
 }
 
 define weak i32 @_Z3barv() nounwind {
-  %1 = call i32 @_Z3bazv()
-  ret i32 %1
+  %call = call i32 @_Z3bazv()
+  ret i32 %call
 ; CHECK:      _Z3barv:
 ; CHECK-NEXT:   .weak __llvm_prefetch_target__Z3barv_0_0
 ; CHECK-NEXT: __llvm_prefetch_target__Z3barv_0_0:
@@ -67,8 +56,8 @@ define weak i32 @_Z3barv() nounwind {
 }
 
 define internal i32 @_Z3quxv() nounwind {
-  %1 = call i32 @_Z3bazv()
-  ret i32 %1
+  %call = call i32 @_Z3bazv()
+  ret i32 %call
 ; CHECK:      _Z3quxv:
 ; CHECK-NEXT:   .globl __llvm_prefetch_target__Z3quxv_0_0
 ; CHECK-NEXT: __llvm_prefetch_target__Z3quxv_0_0:
@@ -78,3 +67,4 @@ define internal i32 @_Z3quxv() nounwind {
 }
 
 declare i32 @_Z3bazv() #1
+declare i32 @_Z3dummy() #2


### PR DESCRIPTION
This is the first PR to enable the prefetch optimization via Propeller based on our [RFC](https://discourse.llvm.org/t/rfc-code-prefetch-insertion/88668/22). It enables emitting special symbols prefixed with `__llvm_prefetch_target` to point to the prefetch targets as specified via directives in the profile. A prefetch target is uniquely identified by its function name, basic block ID, and the subblock index (used when the target is after a call instruction).

A new pass is added which sets a field in basic blocks which have prefetch targets.  The next PR will add the prefetch insertion logic into the same pass.