### PR TITLE
Fix build breakage (MLIR LLVM dialect requires MLIRInferIntRangeInterface)

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
@@ -31,6 +31,7 @@ add_mlir_dialect_library(MLIRLLVMDialect
   MLIRControlFlowInterfaces
   MLIRDataLayoutInterfaces
   MLIRFunctionInterfaces
+  MLIRInferIntRangeInterface
   MLIRInferTypeOpInterface
   MLIRIR
   MLIRMemorySlotInterfaces

--- a/mlir/unittests/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/unittests/Dialect/LLVMIR/CMakeLists.txt
@@ -4,5 +4,4 @@ add_mlir_unittest(MLIRLLVMIRTests
 mlir_target_link_libraries(MLIRLLVMIRTests
   PRIVATE
   MLIRLLVMDialect
-  MLIRInferIntRangeInterface
   )


### PR DESCRIPTION
This MR fixes a recent build breakage by this MR: https://github.com/llvm/llvm-project/pull/166648

(Post-merge build error here: https://lab.llvm.org/buildbot/#/builders/138/builds/21929)

The `MLIRInferIntRangeInterface` library is now a public dependency of `MLIRLLVMDialect`. 