### PR TITLE
[CFIInserter] Turn a reachable llvm_unreachable into a report_fatal_error.

### DIFF
--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -272,7 +272,7 @@ void CFIInstrInserter::calculateOutgoingCFAInfo(MBBCFAInfo &MBBInfo) {
           CSRLocMap.insert(
               {CFI.getRegister(), CSRSavedLocation(CSRReg, CSROffset)});
         } else if (It->second.Reg != CSRReg || It->second.Offset != CSROffset) {
-          llvm_unreachable("Different saved locations for the same CSR");
+          report_fatal_error("Different saved locations for the same CSR");
         }
         CSRSaved.set(CFI.getRegister());
       }

--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -272,7 +272,8 @@ void CFIInstrInserter::calculateOutgoingCFAInfo(MBBCFAInfo &MBBInfo) {
           CSRLocMap.insert(
               {CFI.getRegister(), CSRSavedLocation(CSRReg, CSROffset)});
         } else if (It->second.Reg != CSRReg || It->second.Offset != CSROffset) {
-          report_fatal_error("Different saved locations for the same CSR");
+          reportFatalInternalError(
+              "Different saved locations for the same CSR");
         }
         CSRSaved.set(CFI.getRegister());
       }

--- a/llvm/test/CodeGen/RISCV/cfi-multiple-locations.mir
+++ b/llvm/test/CodeGen/RISCV/cfi-multiple-locations.mir
@@ -1,7 +1,8 @@
-# RUN: llc -x mir < %s -mtriple=riscv64 \
+# RUN: not --crash llc %s -mtriple=riscv64 \
 # RUN: -run-pass=cfi-instr-inserter \
-# RUN: -riscv-enable-cfi-instr-inserter=true
-# UNSUPPORTED: target={{.*}}
+# RUN: -riscv-enable-cfi-instr-inserter=true 2>&1 | FileCheck %s
+
+# CHECK: LLVM ERROR: Different saved locations for the same CSR
 
 # Technically, it is possible that a callee-saved register is saved in multiple different locations.
 # CFIInstrInserter should handle this, but currently it does not.

--- a/llvm/test/CodeGen/X86/cfi-inserter-verify-inconsistent-loc.mir
+++ b/llvm/test/CodeGen/X86/cfi-inserter-verify-inconsistent-loc.mir
@@ -1,4 +1,3 @@
-# REQUIRES: asserts
 # RUN: not --crash llc -o - %s -mtriple=x86_64-- \
 # RUN:     -run-pass=cfi-instr-inserter 2>&1 | FileCheck %s
 # Test that CSR being saved in multiple locations can be caught by
@@ -10,8 +9,7 @@
   }
 ...
 ---
-# CHECK: Different saved locations for the same CSR
-# CHECK-NEXT: UNREACHABLE executed 
+# CHECK: LLVM ERROR: Different saved locations for the same CSR
 name: inconsistentlocs
 body: |
   bb.0:


### PR DESCRIPTION
This prevents it from being optimized out in non-assert builds.

Update X86 test to remove REQUIRES: asserts and check for LLVM ERROR. Add FileCheck to RISC-V test and remove UNSUPPORTED.

This is the more complete fix for #168772 and #168525.