### PR TITLE
[profcheck] Exclude `naked`, asm-only functions from profcheck

### DIFF
--- a/llvm/test/Transforms/PGOProfile/profcheck-exclusions.ll
+++ b/llvm/test/Transforms/PGOProfile/profcheck-exclusions.ll
@@ -1,0 +1,10 @@
+; RUN: opt -passes=prof-inject %s -S -o - | FileCheck %s
+; RUN: opt -passes=prof-verify %s --disable-output
+
+
+define void @bar(i1 %c) #0 {
+  ret void
+}
+
+attributes #0 = { naked }
+; CHECK-NOT: !prof


### PR DESCRIPTION
We can't do anything meaningful to such functions: they aren't optimizable, and even if inlined, they would bring no code open to optimization.