### PR TITLE
AMDGPU: Fix treating divergent loads as uniform

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -4420,10 +4420,18 @@ bool AMDGPUDAGToDAGISel::isVGPRImm(const SDNode * N) const {
 
 bool AMDGPUDAGToDAGISel::isUniformLoad(const SDNode *N) const {
   const auto *Ld = cast<LoadSDNode>(N);
-
   const MachineMemOperand *MMO = Ld->getMemOperand();
-  if (N->isDivergent() && !AMDGPU::isUniformMMO(MMO))
-    return false;
+
+  if (Ld->isDivergent()) {
+    // FIXME: We ought to able able to take the direct isDivergent result. We
+    // cannot rely on the MMO for a uniformity check, and should stop using
+    // it. This is a hack for 2 ways that the IR divergence analysis is superior
+    // to the DAG divergence: Recognizing shift-of-workitem-id as always
+    // uniform, and isSingleLaneExecution. These should be handled in the DAG
+    // version, and then this can be dropped.
+    if (!MMO->getValue() || !AMDGPU::isUniformMMO(MMO))
+      return false;
+  }
 
   return MMO->getSize().hasValue() &&
          Ld->getAlign() >=

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstrInfo.cpp
@@ -28,6 +28,7 @@ Intrinsic::ID AMDGPU::getIntrinsicID(const MachineInstr &I) {
 
 // TODO: Should largely merge with AMDGPUTTIImpl::isSourceOfDivergence.
 bool AMDGPU::isUniformMMO(const MachineMemOperand *MMO) {
+  // FIXME: null value is should be treated as unknown, not as uniform.
   const Value *Ptr = MMO->getValue();
   // UndefValue means this is a load of a kernel input.  These are uniform.
   // Sometimes LDS instructions have constant pointers.


### PR DESCRIPTION
Avoids regression which caused the revert 6d5f87fc42.

This is a hack on a hack. We currently have isUniformMMO,
which improperly treats unknown source value as known uniform.
This is hack from before we had divergence information in the
DAG, and should be removed. This is the minimum change to avoid
the regression; removing the aggressive handling of the unknown
case (or dropping isUniformMMO entirely) are more involved fixes.