### PR TITLE
[compiler-rt] [libFuzzer] Fix merge-posix test (again)

### DIFF
--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -14,10 +14,10 @@ RUN: echo ....U. > %tmp/T2/2
 RUN: echo ...Z.. > %tmp/T2/3
 RUN: echo ...Z.. > %tmp/T2/4
 RUN: echo ....E. > %tmp/T2/5
-RUN: %python -c "print('.....R' + 'X' * 1024, end='')" > %tmp/T2/6
+RUN: %python -c "print('.....R' + 'X' * 4096, end='')" > %tmp/T2/6
 
 # Check that we can report an error if file size exceeded
-RUN: (ulimit -f 1; not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=SIGXFSZ)
+RUN: (ulimit -f 4; not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=SIGXFSZ)
 SIGXFSZ: ERROR: libFuzzer: file size exceeded
 
 # Check that we honor TMPDIR


### PR DESCRIPTION
#168137 fixed an issue where this test failed because there was not a sufficiently large file in the corpus.

However, there is still another issue: the MERGE-INNER process can try to write a control file that is above the 1024B limit. This also fails the test, since the test expects the MERGE-OUTER process to be the one to get the SIGXFSZ.

To get around this, increase the ulimit to 4K and the largest testcase to 4K (plus 6B). We will assume that on every test platform, the control file will be less than 4K.

rdar://164738648