### PR TITLE
[clang][clang-linker-wrapper] Use the correct triple for clang-offload-bundler and AMD SPIR-V.

### DIFF
--- a/clang/test/Driver/linker-wrapper-hip-amdgcnspirv.c
+++ b/clang/test/Driver/linker-wrapper-hip-amdgcnspirv.c
@@ -1,0 +1,16 @@
+// RUN: %clang -cc1 %s -triple "spirv64-amd-amdhsa" -emit-llvm-bc -o %t.bc
+// RUN: llvm-offload-binary -o %t.out "--image=file=%t.bc,triple=spirv64-amd-amdhsa,arch=amdgcnspirv,kind=hip"
+// RUN: clang-linker-wrapper \
+// RUN:     "--should-extract=amdgcnspirv" \
+// RUN:     "--host-triple=spirv64-amd-amdhsa" \
+// RUN:     "--linker-path=clang-offload-bundler" \
+// RUN:     "--emit-fatbin-only" \
+// RUN:     "-o" "%t.hipfb" \
+// RUN:     "%t.out" \
+// RUN:     --dry-run \
+// RUN: 2>&1 | FileCheck %s
+
+// clang-linker-wrapper was previously calling clang-offload-bundler with -targets=...,hip-amdgcn-amd-amdhsa--amdgcnspirv
+// This caused the runtime not to recognise the triple for the AMD SPIR-V code.
+
+// CHECK: {{".*clang-offload-bundler.*"}} {{.*}} -targets={{.*}},hip-spirv64-amd-amdhsa--amdgcnspirv

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -439,8 +439,11 @@ fatbinary(ArrayRef<std::pair<StringRef, StringRef>> InputFiles,
         Args.MakeArgString(Twine("-compression-level=") + Arg->getValue()));
 
   SmallVector<StringRef> Targets = {"-targets=host-x86_64-unknown-linux-gnu"};
-  for (const auto &[File, Arch] : InputFiles)
-    Targets.push_back(Saver.save("hip-amdgcn-amd-amdhsa--" + Arch));
+  for (const auto &[File, Arch] : InputFiles) {
+    Targets.push_back(Saver.save(Arch == "amdgcnspirv"
+                                     ? "hip-spirv64-amd-amdhsa--" + Arch
+                                     : "hip-amdgcn-amd-amdhsa--" + Arch));
+  }
   CmdArgs.push_back(Saver.save(llvm::join(Targets, ",")));
 
 #ifdef _WIN32


### PR DESCRIPTION
`clang-linker-wrapper` was incorrectly calling `clang-offload-bundler` for AMD SPIR-V. This resulted in a binary that couldn't be executed if built using the new driver. 

The runtime couldn't recognise the triple triggering this error at execution time:

```
No compatible code objects found for: gfx90a:sramecc+:xnack-,
```

With this PR, this is solved:

```
Creating ISA for: gfx90a:sramecc+:xnack- from spirv
```
