### PR TITLE
[CIR] Upstream CIR codegen for `lzcnt` and `tzcnt` x86 builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -121,13 +121,26 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
     return emitIntrinsicCallOp(*this, expr, "x86.sse.sfence", voidTy);
   case X86::BI_mm_prefetch:
   case X86::BI__rdtsc:
-  case X86::BI__builtin_ia32_rdtscp:
+  case X86::BI__builtin_ia32_rdtscp: {
+    cgm.errorNYI(expr->getSourceRange(),
+                 std::string("unimplemented X86 builtin call: ") +
+                     getContext().BuiltinInfo.getName(builtinID));
+    return {};
+  }
   case X86::BI__builtin_ia32_lzcnt_u16:
   case X86::BI__builtin_ia32_lzcnt_u32:
-  case X86::BI__builtin_ia32_lzcnt_u64:
+  case X86::BI__builtin_ia32_lzcnt_u64: {
+    mlir::Value isZeroPoison = builder.getFalse(getLoc(expr->getExprLoc()));
+    return emitIntrinsicCallOp(*this, expr, "ctlz", ops[0].getType(),
+                               mlir::ValueRange{ops[0], isZeroPoison});
+  }
   case X86::BI__builtin_ia32_tzcnt_u16:
   case X86::BI__builtin_ia32_tzcnt_u32:
-  case X86::BI__builtin_ia32_tzcnt_u64:
+  case X86::BI__builtin_ia32_tzcnt_u64: {
+    mlir::Value isZeroPoison = builder.getFalse(getLoc(expr->getExprLoc()));
+    return emitIntrinsicCallOp(*this, expr, "cttz", ops[0].getType(),
+                               mlir::ValueRange{ops[0], isZeroPoison});
+  }
   case X86::BI__builtin_ia32_undef128:
   case X86::BI__builtin_ia32_undef256:
   case X86::BI__builtin_ia32_undef512:

--- a/clang/test/CIR/CodeGen/X86/bmi-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/bmi-builtins.c
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 -x c -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+// RUN: %clang_cc1 -x c -ffreestanding -triple=x86_64-unknown-linux -emit-llvm -Wall -Werror %s -o - | FileCheck %s -check-prefix=OGCG
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple=x86_64-unknown-linux -emit-llvm -Wall -Werror %s -o - | FileCheck %s -check-prefix=OGCG
+
+// This test mimics clang/test/CodeGen/X86/bmi-builtins.c, which eventually
+// CIR shall be able to support fully.
+
+#include <immintrin.h>
+
+unsigned short test__tzcnt_u16(unsigned short __X) {
+  // CIR-LABEL: __tzcnt_u16
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "cttz" {{%.*}} : (!u16i, !cir.bool) -> !u16i
+  // LLVM-LABEL: __tzcnt_u16
+  // LLVM: i16 @llvm.cttz.i16(i16 %{{.*}}, i1 false)
+  // OGCG-LABEL: __tzcnt_u16
+  // OGCG: i16 @llvm.cttz.i16(i16 %{{.*}}, i1 false)
+  return __tzcnt_u16(__X);
+}
+
+unsigned int test__tzcnt_u32(unsigned int __X) {
+  // CIR-LABEL: __tzcnt_u32
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "cttz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // LLVM-LABEL: __tzcnt_u32
+  // LLVM: i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
+  // OGCG-LABEL: __tzcnt_u32
+  // OGCG: i32 @llvm.cttz.i32(i32 %{{.*}}, i1 false)
+  return __tzcnt_u32(__X);
+}
+
+#ifdef __x86_64__
+unsigned long long test__tzcnt_u64(unsigned long long __X) {
+  // CIR-LABEL: __tzcnt_u64
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "cttz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // LLVM-LABEL: __tzcnt_u64
+  // LLVM: i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+  // OGCG-LABEL: __tzcnt_u64
+  // OGCG: i64 @llvm.cttz.i64(i64 %{{.*}}, i1 false)
+  return __tzcnt_u64(__X);
+}
+#endif

--- a/clang/test/CIR/CodeGen/X86/lzcnt-builtins.c
+++ b/clang/test/CIR/CodeGen/X86/lzcnt-builtins.c
@@ -1,0 +1,67 @@
+// RUN: %clang_cc1 -x c -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+// RUN: %clang_cc1 -x c -ffreestanding -triple=x86_64-unknown-linux -emit-llvm -Wall -Werror %s -o - | FileCheck %s -check-prefix=OGCG
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple=x86_64-unknown-linux -emit-llvm -Wall -Werror %s -o - | FileCheck %s -check-prefix=OGCG
+
+// This test mimics clang/test/CodeGen/X86/lzcnt-builtins.c, which eventually
+// CIR shall be able to support fully.
+
+#include <immintrin.h>
+
+unsigned int test__lzcnt16(unsigned short __X) {
+  // CIR-LABEL: __lzcnt16
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u16i, !cir.bool) -> !u16i
+  // LLVM-LABEL: __lzcnt16
+  // LLVM: @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
+  // OGCG-LABEL: __lzcnt16
+  // OGCG: @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
+  return __lzcnt16(__X);
+}
+
+unsigned int test__lzcnt32(unsigned int __X) {
+  // CIR-LABEL: __lzcnt32
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // LLVM-LABEL: __lzcnt32
+  // LLVM: @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+  // OGCG-LABEL: __lzcnt32
+  // OGCG: @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+  return __lzcnt32(__X);
+}
+
+unsigned long long test__lzcnt64(unsigned long long __X) {
+  // CIR-LABEL: __lzcnt64
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // LLVM-LABEL: __lzcnt64
+  // LLVM: @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+  // OGCG-LABEL: __lzcnt64
+  // OGCG: @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+  return __lzcnt64(__X);
+}
+
+unsigned int test__lzcnt_u32(unsigned int __X) {
+  // CIR-LABEL: _lzcnt_u32
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u32i, !cir.bool) -> !u32i
+  // LLVM-LABEL: _lzcnt_u32
+  // LLVM: @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+  // OGCG-LABEL: _lzcnt_u32
+  // OGCG: @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
+  return _lzcnt_u32(__X);
+}
+
+unsigned long long test__lzcnt_u64(unsigned long long __X) {
+  // CIR-LABEL: _lzcnt_u64
+  // CIR: {{%.*}} = cir.call_llvm_intrinsic "ctlz" {{%.*}} : (!u64i, !cir.bool) -> !u64i
+  // LLVM-LABEL: _lzcnt_u64
+  // LLVM: @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+  // OGCG-LABEL: _lzcnt_u64
+  // OGCG: @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
+  return _lzcnt_u64(__X);
+}


### PR DESCRIPTION
Support CIR codegen for x86 builtins `__builtin_ia32_lzcnt` and `__builtin_ia32_tzcnt`.