### PR TITLE
[OpenACC][CIR] Fix atomic-capture single-line-postfix

### DIFF
--- a/clang/include/clang/AST/StmtOpenACC.h
+++ b/clang/include/clang/AST/StmtOpenACC.h
@@ -829,8 +829,13 @@ public:
     // Listed as 'expr' in the standard, this is typically a generic expression
     // as a component.
     const Expr *RefExpr;
+    // If this is an 'update', records whether this is a post-fix
+    // increment/decrement.  In the case where we have a single-line variant of
+    // 'capture' we have to form the IR differently if this is the case to make
+    // sure the old value is 'read' in the 2nd step.
+    bool IsPostfixIncDec = false;
     static SingleStmtInfo Empty() {
-      return {nullptr, nullptr, nullptr, nullptr};
+      return {nullptr, nullptr, nullptr, nullptr, false};
     }
 
     static SingleStmtInfo createRead(const Expr *WholeExpr, const Expr *V,
@@ -841,8 +846,9 @@ public:
                                       const Expr *RefExpr) {
       return {WholeExpr, /*V=*/nullptr, X, RefExpr};
     }
-    static SingleStmtInfo createUpdate(const Expr *WholeExpr, const Expr *X) {
-      return {WholeExpr, /*V=*/nullptr, X, /*RefExpr=*/nullptr};
+    static SingleStmtInfo createUpdate(const Expr *WholeExpr, const Expr *X,
+                                       bool PostfixIncDec) {
+      return {WholeExpr, /*V=*/nullptr, X, /*RefExpr=*/nullptr, PostfixIncDec};
     }
   };
 

--- a/clang/test/CIR/CodeGenOpenACC/atomic-capture.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/atomic-capture.cpp
@@ -23,6 +23,7 @@ void use(int x, int v, float f, HasOps ops) {
   // CHECK-NEXT: %[[CMP:.*]] = cir.cmp(ne, %[[X_LOAD]], %[[V_LOAD]]) : !s32i, !cir.bool
   // CHECK-NEXT: %[[IF_COND_CAST:.*]] = builtin.unrealized_conversion_cast %[[CMP:.*]] : !cir.bool to i1
   // CHECK-NEXT: acc.atomic.capture if(%[[IF_COND_CAST]]) {
+  // CHECK-NEXT: acc.atomic.read %[[V_ALLOCA]] = %[[X_ALLOCA]] : !cir.ptr<!s32i>, !cir.ptr<!s32i>, !s32i
   // CHECK-NEXT: acc.atomic.update %[[X_ALLOCA]] : !cir.ptr<!s32i> {
   // CHECK-NEXT: ^bb0(%[[X_VAR:.*]]: !s32i{{.*}}):
   // CHECK-NEXT: %[[X_VAR_ALLOC:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x_var", init]
@@ -35,7 +36,6 @@ void use(int x, int v, float f, HasOps ops) {
   // CHECK-NEXT: %[[X_VAR_LOAD:.*]] = cir.load{{.*}} %[[X_VAR_ALLOC]] : !cir.ptr<!s32i>, !s32i
   // CHECK-NEXT: acc.yield %[[X_VAR_LOAD]] : !s32i
   // CHECK-NEXT: }
-  // CHECK-NEXT: acc.atomic.read %[[V_ALLOCA]] = %[[X_ALLOCA]] : !cir.ptr<!s32i>, !cir.ptr<!s32i>, !s32i
   // CHECK-NEXT: }
 #pragma acc atomic capture if (x != v)
   v = x++;
@@ -59,6 +59,7 @@ void use(int x, int v, float f, HasOps ops) {
   v = ++x;
 
   // CHECK-NEXT: acc.atomic.capture {
+  // CHECK-NEXT: acc.atomic.read %[[V_ALLOCA]] = %[[X_ALLOCA]] : !cir.ptr<!s32i>, !cir.ptr<!s32i>, !s32i
   // CHECK-NEXT: acc.atomic.update %[[X_ALLOCA]] : !cir.ptr<!s32i> {
   // CHECK-NEXT: ^bb0(%[[X_VAR:.*]]: !s32i{{.*}}):
   // CHECK-NEXT: %[[X_VAR_ALLOC:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x_var", init]
@@ -71,7 +72,6 @@ void use(int x, int v, float f, HasOps ops) {
   // CHECK-NEXT: %[[X_VAR_LOAD:.*]] = cir.load{{.*}} %[[X_VAR_ALLOC]] : !cir.ptr<!s32i>, !s32i
   // CHECK-NEXT: acc.yield %[[X_VAR_LOAD]] : !s32i
   // CHECK-NEXT: }
-  // CHECK-NEXT: acc.atomic.read %[[V_ALLOCA]] = %[[X_ALLOCA]] : !cir.ptr<!s32i>, !cir.ptr<!s32i>, !s32i
   // CHECK-NEXT: }
 #pragma acc atomic capture
   v = x--;


### PR DESCRIPTION
In my last patch, it became clear during code review that the postfix operation was actually a read THEN update, not update/read like other single line versions.  It wasn't clear at the time how much additional work this would be to make postfix work correctly (and they are a bit of a 'special' thing in codegen anyway), so this patch adds some functionality to sense this and special-cases it when generating the statement info for capture.