### PR TITLE
[llvm] Construct iterator_range with the conversion constructor (NFC)

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -195,7 +195,7 @@ public:
   /// Get all normal compile/type units in this context.
   unit_iterator_range normal_units() {
     DWARFUnitVector &NormalUnits = State->getNormalUnits();
-    return unit_iterator_range(NormalUnits.begin(), NormalUnits.end());
+    return NormalUnits;
   }
 
   /// Get units from .debug_info..dwo in the DWO context.
@@ -231,7 +231,7 @@ public:
   /// Get all units in the DWO context.
   unit_iterator_range dwo_units() {
     DWARFUnitVector &DWOUnits = State->getDWOUnits();
-    return unit_iterator_range(DWOUnits.begin(), DWOUnits.end());
+    return DWOUnits;
   }
 
   /// Get the number of compile units in this context.

--- a/llvm/include/llvm/Object/OffloadBinary.h
+++ b/llvm/include/llvm/Object/OffloadBinary.h
@@ -100,9 +100,7 @@ public:
   }
 
   // Iterator over all the key and value pairs in the binary.
-  string_iterator_range strings() const {
-    return string_iterator_range(StringData.begin(), StringData.end());
-  }
+  string_iterator_range strings() const { return StringData; }
 
   StringRef getString(StringRef Key) const { return StringData.lookup(Key); }
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SeedCollector.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SeedCollector.h
@@ -314,12 +314,8 @@ public:
                          bool AllowDiffTypes = false);
   LLVM_ABI ~SeedCollector();
 
-  iterator_range<SeedContainer::iterator> getStoreSeeds() {
-    return {StoreSeeds.begin(), StoreSeeds.end()};
-  }
-  iterator_range<SeedContainer::iterator> getLoadSeeds() {
-    return {LoadSeeds.begin(), LoadSeeds.end()};
-  }
+  iterator_range<SeedContainer::iterator> getStoreSeeds() { return StoreSeeds; }
+  iterator_range<SeedContainer::iterator> getLoadSeeds() { return LoadSeeds; }
 #ifndef NDEBUG
   void print(raw_ostream &OS) const;
   LLVM_DUMP_METHOD void dump() const;

--- a/llvm/lib/Object/RecordStreamer.cpp
+++ b/llvm/lib/Object/RecordStreamer.cpp
@@ -126,7 +126,7 @@ void RecordStreamer::emitELFSymverDirective(const MCSymbol *OriginalSym,
 
 iterator_range<RecordStreamer::const_symver_iterator>
 RecordStreamer::symverAliases() {
-  return {SymverAliasMap.begin(), SymverAliasMap.end()};
+  return SymverAliasMap;
 }
 
 void RecordStreamer::flushSymverDirectives() {


### PR DESCRIPTION
This patch simplifies iterator_range construction with the conversion
constructor.
