### PR TITLE
[libc] Move mbtowc, mbstowcs and inverse functions to stdlib.h

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1254,7 +1254,11 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.stdlib.atexit
     libc.src.stdlib.exit
     libc.src.stdlib.getenv
+    libc.src.stdlib.mbstowcs
+    libc.src.stdlib.mbtowc
     libc.src.stdlib.quick_exit
+    libc.src.stdlib.wcstombs
+    libc.src.stdlib.wctomb
 
     # signal.h entrypoints
     libc.src.signal.kill
@@ -1372,13 +1376,9 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.wchar.mbrlen
     libc.src.wchar.mbsinit
     libc.src.wchar.mbrtowc
-    libc.src.wchar.mbtowc
-    libc.src.wchar.mbstowcs
     libc.src.wchar.mbsrtowcs
     libc.src.wchar.mbsnrtowcs
     libc.src.wchar.wcrtomb
-    libc.src.wchar.wctomb
-    libc.src.wchar.wcstombs
     libc.src.wchar.wcsrtombs
     libc.src.wchar.wcsnrtombs
 

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -17,6 +17,7 @@ types:
   - type_name: lldiv_t
   - type_name: locale_t
   - type_name: size_t
+  - type_name: wchar_t  
 enums: []
 objects: []
 functions:
@@ -135,6 +136,22 @@ functions:
     arguments:
       - type: long long
       - type: long long
+  - name: mbstowcs
+    standards:
+      - stdc
+    return_type: size_t
+    arguments:
+      - type: wchar_t *__restrict
+      - type: const char *__restrict
+      - type: size_t
+  - name: mbtowc
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wchar_t *__restrict
+      - type: const char *__restrict
+      - type: size_t
   - name: memalignment
     standards:
       - stdc
@@ -332,3 +349,18 @@ functions:
     return_type: int
     arguments:
       - type: const char *
+  - name: wctomb
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: char *
+      - type: wchar_t
+  - name: wcstombs
+    standards:
+      - stdc
+    return_type: size_t
+    arguments:
+      - type: char *__restrict
+      - type: const wchar_t *__restrict
+      - type: size_t

--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -50,14 +50,6 @@ functions:
       - type: const char *__restrict
       - type: size_t
       - type: mbstate_t *__restrict
-  - name: mbtowc
-    standards:
-      - stdc
-    return_type: int
-    arguments:
-      - type: wchar_t *__restrict
-      - type: const char *__restrict
-      - type: size_t
   - name: mbsnrtowcs
     standards:
       - stdc
@@ -77,14 +69,6 @@ functions:
       - type: const char **__restrict
       - type: size_t
       - type: mbstate_t *__restrict
-  - name: mbstowcs
-    standards:
-      - stdc
-    return_type: size_t
-    arguments:
-      - type: wchar_t *__restrict
-      - type: const char *__restrict
-      - type: size_t
   - name: mbsinit
     standards:
       - stdc
@@ -269,13 +253,6 @@ functions:
       - type: char *__restrict
       - type: wchar_t
       - type: mbstate_t *__restrict
-  - name: wctomb
-    standards:
-      - stdc
-    return_type: int
-    arguments:
-      - type: char *
-      - type: wchar_t
   - name: wcscpy
     standards:
       - stdc
@@ -336,14 +313,6 @@ functions:
       - type: const wchar_t *__restrict
       - type: wchar_t **__restrict
       - type: int
-  - name: wcstombs
-    standards:
-      - stdc
-    return_type: size_t
-    arguments:
-      - type: char *__restrict
-      - type: const wchar_t *__restrict
-      - type: size_t
   - name: wcstoul
     standards:
       - stdc

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -368,6 +368,65 @@ add_entrypoint_object(
     libc.hdr.types.size_t
 )
 
+add_entrypoint_object(
+  mbtowc
+  SRCS
+    mbtowc.cpp
+  HDRS
+    mbtowc.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.hdr.types.wchar_t
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.libc_errno
+    libc.src.__support.wchar.mbrtowc
+    libc.src.__support.wchar.mbstate
+)
+
+add_entrypoint_object(
+  mbstowcs
+  SRCS
+    mbstowcs.cpp
+  HDRS
+    mbstowcs.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.hdr.types.wchar_t
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
+    libc.src.__support.libc_errno
+    libc.src.__support.wchar.mbstate
+    libc.src.__support.wchar.mbsnrtowcs
+)
+
+add_entrypoint_object(
+  wctomb
+  SRCS
+    wctomb.cpp
+  HDRS
+    wctomb.h
+  DEPENDS
+    libc.hdr.types.wchar_t
+    libc.src.__support.wchar.wcrtomb
+    libc.src.__support.wchar.mbstate
+    libc.src.__support.libc_errno
+)
+
+add_entrypoint_object(
+  wcstombs
+  SRCS
+    wcstombs.cpp
+  HDRS
+    wcstombs.h
+  DEPENDS
+    libc.hdr.types.wchar_t
+    libc.src.__support.wchar.mbstate
+    libc.src.__support.wchar.wcsnrtombs
+    libc.src.__support.libc_errno
+)
+
 if(NOT LIBC_TARGET_OS_IS_BAREMETAL AND NOT LIBC_TARGET_OS_IS_GPU)
   if(LLVM_LIBC_INCLUDE_SCUDO)
     set(SCUDO_DEPS "")

--- a/libc/src/stdlib/mbstowcs.cpp
+++ b/libc/src/stdlib/mbstowcs.cpp
@@ -1,4 +1,4 @@
-//===-- Implementation of mbtowc -----------------------------------------===//
+//===-- Implementation of mbstowcs ----------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,32 +6,35 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/wchar/mbtowc.h"
+#include "src/stdlib/mbstowcs.h"
 
 #include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/wchar/mbrtowc.h"
+#include "src/__support/macros/null_check.h"
+#include "src/__support/wchar/mbsnrtowcs.h"
 #include "src/__support/wchar/mbstate.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, mbtowc,
-                   (wchar_t *__restrict pwc, const char *__restrict s,
+LLVM_LIBC_FUNCTION(size_t, mbstowcs,
+                   (wchar_t *__restrict pwcs, const char *__restrict s,
                     size_t n)) {
-  // returns 0 since UTF-8 encoding is not state-dependent
-  if (s == nullptr)
-    return 0;
-  internal::mbstate internal_mbstate;
-  auto ret = internal::mbrtowc(pwc, s, n, &internal_mbstate);
-  if (!ret.has_value() || static_cast<int>(ret.value()) == -2) {
+  LIBC_CRASH_ON_NULLPTR(s);
+  // If destination is null, ignore n
+  n = pwcs == nullptr ? SIZE_MAX : n;
+  static internal::mbstate internal_mbstate;
+  const char *temp = s;
+  auto ret = internal::mbsnrtowcs(pwcs, &temp, SIZE_MAX, n, &internal_mbstate);
+
+  if (!ret.has_value()) {
     // Encoding failure
-    libc_errno = EILSEQ;
+    libc_errno = ret.error();
     return -1;
   }
-  return static_cast<int>(ret.value());
+  return ret.value();
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/mbstowcs.h
+++ b/libc/src/stdlib/mbstowcs.h
@@ -1,4 +1,4 @@
-//===-- Implementation header for wcstombs --------------------------------===//
+//===-- Implementation header for mbstowcs --------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_WCHAR_WCSTOMBS_H
-#define LLVM_LIBC_SRC_WCHAR_WCSTOMBS_H
+#ifndef LLVM_LIBC_SRC_STDLIB_MBSTOWCS_H
+#define LLVM_LIBC_SRC_STDLIB_MBSTOWCS_H
 
 #include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
@@ -15,8 +15,8 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-size_t wcstombs(char *__restrict s, const wchar_t *__restrict pwcs, size_t n);
+size_t mbstowcs(wchar_t *__restrict pwcs, const char *__restrict s, size_t n);
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_WCHAR_WCSTOMBS_H
+#endif // LLVM_LIBC_SRC_STDLIB_MBSTOWCS_H

--- a/libc/src/stdlib/mbtowc.cpp
+++ b/libc/src/stdlib/mbtowc.cpp
@@ -1,4 +1,4 @@
-//===-- Implementation of mbstowcs ----------------------------------------===//
+//===-- Implementation of mbtowc -----------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,35 +6,32 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/wchar/mbstowcs.h"
+#include "src/stdlib/mbtowc.h"
 
 #include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/macros/null_check.h"
-#include "src/__support/wchar/mbsnrtowcs.h"
+#include "src/__support/wchar/mbrtowc.h"
 #include "src/__support/wchar/mbstate.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(size_t, mbstowcs,
-                   (wchar_t *__restrict pwcs, const char *__restrict s,
+LLVM_LIBC_FUNCTION(int, mbtowc,
+                   (wchar_t *__restrict pwc, const char *__restrict s,
                     size_t n)) {
-  LIBC_CRASH_ON_NULLPTR(s);
-  // If destination is null, ignore n
-  n = pwcs == nullptr ? SIZE_MAX : n;
-  static internal::mbstate internal_mbstate;
-  const char *temp = s;
-  auto ret = internal::mbsnrtowcs(pwcs, &temp, SIZE_MAX, n, &internal_mbstate);
-
-  if (!ret.has_value()) {
+  // returns 0 since UTF-8 encoding is not state-dependent
+  if (s == nullptr)
+    return 0;
+  internal::mbstate internal_mbstate;
+  auto ret = internal::mbrtowc(pwc, s, n, &internal_mbstate);
+  if (!ret.has_value() || static_cast<int>(ret.value()) == -2) {
     // Encoding failure
-    libc_errno = ret.error();
+    libc_errno = EILSEQ;
     return -1;
   }
-  return ret.value();
+  return static_cast<int>(ret.value());
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/mbtowc.h
+++ b/libc/src/stdlib/mbtowc.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_WCHAR_MBTOWC_H
-#define LLVM_LIBC_SRC_WCHAR_MBTOWC_H
+#ifndef LLVM_LIBC_SRC_STDLIB_MBTOWC_H
+#define LLVM_LIBC_SRC_STDLIB_MBTOWC_H
 
 #include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
@@ -19,4 +19,4 @@ int mbtowc(wchar_t *__restrict pwc, const char *__restrict s, size_t n);
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_WCHAR_MBTOWC_H
+#endif // LLVM_LIBC_SRC_STDLIB_MBTOWC_H

--- a/libc/src/stdlib/wcstombs.cpp
+++ b/libc/src/stdlib/wcstombs.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/wchar/wcstombs.h"
+#include "src/stdlib/wcstombs.h"
 
 #include "hdr/types/char32_t.h"
 #include "hdr/types/size_t.h"

--- a/libc/src/stdlib/wcstombs.h
+++ b/libc/src/stdlib/wcstombs.h
@@ -1,4 +1,4 @@
-//===-- Implementation header for wctomb ------------------------*- C++ -*-===//
+//===-- Implementation header for wcstombs --------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,17 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_WCHAR_WCTOMB_H
-#define LLVM_LIBC_SRC_WCHAR_WCTOMB_H
+#ifndef LLVM_LIBC_SRC_STDLIB_WCSTOMBS_H
+#define LLVM_LIBC_SRC_STDLIB_WCSTOMBS_H
 
-#include "hdr/types/mbstate_t.h"
+#include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-int wctomb(char *s, wchar_t wc);
+size_t wcstombs(char *__restrict s, const wchar_t *__restrict pwcs, size_t n);
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_WCHAR_WCTOMB_H
+#endif // LLVM_LIBC_SRC_STDLIB_WCSTOMBS_H

--- a/libc/src/stdlib/wctomb.cpp
+++ b/libc/src/stdlib/wctomb.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/wchar/wctomb.h"
+#include "src/stdlib/wctomb.h"
 
 #include "hdr/types/wchar_t.h"
 #include "src/__support/common.h"

--- a/libc/src/stdlib/wctomb.h
+++ b/libc/src/stdlib/wctomb.h
@@ -1,4 +1,4 @@
-//===-- Implementation header for mbstowcs --------------------------------===//
+//===-- Implementation header for wctomb ------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,17 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_WCHAR_MBSTOWCS_H
-#define LLVM_LIBC_SRC_WCHAR_MBSTOWCS_H
+#ifndef LLVM_LIBC_SRC_STDLIB_WCTOMB_H
+#define LLVM_LIBC_SRC_STDLIB_WCTOMB_H
 
-#include "hdr/types/size_t.h"
+#include "hdr/types/mbstate_t.h"
 #include "hdr/types/wchar_t.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-size_t mbstowcs(wchar_t *__restrict pwcs, const char *__restrict s, size_t n);
+int wctomb(char *s, wchar_t wc);
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_WCHAR_MBSTOWCS_H
+#endif // LLVM_LIBC_SRC_STDLIB_WCTOMB_H

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -157,19 +157,6 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  wctomb
-  SRCS
-    wctomb.cpp
-  HDRS
-    wctomb.h
-  DEPENDS
-    libc.hdr.types.wchar_t
-    libc.src.__support.wchar.wcrtomb
-    libc.src.__support.wchar.mbstate
-    libc.src.__support.libc_errno
-)
-
-add_entrypoint_object(
   mbsinit
   SRCS
     mbsinit.cpp
@@ -202,39 +189,6 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  mbtowc
-  SRCS
-    mbtowc.cpp
-  HDRS
-    mbtowc.h
-  DEPENDS
-    libc.hdr.types.size_t
-    libc.hdr.types.wchar_t
-    libc.src.__support.common
-    libc.src.__support.macros.config
-    libc.src.__support.libc_errno
-    libc.src.__support.wchar.mbrtowc
-    libc.src.__support.wchar.mbstate
-)
-
-add_entrypoint_object(
-  mbstowcs
-  SRCS
-    mbstowcs.cpp
-  HDRS
-    mbstowcs.h
-  DEPENDS
-    libc.hdr.types.size_t
-    libc.hdr.types.wchar_t
-    libc.src.__support.common
-    libc.src.__support.macros.config
-    libc.src.__support.macros.null_check
-    libc.src.__support.libc_errno
-    libc.src.__support.wchar.mbstate
-    libc.src.__support.wchar.mbsnrtowcs
-)
-
-add_entrypoint_object(
   mbsrtowcs
   SRCS
     mbsrtowcs.cpp
@@ -264,19 +218,6 @@ add_entrypoint_object(
     libc.src.__support.libc_errno
     libc.src.__support.wchar.mbstate
     libc.src.__support.wchar.mbsnrtowcs
-)
-
-add_entrypoint_object(
-  wcstombs
-  SRCS
-    wcstombs.cpp
-  HDRS
-    wcstombs.h
-  DEPENDS
-    libc.hdr.types.wchar_t
-    libc.src.__support.wchar.mbstate
-    libc.src.__support.wchar.wcsnrtombs
-    libc.src.__support.libc_errno
 )
 
 add_entrypoint_object(

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -388,6 +388,56 @@ add_libc_test(
     libc.src.stdlib.memalignment
 )
 
+add_libc_test(
+  mbtowc_test
+  SUITE
+    libc-stdlib-tests
+  SRCS
+    mbtowc_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.stdlib.mbtowc
+    libc.hdr.types.wchar_t
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  mbstowcs_test
+  SUITE
+    libc-stdlib-tests
+  SRCS
+    mbstowcs_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.stdlib.mbstowcs
+    libc.hdr.types.wchar_t
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
+  wctomb_test
+  SUITE
+    libc-stdlib-tests
+  SRCS
+    wctomb_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.stdlib.wctomb
+    libc.hdr.types.wchar_t
+)
+
+add_libc_test(
+  wcstombs_test
+  SUITE
+    libc-stdlib-tests
+  SRCS
+    wcstombs_test.cpp
+  DEPENDS
+    libc.src.stdlib.wcstombs
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.hdr.types.wchar_t
+)
+
 if(LLVM_LIBC_FULL_BUILD)
 
   add_libc_test(

--- a/libc/test/src/stdlib/mbstowcs_test.cpp
+++ b/libc/test/src/stdlib/mbstowcs_test.cpp
@@ -9,7 +9,7 @@
 #include "hdr/errno_macros.h"
 #include "hdr/types/wchar_t.h"
 #include "src/__support/macros/null_check.h"
-#include "src/wchar/mbstowcs.h"
+#include "src/stdlib/mbstowcs.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 

--- a/libc/test/src/stdlib/mbtowc_test.cpp
+++ b/libc/test/src/stdlib/mbtowc_test.cpp
@@ -8,7 +8,7 @@
 
 #include "hdr/errno_macros.h"
 #include "hdr/types/wchar_t.h"
-#include "src/wchar/mbtowc.h"
+#include "src/stdlib/mbtowc.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 

--- a/libc/test/src/stdlib/wcstombs_test.cpp
+++ b/libc/test/src/stdlib/wcstombs_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/wchar/wcstombs.h"
+#include "src/stdlib/wcstombs.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 

--- a/libc/test/src/stdlib/wctomb_test.cpp
+++ b/libc/test/src/stdlib/wctomb_test.cpp
@@ -8,7 +8,7 @@
 
 #include "hdr/errno_macros.h"
 #include "hdr/types/wchar_t.h"
-#include "src/wchar/wctomb.h"
+#include "src/stdlib/wctomb.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 

--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -63,32 +63,6 @@ add_libc_test(
 )
 
 add_libc_test(
-  mbtowc_test
-  SUITE
-    libc_wchar_unittests
-  SRCS
-    mbtowc_test.cpp
-  DEPENDS
-    libc.hdr.errno_macros
-    libc.src.wchar.mbtowc
-    libc.hdr.types.wchar_t
-    libc.test.UnitTest.ErrnoCheckingTest
-)
-
-add_libc_test(
-  mbstowcs_test
-  SUITE
-    libc_wchar_unittests
-  SRCS
-    mbstowcs_test.cpp
-  DEPENDS
-    libc.hdr.errno_macros
-    libc.src.wchar.mbstowcs
-    libc.hdr.types.wchar_t
-    libc.test.UnitTest.ErrnoCheckingTest
-)
-
-add_libc_test(
   mblen_test
   SUITE
     libc_wchar_unittests
@@ -186,30 +160,6 @@ add_libc_test(
     libc.hdr.types.mbstate_t
     libc.src.__support.wchar.mbstate
     libc.test.UnitTest.ErrnoCheckingTest
-)
-
-add_libc_test(
-  wctomb_test
-  SUITE
-    libc_wchar_unittests
-  SRCS
-    wctomb_test.cpp
-  DEPENDS
-    libc.hdr.errno_macros
-    libc.src.wchar.wctomb
-    libc.hdr.types.wchar_t
-)
-
-add_libc_test(
-  wcstombs_test
-  SUITE
-    libc_wchar_unittests
-  SRCS
-    wcstombs_test.cpp
-  DEPENDS
-    libc.src.wchar.wcstombs
-    libc.test.UnitTest.ErrnoCheckingTest
-    libc.hdr.types.wchar_t
 )
 
 add_libc_test(


### PR DESCRIPTION
These functions should be declared in `stdlib.h`, not `wchar.h`, as confusing as it is. Move them to the proper header file and matching directories in src/ and test/ trees.

This was discovered while testing libc++ build against llvm-libc, which re-declares functions like mbtowc in std-namespace in `<cstdlib>` header, and then uses those functions in its locale implementation.