### PR TITLE
[RISCV] Make XFAIL test UNSUPPORTED.

### DIFF
--- a/llvm/test/CodeGen/RISCV/cfi-multiple-locations.mir
+++ b/llvm/test/CodeGen/RISCV/cfi-multiple-locations.mir
@@ -1,7 +1,7 @@
 # RUN: llc %s -mtriple=riscv64 \
 # RUN: -run-pass=cfi-instr-inserter \
 # RUN: -riscv-enable-cfi-instr-inserter=true
-# XFAIL: *
+# UNSUPPORTED: target={{.*}}
 
 # Technically, it is possible that a callee-saved register is saved in multiple different locations.
 # CFIInstrInserter should handle this, but currently it does not.


### PR DESCRIPTION
Currently the test cfi-multiple-location.mir is marked as XFAIL. This causes failures on some build bots because the test unexpectedly passes.

Mark this test as UNSUPPORTED for now. Later I plan to merge an MR which fixes an issue in CFIInstrInserter and this test will be enabled.