### PR TITLE
[ORC] Make tests work with Internal Shell

### DIFF
--- a/compiler-rt/test/orc/TestCases/Darwin/arm64/objc-imageinfo.S
+++ b/compiler-rt/test/orc/TestCases/Darwin/arm64/objc-imageinfo.S
@@ -5,7 +5,9 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: (cd %t; %clang -c *.S)
+// RUN: pushd %t
+// RUN: %clang -c *.S
+// RUN: popd
 
 // Check individual versions are loadable.
 


### PR DESCRIPTION
This patch makes objc-imageinfo.S work with the internal shell. The test uses a subshell to temporarily change the directory. The internal shell does not support subshells, so this construct was replaced with a pushd/popd sequence.