### PR TITLE
[OpenACC] Fix crash when checking an section in a 'link' clause

### DIFF
--- a/clang/lib/Sema/SemaOpenACCClause.cpp
+++ b/clang/lib/Sema/SemaOpenACCClause.cpp
@@ -1891,13 +1891,6 @@ SemaOpenACC::ActOnClause(ArrayRef<const OpenACCClause *> ExistingClauses,
   if (DiagnoseAllowedClauses(Clause.getDirectiveKind(), Clause.getClauseKind(),
                              Clause.getBeginLoc()))
     return nullptr;
-  //// Diagnose that we don't support this clause on this directive.
-  // if (!doesClauseApplyToDirective(Clause.getDirectiveKind(),
-  //                                 Clause.getClauseKind())) {
-  //   Diag(Clause.getBeginLoc(), diag::err_acc_clause_appertainment)
-  //       << Clause.getDirectiveKind() << Clause.getClauseKind();
-  //   return nullptr;
-  // }
 
   if (const auto *DevTypeClause = llvm::find_if(
           ExistingClauses, llvm::IsaPred<OpenACCDeviceTypeClause>);
@@ -2254,6 +2247,14 @@ SemaOpenACC::CheckLinkClauseVarList(ArrayRef<Expr *> VarExprs) {
     if (isa<MemberExpr>(VarExpr)) {
       NewVarList.push_back(VarExpr);
       continue;
+    }
+
+    while (isa<ArraySectionExpr, ArraySubscriptExpr>(VarExpr)) {
+      if (auto *ASE = dyn_cast<ArraySectionExpr>(VarExpr))
+        VarExpr = ASE->getBase()->IgnoreParenImpCasts();
+      else
+        VarExpr =
+            cast<ArraySubscriptExpr>(VarExpr)->getBase()->IgnoreParenImpCasts();
     }
 
     const auto *DRE = cast<DeclRefExpr>(VarExpr);

--- a/clang/test/SemaOpenACC/declare-construct.cpp
+++ b/clang/test/SemaOpenACC/declare-construct.cpp
@@ -308,6 +308,13 @@ struct Struct2 {
   // expected-error@+2{{variable referenced by 'link' clause not in global or namespace scope must be marked 'extern'}}
   // expected-error@+1{{variable referenced by 'link' clause not in global or namespace scope must be marked 'extern'}}
 #pragma acc declare link(I, Local, ExternLocal)
+
+    int Local2[5];
+    int Local3[5];
+  // expected-error@+3{{OpenACC variable on 'declare' construct is not a valid variable name or array name}}
+  // expected-warning@+2{{sub-array as a variable on 'declare' construct is not a valid variable name or array name}}
+  // expected-error@+1{{variable referenced by 'link' clause not in global or namespace scope must be marked 'extern'}}
+#pragma acc declare link(Local2[1], Local3[1:1])
 }
 };
 


### PR DESCRIPTION
I saw this while doing lowering, we were not properly looking into the array sections for the variable.  Presumably we didn't do a good job of making sure we did this right when making this extension, and missed this spot.