### PR TITLE
[sanitizer_common] posix_spawn test should forward DYLD_LIBRARY_PATH

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
@@ -6,9 +6,9 @@
 #include <assert.h>
 #include <spawn.h>
 #include <stdio.h>
-#include <sys/wait.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
 
 int main(int argc, char **argv) {
   if (argc > 1) {

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
+extern char **environ;
+
 int main(int argc, char **argv) {
   if (argc > 1) {
     // CHECK: SPAWNED
@@ -30,9 +32,11 @@ int main(int argc, char **argv) {
       "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", NULL,
   };
 
-  char *lib_path = getenv("DYLD_LIRARY_PATH");
-  if (lib_path) {
-    env[0] = strdup(lib_path);
+  for (char **e = environ; *e; e++) {
+    if (strncmp(*e, "DYLD_LIBRARY_PATH=", sizeof("DYLD_LIBRARY_PATH=") - 1) ==
+        0) {
+      env[0] = *e;
+    }
   }
 
   pid_t pid;

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
       argv[0], "2", "3", "4", "2", "3", "4", "2", "3", "4",
       "2",     "3", "4", "2", "3", "4", "2", "3", "4", NULL,
   };
-  const char *env[] = {
+  char *env[] = {
       "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B",
       "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", NULL,
   };

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
@@ -7,6 +7,8 @@
 #include <spawn.h>
 #include <stdio.h>
 #include <sys/wait.h>
+#include <string.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv) {
   if (argc > 1) {
@@ -23,10 +25,15 @@ int main(int argc, char **argv) {
       argv[0], "2", "3", "4", "2", "3", "4", "2", "3", "4",
       "2",     "3", "4", "2", "3", "4", "2", "3", "4", NULL,
   };
-  char *const env[] = {
+  const char *env[] = {
       "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B",
       "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", NULL,
   };
+
+  char *lib_path = getenv("DYLD_LIRARY_PATH");
+  if (lib_path) {
+    env[0] = strdup(lib_path);
+  }
 
   pid_t pid;
   int s = posix_spawn(&pid, argv[0], &file_actions, &attr, args, env);

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
@@ -32,12 +32,16 @@ int main(int argc, char **argv) {
       "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", NULL,
   };
 
-  for (char **e = environ; *e; e++) {
+  // When this test runs with a runtime (e.g. ASAN), the spawned process needs
+  // to use the same runtime search path as the parent. Otherwise, it might
+  // try to load a runtime that doesn't work and crash before hitting main(),
+  // failing the test. We technically should forward the variable for the
+  // current platform, but some platforms have multiple such variables and
+  // it's quite difficult to plumb this through the lit config.
+  for (char **e = environ; *e; e++)
     if (strncmp(*e, "DYLD_LIBRARY_PATH=", sizeof("DYLD_LIBRARY_PATH=") - 1) ==
-        0) {
+        0)
       env[0] = *e;
-    }
-  }
 
   pid_t pid;
   int s = posix_spawn(&pid, argv[0], &file_actions, &attr, args, env);


### PR DESCRIPTION
This test explicitly sets the environment for a spawned process. Without DYLD_LIBRARY_PATH, the spawned process may use a ASAN runtime other than the one that was used by the parent process That other runtime library may not work at all, or may not be in the default search path. Either case can cause the spawned process to die before it makes it to main, thus failing the test. The compiler-rt lit config sets the library path variable [here](https://github.com/llvm/llvm-project/blob/main/compiler-rt/test/lit.common.cfg.py#L84) (i.e. to ensure that just-built runtimes are used for tests, in the case of a standalone compiler-rt build), and that is currently used by the parent process but not the spawned ones.

My change only forwards the variable for Darwin (DYLD_LIBRARY_PATH), but we **_ought_** to also forward the variable for other platforms. However, it's not clear that there's any good way to plumb this into the test, since some platforms actually have multiple library path variables which would need to be forwarded (see: SunOS [here](https://github.com/llvm/llvm-project/blob/main/compiler-rt/test/lit.common.cfg.py#L102)). I considered adding a substitution variable for the library path variable, but that doesn't really work if there's multiple such variables.