### PR TITLE
[AMDGPU] Fix issue in amdgpu-rewrite-agpr-copy-mfma, which reassigns …

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -302,6 +302,10 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::attemptReassignmentsToAGPR(
     const TargetRegisterClass *EquivalentAGPRRegClass =
         TRI.getEquivalentAGPRClass(MRI.getRegClass(InterferingReg));
 
+    // Do not reassign scale operands
+    if (EquivalentAGPRRegClass == &AMDGPU::AGPR_32RegClass)
+      return false;
+
     MCPhysReg Assignable = AMDGPU::NoRegister;
     if (EquivalentAGPRRegClass->contains(PrefPhysReg) &&
         LRM.checkInterference(ReassignLI, PrefPhysReg) ==


### PR DESCRIPTION
…scale

operand in vgpr_32 register to agpr_32, not permitted by instruction format.