### PR TITLE
[flang][NFC] Strip trailing whitespace from tests (7 of N)

### DIFF
--- a/flang/test/Lower/assignment.f90
+++ b/flang/test/Lower/assignment.f90
@@ -26,7 +26,7 @@ end
 integer function negi(a)
   integer :: a
   negi = -a
-end 
+end
 
 ! CHECK-LABEL: func @_QPnegi(
 ! CHECK-SAME:    %[[A:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}) -> i32 {
@@ -41,7 +41,7 @@ end
 real function negr(a)
   real :: a
   negr = -a
-end 
+end
 
 ! CHECK-LABEL: func @_QPnegr(
 ! CHECK-SAME:    %[[A:.*]]: !fir.ref<f32> {fir.bindc_name = "a"}) -> f32 {
@@ -55,7 +55,7 @@ end
 complex function negc(a)
   complex :: a
   negc = -a
-end 
+end
 
 ! CHECK-LABEL: func @_QPnegc(
 ! CHECK-SAME:    %[[A:.*]]: !fir.ref<complex<f32>> {fir.bindc_name = "a"}) -> complex<f32> {

--- a/flang/test/Lower/assumed-shape-callee.f90
+++ b/flang/test/Lower/assumed-shape-callee.f90
@@ -8,7 +8,7 @@
 ! of making a new fir.box and this would break all these tests. In fact, for non
 ! contiguous arrays, this is the case. Find a better way to tests symbol lowering/mapping.
 
-! CHECK-LABEL: func @_QPtest_assumed_shape_1(%arg0: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "x", fir.contiguous}) 
+! CHECK-LABEL: func @_QPtest_assumed_shape_1(%arg0: !fir.box<!fir.array<?xi32>> {fir.bindc_name = "x", fir.contiguous})
 subroutine test_assumed_shape_1(x)
   integer, contiguous :: x(:)
   ! CHECK: %[[addr:.*]] = fir.box_addr %arg0 : (!fir.box<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>

--- a/flang/test/Lower/assumed-shape-caller.f90
+++ b/flang/test/Lower/assumed-shape-caller.f90
@@ -59,7 +59,7 @@ subroutine test_vector_subcripted_section_to_box(v, x)
     end subroutine
   end interface
   integer :: v(:)
-  real :: x(:) 
+  real :: x(:)
   call takes_box(x(v))
 ! CHECK:  %[[VAL_2:.*]] = arith.constant 1 : index
 ! CHECK:  %[[VAL_3:.*]] = arith.constant 0 : index

--- a/flang/test/Lower/big-integer-parameter.f90
+++ b/flang/test/Lower/big-integer-parameter.f90
@@ -31,7 +31,7 @@ end
 
 ! CHECK-LABEL: fir.global internal @_QFECx constant : i128 {
 ! CHECK-NEXT:   %{{.*}} = arith.constant 9223372036854775808 : i128
- 
+
 ! CHECK-LABEL: fir.global internal @_QFECy constant : i128 {
 ! CHECK-NEXT: %{{.*}} = arith.constant -9223372036854775809 : i128
 

--- a/flang/test/Lower/c-interoperability.f90
+++ b/flang/test/Lower/c-interoperability.f90
@@ -26,7 +26,7 @@ module c_interoperability_test
   end type thing_with_pointer
 
   type(thing_with_pointer) :: this_thing
-  
+
 contains
   function get_a_thing()
     type(thing_with_pointer) :: get_a_thing

--- a/flang/test/Lower/call-copy-in-out.f90
+++ b/flang/test/Lower/call-copy-in-out.f90
@@ -120,7 +120,7 @@ subroutine test_intent_out(x)
 ! CHECK:  %[[cast:.*]] = fir.convert %[[addr]] : (!fir.heap<!fir.array<?xf32>>) -> !fir.ref<!fir.array<100xf32>>
 ! CHECK:  fir.call @_QPbar_intent_out(%[[cast]]) {{.*}}: (!fir.ref<!fir.array<100xf32>>) -> ()
   call bar_intent_out(x)
-  
+
 ! CHECK: fir.if %[[not_contiguous]]
 ! CHECK: fir.call @_FortranACopyOutAssign
 ! CHECK: return
@@ -224,7 +224,7 @@ subroutine test_char(x)
 ! CHECK:             %[[VAL_32:.*]] = fir.convert %[[TMP_BOX_REF]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,10>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:             fir.call @_FortranACopyOutAssign(%[[VAL_31]], %[[VAL_32]], %{{.*}}, %{{.*}}) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<i8>, i32) -> ()
 ! CHECK:           }
-  
+
   character(10) :: x(:)
   call bar_char(x)
   ! CHECK:         return

--- a/flang/test/Lower/charconvert.f90
+++ b/flang/test/Lower/charconvert.f90
@@ -1,17 +1,17 @@
 ! RUN: bbc -emit-hlfir %s -o - | FileCheck %s
 
 subroutine test_c1_to_c4(c4, c1)
-  character(len=*, kind=4) :: c4                           
-  character(len=*, kind=1) :: c1            
-  c4 = c1                                         
-end subroutine                                           
+  character(len=*, kind=4) :: c4
+  character(len=*, kind=1) :: c1
+  c4 = c1
+end subroutine
 
 subroutine test_c4_to_c1(c4, c1)
-  character(len=*, kind=4) :: c4                           
-  character(len=*, kind=1) :: c1            
-  c1 = c4                                         
-end subroutine                                           
-                                                
+  character(len=*, kind=4) :: c4
+  character(len=*, kind=1) :: c1
+  c1 = c4
+end subroutine
+
 ! CHECK: func.func @_QPtest_c1_to_c4(%[[ARG0:.*]]: !fir.boxchar<4> {fir.bindc_name = "c4"}, %[[ARG1:.*]]: !fir.boxchar<1> {fir.bindc_name = "c1"}) {
 ! CHECK:   %[[VAL_0:.*]]:2 = fir.unboxchar %[[ARG1]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
 ! CHECK:   %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]]#0 typeparams %[[VAL_0]]#1 dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFtest_c1_to_c4Ec1"} : (!fir.ref<!fir.char<1,?>>, index, !fir.dscope) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)

--- a/flang/test/Lower/control-flow.f90
+++ b/flang/test/Lower/control-flow.f90
@@ -22,4 +22,4 @@ subroutine one(a,b,c)
  ! CHECK: ^bb[[EXIT]]:
  ! CHECK-NEXT: return
 end subroutine one
-    
+

--- a/flang/test/Lower/default-initialization.f90
+++ b/flang/test/Lower/default-initialization.f90
@@ -3,14 +3,14 @@
 
 module test_dinit
   type t
-    integer :: i = 42 
+    integer :: i = 42
   end type
   type t_alloc_comp
     real, allocatable :: i(:)
   end type
   type tseq
     sequence
-    integer :: i = 42 
+    integer :: i = 42
   end type
 contains
 
@@ -26,7 +26,7 @@ contains
     !CHECK: fir.copy %[[ADDR]] to %[[x]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt{i:i32}>>, !fir.ref<!fir.type<_QMtest_dinitTt{i:i32}>>
     type(t) :: x
     print *, x%i
-  end subroutine 
+  end subroutine
 
   ! Test local array is default initialized
   ! CHECK-LABEL: func @_QMtest_dinitPlocal_array()
@@ -38,7 +38,7 @@ contains
     ! CHECK: fir.call @_FortranAInitialize(%[[xboxNone]], %{{.*}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.ref<i8>, i32) -> ()
     type(t) :: x(4)
     print *, x(2)%i
-  end subroutine 
+  end subroutine
 
   ! Test allocatable component triggers default initialization of local
   ! scalars.
@@ -48,7 +48,7 @@ contains
     !CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTt_alloc_comp.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTt_alloc_comp{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
     !CHECK: fir.copy %[[ADDR]] to %[[x]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTt_alloc_comp{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>, !fir.ref<!fir.type<_QMtest_dinitTt_alloc_comp{i:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
     type(t_alloc_comp) :: x
-  end subroutine 
+  end subroutine
 
   ! Test function results are default initialized.
   ! CHECK-LABEL: func @_QMtest_dinitPresult() -> !fir.type<_QMtest_dinitTt{i:i32}>
@@ -110,7 +110,7 @@ contains
     ! CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTtseq.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>
     ! CHECK: fir.copy %[[ADDR]] to %[[x]] no_overlap : !fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>, !fir.ptr<!fir.type<_QMtest_dinitTtseq{i:i32}>>
 
-  
+
     ! CHECK: %[[ycoor:.*]] = fir.coordinate_of %[[equiv]], %c0{{.*}} : (!fir.ref<!fir.array<4xi8>>, index) -> !fir.ref<i8>
     ! CHECK: %[[y:.*]] = fir.convert %[[ycoor]] : (!fir.ref<i8>) -> !fir.ptr<!fir.type<_QMtest_dinitTtseq{i:i32}>>
     ! CHECK: %[[ADDR:.*]] = fir.address_of(@_QQ_QMtest_dinitTtseq.DerivedInit) : !fir.ref<!fir.type<_QMtest_dinitTtseq{i:i32}>>
@@ -129,14 +129,14 @@ contains
     ! CHECK-NOT: fir.call @_FortranAInitialize
     type(t), allocatable :: x
     ! CHECK: return
-  end subroutine 
+  end subroutine
 
   ! CHECK-LABEL: func @_QMtest_dinitPnoinit_local_pointer
   subroutine noinit_local_pointer
     ! CHECK-NOT: fir.call @_FortranAInitialize
     type(t), pointer :: x
     ! CHECK: return
-  end subroutine 
+  end subroutine
 
   ! CHECK-LABEL: func @_QMtest_dinitPnoinit_normal_dummy
   subroutine noinit_normal_dummy(x)
@@ -150,7 +150,7 @@ contains
     ! CHECK-NOT: fir.call @_FortranAInitialize
     type(t), intent(inout) :: x
     ! CHECK: return
-  end subroutine 
+  end subroutine
 
 
   subroutine test_pointer_intentout(a, b)

--- a/flang/test/Lower/derived-allocatable-components.f90
+++ b/flang/test/Lower/derived-allocatable-components.f90
@@ -241,9 +241,9 @@ subroutine ref_scalar_def_char_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
   ! CHECK-DAG: %[[base:.*]] = fir.box_addr %[[box]]
   ! CHECK: %[[cast:.*]] = fir.convert %[[base]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
-  ! CHECK: %[[c7:.*]] = fir.convert %c7{{.*}} : (i64) -> index 
-  ! CHECK: %[[sub:.*]] = arith.subi %[[c7]], %[[dims]]#0 : index 
-  ! CHECK: %[[mul:.*]] = arith.muli %[[len]], %[[sub]] : index 
+  ! CHECK: %[[c7:.*]] = fir.convert %c7{{.*}} : (i64) -> index
+  ! CHECK: %[[sub:.*]] = arith.subi %[[c7]], %[[dims]]#0 : index
+  ! CHECK: %[[mul:.*]] = arith.muli %[[len]], %[[sub]] : index
   ! CHECK: %[[offset:.*]] = arith.addi %[[mul]], %c0{{.*}} : index
   ! CHECK: %[[cnvt:.*]] = fir.convert %[[cast]]
   ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[cnvt]], %[[offset]]
@@ -260,9 +260,9 @@ subroutine ref_scalar_def_char_a(a0_0, a1_0, a0_1, a1_1)
   ! CHECK-DAG: %[[len:.*]] = fir.box_elesize %[[box]]
   ! CHECK-DAG: %[[base:.*]] = fir.box_addr %[[box]]
   ! CHECK: %[[cast:.*]] = fir.convert %[[base]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>) -> !fir.ref<!fir.array<?x!fir.char<1,?>>>
-  ! CHECK: %[[c7:.*]] = fir.convert %c7{{.*}} : (i64) -> index 
-  ! CHECK: %[[sub:.*]] = arith.subi %[[c7]], %[[dims]]#0 : index 
-  ! CHECK: %[[mul:.*]] = arith.muli %[[len]], %[[sub]] : index 
+  ! CHECK: %[[c7:.*]] = fir.convert %c7{{.*}} : (i64) -> index
+  ! CHECK: %[[sub:.*]] = arith.subi %[[c7]], %[[dims]]#0 : index
+  ! CHECK: %[[mul:.*]] = arith.muli %[[len]], %[[sub]] : index
   ! CHECK: %[[offset:.*]] = arith.addi %[[mul]], %c0{{.*}} : index
   ! CHECK: %[[cnvt:.*]] = fir.convert %[[cast]]
   ! CHECK: %[[addr:.*]] = fir.coordinate_of %[[cnvt]], %[[offset]]

--- a/flang/test/Lower/derived-type-descriptor.f90
+++ b/flang/test/Lower/derived-type-descriptor.f90
@@ -39,7 +39,7 @@ end subroutine
 ! CHECK: }
 
 subroutine char_comp_init()
-  implicit none  
+  implicit none
   type t
      character(8) :: name='Empty'
   end type t

--- a/flang/test/Lower/derived-types.f90
+++ b/flang/test/Lower/derived-types.f90
@@ -19,7 +19,7 @@ module d
 contains
 
 ! -----------------------------------------------------------------------------
-!            Test simple derived type symbol lowering 
+!            Test simple derived type symbol lowering
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QMdPderived_dummy(
@@ -50,7 +50,7 @@ end subroutine
 
 
 ! -----------------------------------------------------------------------------
-!            Test simple derived type references 
+!            Test simple derived type references
 ! -----------------------------------------------------------------------------
 
 ! CHECK-LABEL: func @_QMdPscalar_numeric_ref(
@@ -157,7 +157,7 @@ end subroutine
 end module
 
 ! -----------------------------------------------------------------------------
-!            Test derived type with pointer/allocatable components 
+!            Test derived type with pointer/allocatable components
 ! -----------------------------------------------------------------------------
 
 module d2
@@ -174,7 +174,7 @@ end subroutine
 end module
 
 ! -----------------------------------------------------------------------------
-!            Test global derived type symbol lowering 
+!            Test global derived type symbol lowering
 ! -----------------------------------------------------------------------------
 
 module data_mod

--- a/flang/test/Lower/dispatch.f90
+++ b/flang/test/Lower/dispatch.f90
@@ -155,7 +155,7 @@ module call_dispatch
 ! CHECK:       fir.dispatch "tbp_nopass"(%[[P_DECL]]#1 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>){{$}}
 ! CHECK:       fir.dispatch "tbp_pass"(%[[P_DECL]]#0 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>) (%[[P_DECL]]#0 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>) {pass_arg_pos = 0 : i32}
 ! CHECK:       fir.dispatch "tbp_pass_arg0"(%[[P_DECL]]#0 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>) (%[[P_DECL]]#0 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>) {pass_arg_pos = 0 : i32}
-! CHECK:       fir.dispatch "tbp_pass_arg1"(%[[P_DECL]]#0 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>)  (%{{.*}}, %[[P_DECL]]#0 : !fir.ref<i32>, !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>) {pass_arg_pos = 1 : i32} 
+! CHECK:       fir.dispatch "tbp_pass_arg1"(%[[P_DECL]]#0 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>)  (%{{.*}}, %[[P_DECL]]#0 : !fir.ref<i32>, !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>) {pass_arg_pos = 1 : i32}
 
 ! CHECK:       fir.dispatch "proc1"(%[[P_DECL]]#1 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>){{$}}
 ! CHECK:       fir.dispatch "proc2"(%[[P_DECL]]#0 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>) (%[[P_DECL]]#0 : !fir.class<!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>) {pass_arg_pos = 0 : i32}
@@ -174,7 +174,7 @@ module call_dispatch
   end subroutine
 
 ! CHECK-LABEL: func.func @_QMcall_dispatchPcheck_dispatch_deferred(
-! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.type<_QMcall_dispatchTa1{a:f32,b:f32}>> {fir.bindc_name = "a"}, 
+! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.type<_QMcall_dispatchTa1{a:f32,b:f32}>> {fir.bindc_name = "a"},
 ! CHECK-SAME: %[[ARG1:.*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
 ! CHECK: %[[ARG0_DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMcall_dispatchFcheck_dispatch_deferredEa"} : (!fir.class<!fir.type<_QMcall_dispatchTa1{a:f32,b:f32}>>, !fir.dscope) -> (!fir.class<!fir.type<_QMcall_dispatchTa1{a:f32,b:f32}>>, !fir.class<!fir.type<_QMcall_dispatchTa1{a:f32,b:f32}>>)
 ! CHECK: %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMcall_dispatchFcheck_dispatch_deferredEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
@@ -218,7 +218,7 @@ module call_dispatch
     end subroutine
 
 ! CHECK-LABEL: func.func @_QMcall_dispatchPcheck_dispatch_static_array(
-! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.array<10x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>> {fir.bindc_name = "p"}, 
+! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.array<10x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>> {fir.bindc_name = "p"},
 ! CHECK-SAME: %[[ARG1:.*]]: !fir.ref<!fir.array<10x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>> {fir.bindc_name = "t"}) {
 ! CHECK: %[[ARG0_DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMcall_dispatchFcheck_dispatch_static_arrayEp"} : (!fir.class<!fir.array<10x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.dscope) -> (!fir.class<!fir.array<10x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.class<!fir.array<10x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>)
 ! CHECK: %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]](%{{.*}}) dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMcall_dispatchFcheck_dispatch_static_arrayEt"} : (!fir.ref<!fir.array<10x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<10x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.ref<!fir.array<10x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>)
@@ -246,7 +246,7 @@ module call_dispatch
     end subroutine
 
 ! CHECK-LABEL: func.func @_QMcall_dispatchPcheck_dispatch_dynamic_array(
-! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>> {fir.bindc_name = "p"}, 
+! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>> {fir.bindc_name = "p"},
 ! CHECK-SAME: %[[ARG1:.*]]: !fir.box<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>> {fir.bindc_name = "t"}) {
 ! CHECK: %[[ARG0_DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMcall_dispatchFcheck_dispatch_dynamic_arrayEp"} : (!fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.dscope) -> (!fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>)
 ! CHECK: %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMcall_dispatchFcheck_dispatch_dynamic_arrayEt"} : (!fir.box<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.dscope) -> (!fir.box<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.box<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>)
@@ -274,7 +274,7 @@ module call_dispatch
     end subroutine
 
 ! CHECK-LABEL: func.func @_QMcall_dispatchPcheck_dispatch_allocatable_array(
-! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.class<!fir.heap<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>> {fir.bindc_name = "p"}, 
+! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.class<!fir.heap<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>> {fir.bindc_name = "p"},
 ! CHECK-SAME: %[[ARG1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>> {fir.bindc_name = "t"}) {
 ! CHECK: %[[ARG0_DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QMcall_dispatchFcheck_dispatch_allocatable_arrayEp"} : (!fir.ref<!fir.class<!fir.heap<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>, !fir.dscope) -> (!fir.ref<!fir.class<!fir.heap<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>, !fir.ref<!fir.class<!fir.heap<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>)
 ! CHECK: %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QMcall_dispatchFcheck_dispatch_allocatable_arrayEt"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>)
@@ -304,7 +304,7 @@ module call_dispatch
     end subroutine
 
 ! CHECK-LABEL: func.func @_QMcall_dispatchPcheck_dispatch_pointer_array(
-! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.class<!fir.ptr<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>> {fir.bindc_name = "p"}, 
+! CHECK-SAME: %[[ARG0:.*]]: !fir.ref<!fir.class<!fir.ptr<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>> {fir.bindc_name = "p"},
 ! CHECK-SAME: %[[ARG1:.*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>> {fir.bindc_name = "t"}) {
 ! CHECK: %[[ARG0_DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMcall_dispatchFcheck_dispatch_pointer_arrayEp"} : (!fir.ref<!fir.class<!fir.ptr<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>, !fir.dscope) -> (!fir.ref<!fir.class<!fir.ptr<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>, !fir.ref<!fir.class<!fir.ptr<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>)
 ! CHECK: %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QMcall_dispatchFcheck_dispatch_pointer_arrayEt"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>>>)
@@ -332,7 +332,7 @@ module call_dispatch
     end subroutine
 
 ! CHECK-LABEL: func.func @_QMcall_dispatchPcheck_dispatch_dynamic_array_copy(
-! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>> {fir.bindc_name = "p"}, 
+! CHECK-SAME: %[[ARG0:.*]]: !fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>> {fir.bindc_name = "p"},
 ! CHECK-SAME: %[[ARG1:.*]]: !fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>> {fir.bindc_name = "o"}) {
 ! CHECK: %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMcall_dispatchFcheck_dispatch_dynamic_array_copyEo"} : (!fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.dscope) -> (!fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>)
 ! CHECK: %[[ARG0_DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QMcall_dispatchFcheck_dispatch_dynamic_array_copyEp"} : (!fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.dscope) -> (!fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>, !fir.class<!fir.array<?x!fir.type<_QMcall_dispatchTp1{a:i32,b:i32}>>>)

--- a/flang/test/Lower/do_concurrent_delayed_locality.f90
+++ b/flang/test/Lower/do_concurrent_delayed_locality.f90
@@ -7,7 +7,7 @@ subroutine do_concurrent_with_locality_specs
   do concurrent (i=1:10) local(local_var) local_init(local_init_var)
     if (i < 5) then
       local_var = 42
-    else 
+    else
       local_init_var = 84
     end if
   end do

--- a/flang/test/Lower/do_concurrent_reduce.f90
+++ b/flang/test/Lower/do_concurrent_reduce.f90
@@ -26,7 +26,7 @@ end
 ! CHECK:           fir.do_concurrent {
 ! CHECK:             %[[VAL_0:.*]] = fir.alloca i32 {bindc_name = "i"}
 ! CHECK:             %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "_QFdo_concurrent_reduceEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:             fir.do_concurrent.loop (%{{.*}}) = (%{{.*}}) to (%{{.*}}) step (%{{[^[:space:]]+}}) 
+! CHECK:             fir.do_concurrent.loop (%{{.*}}) = (%{{.*}}) to (%{{.*}}) step (%{{[^[:space:]]+}})
 ! CHECK-SAME:          reduce(@add_reduction_i32 #fir.reduce_attr<add> %[[S_DECL]]#0 -> %[[S_ARG:.*]] : !fir.ref<i32>) {
 
 ! CHECK:               %[[S_ARG_DECL:.*]]:2 = hlfir.declare %[[S_ARG]] {uniq_name = "_QFdo_concurrent_reduceEs"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)

--- a/flang/test/Lower/do_loop.f90
+++ b/flang/test/Lower/do_loop.f90
@@ -3,7 +3,7 @@
 ! RUN: %flang_fc1 -mllvm --use-desc-for-alloc=false -emit-fir -flang-deprecated-no-hlfir -fwrapv -o - %s | FileCheck %s --check-prefix=NO-NSW
 
 ! Simple tests for structured ordered loops with loop-control.
-! Tests the structure of the loop, storage to index variable and return and 
+! Tests the structure of the loop, storage to index variable and return and
 ! storage of the final value of the index variable.
 
 ! NO-NSW-NOT: overflow<nsw>

--- a/flang/test/Lower/dummy-argument-contiguous.f90
+++ b/flang/test/Lower/dummy-argument-contiguous.f90
@@ -2,7 +2,7 @@
 ! RUN: bbc -emit-fir -hlfir=false -gen-array-coor %s -o - | FileCheck %s --check-prefix=ArrayCoorCHECK
 
 ! Test that non-contiguous assumed-shape memory layout is handled in lowering.
-! In practice, test that input fir.box is propagated to fir operations 
+! In practice, test that input fir.box is propagated to fir operations
 
 ! Also test that when the contiguous keyword is present, lowering adds the
 ! attribute to the fir argument and that is takes the contiguity into account

--- a/flang/test/Lower/dummy-procedure-character.f90
+++ b/flang/test/Lower/dummy-procedure-character.f90
@@ -234,7 +234,7 @@ end subroutine
 ! CHECK-SAME:  %[[VAL_0:.*]]: tuple<!fir.boxproc<() -> ()>, i64> {fir.char_proc})
 subroutine host2(f)
   ! Test that dummy length is overridden by local length even when used
-  ! in the internal procedure. 
+  ! in the internal procedure.
   character*(42) :: f
   external :: f
   ! CHECK:  %[[VAL_3:.*]] = fir.coordinate_of %[[VAL_1:.*]], %{{.*}} : (!fir.ref<tuple<tuple<!fir.boxproc<() -> ()>, i64>>>, i32) -> !fir.ref<tuple<!fir.boxproc<() -> ()>, i64>>

--- a/flang/test/Lower/dummy-procedure.f90
+++ b/flang/test/Lower/dummy-procedure.f90
@@ -141,7 +141,7 @@ subroutine test_iabs()
   call foo_iabs(iabs)
 end subroutine
 
-! TODO: exhaustive test of unrestricted intrinsic table 16.2 
+! TODO: exhaustive test of unrestricted intrinsic table 16.2
 
 ! TODO: improve dummy procedure types when interface is given.
 ! CHECK: func @_QPtodo3(

--- a/flang/test/Lower/equivalence-1.f90
+++ b/flang/test/Lower/equivalence-1.f90
@@ -53,7 +53,7 @@ SUBROUTINE s3
   ! CHECK: %{{.*}} = fir.load %[[v2loc]] : !fir.ref<f32>
   PRINT *, r(9)
 END SUBROUTINE s3
-  
+
 ! test that equivalence in main program containing arrays are placed in global memory.
 ! CHECK: fir.global internal @_QFEa : !fir.array<400000000xi8>
   integer :: a, b(100000000)

--- a/flang/test/Lower/equivalence-2.f90
+++ b/flang/test/Lower/equivalence-2.f90
@@ -61,7 +61,7 @@ end subroutine
 subroutine eq_and_entry_foo
   SAVE x, i
   DIMENSION :: x(2)
-  EQUIVALENCE (x(2), i) 
+  EQUIVALENCE (x(2), i)
   call foo1(x, i)
   ! CHECK: %[[xi:.*]] = fir.address_of(@_QFeq_and_entry_fooEi) : !fir.ref<!fir.array<8xi8>>
 

--- a/flang/test/Lower/explicit-interface-results.f90
+++ b/flang/test/Lower/explicit-interface-results.f90
@@ -313,7 +313,7 @@ contains
   function result_depends_on_equiv_sym()
     character(l) :: result_depends_on_equiv_sym
     call set_result_with_some_value(result_depends_on_equiv_sym)
-  end function  
+  end function
 end module
 
 ! CHECK-LABEL: func @_QPtest_result_depends_on_equiv_sym
@@ -387,7 +387,7 @@ function test_recursion(n) result(res)
   if (n.eq.1) then
     res = char(some_local(1))
   ! CHECK: else
-  else 
+  else
     ! CHECK-NOT: fir.alloca !fir.array<?xi32>
 
     ! verify that the actual argument for symbol n ("n-1") is used to allocate

--- a/flang/test/Lower/host-associated.f90
+++ b/flang/test/Lower/host-associated.f90
@@ -135,7 +135,7 @@ subroutine test3(p,q,i)
   if (p(2) .ne. -42.0) then
      print *, "failed"
   end if
-  
+
 contains
   ! CHECK-LABEL: func private @_QFtest3Ptest3_inner(
   ! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>>> {fir.host_assoc}) attributes {fir.host_symbol = {{.*}}, llvm.linkage = #llvm.linkage<internal>} {
@@ -182,7 +182,7 @@ subroutine test3a(p)
   if (p(1) .ne. -42.0) then
      print *, "failed"
   end if
-  
+
 contains
   ! CHECK: func private @_QFtest3aPtest3a_inner(
   ! CHECK-SAME: %[[tup:.*]]: !fir.ref<tuple<!fir.box<!fir.array<10xf32>>, !fir.box<!fir.array<10xf32>>>> {fir.host_assoc}) attributes {fir.host_symbol = {{.*}}, llvm.linkage = #llvm.linkage<internal>} {
@@ -226,7 +226,7 @@ subroutine test4
   if (p .ne. -42.0) then
      print *, "failed"
   end if
-  
+
 contains
   ! CHECK-LABEL: func private @_QFtest4Ptest4_inner(
   ! CHECK-SAME:%[[tup:.*]]: !fir.ref<tuple<!fir.ref<!fir.box<!fir.ptr<f32>>>, !fir.ref<!fir.box<!fir.heap<f32>>>>> {fir.host_assoc}) attributes {fir.host_symbol = {{.*}}, llvm.linkage = #llvm.linkage<internal>} {
@@ -268,7 +268,7 @@ subroutine test5
   if (p(1) .ne. -42.0) then
      print *, "failed"
   end if
-  
+
 contains
   ! CHECK-LABEL: func private @_QFtest5Ptest5_inner(
   ! CHECK-SAME:%[[tup:.*]]: !fir.ref<tuple<!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>>> {fir.host_assoc}) attributes {fir.host_symbol = {{.*}}, llvm.linkage = #llvm.linkage<internal>} {
@@ -420,7 +420,7 @@ contains
 subroutine bar()
   ! CHECK: %[[tupAddr:.*]] = fir.coordinate_of %[[tup]], %c0{{.*}} : (!fir.ref<tuple<!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>>>, i32) -> !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>>
   ! CHECK: fir.load %[[tupAddr]] : !fir.llvm_ptr<!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>>
-  read (88, NML = a_namelist) 
+  read (88, NML = a_namelist)
 end subroutine
 end subroutine
 
@@ -642,7 +642,7 @@ end subroutine test_proc_dummy_char
 function get_message(a)
   character(40) :: get_message
   character(*) :: a
-  get_message = "message is: " // a() 
+  get_message = "message is: " // a()
 end function get_message
 
 ! CHECK-LABEL: func @_QPtest_11a() {


### PR DESCRIPTION
Only some fortran source files in flang/test/Lower have been modified. The other files in the directory will be cleaned up in subsequent commits