### PR TITLE
[libLTO] add thinlto caching flags to libLTO

### DIFF
--- a/llvm/tools/lto/lto.cpp
+++ b/llvm/tools/lto/lto.cpp
@@ -24,6 +24,7 @@
 #include "llvm/LTO/legacy/LTOCodeGenerator.h"
 #include "llvm/LTO/legacy/LTOModule.h"
 #include "llvm/LTO/legacy/ThinLTOCodeGenerator.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
@@ -43,6 +44,29 @@ static cl::opt<char>
 static cl::opt<bool> EnableFreestanding(
     "lto-freestanding", cl::init(false),
     cl::desc("Enable Freestanding (disable builtins / TLI) during LTO"));
+
+static cl::opt<std::string> ThinLTOCacheDir(
+    "thinlto-cache-dir",
+    cl::desc("Experimental option, enable ThinLTO caching. Note: the cache "
+             "currently does not take the mcmodel setting into account, so you "
+             "might get false hits if different mcmodels are used in different "
+             "builds using the same cache directory."));
+
+static cl::opt<int> ThinLTOCachePruningInterval(
+    "thinlto-cache-pruning-interval", cl::init(1200),
+    cl::desc("Set ThinLTO cache pruning interval (seconds)."));
+
+static cl::opt<uint64_t> ThinLTOCacheMaxSizeBytes(
+    "thinlto-cache-max-size-bytes",
+    cl::desc("Set ThinLTO cache pruning directory maximum size in bytes."));
+
+static cl::opt<int> ThinLTOCacheMaxSizeFiles(
+    "thinlto-cache-max-size-files", cl::init(1000000),
+    cl::desc("Set ThinLTO cache pruning directory maximum number of files."));
+
+static cl::opt<unsigned> ThinLTOCacheEntryExpiration(
+    "thinlto-cache-entry-expiration", cl::init(604800) /* 1w */,
+    cl::desc("Set ThinLTO cache entry expiration time (seconds)."));
 
 #ifdef NDEBUG
 static bool VerifyByDefault = false;
@@ -543,6 +567,24 @@ thinlto_code_gen_t thinlto_create_codegen(void) {
     assert(CGOptLevelOrNone);
     CodeGen->setCodeGenOptLevel(*CGOptLevelOrNone);
   }
+  if (!ThinLTOCacheDir.empty()) {
+    auto Err = llvm::sys::fs::create_directories(ThinLTOCacheDir.getValue());
+    if (Err)
+      report_fatal_error(Twine("Unable to create thinLTO cache directory: ") +
+                         Err.message());
+    bool result;
+    Err = llvm::sys::fs::is_directory(ThinLTOCacheDir.getValue(), result);
+    if (Err || !result)
+      report_fatal_error(Twine("Unable to get status of thinLTO cache path or "
+                               "path is not a directory: ") +
+                         Err.message());
+    CodeGen->setCacheDir(ThinLTOCacheDir);
+  }
+  CodeGen->setCachePruningInterval(ThinLTOCachePruningInterval);
+  CodeGen->setCacheEntryExpiration(ThinLTOCacheEntryExpiration);
+  CodeGen->setCacheMaxSizeFiles(ThinLTOCacheMaxSizeFiles);
+  CodeGen->setCacheMaxSizeBytes(ThinLTOCacheMaxSizeBytes);
+
   return wrap(CodeGen);
 }
 


### PR DESCRIPTION
On AIX, the linker's release cadence is once per year and it doesn't backport non-critical fixes to previous releases.
We would like to get thinLTO caching accessible for current customers, so this PR adds the cache flags as cl::opt options.
We can surround the code with #ifdef AIX if the patch is unacceptable as is.