### PR TITLE
[LLDB] Add log channel for InstrumentationRuntime plugins

### DIFF
--- a/lldb/include/lldb/Utility/LLDBLog.h
+++ b/lldb/include/lldb/Utility/LLDBLog.h
@@ -50,7 +50,8 @@ enum class LLDBLog : Log::MaskType {
   OnDemand = Log::ChannelFlag<31>,
   Source = Log::ChannelFlag<32>,
   Disassembler = Log::ChannelFlag<33>,
-  LLVM_MARK_AS_BITMASK_ENUM(Disassembler),
+  InstrumentationRuntime = Log::ChannelFlag<34>,
+  LLVM_MARK_AS_BITMASK_ENUM(InstrumentationRuntime),
 };
 
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
@@ -207,8 +207,11 @@ bool ReportRetriever::NotifyBreakpointHit(ProcessSP process_sp,
     return false;
 
   StructuredData::ObjectSP report = RetrieveReportData(process_sp);
-  if (!report || report->GetType() != lldb::eStructuredDataTypeDictionary)
+  if (!report || report->GetType() != lldb::eStructuredDataTypeDictionary) {
+    LLDB_LOGF(GetLog(LLDBLog::InstrumentationRuntime),
+              "ReportRetriever::RetrieveReportData() failed");
     return false;
+  }
 
   std::string description = FormatDescription(report);
 

--- a/lldb/source/Utility/LLDBLog.cpp
+++ b/lldb/source/Utility/LLDBLog.cpp
@@ -67,6 +67,9 @@ static constexpr Log::Category g_categories[] = {
     {{"disassembler"},
      {"log disassembler related activities"},
      LLDBLog::Disassembler},
+    {{"instrumentation-runtime"},
+     {"log instrumentation runtime plugin related activities"},
+     LLDBLog::InstrumentationRuntime},
 };
 
 static Log::Channel g_log_channel(g_categories,


### PR DESCRIPTION
This patch adds `LLDBLog::InstrumentationRuntime` as a log channel to provide an appropriate channel for instrumentation runtime plugins as previously one did not exist.

A small use of the channel is added to illustrate its use. The logging added is not intended to be comprehensive.

This is primarily motivated by an `-fbounds-safety` instrumentation plugin (https://github.com/swiftlang/llvm-project/pull/11835).

rdar://164920875