### PR TITLE
[clang-doc] Fix whitespace issues in Mustache basic test

### DIFF
--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -174,7 +174,7 @@
                 <h2>Public Methods</h2>
                 <div>
                     {{#PublicFunctions}}
-{{>FunctionPartial}}
+                    {{>FunctionPartial}}
                     {{/PublicFunctions}}
                 </div>
             </section>

--- a/clang-tools-extra/clang-doc/assets/comment-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/comment-template.mustache
@@ -6,61 +6,61 @@
     This file defines templates for generating comments
 }}
 {{#BriefComments}}
-    <div>
-    {{#.}}
-        <p>{{TextComment}}</p>
-    {{/.}}
-    </div>
+<div>
+{{#.}}
+    <p>{{TextComment}}</p>
+{{/.}}
+</div>
 {{/BriefComments}}
 {{#ParagraphComments}}
-    <div>
-    {{#.}}
-        <p>{{TextComment}}</p>
-    {{/.}}
-    </div>
+<div>
+{{#.}}
+    <p>{{TextComment}}</p>
+{{/.}}
+</div>
 {{/ParagraphComments}}
 {{#ParagraphComment}}
-    {{#Children}}
-    {{>Comments}}
-    {{/Children}}
+{{#Children}}
+{{TextComment}}
+{{/Children}}
 {{/ParagraphComment}}
 {{#HasParamComments}}
-    <h3>Parameters</h3>
-    {{#ParamComments}}
-    <div>
-        <b>{{ParamName}}</b> {{#Explicit}}{{Direction}}{{/Explicit}} {{#Children}}{{>Comments}}{{/Children}}
-    </div> 
-    {{/ParamComments}}
+<h3>Parameters</h3>
+{{#ParamComments}}
+<div>
+    <b>{{ParamName}}</b> {{#Explicit}}{{Direction}}{{/Explicit}} {{#Children}}{{TextComment}}{{/Children}}
+</div> 
+{{/ParamComments}}
 {{/HasParamComments}}
 {{#HasReturnComments}}
-    <h3>Returns</h3>
-    {{#ReturnComments}}
-        {{#.}}
-        <p>{{TextComment}}</p>
-        {{/.}}
-    {{/ReturnComments}}
+<h3>Returns</h3>
+{{#ReturnComments}}
+{{#.}}
+<p>{{TextComment}}</p>
+{{/.}}
+{{/ReturnComments}}
 {{/HasReturnComments}}
 {{#HasCodeComments}}
-    <h3>Code</h3> 
-    {{#CodeComments}}
-    <div>
-        <pre class="code-block">
-            <code>
-            {{#.}}
+<h3>Code</h3> 
+{{#CodeComments}}
+<div>
+    <pre class="code-block">
+        <code>
+        {{#.}}
             {{.}}
-            {{/.}}
-            </code>
-        </pre>
-    </div>
-    {{/CodeComments}}
+        {{/.}}
+        </code>
+    </pre>
+</div>
+{{/CodeComments}}
 {{/HasCodeComments}}
 {{#HasThrowsComments}}
-    <h3>Throws</h3>
-    {{#ThrowsComments}}
-    <div>
-        <b>{{Exception}}</b> {{#Children}}{{TextComment}}{{/Children}}
-    </div>
-    {{/ThrowsComments}}
+<h3>Throws</h3>
+{{#ThrowsComments}}
+<div>
+    <b>{{Exception}}</b> {{#Children}}{{TextComment}}{{/Children}}
+</div>
+{{/ThrowsComments}}
 {{/HasThrowsComments}}
 {{#BlockCommandComment}}
     <div class="block-command-comment__command">
@@ -74,8 +74,3 @@
         </div>
     </div>
 {{/BlockCommandComment}}
-{{#TextComment}}
-    <div>
-        <p>{{TextComment}}</p>
-    </div>
-{{/TextComment}}

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -8,11 +8,7 @@
 <div class="delimiter-container">
     <div id="{{USR}}">
         {{! Function Prototype }}
-        <pre>
-            <code class="language-cpp code-clang-doc">
-{{ReturnType.Name}} {{Name}} ({{#Params}}{{^End}}{{Type}} {{Name}}, {{/End}}{{#End}}{{Type}} {{Name}}{{/End}}{{/Params}})
-            </code>
-        </pre>
+        <pre><code class="language-cpp code-clang-doc">{{ReturnType.Name}} {{Name}} ({{#Params}}{{^End}}{{Type}} {{Name}}, {{/End}}{{#End}}{{Type}} {{Name}}{{/End}}{{/Params}})</code></pre>
         {{! Function Comments }}
         {{#Description}}
         <div>

--- a/clang-tools-extra/test/clang-doc/basic-project.mustache.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.mustache.test
@@ -60,84 +60,72 @@ HTML-SHAPE:         <div class="content">
 HTML-SHAPE:             <section class="hero section-container">
 HTML-SHAPE:                 <div class="hero__title">
 HTML-SHAPE:                     <h1 class="hero__title-large">class Shape</h1>
-HTML-SHAPE:                    <div class="hero__subtitle">
-HTML-SHAPE:                                    <div>
-HTML-SHAPE:                                        <p> Abstract base class for shapes.</p>
-HTML-SHAPE:                                    </div>
-HTML-SHAPE:                                        <div>
-HTML-SHAPE:                                    <p></p>
-HTML-SHAPE:                                </div>
-HTML-SHAPE:                                    <div>
-HTML-SHAPE:                                    <p> Provides a common interface for different types of shapes.</p>
-HTML-SHAPE:                                </div>
-HTML-SHAPE:                                                </div>
+HTML-SHAPE:                     <div class="hero__subtitle">
+HTML-SHAPE:                         <div>
+HTML-SHAPE:                             <p> Abstract base class for shapes.</p>
+HTML-SHAPE:                         </div>
+HTML-SHAPE:                         <div>
+HTML-SHAPE:                             <p></p>
+HTML-SHAPE:                         </div>
+HTML-SHAPE:                         <div>
+HTML-SHAPE:                             <p> Provides a common interface for different types of shapes.</p>
+HTML-SHAPE:                         </div>
+HTML-SHAPE:                     </div>
 HTML-SHAPE:                 </div>
 HTML-SHAPE:             </section>
 HTML-SHAPE:             <section id="PublicMethods" class="section-container">
 HTML-SHAPE:                 <h2>Public Methods</h2>
 HTML-SHAPE:                 <div>
-HTML-SHAPE: <div class="delimiter-container">
-HTML-SHAPE:     <div id="{{([0-9A-F]{40})}}">
-HTML-SHAPE:         <pre>
-HTML-SHAPE:             <code class="language-cpp code-clang-doc">
-HTML-SHAPE: double area ()
-HTML-SHAPE:             </code>
-HTML-SHAPE:         </pre>
-HTML-SHAPE:        <div>
-HTML-SHAPE:                        <div>
-HTML-SHAPE:                            <p> Calculates the area of the shape.</p>
-HTML-SHAPE:                        </div>
-HTML-SHAPE:                            <div>
-HTML-SHAPE:                        <p></p>
-HTML-SHAPE:                    </div>
-HTML-SHAPE:                        <div>
-HTML-SHAPE:                        <p></p>
-HTML-SHAPE:                    </div>
-HTML-SHAPE:                    <h3>Returns</h3>
-HTML-SHAPE:                        <p> double The area of the shape.</p>
-HTML-SHAPE:                        </div>
-HTML-SHAPE:     </div>
-HTML-SHAPE: </div>
-HTML-SHAPE: <div class="delimiter-container">
-HTML-SHAPE:     <div id="{{([0-9A-F]{40})}}">
-HTML-SHAPE:         <pre>
-HTML-SHAPE:             <code class="language-cpp code-clang-doc">
-HTML-SHAPE: double perimeter ()
-HTML-SHAPE:             </code>
-HTML-SHAPE:         </pre>
-HTML-SHAPE:        <div>
-HTML-SHAPE:                        <div>
-HTML-SHAPE:                            <p> Calculates the perimeter of the shape.</p>
-HTML-SHAPE:                        </div>
-HTML-SHAPE:                            <div>
-HTML-SHAPE:                        <p></p>
-HTML-SHAPE:                    </div>
-HTML-SHAPE:                        <div>
-HTML-SHAPE:                        <p></p>
-HTML-SHAPE:                    </div>
-HTML-SHAPE:                    <h3>Returns</h3>
-HTML-SHAPE:                        <p> double The perimeter of the shape.</p>
-HTML-SHAPE:                        </div>
-HTML-SHAPE:     </div>
-HTML-SHAPE: </div>
-HTML-SHAPE: <div class="delimiter-container">
-HTML-SHAPE:     <div id="{{([0-9A-F]{40})}}">
-HTML-SHAPE:         <pre>
-HTML-SHAPE:             <code class="language-cpp code-clang-doc">
-HTML-SHAPE: void ~Shape ()
-HTML-SHAPE:             </code>
-HTML-SHAPE:         </pre>
-HTML-SHAPE:        <div>
-HTML-SHAPE:                        <div>
-HTML-SHAPE:                            <p> Virtual destructor.</p>
-HTML-SHAPE:                        </div>
-HTML-SHAPE:                            <div>
-HTML-SHAPE:                        <p></p>
-HTML-SHAPE:                    </div>
-HTML-SHAPE:                        </div>
-HTML-SHAPE:     </div>
-HTML-SHAPE: </div>
-HTML-SHAPE: </div>
+HTML-SHAPE:                     <div class="delimiter-container">
+HTML-SHAPE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-SHAPE:                             <pre><code class="language-cpp code-clang-doc">double area ()</code></pre>
+HTML-SHAPE:                             <div>
+HTML-SHAPE:                                 <div>
+HTML-SHAPE:                                     <p> Calculates the area of the shape.</p>
+HTML-SHAPE:                                 </div>
+HTML-SHAPE:                                 <div>
+HTML-SHAPE:                                     <p></p>
+HTML-SHAPE:                                 </div>
+HTML-SHAPE:                                 <div>
+HTML-SHAPE:                                     <p></p>
+HTML-SHAPE:                                 </div>
+HTML-SHAPE:                                 <h3>Returns</h3>
+HTML-SHAPE:                                 <p> double The area of the shape.</p>
+HTML-SHAPE:                             </div>
+HTML-SHAPE:                         </div>
+HTML-SHAPE:                     </div>
+HTML-SHAPE:                     <div class="delimiter-container">
+HTML-SHAPE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-SHAPE:                             <pre><code class="language-cpp code-clang-doc">double perimeter ()</code></pre>
+HTML-SHAPE:                             <div>
+HTML-SHAPE:                                 <div>
+HTML-SHAPE:                                     <p> Calculates the perimeter of the shape.</p>
+HTML-SHAPE:                                 </div>
+HTML-SHAPE:                                 <div>
+HTML-SHAPE:                                     <p></p>
+HTML-SHAPE:                                 </div>
+HTML-SHAPE:                                 <div>
+HTML-SHAPE:                                     <p></p>
+HTML-SHAPE:                                 </div>
+HTML-SHAPE:                                 <h3>Returns</h3>
+HTML-SHAPE:                                 <p> double The perimeter of the shape.</p>
+HTML-SHAPE:                             </div>
+HTML-SHAPE:                         </div>
+HTML-SHAPE:                     </div>
+HTML-SHAPE:                     <div class="delimiter-container">
+HTML-SHAPE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-SHAPE:                             <pre><code class="language-cpp code-clang-doc">void ~Shape ()</code></pre>
+HTML-SHAPE:                             <div>
+HTML-SHAPE:                                 <div>
+HTML-SHAPE:                                     <p> Virtual destructor.</p>
+HTML-SHAPE:                                 </div>
+HTML-SHAPE:                                 <div>
+HTML-SHAPE:                                     <p></p>
+HTML-SHAPE:                                 </div>
+HTML-SHAPE:                             </div>
+HTML-SHAPE:                         </div>
+HTML-SHAPE:                     </div>
+HTML-SHAPE:                 </div>
 HTML-SHAPE:             </section>
 HTML-SHAPE:         </div>
 HTML-SHAPE:     </div>
@@ -217,225 +205,171 @@ HTML-CALC:         <div class="content">
 HTML-CALC:             <section class="hero section-container">
 HTML-CALC:                 <div class="hero__title">
 HTML-CALC:                     <h1 class="hero__title-large">class Calculator</h1>
-HTML-CALC:                                    <div>
-HTML-CALC:                                        <p> A simple calculator class.</p>
-HTML-CALC:                                    </div>
-HTML-CALC:                                        <div>
-HTML-CALC:                                    <p></p>
-HTML-CALC:                                </div>
-HTML-CALC:                                    <div>
-HTML-CALC:                                    <p> Provides basic arithmetic operations.</p>
-HTML-CALC:                                </div>
-HTML-CALC:                                                </div>
+HTML-CALC:                     <div class="hero__subtitle">
+HTML-CALC:                         <div>
+HTML-CALC:                             <p> A simple calculator class.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div>
+HTML-CALC:                             <p></p>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div>
+HTML-CALC:                             <p> Provides basic arithmetic operations.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                     </div>
 HTML-CALC:                 </div>
 HTML-CALC:             </section>
 HTML-CALC:             <section id="PublicMembers" class="section-container">
 HTML-CALC:                 <h2>Public Members</h2>
 HTML-CALC:                 <div>
 HTML-CALC:                     <div id="public_val" class="delimiter-container">
-HTML-CALC:                         <pre>
-HTML-CALC: <code class="language-cpp code-clang-doc" >int public_val</code>
-HTML-CALC:                         </pre>
+HTML-CALC:                         <pre><code class="language-cpp code-clang-doc" >int public_val</code></pre>
 HTML-CALC:                     </div>
 HTML-CALC:                     <div id="static_val" class="delimiter-container">
-HTML-CALC:                         <pre>
-HTML-CALC: <code class="language-cpp code-clang-doc" >const int static_val</code>
-HTML-CALC:                         </pre>
+HTML-CALC:                         <pre><code class="language-cpp code-clang-doc" >const int static_val</code></pre>
 HTML-CALC:                     </div>
 HTML-CALC:                 </div>
 HTML-CALC:             </section>
 HTML-CALC:             <section id="PublicMethods" class="section-container">
 HTML-CALC:                 <h2>Public Methods</h2>
 HTML-CALC:                 <div>
-HTML-CALC: <div class="delimiter-container">
-HTML-CALC:     <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:         <pre>
-HTML-CALC:             <code class="language-cpp code-clang-doc">
-HTML-CALC: int add (int a, int b)
-HTML-CALC:             </code>
-HTML-CALC:         </pre>
-HTML-CALC:        <div>
-HTML-CALC:                        <div>
-HTML-CALC:                            <p> Adds two integers.</p>
-HTML-CALC:                        </div>
-HTML-CALC:                            <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                        <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <h3>Parameters</h3>
-HTML-CALC:                    <div>
-HTML-CALC:                        <b>a</b>      <div>
-HTML-CALC:                        <p> First integer.</p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <b>b</b>      <div>
-HTML-CALC:                        <p> Second integer.</p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    </div>
-HTML-CALC:                    <h3>Returns</h3>
-HTML-CALC:                        <p> int The sum of a and b.</p>
-HTML-CALC:                        </div>
-HTML-CALC:     </div>
-HTML-CALC: </div>
-HTML-CALC: <div class="delimiter-container">
-HTML-CALC:     <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:         <pre>
-HTML-CALC:             <code class="language-cpp code-clang-doc">
-HTML-CALC: int subtract (int a, int b)
-HTML-CALC:             </code>
-HTML-CALC:         </pre>
-HTML-CALC:        <div>
-HTML-CALC:                        <div>
-HTML-CALC:                            <p> Subtracts the second integer from the first.</p>
-HTML-CALC:                        </div>
-HTML-CALC:                            <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                        <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <h3>Returns</h3>
-HTML-CALC:                        <p> int The result of a - b.</p>
-HTML-CALC:                        </div>
-HTML-CALC:     </div>
-HTML-CALC: </div>
-HTML-CALC: <div class="delimiter-container">
-HTML-CALC:     <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:         <pre>
-HTML-CALC:             <code class="language-cpp code-clang-doc">
-HTML-CALC: int multiply (int a, int b)
-HTML-CALC:             </code>
-HTML-CALC:         </pre>
-HTML-CALC:        <div>
-HTML-CALC:                        <div>
-HTML-CALC:                            <p> Multiplies two integers.</p>
-HTML-CALC:                        </div>
-HTML-CALC:                            <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                        <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <h3>Parameters</h3>
-HTML-CALC:                    <div>
-HTML-CALC:                        <b>a</b>      <div>
-HTML-CALC:                        <p> First integer.</p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <b>b</b>      <div>
-HTML-CALC:                        <p> Second integer.</p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    </div>
-HTML-CALC:                    <h3>Returns</h3>
-HTML-CALC:                        <p> int The product of a and b.</p>
-HTML-CALC:                        </div>
-HTML-CALC:     </div>
-HTML-CALC: </div>
-HTML-CALC: <div class="delimiter-container">
-HTML-CALC:     <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:         <pre>
-HTML-CALC:             <code class="language-cpp code-clang-doc">
-HTML-CALC: double divide (int a, int b)
-HTML-CALC:             </code>
-HTML-CALC:         </pre>
-HTML-CALC:        <div>
-HTML-CALC:                        <div>
-HTML-CALC:                            <p> Divides the first integer by the second.</p>
-HTML-CALC:                        </div>
-HTML-CALC:                            <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                        <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <h3>Parameters</h3>
-HTML-CALC:                    <div>
-HTML-CALC:                        <b>a</b>      <div>
-HTML-CALC:                        <p> First integer.</p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <b>b</b>      <div>
-HTML-CALC:                        <p> Second integer.</p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    </div>
-HTML-CALC:                    <h3>Returns</h3>
-HTML-CALC:                        <p> double The result of a / b.</p>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    <h3>Throws</h3>
-HTML-CALC:                    <div>
-HTML-CALC:                        <b>std::invalid_argument</b> if b is zero.
-HTML-CALC:                    </div>
-HTML-CALC:     </div>
-HTML-CALC: </div>
-HTML-CALC: <div class="delimiter-container">
-HTML-CALC:     <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:         <pre>
-HTML-CALC:             <code class="language-cpp code-clang-doc">
-HTML-CALC: int mod (int a, int b)
-HTML-CALC:             </code>
-HTML-CALC:         </pre>
-HTML-CALC:        <div>
-HTML-CALC:                        <div>
-HTML-CALC:                            <p> Performs the mod operation on integers.</p>
-HTML-CALC:                        </div>
-HTML-CALC:                            <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                        <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <h3>Parameters</h3>
-HTML-CALC:                    <div>
-HTML-CALC:                        <b>a</b>      <div>
-HTML-CALC:                        <p> First integer.</p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <b>b</b>      <div>
-HTML-CALC:                        <p> Second integer.</p>
-HTML-CALC:                    </div>
-HTML-CALC:                    <div>
-HTML-CALC:                        <p></p>
-HTML-CALC:                    </div>
-HTML-CALC:                    </div>
-HTML-CALC:                    <h3>Returns</h3>
-HTML-CALC:                        <p> The result of a % b.</p>
-HTML-CALC:                        </div>
-HTML-CALC:     </div>
-HTML-CALC: </div>
-HTML-CALC: </div>
+HTML-CALC:                     <div class="delimiter-container">
+HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
+HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">int add (int a, int b)</code></pre>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p> Adds two integers.</p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Parameters</h3>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>a</b>   First integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>b</b>   Second integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Returns</h3>
+HTML-CALC:                                 <p> int The sum of a and b.</p>
+HTML-CALC:                             </div>
+HTML-CALC:                         </div>
+HTML-CALC:                     </div>
+HTML-CALC:                     <div class="delimiter-container">
+HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
+HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">int subtract (int a, int b)</code></pre>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p> Subtracts the second integer from the first.</p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Parameters</h3>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>a</b>   First integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>b</b>   Second integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Returns</h3>
+HTML-CALC:                                 <p> int The result of a - b.</p>
+HTML-CALC:                             </div>
+HTML-CALC:                         </div>
+HTML-CALC:                     </div>
+HTML-CALC:                     <div class="delimiter-container">
+HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
+HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">int multiply (int a, int b)</code></pre>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p> Multiplies two integers.</p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Parameters</h3>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>a</b>   First integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>b</b>   Second integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Returns</h3>
+HTML-CALC:                                 <p> int The product of a and b.</p>
+HTML-CALC:                             </div>
+HTML-CALC:                         </div>
+HTML-CALC:                     </div>
+HTML-CALC:                     <div class="delimiter-container">
+HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
+HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">double divide (int a, int b)</code></pre>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p> Divides the first integer by the second.</p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Parameters</h3>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>a</b>   First integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>b</b>   Second integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Returns</h3>
+HTML-CALC:                                 <p> double The result of a / b.</p>
+HTML-CALC:                                 <p></p>
+HTML-CALC:                                 <h3>Throws</h3>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>std::invalid_argument</b> if b is zero.
+HTML-CALC:                                 </div>
+HTML-CALC:                             </div>
+HTML-CALC:                         </div>
+HTML-CALC:                     </div>
+HTML-CALC:                     <div class="delimiter-container">
+HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
+HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">int mod (int a, int b)</code></pre>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p> Performs the mod operation on integers.</p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <p></p>
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Parameters</h3>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>a</b>   First integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <div>
+HTML-CALC:                                     <b>b</b>   Second integer.
+HTML-CALC:                                 </div>
+HTML-CALC:                                 <h3>Returns</h3>
+HTML-CALC:                                 <p> The result of a % b.</p>
+HTML-CALC:                             </div>
+HTML-CALC:                         </div>
+HTML-CALC:                     </div>
+HTML-CALC:                 </div>
 HTML-CALC:             </section>
 HTML-CALC:         </div>
 HTML-CALC:     </div>
 HTML-CALC: </main>
 HTML-CALC: </body>
 HTML-CALC: </html>
+
 
 
 HTML-RECTANGLE: <!DOCTYPE html>
@@ -492,107 +426,89 @@ HTML-RECTANGLE:         <div class="content">
 HTML-RECTANGLE:             <section class="hero section-container">
 HTML-RECTANGLE:                 <div class="hero__title">
 HTML-RECTANGLE:                     <h1 class="hero__title-large">class Rectangle</h1>
-HTML-RECTANGLE:                    <div class="hero__subtitle">
-HTML-RECTANGLE:                                    <div>
-HTML-RECTANGLE:                                        <p> Rectangle class derived from Shape.</p>
-HTML-RECTANGLE:                                    </div>
-HTML-RECTANGLE:                                        <div>
-HTML-RECTANGLE:                                    <p></p>
-HTML-RECTANGLE:                                </div>
-HTML-RECTANGLE:                                    <div>
-HTML-RECTANGLE:                                    <p> Represents a rectangle with a given width and height.</p>
-HTML-RECTANGLE:                                </div>
-HTML-RECTANGLE:                                                </div>
+HTML-RECTANGLE:                     <div class="hero__subtitle">
+HTML-RECTANGLE:                         <div>
+HTML-RECTANGLE:                             <p> Rectangle class derived from Shape.</p>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                         <div>
+HTML-RECTANGLE:                             <p></p>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                         <div>
+HTML-RECTANGLE:                             <p> Represents a rectangle with a given width and height.</p>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                     </div>
 HTML-RECTANGLE:                 </div>
 HTML-RECTANGLE:             </section>
 HTML-RECTANGLE:             <section id="PublicMethods" class="section-container">
 HTML-RECTANGLE:                 <h2>Public Methods</h2>
 HTML-RECTANGLE:                 <div>
-HTML-RECTANGLE: <div class="delimiter-container">
-HTML-RECTANGLE:     <div id="{{([0-9A-F]{40})}}">
-HTML-RECTANGLE:         <pre>
-HTML-RECTANGLE:             <code class="language-cpp code-clang-doc">
-HTML-RECTANGLE: void Rectangle (double width, double height)
-HTML-RECTANGLE:             </code>
-HTML-RECTANGLE:         </pre>
-HTML-RECTANGLE:        <div>
-HTML-RECTANGLE:                        <div>
-HTML-RECTANGLE:                            <p> Constructs a new Rectangle object.</p>
-HTML-RECTANGLE:                        </div>
-HTML-RECTANGLE:                            <div>
-HTML-RECTANGLE:                        <p></p>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                        <div>
-HTML-RECTANGLE:                        <p></p>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                    <h3>Parameters</h3>
-HTML-RECTANGLE:                    <div>
-HTML-RECTANGLE:                        <b>width</b>      <div>
-HTML-RECTANGLE:                        <p> Width of the rectangle.</p>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                    <div>
-HTML-RECTANGLE:                        <p></p>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                    <div>
-HTML-RECTANGLE:                        <b>height</b>      <div>
-HTML-RECTANGLE:                        <p> Height of the rectangle.</p>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                        </div>
-HTML-RECTANGLE:     </div>
-HTML-RECTANGLE: </div>
-HTML-RECTANGLE: <div class="delimiter-container">
-HTML-RECTANGLE:     <div id="{{([0-9A-F]{40})}}">
-HTML-RECTANGLE:         <pre>
-HTML-RECTANGLE:             <code class="language-cpp code-clang-doc">
-HTML-RECTANGLE: double area ()
-HTML-RECTANGLE:             </code>
-HTML-RECTANGLE:         </pre>
-HTML-RECTANGLE:        <div>
-HTML-RECTANGLE:                        <div>
-HTML-RECTANGLE:                            <p> Calculates the area of the rectangle.</p>
-HTML-RECTANGLE:                        </div>
-HTML-RECTANGLE:                            <div>
-HTML-RECTANGLE:                        <p></p>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                        <div>
-HTML-RECTANGLE:                        <p></p>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                    <h3>Returns</h3>
-HTML-RECTANGLE:                        <p> double The area of the rectangle.</p>
-HTML-RECTANGLE:                        </div>
-HTML-RECTANGLE:     </div>
-HTML-RECTANGLE: </div>
-HTML-RECTANGLE: <div class="delimiter-container">
-HTML-RECTANGLE:     <div id="{{([0-9A-F]{40})}}">
-HTML-RECTANGLE:         <pre>
-HTML-RECTANGLE:             <code class="language-cpp code-clang-doc">
-HTML-RECTANGLE: double perimeter ()
-HTML-RECTANGLE:             </code>
-HTML-RECTANGLE:         </pre>
-HTML-RECTANGLE:        <div>
-HTML-RECTANGLE:                        <div>
-HTML-RECTANGLE:                            <p> Calculates the perimeter of the rectangle.</p>
-HTML-RECTANGLE:                        </div>
-HTML-RECTANGLE:                            <div>
-HTML-RECTANGLE:                        <p></p>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                        <div>
-HTML-RECTANGLE:                        <p></p>
-HTML-RECTANGLE:                    </div>
-HTML-RECTANGLE:                    <h3>Returns</h3>
-HTML-RECTANGLE:                        <p> double The perimeter of the rectangle.</p>
-HTML-RECTANGLE:                        </div>
-HTML-RECTANGLE:     </div>
-HTML-RECTANGLE: </div>
-HTML-RECTANGLE: </div>
+HTML-RECTANGLE:                     <div class="delimiter-container">
+HTML-RECTANGLE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-RECTANGLE:                             <pre><code class="language-cpp code-clang-doc">void Rectangle (double width, double height)</code></pre>
+HTML-RECTANGLE:                             <div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <p> Constructs a new Rectangle object.</p>
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <p></p>
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <p></p>
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <h3>Parameters</h3>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <b>width</b>   Width of the rectangle.
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <b>height</b>   Height of the rectangle.
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                             </div>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                     </div>
+HTML-RECTANGLE:                     <div class="delimiter-container">
+HTML-RECTANGLE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-RECTANGLE:                             <pre><code class="language-cpp code-clang-doc">double area ()</code></pre>
+HTML-RECTANGLE:                             <div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <p> Calculates the area of the rectangle.</p>
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <p></p>
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <p></p>
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <h3>Returns</h3>
+HTML-RECTANGLE:                                 <p> double The area of the rectangle.</p>
+HTML-RECTANGLE:                             </div>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                     </div>
+HTML-RECTANGLE:                     <div class="delimiter-container">
+HTML-RECTANGLE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-RECTANGLE:                             <pre><code class="language-cpp code-clang-doc">double perimeter ()</code></pre>
+HTML-RECTANGLE:                             <div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <p> Calculates the perimeter of the rectangle.</p>
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <p></p>
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <div>
+HTML-RECTANGLE:                                     <p></p>
+HTML-RECTANGLE:                                 </div>
+HTML-RECTANGLE:                                 <h3>Returns</h3>
+HTML-RECTANGLE:                                 <p> double The perimeter of the rectangle.</p>
+HTML-RECTANGLE:                             </div>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                     </div>
+HTML-RECTANGLE:                 </div>
 HTML-RECTANGLE:             </section>
 HTML-RECTANGLE:         </div>
 HTML-RECTANGLE:     </div>
 HTML-RECTANGLE: </main>
 HTML-RECTANGLE: </body>
 HTML-RECTANGLE: </html>
+
 
 
 HTML-CIRCLE: <!DOCTYPE html>
@@ -649,102 +565,91 @@ HTML-CIRCLE:         <div class="content">
 HTML-CIRCLE:             <section class="hero section-container">
 HTML-CIRCLE:                 <div class="hero__title">
 HTML-CIRCLE:                     <h1 class="hero__title-large">class Circle</h1>
-HTML-CIRCLE:                    <div class="hero__subtitle">
-HTML-CIRCLE:                                    <div>
-HTML-CIRCLE:                                        <p> Circle class derived from Shape.</p>
-HTML-CIRCLE:                                    </div>
-HTML-CIRCLE:                                        <div>
-HTML-CIRCLE:                                    <p></p>
-HTML-CIRCLE:                                </div>
-HTML-CIRCLE:                                    <div>
-HTML-CIRCLE:                                    <p> Represents a circle with a given radius.</p>
-HTML-CIRCLE:                                </div>
-HTML-CIRCLE:                                                </div>
+HTML-CIRCLE:                     <div class="hero__subtitle">
+HTML-CIRCLE:                         <div>
+HTML-CIRCLE:                             <p> Circle class derived from Shape.</p>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                         <div>
+HTML-CIRCLE:                             <p></p>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                         <div>
+HTML-CIRCLE:                             <p> Represents a circle with a given radius.</p>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                     </div>
 HTML-CIRCLE:                 </div>
 HTML-CIRCLE:             </section>
 HTML-CIRCLE:             <section id="PublicMethods" class="section-container">
 HTML-CIRCLE:                 <h2>Public Methods</h2>
 HTML-CIRCLE:                 <div>
-HTML-CIRCLE: <div class="delimiter-container">
-HTML-CIRCLE:     <div id="{{([0-9A-F]{40})}}">
-HTML-CIRCLE:         <pre>
-HTML-CIRCLE:             <code class="language-cpp code-clang-doc">
-HTML-CIRCLE: void Circle (double radius)
-HTML-CIRCLE:             </code>
-HTML-CIRCLE:         </pre>
-HTML-CIRCLE:        <div>
-HTML-CIRCLE:                        <div>
-HTML-CIRCLE:                            <p> Constructs a new Circle object.</p>
-HTML-CIRCLE:                        </div>
-HTML-CIRCLE:                            <div>
-HTML-CIRCLE:                        <p></p>
-HTML-CIRCLE:                    </div>
-HTML-CIRCLE:                        <div>
-HTML-CIRCLE:                        <p></p>
-HTML-CIRCLE:                    </div>
-HTML-CIRCLE:                    <h3>Parameters</h3>
-HTML-CIRCLE:                    <div>
-HTML-CIRCLE:                        <b>radius</b>      <div>
-HTML-CIRCLE:                        <p> Radius of the circle.</p>
-HTML-CIRCLE:                    </div>
-HTML-CIRCLE:                    </div>
-HTML-CIRCLE:                        </div>
-HTML-CIRCLE:     </div>
-HTML-CIRCLE: </div>
-HTML-CIRCLE: <div class="delimiter-container">
-HTML-CIRCLE:     <div id="{{([0-9A-F]{40})}}">
-HTML-CIRCLE:         <pre>
-HTML-CIRCLE:             <code class="language-cpp code-clang-doc">
-HTML-CIRCLE: double area ()
-HTML-CIRCLE:             </code>
-HTML-CIRCLE:         </pre>
-HTML-CIRCLE:        <div>
-HTML-CIRCLE:                        <div>
-HTML-CIRCLE:                            <p> Calculates the area of the circle.</p>
-HTML-CIRCLE:                        </div>
-HTML-CIRCLE:                            <div>
-HTML-CIRCLE:                        <p></p>
-HTML-CIRCLE:                    </div>
-HTML-CIRCLE:                        <div>
-HTML-CIRCLE:                        <p></p>
-HTML-CIRCLE:                    </div>
-HTML-CIRCLE:                    <h3>Returns</h3>
-HTML-CIRCLE:                        <p> double The area of the circle.</p>
-HTML-CIRCLE:                        </div>
-HTML-CIRCLE:     </div>
-HTML-CIRCLE: </div>
-HTML-CIRCLE: <div class="delimiter-container">
-HTML-CIRCLE:     <div id="{{([0-9A-F]{40})}}">
-HTML-CIRCLE:         <pre>
-HTML-CIRCLE:             <code class="language-cpp code-clang-doc">
-HTML-CIRCLE: double perimeter ()
-HTML-CIRCLE:             </code>
-HTML-CIRCLE:         </pre>
-HTML-CIRCLE:        <div>
-HTML-CIRCLE:                        <div>
-HTML-CIRCLE:                            <p> Calculates the perimeter of the circle.</p>
-HTML-CIRCLE:                        </div>
-HTML-CIRCLE:                            <div>
-HTML-CIRCLE:                        <p></p>
-HTML-CIRCLE:                    </div>
-HTML-CIRCLE:                        <div>
-HTML-CIRCLE:                        <p></p>
-HTML-CIRCLE:                    </div>
-HTML-CIRCLE:                    <h3>Returns</h3>
-HTML-CIRCLE:                        <p> double The perimeter of the circle.</p>
-HTML-CIRCLE:                    <h3>Code</h3> 
-HTML-CIRCLE:                    <div>
-HTML-CIRCLE:                        <pre class="code-block">
-HTML-CIRCLE:                            <code>
-HTML-CIRCLE:                            Circle circle(5.0);
-HTML-CIRCLE:                            double perimeter = circle.perimeter();
-HTML-CIRCLE:                            </code>
-HTML-CIRCLE:                        </pre>
-HTML-CIRCLE:                    </div>
-HTML-CIRCLE:                        </div>
-HTML-CIRCLE:     </div>
-HTML-CIRCLE: </div>
-HTML-CIRCLE: </div>
+HTML-CIRCLE:                     <div class="delimiter-container">
+HTML-CIRCLE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-CIRCLE:                             <pre><code class="language-cpp code-clang-doc">void Circle (double radius)</code></pre>
+HTML-CIRCLE:                             <div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p> Constructs a new Circle object.</p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p></p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p></p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <h3>Parameters</h3>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <b>radius</b>   Radius of the circle.
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                             </div>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                     </div>
+HTML-CIRCLE:                     <div class="delimiter-container">
+HTML-CIRCLE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-CIRCLE:                             <pre><code class="language-cpp code-clang-doc">double area ()</code></pre>
+HTML-CIRCLE:                             <div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p> Calculates the area of the circle.</p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p></p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p></p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <h3>Returns</h3>
+HTML-CIRCLE:                                 <p> double The area of the circle.</p>
+HTML-CIRCLE:                             </div>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                     </div>
+HTML-CIRCLE:                     <div class="delimiter-container">
+HTML-CIRCLE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-CIRCLE:                             <pre><code class="language-cpp code-clang-doc">double perimeter ()</code></pre>
+HTML-CIRCLE:                             <div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p> Calculates the perimeter of the circle.</p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p></p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p></p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <p></p>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <h3>Returns</h3>
+HTML-CIRCLE:                                 <p> double The perimeter of the circle.</p>
+HTML-CIRCLE:                                 <h3>Code</h3>
+HTML-CIRCLE:                                 <div>
+HTML-CIRCLE:                                     <pre class="code-block">
+HTML-CIRCLE:                                         <code>
+HTML-CIRCLE:                                              Circle circle(5.0);
+HTML-CIRCLE:                                              double perimeter = circle.perimeter();
+HTML-CIRCLE:                                         </code>
+HTML-CIRCLE:                                     </pre>
+HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                             </div>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                     </div>
+HTML-CIRCLE:                 </div>
 HTML-CIRCLE:             </section>
 HTML-CIRCLE:         </div>
 HTML-CIRCLE:     </div>


### PR DESCRIPTION
I found that the issues we've been seeing in the HTML
whitespace/alignment are due to partials inserting their own whitespace
and calling partials on indented lines or lines containing text already.
This patch gets rid of unnecessary whitespace in the comment and
function partials so that they are properly indented when inserted.