### PR TITLE
[lldb][windows] make PseudoTerminal::GetPTY return a shared pointer

### DIFF
--- a/lldb/include/lldb/Host/ProcessLaunchInfo.h
+++ b/lldb/include/lldb/Host/ProcessLaunchInfo.h
@@ -118,7 +118,7 @@ public:
 
   bool MonitorProcess() const;
 
-  PseudoTerminal &GetPTY() { return *m_pty; }
+  std::shared_ptr<PseudoTerminal> GetPTY() const { return m_pty; }
 
   void SetLaunchEventData(const char *data) { m_event_data.assign(data); }
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -215,7 +215,7 @@ PlatformAppleSimulator::DebugProcess(ProcessLaunchInfo &launch_info,
         // been used where the secondary side was given as the file to open for
         // stdin/out/err after we have already opened the primary so we can
         // read/write stdin/out/err.
-        int pty_fd = launch_info.GetPTY().ReleasePrimaryFileDescriptor();
+        int pty_fd = launch_info.GetPTY()->ReleasePrimaryFileDescriptor();
         if (pty_fd != PseudoTerminal::invalid_fd) {
           process_sp->SetSTDIOFileDescriptor(pty_fd);
         }

--- a/lldb/source/Plugins/Platform/MacOSX/objcxx/PlatformiOSSimulatorCoreSimulatorSupport.mm
+++ b/lldb/source/Plugins/Platform/MacOSX/objcxx/PlatformiOSSimulatorCoreSimulatorSupport.mm
@@ -399,18 +399,18 @@ static Status HandleFileAction(ProcessLaunchInfo &launch_info,
     case FileAction::eFileActionOpen: {
       FileSpec file_spec = file_action->GetFileSpec();
       if (file_spec) {
-        const int primary_fd = launch_info.GetPTY().GetPrimaryFileDescriptor();
+        const int primary_fd = launch_info.GetPTY()->GetPrimaryFileDescriptor();
         if (primary_fd != PseudoTerminal::invalid_fd) {
           // Check in case our file action open wants to open the secondary
-          FileSpec secondary_spec(launch_info.GetPTY().GetSecondaryName());
+          FileSpec secondary_spec(launch_info.GetPTY()->GetSecondaryName());
           if (file_spec == secondary_spec) {
             int secondary_fd =
-                launch_info.GetPTY().GetSecondaryFileDescriptor();
+                launch_info.GetPTY()->GetSecondaryFileDescriptor();
             if (secondary_fd == PseudoTerminal::invalid_fd) {
-              if (llvm::Error Err = launch_info.GetPTY().OpenSecondary(O_RDWR))
+              if (llvm::Error Err = launch_info.GetPTY()->OpenSecondary(O_RDWR))
                 return Status::FromError(std::move(Err));
             }
-            secondary_fd = launch_info.GetPTY().GetSecondaryFileDescriptor();
+            secondary_fd = launch_info.GetPTY()->GetSecondaryFileDescriptor();
             assert(secondary_fd != PseudoTerminal::invalid_fd);
             [options setValue:[NSNumber numberWithInteger:secondary_fd]
                        forKey:key];

--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -488,7 +488,7 @@ lldb::ProcessSP PlatformPOSIX::DebugProcess(ProcessLaunchInfo &launch_info,
   if (error.Success()) {
     // Hook up process PTY if we have one (which we should for local debugging
     // with llgs).
-    int pty_fd = launch_info.GetPTY().ReleasePrimaryFileDescriptor();
+    int pty_fd = launch_info.GetPTY()->ReleasePrimaryFileDescriptor();
     if (pty_fd != PseudoTerminal::invalid_fd) {
       process_sp->SetSTDIOFileDescriptor(pty_fd);
       LLDB_LOG(log, "hooked up STDIO pty to process");

--- a/lldb/source/Plugins/Platform/QemuUser/PlatformQemuUser.cpp
+++ b/lldb/source/Plugins/Platform/QemuUser/PlatformQemuUser.cpp
@@ -235,10 +235,10 @@ lldb::ProcessSP PlatformQemuUser::DebugProcess(ProcessLaunchInfo &launch_info,
   if (error.Fail())
     return nullptr;
 
-  if (launch_info.GetPTY().GetPrimaryFileDescriptor() !=
+  if (launch_info.GetPTY()->GetPrimaryFileDescriptor() !=
       PseudoTerminal::invalid_fd)
     process_sp->SetSTDIOFileDescriptor(
-        launch_info.GetPTY().ReleasePrimaryFileDescriptor());
+        launch_info.GetPTY()->ReleasePrimaryFileDescriptor());
 
   return process_sp;
 }

--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -86,8 +86,9 @@ NativeProcessAIX::Manager::Launch(ProcessLaunchInfo &launch_info,
   LLDB_LOG(log, "inferior started, now in stopped state");
 
   return std::unique_ptr<NativeProcessAIX>(new NativeProcessAIX(
-      pid, launch_info.GetPTY().ReleasePrimaryFileDescriptor(), native_delegate,
-      HostInfo::GetArchitecture(HostInfo::eArchKind64), *this, {pid}));
+      pid, launch_info.GetPTY()->ReleasePrimaryFileDescriptor(),
+      native_delegate, HostInfo::GetArchitecture(HostInfo::eArchKind64), *this,
+      {pid}));
 }
 
 llvm::Expected<std::unique_ptr<NativeProcessProtocol>>

--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
@@ -108,8 +108,8 @@ NativeProcessFreeBSD::Manager::Launch(ProcessLaunchInfo &launch_info,
            Info.GetArchitecture().GetArchitectureName());
 
   std::unique_ptr<NativeProcessFreeBSD> process_up(new NativeProcessFreeBSD(
-      pid, launch_info.GetPTY().ReleasePrimaryFileDescriptor(), native_delegate,
-      Info.GetArchitecture(), m_mainloop));
+      pid, launch_info.GetPTY()->ReleasePrimaryFileDescriptor(),
+      native_delegate, Info.GetArchitecture(), m_mainloop));
 
   status = process_up->SetupTrace();
   if (status.Fail())

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -304,8 +304,8 @@ NativeProcessLinux::Manager::Launch(ProcessLaunchInfo &launch_info,
     return arch_or.takeError();
 
   return std::unique_ptr<NativeProcessLinux>(new NativeProcessLinux(
-      pid, launch_info.GetPTY().ReleasePrimaryFileDescriptor(), native_delegate,
-      *arch_or, *this, {pid}));
+      pid, launch_info.GetPTY()->ReleasePrimaryFileDescriptor(),
+      native_delegate, *arch_or, *this, {pid}));
 }
 
 llvm::Expected<std::unique_ptr<NativeProcessProtocol>>

--- a/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
@@ -94,8 +94,8 @@ NativeProcessNetBSD::Manager::Launch(ProcessLaunchInfo &launch_info,
            Info.GetArchitecture().GetArchitectureName());
 
   std::unique_ptr<NativeProcessNetBSD> process_up(new NativeProcessNetBSD(
-      pid, launch_info.GetPTY().ReleasePrimaryFileDescriptor(), native_delegate,
-      Info.GetArchitecture(), m_mainloop));
+      pid, launch_info.GetPTY()->ReleasePrimaryFileDescriptor(),
+      native_delegate, Info.GetArchitecture(), m_mainloop));
 
   status = process_up->SetupTrace();
   if (status.Fail())

--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -47,9 +47,9 @@ namespace lldb_private {
 NativeProcessWindows::NativeProcessWindows(ProcessLaunchInfo &launch_info,
                                            NativeDelegate &delegate,
                                            llvm::Error &E)
-    : NativeProcessProtocol(LLDB_INVALID_PROCESS_ID,
-                            launch_info.GetPTY().ReleasePrimaryFileDescriptor(),
-                            delegate),
+    : NativeProcessProtocol(
+          LLDB_INVALID_PROCESS_ID,
+          launch_info.GetPTY()->ReleasePrimaryFileDescriptor(), delegate),
       ProcessDebugger(), m_arch(launch_info.GetArchitecture()) {
   ErrorAsOutParameter EOut(&E);
   DebugDelegateSP delegate_sp(new NativeDebugDelegate(*this));

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -1054,7 +1054,7 @@ lldb::ProcessSP Platform::DebugProcess(ProcessLaunchInfo &launch_info,
         // been used where the secondary side was given as the file to open for
         // stdin/out/err after we have already opened the primary so we can
         // read/write stdin/out/err.
-        int pty_fd = launch_info.GetPTY().ReleasePrimaryFileDescriptor();
+        int pty_fd = launch_info.GetPTY()->ReleasePrimaryFileDescriptor();
         if (pty_fd != PseudoTerminal::invalid_fd) {
           process_sp->SetSTDIOFileDescriptor(pty_fd);
         }


### PR DESCRIPTION
This patch refactors the `PseudoTerminal::GetPTY` to return an `std::shared_ptr`. This is effectively an NFC patch and is needed for https://github.com/llvm/llvm-project/pull/168729.