### PR TITLE
[Instcombine]:  Folds`llvm.ucmp` and `llvm.scmp`

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -4474,7 +4474,7 @@ static Value *simplifyWithOpsReplaced(Value *V,
           DropFlags->push_back(II);
         }
 
-        return llvm::ConstantInt::get(I->getType(), 0);
+        return ConstantInt::get(I->getType(), 0);
       }
     }
 

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -4464,17 +4464,17 @@ static Value *simplifyWithOpsReplaced(Value *V,
     if (auto *II = dyn_cast<IntrinsicInst>(I)) {
       // `x == y ? 0 : ucmp(x, y)` where under the replacement y -> x,
       // `ucmp(x, x)` becomes `0`.
-      if (NewOps[0] == NewOps[1] && (II->getIntrinsicID() == Intrinsic::scmp ||
-                                     II->getIntrinsicID() == Intrinsic::ucmp)) {
+      if ((II->getIntrinsicID() == Intrinsic::scmp ||
+           II->getIntrinsicID() == Intrinsic::ucmp) &&
+          NewOps[0] == NewOps[1]) {
         if (II->hasPoisonGeneratingAnnotations()) {
           if (!DropFlags)
             return nullptr;
-          else
-            DropFlags->push_back(II);
+
+          DropFlags->push_back(II);
         }
 
-        return llvm::ConstantInt::get(II->getFunctionType()->getReturnType(),
-                                      0);
+        return llvm::ConstantInt::get(I->getType(), 0);
       }
     }
 

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -4472,8 +4472,8 @@ static Value *simplifyWithOpsReplaced(Value *V,
         // If the call contains (an invalid) range attribute then a replacement
         // might produce an unexpected poison value.
         if (CI->hasRetAttr(Attribute::AttrKind::Range)) {
-          auto Attr = CI->getRetAttr(Attribute::AttrKind::Range);
-          const ConstantRange &CR = Attr.getRange();
+          const ConstantRange &CR =
+              CI->getRetAttr(Attribute::AttrKind::Range).getRange();
 
           APInt Lo = CR.getLower();
           APInt Hi = CR.getUpper();

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -1990,7 +1990,7 @@ static Value *foldSelectToInstrincCmp(SelectInst &SI, const ICmpInst *ICI,
     Value *FrozenX = Builder.CreateFreeze(X, X->getName() + ".frz");
     Value *FrozenY = Builder.CreateFreeze(Y, Y->getName() + ".frz");
     Value *Cmp =
-        Builder.CreateIntrinsic(FrozenX->getType(), IID, {FrozenX, FrozenY});
+        Builder.CreateIntrinsic(FalseVal->getType(), IID, {FrozenX, FrozenY});
     return Builder.CreateSelect(SI.getCondition(), TrueVal, Cmp, "select.ucmp");
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -1979,6 +1979,12 @@ static Value *foldSelectToInstrincCmp(SelectInst &SI, const ICmpInst *ICI,
       (IPred == ICmpInst::ICMP_ULT || IPred == ICmpInst::ICMP_SLT)) {
     Value *X = ICI->getOperand(0);
     Value *Y = ICI->getOperand(1);
+
+    // icmp(ult, ptr %X, ptr %Y) -> cannot be folded because
+    // there is no intrinsic for a pointer comparison.
+    if (!X->getType()->isIntegerTy() || !Y->getType()->isIntegerTy())
+      return nullptr;
+
     Builder.SetInsertPoint(&SI);
     auto IID = IPred == ICmpInst::ICMP_ULT ? Intrinsic::ucmp : Intrinsic::scmp;
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -1955,30 +1955,6 @@ static Instruction *foldSelectICmpEq(SelectInst &SI, ICmpInst *ICI,
   return nullptr;
 }
 
-// Transform
-// select(icmp(eq, X, Y), 0, llvm.cmp(X, Y))
-// ->
-// llvm.cmp(X, Y)
-static Value *foldInstrincCmp(SelectInst &SI, const ICmpInst *ICI,
-                              Value *TrueVal, Value *FalseVal,
-                              InstCombiner::BuilderTy &Builder) {
-  ICmpInst::Predicate Pred = ICI->getPredicate();
-
-  if (Pred != ICmpInst::ICMP_EQ)
-    return nullptr;
-
-  Value *X = ICI->getOperand(0);
-  Value *Y = ICI->getOperand(1);
-
-  auto ucmp = m_Intrinsic<Intrinsic::ucmp>(m_Specific(X), m_Specific(Y));
-  auto scmp = m_Intrinsic<Intrinsic::scmp>(m_Specific(X), m_Specific(Y));
-  if (match(SI.getTrueValue(), m_Zero()) &&
-      (match(SI.getFalseValue(), ucmp) || match(SI.getFalseValue(), scmp)))
-    return SI.getFalseValue();
-
-  return nullptr;
-}
-
 /// Fold `X Pred C1 ? X BOp C2 : C1 BOp C2` to `min/max(X, C1) BOp C2`.
 /// This allows for better canonicalization.
 Value *InstCombinerImpl::foldSelectWithConstOpToBinOp(ICmpInst *Cmp,
@@ -2208,9 +2184,6 @@ Instruction *InstCombinerImpl::foldSelectInstWithICmp(SelectInst &SI,
     return replaceInstUsesWith(SI, V);
 
   if (Value *V = foldSelectWithConstOpToBinOp(ICI, TrueVal, FalseVal))
-    return replaceInstUsesWith(SI, V);
-
-  if (Value *V = foldInstrincCmp(SI, ICI, TrueVal, FalseVal, Builder))
     return replaceInstUsesWith(SI, V);
 
   return Changed ? &SI : nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -1985,7 +1985,7 @@ static Value *foldSelectToInstrincCmp(SelectInst &SI, const ICmpInst *ICI,
     // Edge Case: if Z is the constant 0 then the select can be folded
     // to just the instrinsic comparison.
     if (match(TrueVal, m_Zero()))
-      return Builder.CreateIntrinsic(X->getType(), IID, {X, Y});
+      return Builder.CreateIntrinsic(SI.getType(), IID, {X, Y});
 
     Value *FrozenX = Builder.CreateFreeze(X, X->getName() + ".frz");
     Value *FrozenY = Builder.CreateFreeze(Y, Y->getName() + ".frz");

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -896,6 +896,22 @@ define i16 @icmp_fold_to_llvm_ucmp_when_ne(i16 %x, i16 %y) {
   ret i16 %6
 }
 
+define i32 @icmp_fold_to_llvm_ucmp_mixed_types(i16 %0, i16 %1) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_mixed_types(
+; CHECK-NEXT:    [[DOTFRZ1:%.*]] = freeze i16 [[TMP1:%.*]]
+; CHECK-NEXT:    [[DOTFRZ:%.*]] = freeze i16 [[TMP0:%.*]]
+; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq i16 [[DOTFRZ]], [[DOTFRZ1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.ucmp.i32.i16(i16 [[DOTFRZ]], i16 [[DOTFRZ1]])
+; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[DOTNOT]], i32 1, i32 [[TMP3]]
+; CHECK-NEXT:    ret i32 [[SELECT_UCMP]]
+;
+  %.not = icmp eq i16 %0, %1
+  %3 = icmp ult i16 %0, %1
+  %4 = select i1 %3, i32 -1, i32 1
+  %.1 = select i1 %.not, i32 1, i32 %4
+  ret i32 %.1
+}
+
 define i16 @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_1(i16 %x, i16 %y, i16 %Z) {
 ; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_1(
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
@@ -922,20 +938,23 @@ define i16 @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_2(i16 %x, i16 
   ret i16 %6
 }
 
-define i32 @icmp_fold_to_llvm_ucmp_mixed_types(i16 %0, i16 %1) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_mixed_types(
-; CHECK-NEXT:    [[DOTFRZ1:%.*]] = freeze i16 [[TMP1:%.*]]
-; CHECK-NEXT:    [[DOTFRZ:%.*]] = freeze i16 [[TMP0:%.*]]
-; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq i16 [[DOTFRZ]], [[DOTFRZ1]]
-; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.ucmp.i32.i16(i16 [[DOTFRZ]], i16 [[DOTFRZ1]])
-; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[DOTNOT]], i32 1, i32 [[TMP3]]
-; CHECK-NEXT:    ret i32 [[SELECT_UCMP]]
+define i8 @icmp_fold_to_llvm_ucmp_negative_test_ptr(ptr %0, ptr %1) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_negative_test_ptr(
+; CHECK-NEXT:    [[TMP3:%.*]] = load ptr, ptr [[TMP0:%.*]], align 8
+; CHECK-NEXT:    [[TMP4:%.*]] = load ptr, ptr [[TMP1:%.*]], align 8
+; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult ptr [[TMP3]], [[TMP4]]
+; CHECK-NEXT:    [[TMP6:%.*]] = select i1 [[TMP5]], i8 -1, i8 1
+; CHECK-NEXT:    [[TMP7:%.*]] = icmp eq ptr [[TMP3]], [[TMP4]]
+; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP7]], i8 0, i8 [[TMP6]]
+; CHECK-NEXT:    ret i8 [[TMP8]]
 ;
-  %.not = icmp eq i16 %0, %1
-  %3 = icmp ult i16 %0, %1
-  %4 = select i1 %3, i32 -1, i32 1
-  %.1 = select i1 %.not, i32 1, i32 %4
-  ret i32 %.1
+  %3 = load ptr, ptr %0, align 8
+  %4 = load ptr, ptr %1, align 8
+  %5 = icmp ult ptr %3, %4
+  %6 = select i1 %5, i8 -1, i8 1
+  %7 = icmp eq ptr %3, %4
+  %8 = select i1 %7, i8 0, i8 %6
+  ret i8 %8
 }
 
 declare void @use(i1)

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -922,5 +922,21 @@ define i16 @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_2(i16 %x, i16 
   ret i16 %6
 }
 
+define i32 @icmp_fold_to_llvm_ucmp_mixed_types(i16 %0, i16 %1) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_mixed_types(
+; CHECK-NEXT:    [[DOTFRZ1:%.*]] = freeze i16 [[TMP1:%.*]]
+; CHECK-NEXT:    [[DOTFRZ:%.*]] = freeze i16 [[TMP0:%.*]]
+; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq i16 [[DOTFRZ]], [[DOTFRZ1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.ucmp.i32.i16(i16 [[DOTFRZ]], i16 [[DOTFRZ1]])
+; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[DOTNOT]], i32 1, i32 [[TMP3]]
+; CHECK-NEXT:    ret i32 [[SELECT_UCMP]]
+;
+  %.not = icmp eq i16 %0, %1
+  %3 = icmp ult i16 %0, %1
+  %4 = select i1 %3, i32 -1, i32 1
+  %.1 = select i1 %.not, i32 1, i32 %4
+  ret i32 %.1
+}
+
 declare void @use(i1)
 declare void @use.i8(i8)

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -878,10 +878,10 @@ define i32 @fold_scmp_default_range(i32 %0, i32 %1) {
   ret i32 %5
 }
 
-define i32 @fold_ucmp_drop_range(i32 %0, i32 %1) {
-; CHECK-LABEL: @fold_ucmp_negative_test_updated_range(
-; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
-; CHECK-NEXT:    ret i32 [[TMP4]]
+define i32 @fold_ucmp_drop_poison_generating_range(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_ucmp_drop_poison_generating_range(
+; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
   %3 = icmp eq i32 %0, %1
   %4 = tail call range(i32 1, 2) i32 @llvm.ucmp.i32.i32(i32 %0, i32 %1)
@@ -889,10 +889,10 @@ define i32 @fold_ucmp_drop_range(i32 %0, i32 %1) {
   ret i32 %5
 }
 
-define i32 @fold_scmp_drop_range(i32 %0, i32 %1) {
-; CHECK-LABEL: @fold_scmp_negative_test_updated_range(
-; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
-; CHECK-NEXT:    ret i32 [[TMP4]]
+define i32 @fold_scmp_drop_poison_generating_range(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_scmp_drop_poison_generating_range(
+; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
   %3 = icmp eq i32 %0, %1
   %4 = tail call range(i32 1, 2) i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -808,96 +808,96 @@ define i1 @icmp_lt_slt(i1 %c, i32 %arg) {
   ret i1 %select
 }
 
-define i32 @fold_ucmp(i32 %0, i32 %1) {
+define i32 @fold_ucmp(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @fold_ucmp(
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
-  %3 = icmp eq i32 %0, %1
-  %4 = tail call i32 @llvm.ucmp.i32.i32(i32 %0, i32 %1)
-  %5 = select i1 %3, i32 0, i32 %4
-  ret i32 %5
+  %cmp1 = icmp eq i32 %arg0, %arg1
+  %cmp2 = tail call i32 @llvm.ucmp.i32.i32(i32 %arg0, i32 %arg1)
+  %cmp3 = select i1 %cmp1, i32 0, i32 %cmp2
+  ret i32 %cmp3
 }
 
-define i32 @fold_scmp(i32 %0, i32 %1) {
+define i32 @fold_scmp(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @fold_scmp(
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
-  %3 = icmp eq i32 %0, %1
-  %4 = tail call i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)
-  %5 = select i1 %3, i32 0, i32 %4
-  ret i32 %5
+  %cmp1 = icmp eq i32 %arg0, %arg1
+  %cmp2 = tail call i32 @llvm.scmp.i32.i32(i32 %arg0, i32 %arg1)
+  %cmp3 = select i1 %cmp1, i32 0, i32 %cmp2
+  ret i32 %cmp3
 }
 
-define i32 @fold_ucmp_negative_test(i32 %0, i32 %1) {
+define i32 @fold_ucmp_negative_test(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @fold_ucmp_negative_test(
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0]], i32 [[TMP1]])
 ; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP3]], i32 1, i32 [[TMP4]]
 ; CHECK-NEXT:    ret i32 [[TMP5]]
 ;
-  %3 = icmp eq i32 %0, %1
-  %4 = tail call i32 @llvm.ucmp.i32.i32(i32 %0, i32 %1)
-  %5 = select i1 %3, i32 1, i32 %4 ; wrong constant
-  ret i32 %5
+  %cmp1 = icmp eq i32 %arg0, %arg1
+  %cmp2 = tail call i32 @llvm.ucmp.i32.i32(i32 %arg0, i32 %arg1)
+  %cmp3 = select i1 %cmp1, i32 1, i32 %cmp2 ; wrong constant
+  ret i32 %cmp3
 }
 
-define i32 @fold_scmp_negative_test(i32 %0, i32 %1) {
+define i32 @fold_scmp_negative_test(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @fold_scmp_negative_test(
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0]], i32 [[TMP1]])
 ; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP3]], i32 1, i32 [[TMP4]]
 ; CHECK-NEXT:    ret i32 [[TMP5]]
 ;
-  %3 = icmp eq i32 %0, %1
-  %4 = tail call i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)
-  %5 = select i1 %3, i32 1, i32 %4 ; wrong constant
-  ret i32 %5
+  %cmp1 = icmp eq i32 %arg0, %arg1
+  %cmp2 = tail call i32 @llvm.scmp.i32.i32(i32 %arg0, i32 %arg1)
+  %cmp3 = select i1 %cmp1, i32 1, i32 %cmp2 ; wrong constant
+  ret i32 %cmp3
 }
 
-define i32 @fold_ucmp_default_range(i32 %0, i32 %1) {
+define i32 @fold_ucmp_default_range(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @fold_ucmp_default_range(
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
-  %3 = icmp eq i32 %0, %1
-  %4 = tail call range(i32 -1, 2) i32 @llvm.ucmp.i32.i32(i32 %0, i32 %1)
-  %5 = select i1 %3, i32 0, i32 %4
-  ret i32 %5
+  %cmp1 = icmp eq i32 %arg0, %arg1
+  %cmp2 = tail call range(i32 -1, 2) i32 @llvm.ucmp.i32.i32(i32 %arg0, i32 %arg1)
+  %cmp3 = select i1 %cmp1, i32 0, i32 %cmp2
+  ret i32 %cmp3
 }
 
-define i32 @fold_scmp_default_range(i32 %0, i32 %1) {
+define i32 @fold_scmp_default_range(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @fold_scmp_default_range(
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
-  %3 = icmp eq i32 %0, %1
-  %4 = tail call range(i32 -1, 2) i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)
-  %5 = select i1 %3, i32 0, i32 %4
-  ret i32 %5
+  %cmp1 = icmp eq i32 %arg0, %arg1
+  %cmp2 = tail call range(i32 -1, 2) i32 @llvm.scmp.i32.i32(i32 %arg0, i32 %arg1)
+  %cmp3 = select i1 %cmp1, i32 0, i32 %cmp2
+  ret i32 %cmp3
 }
 
-define i32 @fold_ucmp_drop_poison_generating_range(i32 %0, i32 %1) {
+define i32 @fold_ucmp_drop_poison_generating_range(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @fold_ucmp_drop_poison_generating_range(
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
-  %3 = icmp eq i32 %0, %1
-  %4 = tail call range(i32 1, 2) i32 @llvm.ucmp.i32.i32(i32 %0, i32 %1)
-  %5 = select i1 %3, i32 0, i32 %4
-  ret i32 %5
+  %cmp1 = icmp eq i32 %arg0, %arg1
+  %cmp2 = tail call range(i32 1, 2) i32 @llvm.ucmp.i32.i32(i32 %arg0, i32 %arg1)
+  %cmp3 = select i1 %cmp1, i32 0, i32 %cmp2
+  ret i32 %cmp3
 }
 
-define i32 @fold_scmp_drop_poison_generating_range(i32 %0, i32 %1) {
+define i32 @fold_scmp_drop_poison_generating_range(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @fold_scmp_drop_poison_generating_range(
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
-  %3 = icmp eq i32 %0, %1
-  %4 = tail call range(i32 1, 2) i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)
-  %5 = select i1 %3, i32 0, i32 %4
-  ret i32 %5
+  %cmp1 = icmp eq i32 %arg0, %arg1
+  %cmp2 = tail call range(i32 1, 2) i32 @llvm.scmp.i32.i32(i32 %arg0, i32 %arg1)
+  %cmp3 = select i1 %cmp1, i32 0, i32 %cmp2
+  ret i32 %cmp3
 }
 
 declare void @use(i1)

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -856,5 +856,51 @@ define i32 @fold_scmp_negative_test(i32 %0, i32 %1) {
   ret i32 %5
 }
 
+define i32 @fold_ucmp_default_range(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_ucmp_default_range(
+; CHECK-NEXT:    [[TMP3:%.*]] = tail call range(i32 -1, 2) i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP3]]
+;
+  %3 = icmp eq i32 %0, %1
+  %4 = tail call range(i32 -1, 2) i32 @llvm.ucmp.i32.i32(i32 %0, i32 %1)
+  %5 = select i1 %3, i32 0, i32 %4
+  ret i32 %5
+}
+
+define i32 @fold_scmp_default_range(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_scmp_default_range(
+; CHECK-NEXT:    [[TMP3:%.*]] = tail call range(i32 -1, 2) i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP3]]
+;
+  %3 = icmp eq i32 %0, %1
+  %4 = tail call range(i32 -1, 2) i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)
+  %5 = select i1 %3, i32 0, i32 %4
+  ret i32 %5
+}
+
+define i32 @fold_ucmp_negative_test_updated_range(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_ucmp_negative_test_updated_range(
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp ne i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP4:%.*]] = zext i1 [[TMP3]] to i32
+; CHECK-NEXT:    ret i32 [[TMP4]]
+;
+  %3 = icmp eq i32 %0, %1
+  %4 = tail call range(i32 1, 2) i32 @llvm.ucmp.i32.i32(i32 %0, i32 %1)
+  %5 = select i1 %3, i32 0, i32 %4
+  ret i32 %5
+}
+
+define i32 @fold_scmp_negative_test_updated_range(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_scmp_negative_test_updated_range(
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp ne i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP4:%.*]] = zext i1 [[TMP3]] to i32
+; CHECK-NEXT:    ret i32 [[TMP4]]
+;
+  %3 = icmp eq i32 %0, %1
+  %4 = tail call range(i32 1, 2) i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)
+  %5 = select i1 %3, i32 0, i32 %4
+  ret i32 %5
+}
+
 declare void @use(i1)
 declare void @use.i8(i8)

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -858,7 +858,7 @@ define i32 @fold_scmp_negative_test(i32 %0, i32 %1) {
 
 define i32 @fold_ucmp_default_range(i32 %0, i32 %1) {
 ; CHECK-LABEL: @fold_ucmp_default_range(
-; CHECK-NEXT:    [[TMP3:%.*]] = tail call range(i32 -1, 2) i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
+; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
   %3 = icmp eq i32 %0, %1
@@ -869,7 +869,7 @@ define i32 @fold_ucmp_default_range(i32 %0, i32 %1) {
 
 define i32 @fold_scmp_default_range(i32 %0, i32 %1) {
 ; CHECK-LABEL: @fold_scmp_default_range(
-; CHECK-NEXT:    [[TMP3:%.*]] = tail call range(i32 -1, 2) i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
+; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP3]]
 ;
   %3 = icmp eq i32 %0, %1
@@ -878,10 +878,9 @@ define i32 @fold_scmp_default_range(i32 %0, i32 %1) {
   ret i32 %5
 }
 
-define i32 @fold_ucmp_negative_test_updated_range(i32 %0, i32 %1) {
+define i32 @fold_ucmp_drop_range(i32 %0, i32 %1) {
 ; CHECK-LABEL: @fold_ucmp_negative_test_updated_range(
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp ne i32 [[TMP0:%.*]], [[TMP1:%.*]]
-; CHECK-NEXT:    [[TMP4:%.*]] = zext i1 [[TMP3]] to i32
+; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP4]]
 ;
   %3 = icmp eq i32 %0, %1
@@ -890,10 +889,9 @@ define i32 @fold_ucmp_negative_test_updated_range(i32 %0, i32 %1) {
   ret i32 %5
 }
 
-define i32 @fold_scmp_negative_test_updated_range(i32 %0, i32 %1) {
+define i32 @fold_scmp_drop_range(i32 %0, i32 %1) {
 ; CHECK-LABEL: @fold_scmp_negative_test_updated_range(
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp ne i32 [[TMP0:%.*]], [[TMP1:%.*]]
-; CHECK-NEXT:    [[TMP4:%.*]] = zext i1 [[TMP3]] to i32
+; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
 ; CHECK-NEXT:    ret i32 [[TMP4]]
 ;
   %3 = icmp eq i32 %0, %1

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -824,6 +824,30 @@ define i16 @icmp_fold_to_llvm_ucmp_when_eq(i16 %x, i16 %y) {
   ret i16 %6
 }
 
+define i16 @icmp_fold_to_llvm_ucmp_when_ult_and_Z_zero(i16 %x, i16 %y) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_ult_and_Z_zero(
+; CHECK-NEXT:    [[TMP1:%.*]] = call i16 @llvm.ucmp.i16.i16(i16 [[X:%.*]], i16 [[Y:%.*]])
+; CHECK-NEXT:    ret i16 [[TMP1]]
+;
+  %3 = icmp eq i16 %x, %y
+  %4 = icmp ult i16 %x, %y
+  %5 = select i1 %4, i16 -1, i16 1
+  %6 = select i1 %3, i16 0, i16 %5
+  ret i16 %6
+}
+
+define i16 @icmp_fold_to_llvm_ucmp_when_slt_and_Z_zero(i16 %x, i16 %y) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_slt_and_Z_zero(
+; CHECK-NEXT:    [[TMP1:%.*]] = call i16 @llvm.scmp.i16.i16(i16 [[X:%.*]], i16 [[Y:%.*]])
+; CHECK-NEXT:    ret i16 [[TMP1]]
+;
+  %3 = icmp eq i16 %x, %y
+  %4 = icmp slt i16 %x, %y
+  %5 = select i1 %4, i16 -1, i16 1
+  %6 = select i1 %3, i16 0, i16 %5
+  ret i16 %6
+}
+
 define i16 @icmp_fold_to_llvm_ucmp_when_cmp_slt(i16 %x, i16 %y) {
 ; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_cmp_slt(
 ; CHECK-NEXT:    [[Y_FRZ:%.*]] = freeze i16 [[Y:%.*]]

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -808,5 +808,95 @@ define i1 @icmp_lt_slt(i1 %c, i32 %arg) {
   ret i1 %select
 }
 
+define i16 @icmp_fold_to_llvm_ucmp_when_eq(i16 %x, i16 %y) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_eq(
+; CHECK-NEXT:    [[Y_FRZ:%.*]] = freeze i16 [[Y:%.*]]
+; CHECK-NEXT:    [[X_FRZ:%.*]] = freeze i16 [[X:%.*]]
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X_FRZ]], [[Y_FRZ]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i16 @llvm.ucmp.i16.i16(i16 [[X_FRZ]], i16 [[Y_FRZ]])
+; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[TMP1]], i16 42, i16 [[TMP2]]
+; CHECK-NEXT:    ret i16 [[SELECT_UCMP]]
+;
+  %3 = icmp eq i16 %x, %y
+  %4 = icmp ult i16 %x, %y
+  %5 = select i1 %4, i16 -1, i16 1
+  %6 = select i1 %3, i16 42, i16 %5
+  ret i16 %6
+}
+
+define i16 @icmp_fold_to_llvm_ucmp_when_cmp_slt(i16 %x, i16 %y) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_cmp_slt(
+; CHECK-NEXT:    [[Y_FRZ:%.*]] = freeze i16 [[Y:%.*]]
+; CHECK-NEXT:    [[X_FRZ:%.*]] = freeze i16 [[X:%.*]]
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X_FRZ]], [[Y_FRZ]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i16 @llvm.scmp.i16.i16(i16 [[X_FRZ]], i16 [[Y_FRZ]])
+; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[TMP1]], i16 42, i16 [[TMP2]]
+; CHECK-NEXT:    ret i16 [[SELECT_UCMP]]
+;
+  %3 = icmp eq i16 %x, %y
+  %4 = icmp slt i16 %x, %y ; here "ult" changed to "slt"
+  %5 = select i1 %4, i16 -1, i16 1
+  %6 = select i1 %3, i16 42, i16 %5
+  ret i16 %6
+}
+
+define i16 @icmp_fold_to_llvm_ucmp_when_value(i16 %x, i16 %y, i16 %Z) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_value(
+; CHECK-NEXT:    [[Y_FRZ:%.*]] = freeze i16 [[Y:%.*]]
+; CHECK-NEXT:    [[X_FRZ:%.*]] = freeze i16 [[X:%.*]]
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X_FRZ]], [[Y_FRZ]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i16 @llvm.ucmp.i16.i16(i16 [[X_FRZ]], i16 [[Y_FRZ]])
+; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[TMP1]], i16 [[Z:%.*]], i16 [[TMP2]]
+; CHECK-NEXT:    ret i16 [[SELECT_UCMP]]
+;
+  %3 = icmp eq i16 %x, %y
+  %4 = icmp ult i16 %x, %y
+  %5 = select i1 %4, i16 -1, i16 1
+  %6 = select i1 %3, i16 %Z, i16 %5
+  ret i16 %6
+}
+
+define i16 @icmp_fold_to_llvm_ucmp_when_ne(i16 %x, i16 %y) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_ne(
+; CHECK-NEXT:    [[Y_FRZ:%.*]] = freeze i16 [[Y:%.*]]
+; CHECK-NEXT:    [[X_FRZ:%.*]] = freeze i16 [[X:%.*]]
+; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq i16 [[X_FRZ]], [[Y_FRZ]]
+; CHECK-NEXT:    [[TMP1:%.*]] = call i16 @llvm.ucmp.i16.i16(i16 [[X_FRZ]], i16 [[Y_FRZ]])
+; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[DOTNOT]], i16 42, i16 [[TMP1]]
+; CHECK-NEXT:    ret i16 [[SELECT_UCMP]]
+;
+  %3 = icmp ne i16 %x, %y
+  %4 = icmp ult i16 %x, %y
+  %5 = select i1 %4, i16 -1, i16 1
+  %6 = select i1 %3, i16 %5, i16 42
+  ret i16 %6
+}
+
+define i16 @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_1(i16 %x, i16 %y, i16 %Z) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_1(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i16 [[Z:%.*]], i16 1
+; CHECK-NEXT:    ret i16 [[TMP2]]
+;
+  %3 = icmp eq i16 %x, %y
+  %4 = icmp ult i16 %x, %y
+  %5 = select i1 %4, i16 1, i16 1 ; invalid constant
+  %6 = select i1 %3, i16 %Z, i16 %5
+  ret i16 %6
+}
+
+define i16 @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_2(i16 %x, i16 %y, i16 %Z) {
+; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_2(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i16 [[Z:%.*]], i16 -1
+; CHECK-NEXT:    ret i16 [[TMP2]]
+;
+  %3 = icmp eq i16 %x, %y
+  %4 = icmp ult i16 %x, %y
+  %5 = select i1 %4, i16 -1, i16 -1 ; invalid constant
+  %6 = select i1 %3, i16 %Z, i16 %5
+  ret i16 %6
+}
+
 declare void @use(i1)
 declare void @use.i8(i8)

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -957,5 +957,27 @@ define i8 @icmp_fold_to_llvm_ucmp_negative_test_ptr(ptr %0, ptr %1) {
   ret i8 %8
 }
 
+define i32 @fold_ucmp(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_ucmp(
+; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP3]]
+;
+  %3 = icmp eq i32 %0, %1
+  %4 = tail call i32 @llvm.ucmp.i32.i32(i32 %0, i32 %1)
+  %5 = select i1 %3, i32 0, i32 %4
+  ret i32 %5
+}
+
+define i32 @fold_scmp(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_scmp(
+; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP3]]
+;
+  %3 = icmp eq i32 %0, %1
+  %4 = tail call i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)
+  %5 = select i1 %3, i32 0, i32 %4
+  ret i32 %5
+}
+
 declare void @use(i1)
 declare void @use.i8(i8)

--- a/llvm/test/Transforms/InstCombine/select-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/select-cmp.ll
@@ -808,155 +808,6 @@ define i1 @icmp_lt_slt(i1 %c, i32 %arg) {
   ret i1 %select
 }
 
-define i16 @icmp_fold_to_llvm_ucmp_when_eq(i16 %x, i16 %y) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_eq(
-; CHECK-NEXT:    [[Y_FRZ:%.*]] = freeze i16 [[Y:%.*]]
-; CHECK-NEXT:    [[X_FRZ:%.*]] = freeze i16 [[X:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X_FRZ]], [[Y_FRZ]]
-; CHECK-NEXT:    [[TMP2:%.*]] = call i16 @llvm.ucmp.i16.i16(i16 [[X_FRZ]], i16 [[Y_FRZ]])
-; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[TMP1]], i16 42, i16 [[TMP2]]
-; CHECK-NEXT:    ret i16 [[SELECT_UCMP]]
-;
-  %3 = icmp eq i16 %x, %y
-  %4 = icmp ult i16 %x, %y
-  %5 = select i1 %4, i16 -1, i16 1
-  %6 = select i1 %3, i16 42, i16 %5
-  ret i16 %6
-}
-
-define i16 @icmp_fold_to_llvm_ucmp_when_ult_and_Z_zero(i16 %x, i16 %y) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_ult_and_Z_zero(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i16 @llvm.ucmp.i16.i16(i16 [[X:%.*]], i16 [[Y:%.*]])
-; CHECK-NEXT:    ret i16 [[TMP1]]
-;
-  %3 = icmp eq i16 %x, %y
-  %4 = icmp ult i16 %x, %y
-  %5 = select i1 %4, i16 -1, i16 1
-  %6 = select i1 %3, i16 0, i16 %5
-  ret i16 %6
-}
-
-define i16 @icmp_fold_to_llvm_ucmp_when_slt_and_Z_zero(i16 %x, i16 %y) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_slt_and_Z_zero(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i16 @llvm.scmp.i16.i16(i16 [[X:%.*]], i16 [[Y:%.*]])
-; CHECK-NEXT:    ret i16 [[TMP1]]
-;
-  %3 = icmp eq i16 %x, %y
-  %4 = icmp slt i16 %x, %y
-  %5 = select i1 %4, i16 -1, i16 1
-  %6 = select i1 %3, i16 0, i16 %5
-  ret i16 %6
-}
-
-define i16 @icmp_fold_to_llvm_ucmp_when_cmp_slt(i16 %x, i16 %y) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_cmp_slt(
-; CHECK-NEXT:    [[Y_FRZ:%.*]] = freeze i16 [[Y:%.*]]
-; CHECK-NEXT:    [[X_FRZ:%.*]] = freeze i16 [[X:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X_FRZ]], [[Y_FRZ]]
-; CHECK-NEXT:    [[TMP2:%.*]] = call i16 @llvm.scmp.i16.i16(i16 [[X_FRZ]], i16 [[Y_FRZ]])
-; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[TMP1]], i16 42, i16 [[TMP2]]
-; CHECK-NEXT:    ret i16 [[SELECT_UCMP]]
-;
-  %3 = icmp eq i16 %x, %y
-  %4 = icmp slt i16 %x, %y ; here "ult" changed to "slt"
-  %5 = select i1 %4, i16 -1, i16 1
-  %6 = select i1 %3, i16 42, i16 %5
-  ret i16 %6
-}
-
-define i16 @icmp_fold_to_llvm_ucmp_when_value(i16 %x, i16 %y, i16 %Z) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_value(
-; CHECK-NEXT:    [[Y_FRZ:%.*]] = freeze i16 [[Y:%.*]]
-; CHECK-NEXT:    [[X_FRZ:%.*]] = freeze i16 [[X:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X_FRZ]], [[Y_FRZ]]
-; CHECK-NEXT:    [[TMP2:%.*]] = call i16 @llvm.ucmp.i16.i16(i16 [[X_FRZ]], i16 [[Y_FRZ]])
-; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[TMP1]], i16 [[Z:%.*]], i16 [[TMP2]]
-; CHECK-NEXT:    ret i16 [[SELECT_UCMP]]
-;
-  %3 = icmp eq i16 %x, %y
-  %4 = icmp ult i16 %x, %y
-  %5 = select i1 %4, i16 -1, i16 1
-  %6 = select i1 %3, i16 %Z, i16 %5
-  ret i16 %6
-}
-
-define i16 @icmp_fold_to_llvm_ucmp_when_ne(i16 %x, i16 %y) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_when_ne(
-; CHECK-NEXT:    [[Y_FRZ:%.*]] = freeze i16 [[Y:%.*]]
-; CHECK-NEXT:    [[X_FRZ:%.*]] = freeze i16 [[X:%.*]]
-; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq i16 [[X_FRZ]], [[Y_FRZ]]
-; CHECK-NEXT:    [[TMP1:%.*]] = call i16 @llvm.ucmp.i16.i16(i16 [[X_FRZ]], i16 [[Y_FRZ]])
-; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[DOTNOT]], i16 42, i16 [[TMP1]]
-; CHECK-NEXT:    ret i16 [[SELECT_UCMP]]
-;
-  %3 = icmp ne i16 %x, %y
-  %4 = icmp ult i16 %x, %y
-  %5 = select i1 %4, i16 -1, i16 1
-  %6 = select i1 %3, i16 %5, i16 42
-  ret i16 %6
-}
-
-define i32 @icmp_fold_to_llvm_ucmp_mixed_types(i16 %0, i16 %1) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_mixed_types(
-; CHECK-NEXT:    [[DOTFRZ1:%.*]] = freeze i16 [[TMP1:%.*]]
-; CHECK-NEXT:    [[DOTFRZ:%.*]] = freeze i16 [[TMP0:%.*]]
-; CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq i16 [[DOTFRZ]], [[DOTFRZ1]]
-; CHECK-NEXT:    [[TMP3:%.*]] = call i32 @llvm.ucmp.i32.i16(i16 [[DOTFRZ]], i16 [[DOTFRZ1]])
-; CHECK-NEXT:    [[SELECT_UCMP:%.*]] = select i1 [[DOTNOT]], i32 1, i32 [[TMP3]]
-; CHECK-NEXT:    ret i32 [[SELECT_UCMP]]
-;
-  %.not = icmp eq i16 %0, %1
-  %3 = icmp ult i16 %0, %1
-  %4 = select i1 %3, i32 -1, i32 1
-  %.1 = select i1 %.not, i32 1, i32 %4
-  ret i32 %.1
-}
-
-define i16 @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_1(i16 %x, i16 %y, i16 %Z) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_1(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
-; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i16 [[Z:%.*]], i16 1
-; CHECK-NEXT:    ret i16 [[TMP2]]
-;
-  %3 = icmp eq i16 %x, %y
-  %4 = icmp ult i16 %x, %y
-  %5 = select i1 %4, i16 1, i16 1 ; invalid constant
-  %6 = select i1 %3, i16 %Z, i16 %5
-  ret i16 %6
-}
-
-define i16 @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_2(i16 %x, i16 %y, i16 %Z) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_negative_test_invalid_constant_2(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i16 [[X:%.*]], [[Y:%.*]]
-; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[TMP1]], i16 [[Z:%.*]], i16 -1
-; CHECK-NEXT:    ret i16 [[TMP2]]
-;
-  %3 = icmp eq i16 %x, %y
-  %4 = icmp ult i16 %x, %y
-  %5 = select i1 %4, i16 -1, i16 -1 ; invalid constant
-  %6 = select i1 %3, i16 %Z, i16 %5
-  ret i16 %6
-}
-
-define i8 @icmp_fold_to_llvm_ucmp_negative_test_ptr(ptr %0, ptr %1) {
-; CHECK-LABEL: @icmp_fold_to_llvm_ucmp_negative_test_ptr(
-; CHECK-NEXT:    [[TMP3:%.*]] = load ptr, ptr [[TMP0:%.*]], align 8
-; CHECK-NEXT:    [[TMP4:%.*]] = load ptr, ptr [[TMP1:%.*]], align 8
-; CHECK-NEXT:    [[TMP5:%.*]] = icmp ult ptr [[TMP3]], [[TMP4]]
-; CHECK-NEXT:    [[TMP6:%.*]] = select i1 [[TMP5]], i8 -1, i8 1
-; CHECK-NEXT:    [[TMP7:%.*]] = icmp eq ptr [[TMP3]], [[TMP4]]
-; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP7]], i8 0, i8 [[TMP6]]
-; CHECK-NEXT:    ret i8 [[TMP8]]
-;
-  %3 = load ptr, ptr %0, align 8
-  %4 = load ptr, ptr %1, align 8
-  %5 = icmp ult ptr %3, %4
-  %6 = select i1 %5, i8 -1, i8 1
-  %7 = icmp eq ptr %3, %4
-  %8 = select i1 %7, i8 0, i8 %6
-  ret i8 %8
-}
-
 define i32 @fold_ucmp(i32 %0, i32 %1) {
 ; CHECK-LABEL: @fold_ucmp(
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0:%.*]], i32 [[TMP1:%.*]])
@@ -976,6 +827,32 @@ define i32 @fold_scmp(i32 %0, i32 %1) {
   %3 = icmp eq i32 %0, %1
   %4 = tail call i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)
   %5 = select i1 %3, i32 0, i32 %4
+  ret i32 %5
+}
+
+define i32 @fold_ucmp_negative_test(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_ucmp_negative_test(
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.ucmp.i32.i32(i32 [[TMP0]], i32 [[TMP1]])
+; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP3]], i32 1, i32 [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  %3 = icmp eq i32 %0, %1
+  %4 = tail call i32 @llvm.ucmp.i32.i32(i32 %0, i32 %1)
+  %5 = select i1 %3, i32 1, i32 %4 ; wrong constant
+  ret i32 %5
+}
+
+define i32 @fold_scmp_negative_test(i32 %0, i32 %1) {
+; CHECK-LABEL: @fold_scmp_negative_test(
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP4:%.*]] = tail call i32 @llvm.scmp.i32.i32(i32 [[TMP0]], i32 [[TMP1]])
+; CHECK-NEXT:    [[TMP5:%.*]] = select i1 [[TMP3]], i32 1, i32 [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  %3 = icmp eq i32 %0, %1
+  %4 = tail call i32 @llvm.scmp.i32.i32(i32 %0, i32 %1)
+  %5 = select i1 %3, i32 1, i32 %4 ; wrong constant
   ret i32 %5
 }
 


### PR DESCRIPTION
Folds `select(icmp(eq, X, Y), 0, llvm.cmp(X, Y))` -> `llvm.cmp(X, Y)` for `llvm.ucmp` and `llvm.scmp`.
Alive Proof: https://alive2.llvm.org/ce/z/sPJhgr

Closes https://github.com/llvm/llvm-project/issues/166579