### PR TITLE
[ASan] Fix interface_symbols_darwin.cpp on internal shell

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/interface_symbols_darwin.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/interface_symbols_darwin.cpp
@@ -9,13 +9,17 @@
 // RUN: %clangxx_asan -dead_strip -O2 %s -o %t.exe
 //
 // note: we can not use -D on Darwin.
-// RUN: nm -g `%clang_asan %s -fsanitize=address -### 2>&1 | grep "libclang_rt.asan_osx_dynamic.dylib" | sed -e 's/.*"\(.*libclang_rt.asan_osx_dynamic.dylib\)".*/\1/'` \
-// RUN:  | grep " [TU] "                                                       \
-// RUN:  | grep -o "\(__asan_\|__ubsan_\|__sancov_\|__sanitizer_\)[^ ]*"       \
-// RUN:  | grep -v "__sanitizer_syscall"                                       \
-// RUN:  | grep -v "__sanitizer_weak_hook"                                     \
-// RUN:  | grep -v "__sanitizer_mz"                                            \
-// RUN:  | grep -v "__sancov_lowest_stack"                                     \
+// RUN: %clang_asan %s -fsanitize=address -### 2>&1                       \
+// RUN:   | grep "libclang_rt.asan_osx_dynamic.dylib"                     \
+// RUN:   | sed -e 's/.*"\(.*libclang_rt.asan_osx_dynamic.dylib\)".*/\1/' \
+// RUN:   | tr -d '\n' > %t.compiler_runtime_path
+// RUN: nm -g %{readfile:%t.compiler_runtime_path}                                         \
+// RUN:  | grep " [TU] "                                                                   \
+// RUN:  | grep -o "\(__asan_\|__ubsan_\|__sancov_\|__sanitizer_\)[^ ]*"                   \
+// RUN:  | grep -v "__sanitizer_syscall"                                                   \
+// RUN:  | grep -v "__sanitizer_weak_hook"                                                 \
+// RUN:  | grep -v "__sanitizer_mz"                                                        \
+// RUN:  | grep -v "__sancov_lowest_stack"                                                 \
 // RUN:  | sed -e "s/__asan_version_mismatch_check_v[0-9]+/__asan_version_mismatch_check/" \
 // RUN:  > %t.exports
 //


### PR DESCRIPTION
This test turned out to not actually be that interested. There was just a
subshell usage that needed replacing with readfile, and then the test just
works.
