### PR TITLE
[bazel] Fix bzlmod reference to @vulkan_sdk

### DIFF
--- a/utils/bazel/MODULE.bazel
+++ b/utils/bazel/MODULE.bazel
@@ -21,7 +21,7 @@ use_repo(
     "llvm-raw",
     "llvm_zlib",
     "vulkan_headers",
-    "vulkan_sdk_setup",
+    "vulkan_sdk",
     "gmp",
     "mpfr",
     "mpc",

--- a/utils/bazel/MODULE.bazel.lock
+++ b/utils/bazel/MODULE.bazel.lock
@@ -229,7 +229,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%llvm_repos_extension": {
       "general": {
-        "bzlTransitiveDigest": "3NCQtHwwkFzbdvEprZ+u9gQlcf+2PKpoinmAHZTL35o=",
+        "bzlTransitiveDigest": "5Uc5D84crjXhrcQgNCOOeRsxLkibVlz4ACrhXJCSO2Q=",
         "usagesDigest": "X0yUkkWyxQ2Y5oZVDkRSE/K4YkDWo1IjhHsL+1weKyU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -264,7 +264,7 @@
               ]
             }
           },
-          "vulkan_sdk_setup": {
+          "vulkan_sdk": {
             "repoRuleId": "@@//:vulkan_sdk.bzl%vulkan_sdk_setup",
             "attributes": {}
           },

--- a/utils/bazel/extensions.bzl
+++ b/utils/bazel/extensions.bzl
@@ -36,7 +36,7 @@ def _llvm_repos_extension_impl(module_ctx):
         ],
     )
 
-    vulkan_sdk_setup(name = "vulkan_sdk_setup")
+    vulkan_sdk_setup(name = "vulkan_sdk")
 
     http_archive(
         name = "gmp",


### PR DESCRIPTION
vulkan_sdk_setup is the name of the method that configures it, but the repo itself has the name vulkan_sdk

This was caught by enabling the bzlmod flag for CI. The GH action runs `blaze test @llvm-project/...` but the target is tagged manual, so it's excluded. The buildkite CI runs `bazel query | xargs bazel test` which will include manual targets.