### PR TITLE
[lit] Add LIT_CURRENT_TESTCASE environment variable when running tests

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1226,6 +1226,8 @@ def executeScriptInternal(
     results = []
     timeoutInfo = None
     shenv = ShellEnvironment(cwd, test.config.environment)
+    shenv.env["LIT_CURRENT_TESTCASE"] = test.getFullName()
+
     exitCode, timeoutInfo = executeShCmd(
         cmd, shenv, results, timeout=litConfig.maxIndividualTestTime
     )
@@ -1425,11 +1427,13 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
             # run on clang with no real loss.
             command = litConfig.valgrindArgs + command
 
+    env = dict(test.config.environment)
+    env["LIT_CURRENT_TESTCASE"] = test.getFullName()
     try:
         out, err, exitCode = lit.util.executeCommand(
             command,
             cwd=cwd,
-            env=test.config.environment,
+            env=env,
             timeout=litConfig.maxIndividualTestTime,
         )
         return (out, err, exitCode, None)

--- a/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-current-testcase.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-current-testcase.txt
@@ -1,0 +1,6 @@
+## Tests that the LIT_CURRENT_TESTCASE variable is set to the name of the currently executing testcase
+
+## Check default environment.
+# RUN: bash -c 'echo $LIT_CURRENT_TESTCASE' | FileCheck --match-full-lines %s
+#
+# CHECK: shtest-env :: env-current-testcase.txt

--- a/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-no-subcommand.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-no-subcommand.txt
@@ -1,4 +1,5 @@
 ## Tests the env command in various scenarios: without arguments, setting, unsetting, and mixing envrionment variables.
+# FIXME: All of these tests are broken and will not even call FileCheck.
 
 ## Check default environment.
 # RUN: env | FileCheck -check-prefix=NO-ARGS %s

--- a/llvm/utils/lit/tests/shtest-env-positive.py
+++ b/llvm/utils/lit/tests/shtest-env-positive.py
@@ -7,7 +7,7 @@
 
 ## Test the env command's successful executions.
 
-# CHECK: -- Testing: 10 tests{{.*}}
+# CHECK: -- Testing: 11 tests{{.*}}
 
 # CHECK: PASS: shtest-env :: env-args-last-is-assign.txt ({{[^)]*}})
 # CHECK: env FOO=1
@@ -36,6 +36,11 @@
 # CHECK: PASS: shtest-env :: env-calls-env.txt ({{[^)]*}})
 # CHECK: env env | {{.*}}
 # CHECK: # executed command: env env
+# CHECK-NOT: # error:
+# CHECK: --
+
+# CHECK: PASS: shtest-env :: env-current-testcase.txt ({{[^)]*}})
+# CHECK: # executed command: bash -c 'echo $LIT_CURRENT_TESTCASE'
 # CHECK-NOT: # error:
 # CHECK: --
 
@@ -71,6 +76,6 @@
 # CHECK-NOT: # error:
 # CHECK: --
 
-# CHECK: Total Discovered Tests: 10
-# CHECK: Passed: 10 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK: Total Discovered Tests: 11
+# CHECK: Passed: 11 {{\([0-9]*\.[0-9]*%\)}}
 # CHECK-NOT: {{.}}


### PR DESCRIPTION
I'm not aware of any way for `%run` wrapper scripts like `iosssim_run.py` ([ref](https://github.com/llvm/llvm-project/blob/d2c7c6064259320def7a74e111079725958697d4/compiler-rt/test/sanitizer_common/ios_commands/iossim_run.py#L4)) to know what testcase they are currently running. This can be useful if these wrappers need to create a (potentially remote) temporary directory for each test case.

This adds the `LIT_CURRENT_TESTCASE` environment variable to both the internal shell and the external shell, containing the full name of the current test being run.