### PR TITLE
[Support] Use StringMap::contains (NFC)

### DIFF
--- a/llvm/lib/Support/SpecialCaseList.cpp
+++ b/llvm/lib/Support/SpecialCaseList.cpp
@@ -455,7 +455,7 @@ unsigned SpecialCaseList::Section::getLastMatch(StringRef Prefix,
 }
 
 bool SpecialCaseList::Section::hasPrefix(StringRef Prefix) const {
-  return Impl->Entries.find(Prefix) != Impl->Entries.end();
+  return Impl->Entries.contains(Prefix);
 }
 
 } // namespace llvm


### PR DESCRIPTION
Identified with readability-container-contains.
