### PR TITLE
[mlir][tosa] Fix linker failure in build bots introduced by #165581

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Tosa/Transforms/CMakeLists.txt
@@ -25,4 +25,5 @@ add_mlir_dialect_library(MLIRTosaTransforms
   MLIRPass
   MLIRTosaDialect
   MLIRTransformUtils
+  MLIRFuncTransforms
   )


### PR DESCRIPTION
This commit fixes linker failures evident on some failing build bots.