### PR TITLE
[lldb][windows] add color to the Python.dll not found error

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -508,12 +508,12 @@ void SetupPythonRuntimeLibrary() {
   if (AddPythonDLLToSearchPath() && IsPythonDLLInPath())
     return;
 #endif
-  llvm::errs() << "error: unable to find '"
-               << LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME << "'.\n";
+  WithColor::error() << "unable to find '"
+                     << LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME << "'.\n";
   return;
 #elif defined(LLDB_PYTHON_DLL_RELATIVE_PATH)
   if (!AddPythonDLLToSearchPath())
-    llvm::errs() << "error: unable to find the Python runtime library.\n";
+    WithColor::error() << "unable to find the Python runtime library.\n";
 #endif
 }
 #endif


### PR DESCRIPTION
Make the `Python.dll not found` error message stand out more by using the `llvm::WithColor::error()` method.

---

### Example

#### Before

<img width="782" height="431" alt="Screenshot 2025-11-19 at 15 50 22" src="https://github.com/user-attachments/assets/93960c50-cbf2-41f7-aba3-2f2a8af916cc" />

#### After

<img width="780" height="430" alt="Screenshot 2025-11-19 at 15 54 28" src="https://github.com/user-attachments/assets/f7f4954b-0ce3-4a4b-b9af-5af876032573" />

rdar://165047059