### PR TITLE
[TSan] Make tests work with internal shell

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -875,7 +875,7 @@ for postfix in ["2", "1", ""]:
         config.substitutions.append(
             (
                 "%ld_flags_rpath_so" + postfix,
-                "-install_name @rpath/`basename %dynamiclib{}`".format(postfix),
+                "-install_name @rpath/%base_dynamiclib{}".format(postfix),
             )
         )
     elif config.target_os in ("FreeBSD", "NetBSD", "OpenBSD"):
@@ -907,6 +907,9 @@ for postfix in ["2", "1", ""]:
     # Must be defined after the substitutions that use %dynamiclib.
     config.substitutions.append(
         ("%dynamiclib" + postfix, "%t.dir/%xdynamiclib_filename" + postfix)
+    )
+    config.substitutions.append(
+        ("%base_dynamiclib" + postfix, "%xdynamiclib_filename" + postfix)
     )
     config.substitutions.append(
         (

--- a/compiler-rt/test/tsan/Darwin/dlopen.cpp
+++ b/compiler-rt/test/tsan/Darwin/dlopen.cpp
@@ -9,14 +9,15 @@
 // RUN: %clangxx_tsan %s -o %t.so -shared -DSHARED_LIB
 // RUN: %clangxx_tsan -fno-sanitize=thread %s -o %t
 
-// RUN: TSAN_DYLIB_PATH=`%clangxx_tsan %s -### 2>&1 \
+// RUN: %clangxx_tsan %s -### 2>&1 \
 // RUN:   | grep "libclang_rt.tsan_osx_dynamic.dylib" \
-// RUN:   | sed -e 's/.*"\(.*libclang_rt.tsan_osx_dynamic.dylib\)".*/\1/'`
+// RUN:   | sed -e 's/.*"\(.*libclang_rt.tsan_osx_dynamic.dylib\)".*/\1/' \
+// RUN:   | tr -d '\n' > %t.tsan_dylib_path
 
 // Launching a non-instrumented binary that dlopen's an instrumented library should fail.
 // RUN: not %run %t %t.so 2>&1 | FileCheck %s --check-prefix=CHECK-FAIL
 // Launching a non-instrumented binary with an explicit DYLD_INSERT_LIBRARIES should work.
-// RUN: DYLD_INSERT_LIBRARIES=$TSAN_DYLIB_PATH %run %t %t.so 2>&1 | FileCheck %s
+// RUN: env DYLD_INSERT_LIBRARIES="%{readfile:%t.tsan_dylib_path}" %run %t %t.so 2>&1 | FileCheck %s
 
 #include <dlfcn.h>
 #include <pthread.h>

--- a/compiler-rt/test/tsan/Darwin/external-ignore-noninstrumented.cpp
+++ b/compiler-rt/test/tsan/Darwin/external-ignore-noninstrumented.cpp
@@ -1,8 +1,10 @@
+// RUN: basename %t-lib.dylib | tr -d '\n' > %t.basename
 // RUN: %clangxx_tsan -shared %p/external-lib.cpp -fno-sanitize=thread -DUSE_TSAN_CALLBACKS \
-// RUN:   -o %t-lib.dylib -install_name @rpath/`basename %t-lib.dylib`
+// RUN:   -o %t-lib.dylib -install_name @rpath/%{readfile:%t.basename}
 
+// RUN: basename %t-module.dylib | tr -d '\n' > %t.basename
 // RUN: %clangxx_tsan -shared %p/external-noninstrumented-module.cpp %t-lib.dylib -fno-sanitize=thread \
-// RUN:   -o %t-module.dylib -install_name @rpath/`basename %t-module.dylib`
+// RUN:   -o %t-module.dylib -install_name @rpath/%{readfile:%t.basename}
 
 // RUN: %clangxx_tsan %s %t-module.dylib -o %t
 // RUN: %run %t 2>&1 | FileCheck %s

--- a/compiler-rt/test/tsan/Darwin/external.cpp
+++ b/compiler-rt/test/tsan/Darwin/external.cpp
@@ -1,14 +1,17 @@
+// RUN: basename %t-lib-instrumented.dylib | tr -d '\n' > %t.basename
 // RUN: %clangxx_tsan %p/external-lib.cpp -shared \
 // RUN:                               -o %t-lib-instrumented.dylib \
-// RUN:   -install_name @rpath/`basename %t-lib-instrumented.dylib`
+// RUN:   -install_name @rpath/%{readfile:%t.basename}
 
+// RUN: basename %t-lib-noninstrumented.dylib | tr -d '\n' > %t.basename
 // RUN: %clangxx_tsan %p/external-lib.cpp -shared -fno-sanitize=thread \
 // RUN:                               -o %t-lib-noninstrumented.dylib \
-// RUN:   -install_name @rpath/`basename %t-lib-noninstrumented.dylib`
+// RUN:   -install_name @rpath/%{readfile:%t.basename}
 
+// RUN: basename %t-lib-noninstrumented-callbacks.dylib | tr -d '\n' > %t.basename
 // RUN: %clangxx_tsan %p/external-lib.cpp -shared -fno-sanitize=thread -DUSE_TSAN_CALLBACKS \
 // RUN:                               -o %t-lib-noninstrumented-callbacks.dylib \
-// RUN:   -install_name @rpath/`basename %t-lib-noninstrumented-callbacks.dylib`
+// RUN:   -install_name @rpath/%{readfile:%t.basename}
 
 // RUN: %clangxx_tsan %s %t-lib-instrumented.dylib -o %t-lib-instrumented
 // RUN: %clangxx_tsan %s %t-lib-noninstrumented.dylib -o %t-lib-noninstrumented

--- a/compiler-rt/test/tsan/Darwin/malloc-stack-logging.cpp
+++ b/compiler-rt/test/tsan/Darwin/malloc-stack-logging.cpp
@@ -4,7 +4,7 @@
 // use syscalls directly) to make sure other interceptors aren't called.
 
 // RUN: %clangxx_tsan -O1 %s -o %t
-// RUN: MallocStackLogging=1 %run %t 2>&1 | FileCheck %s
+// RUN: env MallocStackLogging=1 %run %t 2>&1 | FileCheck %s
 #include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/compiler-rt/test/tsan/on_initialize_finalize_hooks.cpp
+++ b/compiler-rt/test/tsan/on_initialize_finalize_hooks.cpp
@@ -1,7 +1,4 @@
 // RUN: mkdir -p %t.dir && cd %t.dir
-// RUN: basename %dynamiclib > /tmp/test
-// RUN: echo %dynamiclib >> /tmp/test
-// RUN: echo %t >> /tmp/test
 // RUN: %clang_tsan -O1 %s -DBUILD_LIB=1 -fno-sanitize=thread -shared -fPIC -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clang_tsan -O1 %s -o %t.dir/exe %ld_flags_rpath_exe
 // RUN: %run %t.dir/exe | FileCheck %s

--- a/compiler-rt/test/tsan/on_initialize_finalize_hooks.cpp
+++ b/compiler-rt/test/tsan/on_initialize_finalize_hooks.cpp
@@ -1,4 +1,7 @@
 // RUN: mkdir -p %t.dir && cd %t.dir
+// RUN: basename %dynamiclib > /tmp/test
+// RUN: echo %dynamiclib >> /tmp/test
+// RUN: echo %t >> /tmp/test
 // RUN: %clang_tsan -O1 %s -DBUILD_LIB=1 -fno-sanitize=thread -shared -fPIC -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clang_tsan -O1 %s -o %t.dir/exe %ld_flags_rpath_exe
 // RUN: %run %t.dir/exe | FileCheck %s


### PR DESCRIPTION
This patch makes all tsan tests work with the internal shell on Darwin. Tests
were using various features not supported by the internal shell, mainly subshells
and not using env to set environment variables. This patch also fixes one of the
dynamiclib substitutions to not use a subshell.
