### PR TITLE
Fixed 2 tests that failed on MacOS 

### DIFF
--- a/cross-project-tests/dtlto/dtlto-cache.test
+++ b/cross-project-tests/dtlto/dtlto-cache.test
@@ -17,7 +17,7 @@ RUN:   -Wl,--thinlto-cache-dir=cache.dir \
 RUN:   -Wl,--save-temps
 
 # Check that there are two backend compilation jobs occurred.
-RUN: grep -wo args populate1.*.dist-file.json | wc -l | grep -qx 3
+RUN: grep -wo args populate1.*.dist-file.json | wc -l | grep -qx "\s*3"
 RUN: ls cache.dir/llvmcache.timestamp
 RUN: ls cache.dir | count 3
 
@@ -32,7 +32,7 @@ RUN:   -Wl,--thinlto-cache-dir=cache.dir \
 RUN:   -Wl,--save-temps
 
 # Check that there are no backend compilation jobs occurred.
-RUN: grep -wo args populate2.*.dist-file.json | wc -l | grep -qx 1
+RUN: grep -wo args populate2.*.dist-file.json | wc -l | grep -qx "\s*1"
 RUN: ls cache.dir | count 3
 
 RUN: %clang -O0 --target=x86_64-linux-gnu -flto=thin -c foo.c -o foo.O0.o
@@ -52,7 +52,7 @@ RUN:   -Wl,--thinlto-cache-dir=cache.dir \
 RUN:   -Wl,--save-temps
 
 # Check that there are two new backend compilation jobs occurred.
-RUN: grep -wo args populate3.*.dist-file.json | wc -l | grep -qx 3
+RUN: grep -wo args populate3.*.dist-file.json | wc -l | grep -qx "\s*3"
 RUN: ls cache.dir | count 5
 
 RUN: %clang -O2 --target=x86_64-linux-gnu -flto=thin -c main-partial.c 
@@ -69,7 +69,7 @@ RUN:   -Wl,--thinlto-cache-dir=cache.dir \
 RUN:   -Wl,--save-temps
 
 # Check that there is one new backend compilation jobs occurred.
-RUN: grep -wo args main-partial.*.dist-file.json | wc -l | grep -qx 2
+RUN: grep -wo args main-partial.*.dist-file.json | wc -l | grep -qx "\s*2"
 RUN: ls cache.dir | count 6
 
 #--- foo.c

--- a/cross-project-tests/dtlto/dtlto-thinlto-cache.test
+++ b/cross-project-tests/dtlto/dtlto-thinlto-cache.test
@@ -29,7 +29,7 @@ RUN:   -Wl,--thinlto-cache-dir=cache.dir \
 RUN:   -Wl,--save-temps
 
 # Check that there are two backend compilation jobs occurred.
-RUN: grep -wo args populate1.*.dist-file.json | wc -l | grep -qx 3
+RUN: grep -wo args populate1.*.dist-file.json | wc -l | grep -qx "\s*3"
 RUN: ls cache.dir | count 5
 
 # Clean up cache directory.
@@ -45,7 +45,7 @@ RUN:   -Wl,--thinlto-cache-dir=cache.dir \
 RUN:   -Wl,--save-temps
 
 # Check that there are two backend compilation jobs occurred.
-RUN: grep -wo args populate2.*.dist-file.json | wc -l | grep -qx 3
+RUN: grep -wo args populate2.*.dist-file.json | wc -l | grep -qx "\s*3"
 RUN: ls cache.dir/llvmcache.timestamp
 RUN: ls cache.dir | count 3
 

--- a/llvm/test/ThinLTO/X86/dtlto/dtlto-cache.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/dtlto-cache.ll
@@ -43,17 +43,10 @@ THINLTO-DAG: {{^}}t.o.2{{$}}
 
 RUN: %{command}
 
-; Check that the expected output files have been created.
 RUN: ls | count 3
-; Check that two native object files has been created
 RUN: ls | FileCheck %s --check-prefix=THINLTO
-; Check that DTLTO cache directory has been created
 RUN: ls cache-dir/* | count 2
-; Check that 2 cache entries are created
 RUN: ls cache-dir/llvmcache-* | count 2
-
-
-
 
 ;--- t1.ll
 


### PR DESCRIPTION
1. Fixed 2 DTLTO cache tests that failed on MacOS because input to grep command is different compared to Windows
2. Removed unneeded comments from  dtlto-cache.ll