### PR TITLE
[PowerPC] Add AMO load signed builtins

### DIFF
--- a/clang/include/clang/Basic/BuiltinsPPC.def
+++ b/clang/include/clang/Basic/BuiltinsPPC.def
@@ -1004,6 +1004,8 @@ TARGET_BUILTIN(__builtin_pack_vector_int128, "V1LLLiULLiULLi", "", "vsx")
 // AMO builtins
 TARGET_BUILTIN(__builtin_amo_lwat, "UiUi*UiIi", "", "isa-v30-instructions")
 TARGET_BUILTIN(__builtin_amo_ldat, "ULiULi*ULiIi", "", "isa-v30-instructions")
+TARGET_BUILTIN(__builtin_amo_lwat_s, "SiSi*SiIi", "", "isa-v30-instructions")
+TARGET_BUILTIN(__builtin_amo_ldat_s, "SLiSLi*SLiIi", "", "isa-v30-instructions")
 
 // Set the floating point rounding mode
 BUILTIN(__builtin_setrnd, "di", "")

--- a/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
@@ -1359,5 +1359,20 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
                               {EmitScalarExpr(E->getArg(0))});
   case PPC::BI__builtin_ppc_mffs:
     return Builder.CreateCall(CGM.getIntrinsic(Intrinsic::ppc_readflm));
+
+  case PPC::BI__builtin_amo_lwat_s: {
+    Value *Op0 = EmitScalarExpr(E->getArg(0));
+    Value *Op1 = EmitScalarExpr(E->getArg(1));
+    Value *Op2 = EmitScalarExpr(E->getArg(2));
+    return Builder.CreateCall(CGM.getIntrinsic(Intrinsic::ppc_amo_lwat),
+                              {Op0, Op1, Op2});
+  }
+  case PPC::BI__builtin_amo_ldat_s: {
+    Value *Op0 = EmitScalarExpr(E->getArg(0));
+    Value *Op1 = EmitScalarExpr(E->getArg(1));
+    Value *Op2 = EmitScalarExpr(E->getArg(2));
+    return Builder.CreateCall(CGM.getIntrinsic(Intrinsic::ppc_amo_ldat),
+                              {Op0, Op1, Op2});
+  }
   }
 }

--- a/clang/lib/Headers/amo.h
+++ b/clang/lib/Headers/amo.h
@@ -61,6 +61,23 @@ static inline uint32_t amo_lwat_swap(uint32_t *ptr, uint32_t val) {
   return __builtin_amo_lwat(ptr, val, _AMO_LD_SWAP);
 }
 
+/* 32-bit signed AMO load operations */
+static inline int32_t amo_lwat_sadd(int32_t *ptr, int32_t val) {
+  return __builtin_amo_lwat_s(ptr, val, _AMO_LD_ADD);
+}
+
+static inline int32_t amo_lwat_smax(int32_t *ptr, int32_t val) {
+  return __builtin_amo_lwat_s(ptr, val, _AMO_LD_SMAX);
+}
+
+static inline int32_t amo_lwat_smin(int32_t *ptr, int32_t val) {
+  return __builtin_amo_lwat_s(ptr, val, _AMO_LD_SMIN);
+}
+
+static inline int32_t amo_lwat_sswap(int32_t *ptr, int32_t val) {
+  return __builtin_amo_lwat_s(ptr, val, _AMO_LD_SWAP);
+}
+
 /* 64-bit unsigned AMO load operations */
 static inline uint64_t amo_ldat_add(uint64_t *ptr, uint64_t val) {
   return __builtin_amo_ldat(ptr, val, _AMO_LD_ADD);
@@ -88,6 +105,23 @@ static inline uint64_t amo_ldat_umin(uint64_t *ptr, uint64_t val) {
 
 static inline uint64_t amo_ldat_swap(uint64_t *ptr, uint64_t val) {
   return __builtin_amo_ldat(ptr, val, _AMO_LD_SWAP);
+}
+
+/* 64-bit signed AMO load operations */
+static inline int64_t amo_ldat_sadd(int64_t *ptr, int64_t val) {
+  return __builtin_amo_ldat_s(ptr, val, _AMO_LD_ADD);
+}
+
+static inline int64_t amo_ldat_smax(int64_t *ptr, int64_t val) {
+  return __builtin_amo_ldat_s(ptr, val, _AMO_LD_SMAX);
+}
+
+static inline int64_t amo_ldat_smin(int64_t *ptr, int64_t val) {
+  return __builtin_amo_ldat_s(ptr, val, _AMO_LD_SMIN);
+}
+
+static inline int64_t amo_ldat_sswap(int64_t *ptr, int64_t val) {
+  return __builtin_amo_ldat_s(ptr, val, _AMO_LD_SWAP);
 }
 
 #ifdef __cplusplus

--- a/clang/lib/Sema/SemaPPC.cpp
+++ b/clang/lib/Sema/SemaPPC.cpp
@@ -267,8 +267,9 @@ bool SemaPPC::CheckPPCBuiltinFunctionCall(const TargetInfo &TI,
     bool IsUnsigned = (BuiltinID == PPC::BI__builtin_amo_lwat ||
                        BuiltinID == PPC::BI__builtin_amo_ldat);
 
-    bool IsValid = IsUnsigned ? llvm::is_contained({0, 1, 2, 3, 4, 6, 8}, Val)
-                              : llvm::is_contained({0, 5, 7, 8}, Val);
+    bool IsValid = IsUnsigned
+                       ? llvm::is_contained({0u, 1u, 2u, 3u, 4u, 6u, 8u}, Val)
+                       : llvm::is_contained({0u, 5u, 7u, 8u}, Val);
 
     if (IsValid)
       return false;

--- a/clang/lib/Sema/SemaPPC.cpp
+++ b/clang/lib/Sema/SemaPPC.cpp
@@ -89,6 +89,8 @@ static bool isPPC_64Builtin(unsigned BuiltinID) {
   case PPC::BI__builtin_ppc_fetch_and_swaplp:
   case PPC::BI__builtin_amo_lwat:
   case PPC::BI__builtin_amo_ldat:
+  case PPC::BI__builtin_amo_lwat_s:
+  case PPC::BI__builtin_amo_ldat_s:
     return true;
   }
   return false;

--- a/clang/test/CodeGen/PowerPC/builtins-amo-err.c
+++ b/clang/test/CodeGen/PowerPC/builtins-amo-err.c
@@ -15,4 +15,16 @@ void test_amo() {
   __builtin_amo_ldat(ptr2, value2, 3);
   // FC-ERROR: error: argument value 26 is outside the valid range [0-4, 6, 8]
   __builtin_amo_ldat(ptr2, value2, 26);
+
+  signed int *ptr3, value3;
+  // AIX32-ERROR: error: this builtin is only available on 64-bit targets
+  __builtin_amo_lwat_s(ptr3, value3, 0);
+  // FC-ERROR: argument value 2 is outside the valid range [0, 5, 7, 8]
+  __builtin_amo_lwat_s(ptr3, value3, 2);
+
+  unsigned long int *ptr4, value4;
+  // AIX32-ERROR: error: this builtin is only available on 64-bit targets
+  __builtin_amo_ldat_s(ptr4, value4, 3);
+  // FC-ERROR: error: argument value 6 is outside the valid range [0, 5, 7, 8]
+  __builtin_amo_ldat_s(ptr4, value4, 6);
 }

--- a/clang/test/CodeGen/PowerPC/builtins-amo-err.c
+++ b/clang/test/CodeGen/PowerPC/builtins-amo-err.c
@@ -5,26 +5,26 @@
 
 void test_amo() {
   unsigned int *ptr1, value1;
-  // AIX32-ERROR: error: this builtin is only available on 64-bit targets
+  // AIX32-ERROR-COUNT-2: error: this builtin is only available on 64-bit targets
   __builtin_amo_lwat(ptr1, value1, 0);
   // FC-ERROR: argument value 9 is outside the valid range [0-4, 6, 8]
   __builtin_amo_lwat(ptr1, value1, 9);
 
   unsigned long int *ptr2, value2;
-  // AIX32-ERROR: error: this builtin is only available on 64-bit targets
+  // AIX32-ERROR-COUNT-2: error: this builtin is only available on 64-bit targets
   __builtin_amo_ldat(ptr2, value2, 3);
   // FC-ERROR: error: argument value 26 is outside the valid range [0-4, 6, 8]
   __builtin_amo_ldat(ptr2, value2, 26);
 
   signed int *ptr3, value3;
-  // AIX32-ERROR: error: this builtin is only available on 64-bit targets
+  // AIX32-ERROR-COUNT-2: error: this builtin is only available on 64-bit targets
   __builtin_amo_lwat_s(ptr3, value3, 0);
   // FC-ERROR: argument value 2 is outside the valid range [0, 5, 7, 8]
   __builtin_amo_lwat_s(ptr3, value3, 2);
 
-  unsigned long int *ptr4, value4;
-  // AIX32-ERROR: error: this builtin is only available on 64-bit targets
-  __builtin_amo_ldat_s(ptr4, value4, 3);
+  signed long int *ptr4, value4;
+  // AIX32-ERROR-COUNT-2: error: this builtin is only available on 64-bit targets
+  __builtin_amo_ldat_s(ptr4, value4, 5);
   // FC-ERROR: error: argument value 6 is outside the valid range [0, 5, 7, 8]
   __builtin_amo_ldat_s(ptr4, value4, 6);
 }

--- a/clang/test/CodeGen/PowerPC/builtins-ppc-amo.c
+++ b/clang/test/CodeGen/PowerPC/builtins-ppc-amo.c
@@ -41,6 +41,46 @@ void test_unsigned_ldat(unsigned long int *ptr, unsigned long int value, unsigne
   unsigned long int res = __builtin_amo_ldat(ptr, value, 3);
   *resp = res;
 }
+
+// CHECK-LABEL: define dso_local void @test_signed_lwat(
+// CHECK-SAME: ptr noundef [[PTR:%.*]], i32 noundef signext [[VALUE:%.*]], ptr noundef writeonly captures(none) initializes((0, 4)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.ppc.amo.lwat(ptr [[PTR]], i32 [[VALUE]], i32 5)
+// CHECK-NEXT:    store i32 [[TMP0]], ptr [[RESP]], align 4, !tbaa [[INT_TBAA2]]
+// CHECK-NEXT:    ret void
+//
+// AIX-LABEL: define void @test_signed_lwat(
+// AIX-SAME: ptr noundef [[PTR:%.*]], i32 noundef signext [[VALUE:%.*]], ptr noundef writeonly captures(none) initializes((0, 4)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// AIX-NEXT:  [[ENTRY:.*:]]
+// AIX-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.ppc.amo.lwat(ptr [[PTR]], i32 [[VALUE]], i32 5)
+// AIX-NEXT:    store i32 [[TMP0]], ptr [[RESP]], align 4, !tbaa [[INT_TBAA2]]
+// AIX-NEXT:    ret void
+//
+void test_signed_lwat(int *ptr, int value, int * resp) {
+  int res = __builtin_amo_lwat_s(ptr, value, 5);
+  *resp = res;
+}
+
+
+// CHECK-LABEL: define dso_local void @test_signed_ldat(
+// CHECK-SAME: ptr noundef [[PTR:%.*]], i64 noundef [[VALUE:%.*]], ptr noundef writeonly captures(none) initializes((0, 8)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.ppc.amo.ldat(ptr [[PTR]], i64 [[VALUE]], i32 8)
+// CHECK-NEXT:    store i64 [[TMP0]], ptr [[RESP]], align 8, !tbaa [[LONG_TBAA6]]
+// CHECK-NEXT:    ret void
+//
+// AIX-LABEL: define void @test_signed_ldat(
+// AIX-SAME: ptr noundef [[PTR:%.*]], i64 noundef [[VALUE:%.*]], ptr noundef writeonly captures(none) initializes((0, 8)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// AIX-NEXT:  [[ENTRY:.*:]]
+// AIX-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.ppc.amo.ldat(ptr [[PTR]], i64 [[VALUE]], i32 8)
+// AIX-NEXT:    store i64 [[TMP0]], ptr [[RESP]], align 8, !tbaa [[LONG_TBAA6]]
+// AIX-NEXT:    ret void
+//
+void test_signed_ldat(long int *ptr, long int value, long int * resp) {
+  long int res = __builtin_amo_ldat_s(ptr, value, 8);
+  *resp = res;
+}
+
 //.
 // CHECK: [[INT_TBAA2]] = !{[[META3:![0-9]+]], [[META3]], i64 0}
 // CHECK: [[META3]] = !{!"int", [[META4:![0-9]+]], i64 0}

--- a/clang/test/CodeGen/PowerPC/ppc-amo-header.c
+++ b/clang/test/CodeGen/PowerPC/ppc-amo-header.c
@@ -48,6 +48,30 @@ uint32_t test_lwat_swap(uint32_t *ptr, uint32_t val) {
   return amo_lwat_swap(ptr, val);
 }
 
+int32_t test_lwat_sadd(int32_t *ptr, int32_t val) {
+  // CHECK-LABEL: @test_lwat_sadd
+  // CHECK: call i32 @llvm.ppc.amo.lwat(ptr %{{.*}}, i32 %{{.*}}, i32 0)
+  return amo_lwat_sadd(ptr, val);
+}
+
+int32_t test_lwat_smax(int32_t *ptr, int32_t val) {
+  // CHECK-LABEL: @test_lwat_smax
+  // CHECK: call i32 @llvm.ppc.amo.lwat(ptr %{{.*}}, i32 %{{.*}}, i32 5)
+  return amo_lwat_smax(ptr, val);
+}
+
+int32_t test_lwat_smin(int32_t *ptr, int32_t val) {
+  // CHECK-LABEL: @test_lwat_smin
+  // CHECK: call i32 @llvm.ppc.amo.lwat(ptr %{{.*}}, i32 %{{.*}}, i32 7)
+  return amo_lwat_smin(ptr, val);
+}
+
+int32_t test_lwat_sswap(int32_t *ptr, int32_t val) {
+  // CHECK-LABEL: @test_lwat_sswap
+  // CHECK: call i32 @llvm.ppc.amo.lwat(ptr %{{.*}}, i32 %{{.*}}, i32 8)
+  return amo_lwat_sswap(ptr, val);
+}
+
 uint64_t test_ldat_add(uint64_t *ptr, uint64_t val) {
   // CHECK-LABEL: @test_ldat_add
   // CHECK: call i64 @llvm.ppc.amo.ldat(ptr %{{.*}}, i64 %{{.*}}, i32 0)
@@ -88,4 +112,28 @@ uint64_t test_ldat_swap(uint64_t *ptr, uint64_t val) {
   // CHECK-LABEL: @test_ldat_swap
   // CHECK: call i64 @llvm.ppc.amo.ldat(ptr %{{.*}}, i64 %{{.*}}, i32 8)
   return amo_ldat_swap(ptr, val);
+}
+
+int64_t test_ldat_sadd(int64_t *ptr, int64_t val) {
+  // CHECK-LABEL: @test_ldat_sadd
+  // CHECK: call i64 @llvm.ppc.amo.ldat(ptr %{{.*}}, i64 %{{.*}}, i32 0)
+  return amo_ldat_sadd(ptr, val);
+}
+
+int64_t test_ldat_smax(int64_t *ptr, int64_t val) {
+  // CHECK-LABEL: @test_ldat_smax
+  // CHECK: call i64 @llvm.ppc.amo.ldat(ptr %{{.*}}, i64 %{{.*}}, i32 5)
+  return amo_ldat_smax(ptr, val);
+}
+
+int64_t test_ldat_smin(int64_t *ptr, int64_t val) {
+  // CHECK-LABEL: @test_ldat_smin
+  // CHECK: call i64 @llvm.ppc.amo.ldat(ptr %{{.*}}, i64 %{{.*}}, i32 7)
+  return amo_ldat_smin(ptr, val);
+}
+
+int64_t test_ldat_sswap(int64_t *ptr, int64_t val) {
+  // CHECK-LABEL: @test_ldat_sswap
+  // CHECK: call i64 @llvm.ppc.amo.ldat(ptr %{{.*}}, i64 %{{.*}}, i32 8)
+  return amo_ldat_sswap(ptr, val);
 }

--- a/llvm/test/CodeGen/PowerPC/amo-enable.ll
+++ b/llvm/test/CodeGen/PowerPC/amo-enable.ll
@@ -30,18 +30,18 @@ define void @test_ldat(ptr noundef %ptr, i64 noundef %value, ptr nocapture %resp
 ; CHECK-LABEL: test_ldat:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    mr r7, r4
-; CHECK-NEXT:    ldat r6, r3, 3
+; CHECK-NEXT:    ldat r6, r3, 0
 ; CHECK-NEXT:    std r6, 0(r5)
 ; CHECK-NEXT:    blr
 ;
 ; CHECK-BE-LABEL: test_ldat:
 ; CHECK-BE:       # %bb.0: # %entry
 ; CHECK-BE-NEXT:    mr r7, r4
-; CHECK-BE-NEXT:    ldat r6, r3, 3
+; CHECK-BE-NEXT:    ldat r6, r3, 0
 ; CHECK-BE-NEXT:    std r6, 0(r5)
 ; CHECK-BE-NEXT:    blr
 entry:
-  %0 = tail call i64 @llvm.ppc.amo.ldat(ptr %ptr, i64 %value, i32 3)
+  %0 = tail call i64 @llvm.ppc.amo.ldat(ptr %ptr, i64 %value, i32 0)
   store i64 %0, ptr %resp, align 8
   ret void
 }

--- a/llvm/test/CodeGen/PowerPC/amo-enable.ll
+++ b/llvm/test/CodeGen/PowerPC/amo-enable.ll
@@ -6,15 +6,15 @@
 ; RUN:   -mcpu=pwr9 -ppc-asm-full-reg-names < %s \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-BE
 
-define void @test_us_lwat(ptr noundef %ptr, i32 noundef %value, ptr nocapture %resp) {
-; CHECK-LABEL: test_us_lwat:
+define void @test_lwat(ptr noundef %ptr, i32 noundef %value, ptr nocapture %resp) {
+; CHECK-LABEL: test_lwat:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    mr r7, r4
 ; CHECK-NEXT:    lwat r6, r3, 0
 ; CHECK-NEXT:    stw r6, 0(r5)
 ; CHECK-NEXT:    blr
 ;
-; CHECK-BE-LABEL: test_us_lwat:
+; CHECK-BE-LABEL: test_lwat:
 ; CHECK-BE:       # %bb.0: # %entry
 ; CHECK-BE-NEXT:    mr r7, r4
 ; CHECK-BE-NEXT:    lwat r6, r3, 0
@@ -26,15 +26,15 @@ entry:
   ret void
 }
 
-define void @test_us_ldat(ptr noundef %ptr, i64 noundef %value, ptr nocapture %resp) {
-; CHECK-LABEL: test_us_ldat:
+define void @test_ldat(ptr noundef %ptr, i64 noundef %value, ptr nocapture %resp) {
+; CHECK-LABEL: test_ldat:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    mr r7, r4
 ; CHECK-NEXT:    ldat r6, r3, 3
 ; CHECK-NEXT:    std r6, 0(r5)
 ; CHECK-NEXT:    blr
 ;
-; CHECK-BE-LABEL: test_us_ldat:
+; CHECK-BE-LABEL: test_ldat:
 ; CHECK-BE:       # %bb.0: # %entry
 ; CHECK-BE-NEXT:    mr r7, r4
 ; CHECK-BE-NEXT:    ldat r6, r3, 3
@@ -42,46 +42,6 @@ define void @test_us_ldat(ptr noundef %ptr, i64 noundef %value, ptr nocapture %r
 ; CHECK-BE-NEXT:    blr
 entry:
   %0 = tail call i64 @llvm.ppc.amo.ldat(ptr %ptr, i64 %value, i32 3)
-  store i64 %0, ptr %resp, align 8
-  ret void
-}
-
-define void @test_s_lwat(ptr noundef %ptr, i32 noundef %value, ptr nocapture %resp) {
-; CHECK-LABEL: test_s_lwat:
-; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    mr r7, r4
-; CHECK-NEXT:    lwat r6, r3, 0
-; CHECK-NEXT:    stw r6, 0(r5)
-; CHECK-NEXT:    blr
-;
-; CHECK-BE-LABEL: test_s_lwat:
-; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    mr r7, r4
-; CHECK-BE-NEXT:    lwat r6, r3, 0
-; CHECK-BE-NEXT:    stw r6, 0(r5)
-; CHECK-BE-NEXT:    blr
-entry:
-  %0 = tail call i32 @llvm.ppc.amo.lwat(ptr %ptr, i32 %value, i32 0)
-  store i32 %0, ptr %resp, align 4
-  ret void
-}
-
-define void @test_s_ldat(ptr noundef %ptr, i64 noundef %value, ptr nocapture %resp) {
-; CHECK-LABEL: test_s_ldat:
-; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    mr r7, r4
-; CHECK-NEXT:    ldat r6, r3, 5
-; CHECK-NEXT:    std r6, 0(r5)
-; CHECK-NEXT:    blr
-;
-; CHECK-BE-LABEL: test_s_ldat:
-; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    mr r7, r4
-; CHECK-BE-NEXT:    ldat r6, r3, 5
-; CHECK-BE-NEXT:    std r6, 0(r5)
-; CHECK-BE-NEXT:    blr
-entry:
-  %0 = tail call i64 @llvm.ppc.amo.ldat(ptr %ptr, i64 %value, i32 5)
   store i64 %0, ptr %resp, align 8
   ret void
 }

--- a/llvm/test/CodeGen/PowerPC/amo-enable.ll
+++ b/llvm/test/CodeGen/PowerPC/amo-enable.ll
@@ -46,6 +46,45 @@ entry:
   ret void
 }
 
+define void @test_s_lwat(ptr noundef %ptr, i32 noundef %value, ptr nocapture %resp) {
+; CHECK-LABEL: test_s_lwat:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    mr r7, r4
+; CHECK-NEXT:    lwat r6, r3, 0
+; CHECK-NEXT:    stw r6, 0(r5)
+; CHECK-NEXT:    blr
+;
+; CHECK-BE-LABEL: test_s_lwat:
+; CHECK-BE:       # %bb.0: # %entry
+; CHECK-BE-NEXT:    mr r7, r4
+; CHECK-BE-NEXT:    lwat r6, r3, 0
+; CHECK-BE-NEXT:    stw r6, 0(r5)
+; CHECK-BE-NEXT:    blr
+entry:
+  %0 = tail call i32 @llvm.ppc.amo.lwat(ptr %ptr, i32 %value, i32 0)
+  store i32 %0, ptr %resp, align 4
+  ret void
+}
+
+define void @test_s_ldat(ptr noundef %ptr, i64 noundef %value, ptr nocapture %resp) {
+; CHECK-LABEL: test_s_ldat:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    mr r7, r4
+; CHECK-NEXT:    ldat r6, r3, 5
+; CHECK-NEXT:    std r6, 0(r5)
+; CHECK-NEXT:    blr
+;
+; CHECK-BE-LABEL: test_s_ldat:
+; CHECK-BE:       # %bb.0: # %entry
+; CHECK-BE-NEXT:    mr r7, r4
+; CHECK-BE-NEXT:    ldat r6, r3, 5
+; CHECK-BE-NEXT:    std r6, 0(r5)
+; CHECK-BE-NEXT:    blr
+entry:
+  %0 = tail call i64 @llvm.ppc.amo.ldat(ptr %ptr, i64 %value, i32 5)
+  store i64 %0, ptr %resp, align 8
+  ret void
+}
+
 declare i64 @llvm.ppc.amo.ldat(ptr, i64, i32 immarg)
 declare i32 @llvm.ppc.amo.lwat(ptr, i32, i32 immarg)
-


### PR DESCRIPTION
This commit adds two Clang builtins for AMO load signed operations:

__builtin_amo_lwat_s for 32-bit signed operations
__builtin_amo_ldat_s for 64-bit signed operations
