### PR TITLE
[MLIR][NVVM] Remove constexpr qualifier from getNVVMCtaGroupKind

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -62,7 +62,7 @@ static bool isPtrInSharedCTASpace(mlir::Value ptr) {
 }
 
 // Helper method to convert CtaGroupKind in NVVM Dialect to CtaGroupKind in LLVM
-static constexpr llvm::nvvm::CTAGroupKind
+static llvm::nvvm::CTAGroupKind
 getNVVMCtaGroupKind(NVVM::CTAGroupKind ctaGroup) {
   switch (ctaGroup) {
   case NVVM::CTAGroupKind::CTA_1:


### PR DESCRIPTION
This commit removes constexpr qualifier from getNVVMCtaGroupKind function as llvm_unreachable cannot be used in a constexpr context. The build failures came up during post-merge CI