### PR TITLE
[NFC][MC] Namespace cleanup in MC

### DIFF
--- a/llvm/include/llvm/MC/MCParser/MCAsmParserExtension.h
+++ b/llvm/include/llvm/MC/MCParser/MCAsmParserExtension.h
@@ -120,6 +120,14 @@ public:
   /// @}
 };
 
+MCAsmParserExtension *createDarwinAsmParser();
+MCAsmParserExtension *createELFAsmParser();
+MCAsmParserExtension *createCOFFAsmParser();
+MCAsmParserExtension *createCOFFMasmParser();
+MCAsmParserExtension *createGOFFAsmParser();
+MCAsmParserExtension *createXCOFFAsmParser();
+MCAsmParserExtension *createWasmAsmParser();
+
 } // end namespace llvm
 
 #endif // LLVM_MC_MCPARSER_MCASMPARSEREXTENSION_H

--- a/llvm/include/llvm/MC/MCWin64EH.h
+++ b/llvm/include/llvm/MC/MCWin64EH.h
@@ -70,7 +70,7 @@ public:
   void EmitUnwindInfo(MCStreamer &Streamer, WinEH::FrameInfo *FI,
                       bool HandlerData) const override;
 };
-}
-} // end namespace llvm
+} // namespace Win64EH
+} // namespace llvm
 
 #endif

--- a/llvm/include/llvm/MC/MCWinEH.h
+++ b/llvm/include/llvm/MC/MCWinEH.h
@@ -113,7 +113,7 @@ public:
   virtual void EmitUnwindInfo(MCStreamer &Streamer, FrameInfo *FI,
                               bool HandlerData) const = 0;
 };
-}
-}
+} // namespace WinEH
+} // namespace llvm
 
 #endif

--- a/llvm/lib/MC/MCDisassembler/MCExternalSymbolizer.cpp
+++ b/llvm/lib/MC/MCDisassembler/MCExternalSymbolizer.cpp
@@ -183,14 +183,13 @@ void MCExternalSymbolizer::tryAddingPcLoadReferenceComment(raw_ostream &cStream,
   }
 }
 
-namespace llvm {
-MCSymbolizer *createMCSymbolizer(const Triple &TT, LLVMOpInfoCallback GetOpInfo,
-                                 LLVMSymbolLookupCallback SymbolLookUp,
-                                 void *DisInfo, MCContext *Ctx,
-                                 std::unique_ptr<MCRelocationInfo> &&RelInfo) {
+MCSymbolizer *
+llvm::createMCSymbolizer(const Triple &TT, LLVMOpInfoCallback GetOpInfo,
+                         LLVMSymbolLookupCallback SymbolLookUp, void *DisInfo,
+                         MCContext *Ctx,
+                         std::unique_ptr<MCRelocationInfo> &&RelInfo) {
   assert(Ctx && "No MCContext given for symbolic disassembly");
 
   return new MCExternalSymbolizer(*Ctx, std::move(RelInfo), GetOpInfo,
                                   SymbolLookUp, DisInfo);
-}
 }

--- a/llvm/lib/MC/MCNullStreamer.cpp
+++ b/llvm/lib/MC/MCNullStreamer.cpp
@@ -20,34 +20,33 @@ using namespace llvm;
 
 namespace {
 
-  class MCNullStreamer : public MCStreamer {
-  public:
-    MCNullStreamer(MCContext &Context) : MCStreamer(Context) {}
+class MCNullStreamer : public MCStreamer {
+public:
+  MCNullStreamer(MCContext &Context) : MCStreamer(Context) {}
 
-    /// @name MCStreamer Interface
-    /// @{
+  /// @name MCStreamer Interface
+  /// @{
 
-    bool hasRawTextSupport() const override { return true; }
-    void emitRawTextImpl(StringRef String) override {}
+  bool hasRawTextSupport() const override { return true; }
+  void emitRawTextImpl(StringRef String) override {}
 
-    bool emitSymbolAttribute(MCSymbol *Symbol,
-                             MCSymbolAttr Attribute) override {
-      return true;
-    }
+  bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override {
+    return true;
+  }
 
-    void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
-                          Align ByteAlignment) override {}
-    void emitSubsectionsViaSymbols() override {};
-    void beginCOFFSymbolDef(const MCSymbol *Symbol) override {}
-    void emitCOFFSymbolStorageClass(int StorageClass) override {}
-    void emitCOFFSymbolType(int Type) override {}
-    void endCOFFSymbolDef() override {}
-    void
-    emitXCOFFSymbolLinkageWithVisibility(MCSymbol *Symbol, MCSymbolAttr Linkage,
-                                         MCSymbolAttr Visibility) override {}
-  };
+  void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
+                        Align ByteAlignment) override {}
+  void emitSubsectionsViaSymbols() override {};
+  void beginCOFFSymbolDef(const MCSymbol *Symbol) override {}
+  void emitCOFFSymbolStorageClass(int StorageClass) override {}
+  void emitCOFFSymbolType(int Type) override {}
+  void endCOFFSymbolDef() override {}
+  void emitXCOFFSymbolLinkageWithVisibility(MCSymbol *Symbol,
+                                            MCSymbolAttr Linkage,
+                                            MCSymbolAttr Visibility) override {}
+};
 
-}
+} // namespace
 
 MCStreamer *llvm::createNullStreamer(MCContext &Context) {
   return new MCNullStreamer(Context);

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -739,13 +739,6 @@ namespace llvm {
 
 extern cl::opt<unsigned> AsmMacroMaxNestingDepth;
 
-extern MCAsmParserExtension *createDarwinAsmParser();
-extern MCAsmParserExtension *createELFAsmParser();
-extern MCAsmParserExtension *createCOFFAsmParser();
-extern MCAsmParserExtension *createGOFFAsmParser();
-extern MCAsmParserExtension *createXCOFFAsmParser();
-extern MCAsmParserExtension *createWasmAsmParser();
-
 } // end namespace llvm
 
 AsmParser::AsmParser(SourceMgr &SM, MCContext &Ctx, MCStreamer &Out,
@@ -6270,12 +6263,11 @@ bool HLASMAsmParser::parseStatement(ParseStatementInfo &Info,
   return parseAsMachineInstruction(Info, SI);
 }
 
-namespace llvm {
-namespace MCParserUtils {
-
-bool parseAssignmentExpression(StringRef Name, bool allow_redef,
-                               MCAsmParser &Parser, MCSymbol *&Sym,
-                               const MCExpr *&Value) {
+bool llvm::MCParserUtils::parseAssignmentExpression(StringRef Name,
+                                                    bool allow_redef,
+                                                    MCAsmParser &Parser,
+                                                    MCSymbol *&Sym,
+                                                    const MCExpr *&Value) {
 
   // FIXME: Use better location, we should use proper tokens.
   SMLoc EqualLoc = Parser.getTok().getLoc();
@@ -6311,9 +6303,6 @@ bool parseAssignmentExpression(StringRef Name, bool allow_redef,
 
   return false;
 }
-
-} // end namespace MCParserUtils
-} // end namespace llvm
 
 /// Create an MCAsmParser instance.
 MCAsmParser *llvm::createMCAsmParser(SourceMgr &SM, MCContext &C,

--- a/llvm/lib/MC/MCParser/COFFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/COFFAsmParser.cpp
@@ -796,10 +796,4 @@ bool COFFAsmParser::parseAtUnwindOrAtExcept(bool &unwind, bool &except) {
   return false;
 }
 
-namespace llvm {
-
-MCAsmParserExtension *createCOFFAsmParser() {
-  return new COFFAsmParser;
-}
-
-} // end namespace llvm
+MCAsmParserExtension *llvm::createCOFFAsmParser() { return new COFFAsmParser; }

--- a/llvm/lib/MC/MCParser/COFFMasmParser.cpp
+++ b/llvm/lib/MC/MCParser/COFFMasmParser.cpp
@@ -535,8 +535,6 @@ bool COFFMasmParser::parseSEHDirectiveEndProlog(StringRef Directive,
   return false;
 }
 
-namespace llvm {
-
-MCAsmParserExtension *createCOFFMasmParser() { return new COFFMasmParser; }
-
-} // end namespace llvm
+MCAsmParserExtension *llvm::createCOFFMasmParser() {
+  return new COFFMasmParser;
+}

--- a/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
@@ -1192,10 +1192,6 @@ bool DarwinAsmParser::parseDirectiveCGProfile(StringRef S, SMLoc Loc) {
   return MCAsmParserExtension::parseDirectiveCGProfile(S, Loc);
 }
 
-namespace llvm {
-
-MCAsmParserExtension *createDarwinAsmParser() {
+MCAsmParserExtension *llvm::createDarwinAsmParser() {
   return new DarwinAsmParser;
 }
-
-} // end llvm namespace

--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -887,10 +887,4 @@ bool ELFAsmParser::parseDirectiveCGProfile(StringRef S, SMLoc Loc) {
   return MCAsmParserExtension::parseDirectiveCGProfile(S, Loc);
 }
 
-namespace llvm {
-
-MCAsmParserExtension *createELFAsmParser() {
-  return new ELFAsmParser;
-}
-
-} // end namespace llvm
+MCAsmParserExtension *llvm::createELFAsmParser() { return new ELFAsmParser; }

--- a/llvm/lib/MC/MCParser/GOFFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/GOFFAsmParser.cpp
@@ -32,8 +32,4 @@ public:
 
 } // namespace
 
-namespace llvm {
-
-MCAsmParserExtension *createGOFFAsmParser() { return new GOFFAsmParser; }
-
-} // namespace llvm
+MCAsmParserExtension *llvm::createGOFFAsmParser() { return new GOFFAsmParser; }

--- a/llvm/lib/MC/MCParser/MasmParser.cpp
+++ b/llvm/lib/MC/MCParser/MasmParser.cpp
@@ -963,8 +963,6 @@ namespace llvm {
 
 extern cl::opt<unsigned> AsmMacroMaxNestingDepth;
 
-extern MCAsmParserExtension *createCOFFMasmParser();
-
 } // end namespace llvm
 
 enum { DEFAULT_ADDRSPACE = 0 };

--- a/llvm/lib/MC/MCParser/WasmAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/WasmAsmParser.cpp
@@ -309,10 +309,4 @@ public:
 
 } // end anonymous namespace
 
-namespace llvm {
-
-MCAsmParserExtension *createWasmAsmParser() {
-  return new WasmAsmParser;
-}
-
-} // end namespace llvm
+MCAsmParserExtension *llvm::createWasmAsmParser() { return new WasmAsmParser; }

--- a/llvm/lib/MC/MCParser/XCOFFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/XCOFFAsmParser.cpp
@@ -43,14 +43,12 @@ public:
 
 } // end anonymous namespace
 
-namespace llvm {
-
-MCAsmParserExtension *createXCOFFAsmParser() { return new XCOFFAsmParser; }
-
-} // end namespace llvm
-
 // .csect QualName [, Number ]
 bool XCOFFAsmParser::ParseDirectiveCSect(StringRef, SMLoc) {
   report_fatal_error("XCOFFAsmParser directive not yet supported!");
   return false;
+}
+
+MCAsmParserExtension *llvm::createXCOFFAsmParser() {
+  return new XCOFFAsmParser;
 }

--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -19,7 +19,11 @@
 
 namespace llvm {
 class MCSection;
+}
 
+using namespace llvm;
+
+namespace {
 /// MCExpr that represents the epilog unwind code in an unwind table.
 class MCUnwindV2EpilogTargetExpr final : public MCTargetExpr {
   const MCSymbol *Function;
@@ -60,9 +64,7 @@ public:
     return UnwindV2Start->getFragment();
   }
 };
-}
-
-using namespace llvm;
+} // namespace
 
 // NOTE: All relocations generated here are 4-byte image-relative.
 

--- a/llvm/lib/MC/MCWinEH.cpp
+++ b/llvm/lib/MC/MCWinEH.cpp
@@ -8,11 +8,7 @@
 
 #include "llvm/MC/MCWinEH.h"
 
-namespace llvm {
-namespace WinEH {
+using namespace llvm;
+using namespace WinEH;
 
 UnwindEmitter::~UnwindEmitter() = default;
-
-}
-}
-


### PR DESCRIPTION
- Add declarations of various `MCAsmParserExtension` creation functions to MCAsmParserExtension.h and use namespace qualifiers to define these and some other functions.
- Add end of namespace comments.
- Fix indentation of `MCNullStreamer` class.
- Remove namespace surrounding code in MCWinEH.cpp and use "using namespace" instead.