### PR TITLE
[Github] Make metrics container build use common actions

### DIFF
--- a/.github/workflows/build-metrics-container.yml
+++ b/.github/workflows/build-metrics-container.yml
@@ -21,39 +21,17 @@ jobs:
   build-metrics-container:
     if: github.repository_owner == 'llvm'
     runs-on: ubuntu-24.04
-    outputs:
-      container-name: ${{ steps.vars.outputs.container-name }}
-      container-name-tag: ${{ steps.vars.outputs.container-name-tag }}
-      container-filename: ${{ steps.vars.outputs.container-filename }}
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           sparse-checkout: .ci/metrics/
-      - name: Write Variables
-        id: vars
-        run: |
-          tag=`date +%s`
-          container_name="ghcr.io/$GITHUB_REPOSITORY_OWNER/metrics"
-          echo "container-name=$container_name" >> $GITHUB_OUTPUT
-          echo "container-name-tag=$container_name:$tag" >> $GITHUB_OUTPUT
-          echo "container-filename=$(echo $container_name:$tag  | sed -e 's/\//-/g' -e 's/:/-/g').tar" >> $GITHUB_OUTPUT
       - name: Build Container
-        working-directory: ./.ci/metrics
-        run: |
-          podman build -t ${{ steps.vars.outputs.container-name-tag }} -f Dockerfile .
-      # Save the container so we have it in case the push fails.  This also
-      # allows us to separate the push step into a different job so we can
-      # maintain minimal permissions while building the container.
-      - name: Save Container Image
-        run: |
-          podman save  ${{ steps.vars.outputs.container-name-tag }} >  ${{ steps.vars.outputs.container-filename }}
-      - name: Upload Container Image
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: ./.github/actions/build-container
         with:
-          name: container
-          path: ${{ steps.vars.outputs.container-filename }}
-          retention-days: 14
+          container-name: metrics
+          context: .ci/metrics
+          dockerfile: .ci/metrics/Dockerfile
   
   push-metrics-container:
     if: github.event_name == 'push'
@@ -65,14 +43,12 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Download Container
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      - name: Checkout LLVM
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          name: container
-      - name: Push Container
-        run: |
-          podman load -i ${{ needs.build-metrics-container.outputs.container-filename }}
-          podman tag ${{ needs.build-metrics-container.outputs.container-name-tag }} ${{ needs.build-metrics-container.outputs.container-name }}:latest
-          podman login -u ${{ github.actor }} -p $GITHUB_TOKEN ghcr.io
-          podman push ${{ needs.build-metrics-container.outputs.container-name-tag }}
-          podman push ${{ needs.build-metrics-container.outputs.container-name }}:latest
+          sparse-checkout: |
+            .github/actions/push-container
+
+      - uses: ./.github/actions/push-container
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-metrics-container.yml
+++ b/.github/workflows/build-metrics-container.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Checkout LLVM
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          sparse-checkout: .ci/metrics/
+          sparse-checkout: |
+            .ci/metrics/
+            .github/workflows/containers/github-action-ci/
       - name: Build Container
         uses: ./.github/actions/build-container
         with:

--- a/.github/workflows/build-metrics-container.yml
+++ b/.github/workflows/build-metrics-container.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           sparse-checkout: |
             .ci/metrics/
-            .github/workflows/containers/github-action-ci/
+            .github/actions/build-container
       - name: Build Container
         uses: ./.github/actions/build-container
         with:


### PR DESCRIPTION
This patch makes the metrics container build/push job use the common container build/push actions to simplify the workflow by quite a bit.