### PR TITLE
[lldb] improve the heuristics for checking if a terminal supports Unicode

### DIFF
--- a/lldb/include/lldb/Host/Terminal.h
+++ b/lldb/include/lldb/Host/Terminal.h
@@ -174,10 +174,11 @@ protected:
 /// The value is cached after the first computation.
 ///
 /// On POSIX systems, we check if the LANG environment variable contains the
-/// substring "UTF-8";
+/// substring "UTF-8", case insensitive.
 ///
-/// On Windows, we check that we are running from the Windows Terminal
-/// application.
+/// On Windows, we always return true since we use the `WriteConsoleW` API
+/// internally. Note that the default Windows codepage (437) does not support
+/// all Unicode characters. This function does not check the codepage.
 bool TerminalSupportsUnicode();
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Host/Terminal.h
+++ b/lldb/include/lldb/Host/Terminal.h
@@ -68,6 +68,18 @@ public:
 
   llvm::Error SetHardwareFlowControl(bool enabled);
 
+  /// Returns whether or not the current terminal supports Unicode rendering.
+  ///
+  /// The value is cached after the first computation.
+  ///
+  /// On POSIX systems, we check if the LANG environment variable contains the
+  /// substring "UTF-8", case insensitive.
+  ///
+  /// On Windows, we always return true since we use the `WriteConsoleW` API
+  /// internally. Note that the default Windows codepage (437) does not support
+  /// all Unicode characters. This function does not check the codepage.
+  static bool SupportsUnicode();
+
 protected:
   struct Data;
 
@@ -168,18 +180,6 @@ protected:
   std::unique_ptr<Terminal::Data> m_data; ///< Platform-specific implementation.
   lldb::pid_t m_process_group = -1;       ///< Cached process group information.
 };
-
-/// Returns whether or not the current terminal supports Unicode rendering.
-///
-/// The value is cached after the first computation.
-///
-/// On POSIX systems, we check if the LANG environment variable contains the
-/// substring "UTF-8", case insensitive.
-///
-/// On Windows, we always return true since we use the `WriteConsoleW` API
-/// internally. Note that the default Windows codepage (437) does not support
-/// all Unicode characters. This function does not check the codepage.
-bool TerminalSupportsUnicode();
 
 } // namespace lldb_private
 

--- a/lldb/include/lldb/Host/Terminal.h
+++ b/lldb/include/lldb/Host/Terminal.h
@@ -169,6 +169,17 @@ protected:
   lldb::pid_t m_process_group = -1;       ///< Cached process group information.
 };
 
+/// Returns whether or not the current terminal supports Unicode rendering.
+///
+/// The value is cached after the first computation.
+///
+/// On POSIX systems, we check if the LANG environment variable contains the
+/// substring "UTF-8";
+///
+/// On Windows, we check that we are running from the Windows Terminal
+/// application.
+bool TerminalSupportsUnicode();
+
 } // namespace lldb_private
 
 #endif // LLDB_HOST_TERMINAL_H

--- a/lldb/source/Host/common/DiagnosticsRendering.cpp
+++ b/lldb/source/Host/common/DiagnosticsRendering.cpp
@@ -100,7 +100,7 @@ void RenderDiagnosticDetails(Stream &stream,
   }
 
   llvm::StringRef cursor, underline, vbar, joint, hbar, spacer;
-  if (TerminalSupportsUnicode()) {
+  if (Terminal::SupportsUnicode()) {
     cursor = "˄";
     underline = "˜";
     vbar = "│";

--- a/lldb/source/Host/common/DiagnosticsRendering.cpp
+++ b/lldb/source/Host/common/DiagnosticsRendering.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/common/DiagnosticsRendering.h"
+#include "lldb/Host/Terminal.h"
+
 #include <cstdint>
 
 using namespace lldb_private;
@@ -97,12 +99,8 @@ void RenderDiagnosticDetails(Stream &stream,
     return;
   }
 
-  // Since there is no other way to find this out, use the color
-  // attribute as a proxy for whether the terminal supports Unicode
-  // characters.  In the future it might make sense to move this into
-  // Host so it can be customized for a specific platform.
   llvm::StringRef cursor, underline, vbar, joint, hbar, spacer;
-  if (stream.AsRawOstream().colors_enabled()) {
+  if (TerminalSupportsUnicode()) {
     cursor = "˄";
     underline = "˜";
     vbar = "│";

--- a/lldb/source/Host/common/Terminal.cpp
+++ b/lldb/source/Host/common/Terminal.cpp
@@ -472,3 +472,18 @@ bool TerminalState::TTYStateIsValid() const { return bool(m_data); }
 bool TerminalState::ProcessGroupIsValid() const {
   return static_cast<int32_t>(m_process_group) != -1;
 }
+
+bool lldb_private::TerminalSupportsUnicode() {
+  static std::optional<bool> result;
+  if (result)
+    return result.value();
+#ifdef _WIN32
+  return true;
+#else
+  const char *lang_var = std::getenv("LANG");
+  if (!lang_var)
+    return false;
+  result = llvm::StringRef(lang_var).lower().find("utf-8") != std::string::npos;
+#endif
+  return result.value();
+}


### PR DESCRIPTION
This patch improves the way lldb checks if the terminal it's opened in (if any) supports Unicode or not.

On POSIX systems, we check if `LANG` contains `UTF-8`.

On Windows, we always return `true` since we use the `WriteToConsoleW` api.