### PR TITLE
[ADT] Move the core logic of swapping to DenseMapBase::swap (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -369,7 +369,7 @@ public:
     DerivedT &LHS = derived();
     DerivedT Tmp;
     Tmp.destroyAll();
-    Tmp.derived().kill();
+    Tmp.kill();
     Tmp.moveWithoutRehash(std::move(LHS));
     LHS.moveWithoutRehash(std::move(RHS));
     RHS.moveWithoutRehash(std::move(Tmp));
@@ -443,7 +443,7 @@ protected:
   // - *this is valid.
   // - RHS is valid or killed (but not uninitialized).
   void moveWithoutRehash(DerivedT &&RHS) {
-    if (derived().maybeMoveFast(std::move(RHS.derived())))
+    if (derived().maybeMoveFast(std::move(RHS)))
       return;
 
     derived().allocateBuckets(RHS.getNumBuckets());
@@ -467,7 +467,7 @@ protected:
         R->getSecond().~ValueT();
       }
     }
-    RHS.derived().kill();
+    RHS.kill();
   }
 
   // Move key/value from Other to *this.


### PR DESCRIPTION
This patch moves the core logic of swapping to DenseMapBase::swap.

DenseMapBase::swap attempts to swap LHS and RHS fast with
metadata/pointer updates.  This always succeeds in DenseMap.  For
SmallDenseMap, it succeeds only if both LHS and RHS are in the large
mode.

If that fails, we swap LHS and RHS using three moves involving a
temporary instance.  Even then, we try to move fast with
metadata/pointer updates where we can.

This patch is part of the effort outlined in #168255.
