### PR TITLE
[lldb][test] Correctly skip a test on a 32-bit target

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/invalid-string/TestDataFormatterLibcxxInvalidString.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/invalid-string/TestDataFormatterLibcxxInvalidString.py
@@ -20,7 +20,7 @@ class LibcxxInvalidStringDataFormatterTestCase(TestBase):
         frame = thread.frames[0]
 
         if not self.process().GetAddressByteSize() == 8:
-            self.skip()
+            self.skipTest("The test requires a 64-bit process")
 
         # The test assumes that std::string is in its cap-size-data layout.
         self.expect(


### PR DESCRIPTION
The test was added in #147252. On a 32-bit target, it fails with error:
```
  File "...\TestDataFormatterLibcxxInvalidString.py", line 23, in test
    self.skip()
    ^^^^^^^^^
AttributeError: 'LibcxxInvalidStringDataFormatterTestCase' object has no attribute 'skip'
```