### PR TITLE
[MLIR][XeGPU] Disable block count usage in layout propagation

### DIFF
--- a/mlir/include/mlir/Dialect/XeGPU/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/XeGPU/Transforms/Passes.td
@@ -37,6 +37,18 @@ def XeGPUPropagateLayout : Pass<"xegpu-propagate-layout"> {
     propagate the layouts required for their operands to the producers. With
     this propagated layout information, pass will then update op result type
     with the layout information.
+
+    `inst`:
+      Sets the `inst_data` field of the layout attribute.
+      The goal is to select the highest granularity of the
+      instruction shape to minimize the number of instructions required
+      for processing the user shape.
+      For nd operations, the granularity depends on (W)idth, (H)eight and (B)lock count.
+      It is possible that the max. block count of one operation is different from the
+      max. allowed block count of another operation, whereas both operations
+      may use the same tensor descriptor. The propagation is not the right place for creating a
+      second tdesc with the correct block count and other related ops. Hence,
+      the subsequent optimization passes may decide on if or how to handle the block count.
   }];
   let dependentDialects = ["memref::MemRefDialect", "xegpu::XeGPUDialect",
                            "vector::VectorDialect"];

--- a/mlir/include/mlir/Dialect/XeGPU/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/XeGPU/Transforms/Passes.td
@@ -38,17 +38,18 @@ def XeGPUPropagateLayout : Pass<"xegpu-propagate-layout"> {
     this propagated layout information, pass will then update op result type
     with the layout information.
 
-    `inst`:
-      Sets the `inst_data` field of the layout attribute.
-      The goal is to select the highest granularity of the
-      instruction shape to minimize the number of instructions required
-      for processing the user shape.
-      For nd operations, the granularity depends on (W)idth, (H)eight and (B)lock count.
-      It is possible that the max. block count of one operation is different from the
-      max. allowed block count of another operation, whereas both operations
-      may use the same tensor descriptor. The propagation is not the right place for creating a
-      second tdesc with the correct block count and other related ops. Hence,
-      the subsequent optimization passes may decide on if or how to handle the block count.
+    `layout-kind` option values:
+    - `inst`
+      Propagate the `inst_data` field of the layout attribute. The default is chosen to
+       maximize instruction-level granularity so that the user shape can be processed
+       with the fewest instructions. For N-D operations, this granularity depends on
+       W (width) and H (height) of the instruction shape.
+       The B (block) dimension (or array length) is not included in the default
+       configuration and must be enabled via a separate optimization pass.
+
+    - `lane`
+      Propagate the `lane_layout` and `lane_data` fields of the layout attribute.
+      Default values are selected to align with hardware.
   }];
   let dependentDialects = ["memref::MemRefDialect", "xegpu::XeGPUDialect",
                            "vector::VectorDialect"];

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
@@ -495,8 +495,7 @@ void LayoutInfoPropagation::visitPrefetchNdOp(
   auto [bWidth, bHeight, bCount] = blockWHC.value();
   SmallVector<int> instData;
   int instWidth = xegpu::getLargestDivisor(
-      static_cast<int>(tdescTy.getDimSize(tdescTy.getRank() - 1)), bWidth,
-      bCount);
+      static_cast<int>(tdescTy.getDimSize(tdescTy.getRank() - 1)), bWidth);
   if (instWidth == -1)
     prefetch.emitWarning(
         "No suitable instruction multiple found for the given shape.");
@@ -702,8 +701,7 @@ void LayoutInfoPropagation::visitStoreNdOp(
   auto [bWidth, bHeight, bCount] = blockWHC.value();
   SmallVector<int> instData;
   int instWidth = xegpu::getLargestDivisor(
-      static_cast<int>(dataTy.getDimSize(dataTy.getRank() - 1)), bWidth,
-      bCount);
+      static_cast<int>(dataTy.getDimSize(dataTy.getRank() - 1)), bWidth);
   if (instWidth == -1)
     store.emitWarning(
         "No suitable instruction multiple found for the given shape.");


### PR DESCRIPTION
This small PR disables block count usage in the xegpu layout propagation. 
Block count allows for handling larger instruction sizes. It comes as a separate operand in the xevm operation and implies a certain semantics for the loaded vectors. Currently, the xegpu infra is not fully ready for it.
- The lowering to xevm does not have a way to safely retrieve it yet (tensor desc is not modified by the propagation).
- The transforms also need to be aware of the block count semantics.

For now, the block count decision appears to be better suited for some subsequent optimization pass that might fuse loads, rather than the default setting right away. Therefore, to keep the pipeline functional, the block count is no longer considered when setting `inst_data`. 