### PR TITLE
[RISCV] Convert -mtune=generic to generic-rv32/rv64 in RISCVSubtarget::initializeSubtargetDependencies.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -88,6 +88,8 @@ RISCVSubtarget::initializeSubtargetDependencies(const Triple &TT, StringRef CPU,
 
   if (TuneCPU.empty())
     TuneCPU = CPU;
+  if (TuneCPU == "generic")
+    TuneCPU = Is64Bit ? "generic-rv64" : "generic-rv32";
 
   TuneInfo = RISCVTuneInfoTable::getRISCVTuneInfo(TuneCPU);
   // If there is no TuneInfo for this CPU, we fail back to generic.


### PR DESCRIPTION
The "generic" entry in tablegen is really a dummy entry. We shouldn't use it for anything. Remap "generic" to either generic-rv32 or generic-rv64 based on the triple.