### PR TITLE
[StaticAnalyzer] Fix non decimal macro values in tryExpandAsInteger

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/CheckerHelpers.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CheckerHelpers.cpp
@@ -142,7 +142,7 @@ std::optional<int> tryExpandAsInteger(StringRef Macro, const Preprocessor &PP) {
   if (InvalidSpelling)
     return std::nullopt;
 
-  llvm::APSInt IntValue(0, true);
+  llvm::APSInt IntValue(/*BitWidth=*/0, /*isUnsigned=*/true);
   constexpr unsigned AutoSenseRadix = 0;
   if (ValueStr.getAsInteger(AutoSenseRadix,
                             static_cast<llvm::APInt &>(IntValue)))

--- a/clang/test/Analysis/std-c-library-functions-eof-2-rad.c
+++ b/clang/test/Analysis/std-c-library-functions-eof-2-rad.c
@@ -1,0 +1,16 @@
+// RUN: %clang_analyze_cc1 -std=c23 -analyzer-checker=core,unix.StdCLibraryFunctions,debug.ExprInspection -verify -analyzer-config eagerly-assume=false %s
+
+void clang_analyzer_eval(int);
+
+typedef struct FILE FILE;
+/// Test that the static analyzer doesn't interpret the most significant bit as the sign bit.
+// Unorthodox EOF value with a power of 2 radix
+#define EOF (-0b11)
+
+int getc(FILE *);
+void test_getc(FILE *fp) {
+  int y = getc(fp);
+  if (y < 0) {
+    clang_analyzer_eval(y == EOF); // expected-warning{{TRUE}}
+  }
+}


### PR DESCRIPTION
Values were parsed into an unsigned APInt with just enough of a bit width to hold the number then interpreted as signed values. This resulted in hex, octal and binary literals from being interpreted as negative when the most significant bit is 1.

For example the `-0b11` would have a bit width of 2, would be interpreted as -1, then negated to become 1.