### PR TITLE
[CIR] Handle default arguments in ctors

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -712,7 +712,7 @@ public:
   }
 
   mlir::Value VisitCXXDefaultArgExpr(CXXDefaultArgExpr *dae) {
-    CIRGenFunction::CXXDefaultArgExprScope Scope(cgf, dae);
+    CIRGenFunction::CXXDefaultArgExprScope scope(cgf, dae);
     return Visit(dae->getExpr());
   }
   mlir::Value VisitCXXDefaultInitExpr(CXXDefaultInitExpr *die) {

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -711,6 +711,10 @@ public:
     return Visit(e->getSubExpr());
   }
 
+  mlir::Value VisitCXXDefaultArgExpr(CXXDefaultArgExpr *dae) {
+    CIRGenFunction::CXXDefaultArgExprScope Scope(cgf, dae);
+    return Visit(dae->getExpr());
+  }
   mlir::Value VisitCXXDefaultInitExpr(CXXDefaultInitExpr *die) {
     CIRGenFunction::CXXDefaultInitExprScope scope(cgf, die);
     return Visit(die->getExpr());

--- a/clang/test/CIR/CodeGen/defaultarg.cpp
+++ b/clang/test/CIR/CodeGen/defaultarg.cpp
@@ -30,3 +30,25 @@ void foo() {
 // OGCG:   %[[TMP0:.*]] = alloca i32
 // OGCG:   store i32 42, ptr %[[TMP0]]
 // OGCG:   call void @_Z3barRKi(ptr {{.*}} %[[TMP0]])
+
+struct S
+{
+  S(int n = 2);
+};
+
+void test_ctor_defaultarg() {
+  S s;
+}
+
+// CIR: cir.func {{.*}} @_Z20test_ctor_defaultargv()
+// CIR:   %[[S:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s", init]
+// CIR:   %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
+// CIR:   cir.call @_ZN1SC1Ei(%[[S]], %[[TWO]]) : (!cir.ptr<!rec_S>, !s32i) -> ()
+
+// LLVM: define{{.*}} @_Z20test_ctor_defaultargv()
+// LLVM:   %[[S:.*]] = alloca %struct.S
+// LLVM:   call void @_ZN1SC1Ei(ptr %[[S]], i32 2)
+
+// OGCG: define{{.*}} @_Z20test_ctor_defaultargv()
+// OGCG:   %[[S:.*]] = alloca %struct.S
+// OGCG:   call void @_ZN1SC1Ei(ptr{{.*}} %[[S]], i32 {{.*}} 2)


### PR DESCRIPTION
This adds the scalar expression visitor needed to handle default arguments being passed to constructors.