### PR TITLE
Fix build breakage from: #167948

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -169,23 +169,23 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   case X86::BI__builtin_ia32_vec_set_v16hi:
   case X86::BI__builtin_ia32_vec_set_v8si:
   case X86::BI__builtin_ia32_vec_set_v4di:
-    cgm.errorNYI(e->getSourceRange(),
+    cgm.errorNYI(expr->getSourceRange(),
                  std::string("unimplemented X86 builtin call: ") +
                      getContext().BuiltinInfo.getName(builtinID));
     return {};
   case X86::BI_mm_setcsr:
   case X86::BI__builtin_ia32_ldmxcsr: {
-    mlir::Location loc = getLoc(e->getExprLoc());
-    Address tmp = createMemTemp(e->getArg(0)->getType(), loc);
+    mlir::Location loc = getLoc(expr->getExprLoc());
+    Address tmp = createMemTemp(expr->getArg(0)->getType(), loc);
     builder.createStore(loc, ops[0], tmp);
-    return emitIntrinsicCallOp(*this, e, "x86.sse.ldmxcsr", builder.getVoidTy(),
-                               tmp.getPointer());
+    return emitIntrinsicCallOp(*this, expr, "x86.sse.ldmxcsr",
+                               builder.getVoidTy(), tmp.getPointer());
   }
   case X86::BI_mm_getcsr:
   case X86::BI__builtin_ia32_stmxcsr: {
-    mlir::Location loc = getLoc(e->getExprLoc());
-    Address tmp = createMemTemp(e->getType(), loc);
-    emitIntrinsicCallOp(*this, e, "x86.sse.stmxcsr", builder.getVoidTy(),
+    mlir::Location loc = getLoc(expr->getExprLoc());
+    Address tmp = createMemTemp(expr->getType(), loc);
+    emitIntrinsicCallOp(*this, expr, "x86.sse.stmxcsr", builder.getVoidTy(),
                         tmp.getPointer());
     return builder.createLoad(loc, tmp);
   }


### PR DESCRIPTION
It appears that this broke the build by not using the 'correct' name for the expression.  This is probably something that crossed in review.