### PR TITLE
[TableGen] Use size_t for SubRegIndicesSize (NFC)

### DIFF
--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -703,7 +703,7 @@ void RegisterInfoEmitter::emitComposeSubRegIndices(raw_ostream &OS,
   SmallVector<unsigned, 4> RowMap;
   SmallVector<SmallVector<const CodeGenSubRegIndex *, 4>, 4> Rows;
 
-  auto SubRegIndicesSize = llvm::size(SubRegIndices);
+  size_t SubRegIndicesSize = llvm::size(SubRegIndices);
   for (const auto &Idx : SubRegIndices) {
     unsigned Found = ~0u;
     for (unsigned r = 0, re = Rows.size(); r != re; ++r) {
@@ -1526,7 +1526,7 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
 
   std::string ClassName = Target.getName().str() + "GenRegisterInfo";
 
-  auto SubRegIndicesSize = llvm::size(SubRegIndices);
+  size_t SubRegIndicesSize = llvm::size(SubRegIndices);
 
   if (!SubRegIndices.empty()) {
     emitComposeSubRegIndices(OS, ClassName);


### PR DESCRIPTION
This patch changes the type of SubRegIndicesSize to size_t.  The
original type deduced for "auto" is a signed type, but size_t, an
unsigned type, is safe here according to the usage.
