### PR TITLE
[flang][driver] Do not allow -module-dir to be joined to the value

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -7236,11 +7236,14 @@ def cpp : Flag<["-"], "cpp">, Group<f_Group>,
   HelpText<"Enable predefined and command line preprocessor macros">;
 def nocpp : Flag<["-"], "nocpp">, Group<f_Group>,
   HelpText<"Disable predefined and command line preprocessor macros">;
-def module_dir : JoinedOrSeparate<["-"], "module-dir">, MetaVarName<"<dir>">,
+def J : JoinedOrSeparate<["-"], "J">,
+  Flags<[RenderJoined]>,
   HelpText<"Put MODULE files in <dir>">,
   DocBrief<[{This option specifies where to put .mod files for compiled modules.
 It is also added to the list of directories to be searched by an USE statement.
 The default is the current directory.}]>;
+def module_dir : Separate<["-"], "module-dir">, MetaVarName<"<dir>">,
+  Alias<J>;
 
 def ffixed_form : Flag<["-"], "ffixed-form">, Group<f_Group>,
   HelpText<"Process source files in fixed form">;
@@ -7375,11 +7378,6 @@ def fdo_concurrent_to_openmp_EQ : Joined<["-"], "fdo-concurrent-to-openmp=">,
   HelpText<"Try to map `do concurrent` loops to OpenMP [none|host|device]">,
       Values<"none, host, device">;
 } // let Visibility = [FC1Option, FlangOption]
-
-def J : JoinedOrSeparate<["-"], "J">,
-  Flags<[RenderJoined]>, Visibility<[FlangOption, FC1Option]>,
-  Group<gfortran_Group>,
-  Alias<module_dir>;
 
 //===----------------------------------------------------------------------===//
 // FC1 Options

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -126,7 +126,7 @@ void Flang::addDebugOptions(const llvm::opt::ArgList &Args, const JobAction &JA,
   const auto &TC = getToolChain();
   const Driver &D = TC.getDriver();
   Args.addAllArgs(CmdArgs,
-                  {options::OPT_module_dir, options::OPT_fdebug_module_writer,
+                  {options::OPT_J, options::OPT_fdebug_module_writer,
                    options::OPT_fintrinsic_modules_path, options::OPT_pedantic,
                    options::OPT_std_EQ, options::OPT_W_Joined,
                    options::OPT_fconvert_EQ, options::OPT_fpass_plugin_EQ,

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -959,7 +959,7 @@ static bool parseSemaArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
 
   // -J/module-dir option
   std::vector<std::string> moduleDirList =
-      args.getAllArgValues(clang::options::OPT_module_dir);
+      args.getAllArgValues(clang::options::OPT_J);
   // User can only specify one -J/-module-dir directory, but may repeat
   // -J/-module-dir as long as the directory is the same each time.
   // https://gcc.gnu.org/onlinedocs/gfortran/Directory-Options.html

--- a/flang/test/Driver/write-module.f90
+++ b/flang/test/Driver/write-module.f90
@@ -3,6 +3,19 @@
 !   * is saved in the _directory specified by the user_
 ! We use `-fsyntax-only` as it stops after the semantic checks (the module file is generated when sema checks are run)
 
+! ------------------------------------------------------------------------------
+! At one time, flang accepted -module-dir<value> (note the lack of a separator
+! between -module-dir and <value>). This is no longer allowed.
+! -module-dir=<value> is also not allowed
+!
+! RUN: not %flang -fsyntax-only -module-dir%t %s 2>&1 \
+! RUN:      | FileCheck %s -check-prefix=JOINED
+!
+! RUN: not %flang -fsyntax-only -module-dir=%t %s 2>&1 \
+! RUN:      | FileCheck %s -check-prefix=JOINED
+!
+! JOINED: error: unknown argument: '-module-dir{{.+}}'
+!
 !--------------------------
 ! -module-dir <value>
 !--------------------------
@@ -10,15 +23,7 @@
 ! RUN: cd %t && %flang -fsyntax-only -module-dir %t/dir-flang %s
 ! RUN: ls %t/dir-flang/testmodule.mod && not ls %t/testmodule.mod
 ! RUN: cd -
-
-!--------------------------
-! -module-dir<value>
-!--------------------------
-! RUN: rm -rf %t && mkdir -p %t/dir-flang
-! RUN: cd %t && %flang -fsyntax-only -module-dir%t/dir-flang %s
-! RUN: ls %t/dir-flang/testmodule.mod && not ls %t/testmodule.mod
-! RUN: cd -
-
+!
 !---------------------------
 ! -J <value>
 !---------------------------


### PR DESCRIPTION
In f820625, the -module-dir option was modified to allow it to be joined to the argument value, i.e. `-module-dir<value>` was allowed in addition to `-module-dir <value>`. While this is consistent with its aliasee, '-J', it is not consistent with the way other long options are handled in flang. This also makes it difficult to add another option such as -module-directives since it is not clear if "ectives" is the name of a directory containing .mod files.

`-module-dir<value>` is no longer allowed. Only `-module-dir <value>` may be used. `-module-dir=<value>` is not allowed either. However, both `-J<value>` and `-J <value>` are permitted. `-J` was made into the "primary" option and `-module-dir` was made its aliasee instead of the other way around since the former can be both joined and separated while the latter can only be separate.

Fixes #168740