### PR TITLE
[AArch64] Force dwarf unwind for MTE-tagged stack frames

### DIFF
--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
@@ -586,6 +586,11 @@ public:
   /// Generate the compact unwind encoding from the CFI directives.
   uint64_t generateCompactUnwindEncoding(const MCDwarfFrameInfo *FI,
                                          const MCContext *Ctxt) const override {
+    // MTE-tagged frames must use DWARF unwinding because compact unwind
+    // doesn't handle MTE tags
+    if (FI->IsMTETaggedFrame)
+      return CU::UNWIND_ARM64_MODE_DWARF;
+
     ArrayRef<MCCFIInstruction> Instrs = FI->Instructions;
     if (Instrs.empty())
       return CU::UNWIND_ARM64_MODE_FRAMELESS;

--- a/llvm/test/CodeGen/AArch64/memtag-compact-unwind.ll
+++ b/llvm/test/CodeGen/AArch64/memtag-compact-unwind.ll
@@ -1,0 +1,27 @@
+; RUN: llc -mtriple=arm64-apple-macosx -mattr=+mte %s -filetype=obj -o %t.o
+; RUN: llvm-objdump --unwind-info %t.o | FileCheck %s
+
+; Frames with MTE stack tagging must use DWARF unwinding because compact unwind
+; doesn't handle MTE tag untagging during exception unwinding.
+
+; MTE-tagged frame should use DWARF mode (0x03000000)
+; CHECK-LABEL: Contents of __compact_unwind section:
+; CHECK:       compact encoding: 0x03000000
+
+; Normal frame should NOT use DWARF mode
+; CHECK-NOT:   compact encoding: 0x03000000
+; CHECK:       compact encoding: 0x{{[0-9a-f]+}}
+
+define void @mte_tagged_frame() sanitize_memtag "frame-pointer"="all" {
+  %x = alloca i32, align 4
+  store i32 42, ptr %x
+  call void asm sideeffect "", "r"(ptr %x)
+  ret void
+}
+
+define void @normal_frame() "frame-pointer"="all" {
+  %x = alloca i32, align 4
+  store i32 42, ptr %x
+  call void asm sideeffect "", "r"(ptr %x)
+  ret void
+}


### PR DESCRIPTION
Currently, on Darwin running with -fsanitize=memtag-stack generates compact-unwind exception unwinding that does not untag MTE-tagged memory on the way back up.

This patch forces dwarf unwinding on MTE-tagged frames.

rdar://162195539