### PR TITLE
AMDGPU: Handle invariant loads when considering if a load can be scalar

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -4437,7 +4437,8 @@ bool AMDGPUDAGToDAGISel::isUniformLoad(const SDNode *N) const {
          Ld->getAlign() >=
              Align(std::min(MMO->getSize().getValue().getKnownMinValue(),
                             uint64_t(4))) &&
-         ((Ld->getAddressSpace() == AMDGPUAS::CONSTANT_ADDRESS ||
+         (MMO->isInvariant() ||
+          (Ld->getAddressSpace() == AMDGPUAS::CONSTANT_ADDRESS ||
            Ld->getAddressSpace() == AMDGPUAS::CONSTANT_ADDRESS_32BIT) ||
           (Subtarget->getScalarizeGlobalBehavior() &&
            Ld->getAddressSpace() == AMDGPUAS::GLOBAL_ADDRESS &&

--- a/llvm/test/CodeGen/AMDGPU/invariant-load-no-alias-store.ll
+++ b/llvm/test/CodeGen/AMDGPU/invariant-load-no-alias-store.ll
@@ -10,7 +10,7 @@
 ; GCN-DAG: buffer_load_dwordx2 [[PTR:v\[[0-9]+:[0-9]+\]]],
 ; GCN-DAG: v_mov_b32_e32 [[K:v[0-9]+]], 0x1c8007b
 ; GCN: buffer_store_dword [[K]], [[PTR]]
-define amdgpu_kernel void @test_merge_store_constant_i16_invariant_global_pointer_load(ptr addrspace(1) dereferenceable(4096) nonnull %in) #0 {
+define void @test_merge_store_constant_i16_invariant_global_pointer_load(ptr addrspace(1) dereferenceable(4096) nonnull %in) #0 {
   %ptr = load ptr addrspace(1), ptr addrspace(1) %in, !invariant.load !0
   %ptr.1 = getelementptr i16, ptr addrspace(1) %ptr, i64 1
   store i16 123, ptr addrspace(1) %ptr, align 4
@@ -24,6 +24,19 @@ define amdgpu_kernel void @test_merge_store_constant_i16_invariant_global_pointe
 ; GCN: buffer_store_dword [[K]], off, s[[[SPTR_LO]]:
 define amdgpu_kernel void @test_merge_store_constant_i16_invariant_constant_pointer_load(ptr addrspace(4) dereferenceable(4096) nonnull %in) #0 {
   %ptr = load ptr addrspace(1), ptr addrspace(4) %in, !invariant.load !0
+  %ptr.1 = getelementptr i16, ptr addrspace(1) %ptr, i64 1
+  store i16 123, ptr addrspace(1) %ptr, align 4
+  store i16 456, ptr addrspace(1) %ptr.1
+  ret void
+}
+
+; Invariant global load should be equivalently handled to constant.
+; GCN-LABEL: {{^}}test_merge_store_global_i16_invariant_uniform_global_pointer_load:
+; GCN: s_load_dwordx2 s[[[SPTR_LO:[0-9]+]]:[[SPTR_HI:[0-9]+]]]
+; GCN: v_mov_b32_e32 [[K:v[0-9]+]], 0x1c8007b
+; GCN: buffer_store_dword [[K]], off, s[[[SPTR_LO]]:
+define amdgpu_kernel void @test_merge_store_global_i16_invariant_uniform_global_pointer_load(ptr addrspace(1) dereferenceable(4096) nonnull %in) #0 {
+  %ptr = load ptr addrspace(1), ptr addrspace(1) %in, !invariant.load !0
   %ptr.1 = getelementptr i16, ptr addrspace(1) %ptr, i64 1
   store i16 123, ptr addrspace(1) %ptr, align 4
   store i16 456, ptr addrspace(1) %ptr.1


### PR DESCRIPTION
Doesn't touch the globalisel version because the handling
there looks a bit broken.