### PR TITLE
[clang][diagnostics] added warning for possible enum compare typo

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -415,6 +415,10 @@ Improvements to Clang's diagnostics
 - Clang now emits a diagnostic in case `vector_size` or `ext_vector_type`
   attributes are used with a negative size (#GH165463).
 
+- A new warning ``-Wenum-compare-typo`` has been added to detect potential erroneous
+  comparison operators when mixed with bitwise operators in enum value initializers.
+  This can be locally disabled by explicitly casting the initializer value.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13709,9 +13709,7 @@ def note_amdgcn_load_lds_size_valid_value : Note<"size must be %select{1, 2, or 
 def err_amdgcn_coop_atomic_invalid_as : Error<"cooperative atomic requires a global or generic pointer">;
 
 def warn_comparison_in_enum_initializer
-    : Warning<"comparison operator '%0' in enumerator constant is likely a "
-              "typo for "
-              "the shift operator '%1'">,
+    : Warning<"comparison operator '%0' is potentially a typo for a shift operator '%1'">,
       InGroup<DiagGroup<"enum-compare-typo">>;
 
 def note_enum_compare_typo_suggest

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13708,11 +13708,11 @@ def note_amdgcn_load_lds_size_valid_value : Note<"size must be %select{1, 2, or 
 
 def err_amdgcn_coop_atomic_invalid_as : Error<"cooperative atomic requires a global or generic pointer">;
 
-def warn_comparison_in_enum_initializer
-    : Warning<"comparison operator '%0' is potentially a typo for a shift operator '%1'">,
-      InGroup<DiagGroup<"enum-compare-typo">>;
+def warn_comparison_in_enum_initializer : Warning<
+  "comparison operator '%0' is potentially a typo for a shift operator '%1'">,
+  InGroup<DiagGroup<"enum-compare-typo">>;
 
-def note_enum_compare_typo_suggest
-    : Note<"use '%0' to perform a bitwise shift">;
+def note_enum_compare_typo_suggest : Note<
+  "use '%0' to perform a bitwise shift">;
 
 } // end of sema component.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13707,4 +13707,14 @@ def err_amdgcn_load_lds_size_invalid_value : Error<"invalid size value">;
 def note_amdgcn_load_lds_size_valid_value : Note<"size must be %select{1, 2, or 4|1, 2, 4, 12 or 16}0">;
 
 def err_amdgcn_coop_atomic_invalid_as : Error<"cooperative atomic requires a global or generic pointer">;
+
+def warn_comparison_in_enum_initializer
+    : Warning<"comparison operator '%0' in enumerator constant is likely a "
+              "typo for "
+              "the shift operator '%1'">,
+      InGroup<DiagGroup<"enum-compare-typo">>;
+
+def note_enum_compare_typo_suggest
+    : Note<"use '%0' to perform a bitwise shift">;
+
 } // end of sema component.

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -20589,10 +20589,10 @@ bool Sema::IsValueInFlagEnum(const EnumDecl *ED, const llvm::APInt &Val,
 static void CheckForComparisonInEnumInitializer(SemaBase &Sema,
                                                 const EnumDecl *Enum) {
   bool HasBitwiseOp = false;
-  SmallVector<const BinaryOperator*, 4> SuspiciousCompares;
+  SmallVector<const BinaryOperator *, 4> SuspiciousCompares;
 
   // Iterate over all the enum values, gather suspisious comparison ops and
-  // whether any enum initialisers contain a binary operator.  
+  // whether any enum initialisers contain a binary operator.
   for (const auto *ECD : Enum->enumerators()) {
     const Expr *InitExpr = ECD->getInitExpr();
     if (!InitExpr)

--- a/clang/test/Sema/warn-enum-compare-typo.c
+++ b/clang/test/Sema/warn-enum-compare-typo.c
@@ -1,0 +1,38 @@
+// RUN: %clang_cc1 -fsyntax-only -Wenum-compare-typo -verify %s 
+// RUN: %clang_cc1 -fsyntax-only -Wenum-compare-typo -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+
+enum E {
+  kOptionGood1 = 1ull << 0,
+  kOptionGood2 = 1ull >> 0,
+  // expected-warning@+3 {{comparison operator '<' in enumerator constant is likely a typo for the shift operator '<<'}} 
+  // expected-note@+2 {{use '<<' to perform a bitwise shift}}
+  // CHECK: fix-it:"{{.*}}":{[[@LINE+1]]:22-[[@LINE+1]]:23}:"<<"
+  kOptionBad1 = 1ull < 1,
+  // expected-warning@+3 {{comparison operator '>' in enumerator constant is likely a typo for the shift operator '>>'}}
+  // expected-note@+2 {{use '>>' to perform a bitwise shift}}
+  // CHECK: fix-it:"{{.*}}":{[[@LINE+1]]:19-[[@LINE+1]]:20}:">>"
+  kOptionBad2 = 1 > 3,
+  // expected-warning@+3 {{comparison operator '>' in enumerator constant is likely a typo for the shift operator '>>'}} 
+  // expected-note@+2 {{use '>>' to perform a bitwise shift}}
+  // CHECK: fix-it:"{{.*}}":{[[@LINE+1]]:20-[[@LINE+1]]:21}:">>"
+  kOptionBad3 = (1 > 2)
+};
+
+// Ensure the warning does not fire on valid code
+enum F {
+  kSomeValue = 10,
+  kComparison = kSomeValue > 5, // No warning
+  kMaxEnum = 255,
+  kIsValid = kMaxEnum > 0, // No warning
+  kSum = 10 + 20,          // No warning
+  kShift = 2 << 5          // No warning
+};
+
+// Ensure the diagnostic group works
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wenum-compare-typo"
+enum G {
+  kIgnored = 1 < 10 // No warning
+};
+#pragma clang diagnostic pop


### PR DESCRIPTION
Added diagnosis and fixit comment for possible accidental comparison operator in an enum.

Closes: #168146