### PR TITLE
[IPT] Remove ipt.NumInstScanned statistic

### DIFF
--- a/llvm/lib/Analysis/InstructionPrecedenceTracking.cpp
+++ b/llvm/lib/Analysis/InstructionPrecedenceTracking.cpp
@@ -19,14 +19,10 @@
 
 #include "llvm/Analysis/InstructionPrecedenceTracking.h"
 #include "llvm/Analysis/ValueTracking.h"
-#include "llvm/ADT/Statistic.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
-
-#define DEBUG_TYPE "ipt"
-STATISTIC(NumInstScanned, "Number of insts scanned while updating ibt");
 
 #ifndef NDEBUG
 static cl::opt<bool> ExpensiveAsserts(
@@ -50,7 +46,6 @@ const Instruction *InstructionPrecedenceTracking::getFirstSpecialInstruction(
   auto [It, Inserted] = FirstSpecialInsts.try_emplace(BB);
   if (Inserted) {
     for (const auto &I : *BB) {
-      NumInstScanned++;
       if (isSpecialInstruction(&I)) {
         It->second = &I;
         break;


### PR DESCRIPTION
The NumInstScanned statistic is non-determinstic across multiple identical invocations of LLVM, and leads to noise when trying to diff LLVM statistics with e.g. ./utils/tdiff.py in llvm-test-suite.

My understanding is that it's non-deterministic because the users of IPT's hasSpecialInstructions/isPreceededBySpecialInstruction API aren't deterministic themselves.

This PR removes it and fixes #157598. This is just a small quality-of-life improvement for the ./utils/tdiff.py workflow, but happy to leave the statistic in if others are using it.
