### PR TITLE
[RTSan] Fix tests under Internal Shell

### DIFF
--- a/compiler-rt/test/rtsan/Darwin/dlopen.cpp
+++ b/compiler-rt/test/rtsan/Darwin/dlopen.cpp
@@ -8,18 +8,19 @@
 // RUN: %clangxx -fsanitize=realtime %s -o %t.so -shared -DSHARED_LIB
 // RUN: %clangxx %s -o %t
 
-// RUN: RTSAN_DYLIB_PATH=`%clangxx -fsanitize=realtime %s -### 2>&1 \
+// RUN: %clangxx -fsanitize=realtime %s -### 2>&1 \
 // RUN:   | grep "libclang_rt.rtsan_osx_dynamic.dylib" \
-// RUN:   | sed -e 's/.*"\(.*libclang_rt.rtsan_osx_dynamic.dylib\)".*/\1/'`
+// RUN:   | sed -e 's/.*"\(.*libclang_rt.rtsan_osx_dynamic.dylib\)".*/\1/' \
+// RUN:   | tr -d '\n' > %t.rtsan_dylib_path
 
 // Launching a non-instrumented binary that dlopen's an instrumented library should fail.
 // RUN: not %run %t %t.so 2>&1 | FileCheck %s --check-prefix=CHECK-FAIL
 // Launching a non-instrumented binary with an explicit DYLD_INSERT_LIBRARIES should work.
-// RUN: DYLD_INSERT_LIBRARIES=$RTSAN_DYLIB_PATH %run %t %t.so 2>&1 | FileCheck %s
+// RUN: env DYLD_INSERT_LIBRARIES="%{readfile:%t.rtsan_dylib_path}" %run %t %t.so 2>&1 | FileCheck %s
 
 // Launching an instrumented binary with the DYLD_INSERT_LIBRARIES env variable has no error
 // RUN: %clangxx -fsanitize=realtime %s -o %t
-// RUN: DYLD_INSERT_LIBRARIES=$RTSAN_DYLIB_PATH %run %t %t.so 2>&1 | FileCheck %s --check-prefix=CHECK-INSTRUMENTED
+// RUN: env DYLD_INSERT_LIBRARIES="%{readfile:%t.rtsan_dylib_path}" %run %t %t.so 2>&1 | FileCheck %s --check-prefix=CHECK-INSTRUMENTED
 
 #include <dlfcn.h>
 #include <stdio.h>


### PR DESCRIPTION
This patch fixes the only RTSan test that was broken by enabling lit's internal shell on Darwin. This patch rewrites the test to prefix env variables with `env` and to avoid the use of subshells.