### PR TITLE
[TableGen] Report a better error when an InstAlias does not use a RegClass

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
@@ -55,9 +55,10 @@ static Expected<ResultOperand> matchSimpleOperand(const Init *Arg,
       // Match 'RegClass:$name' or 'RegOp:$name'.
       if (const Record *ArgRC = T.getInitValueAsRegClassLike(Arg)) {
         if (ArgRC->isSubClassOf("RegisterClass")) {
-          if (!T.getRegisterClass(OpRC).hasSubClass(&T.getRegisterClass(ArgRC)))
+          if (!OpRC->isSubClassOf("RegisterClass") ||
+              !T.getRegisterClass(OpRC).hasSubClass(&T.getRegisterClass(ArgRC)))
             return createStringError(
-                "argument register class" + ArgRC->getName() +
+                "argument register class " + ArgRC->getName() +
                 " is not a subclass of operand register class " +
                 OpRC->getName());
           if (!ArgName)


### PR DESCRIPTION
Also fix the missing space in the error message. I notice while changing
RISC-V's loads and stores to use RegClassByHwMode and got a non-descriptive
error from `T.getRegisterClass(OpRC)` when parsing the InstAliases.
