### PR TITLE
CodeGen: Add missing subtarget to TargetLoweringBase constructor for ARC, CSKY and M68K

### DIFF
--- a/llvm/lib/Target/ARC/ARCISelLowering.cpp
+++ b/llvm/lib/Target/ARC/ARCISelLowering.cpp
@@ -96,7 +96,7 @@ void ARCTargetLowering::ReplaceNodeResults(SDNode *N,
 
 ARCTargetLowering::ARCTargetLowering(const TargetMachine &TM,
                                      const ARCSubtarget &Subtarget)
-    : TargetLowering(TM), Subtarget(Subtarget) {
+    : TargetLowering(TM, Subtarget), Subtarget(Subtarget) {
   // Set up the register classes.
   addRegisterClass(MVT::i32, &ARC::GPR32RegClass);
 

--- a/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
+++ b/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
@@ -35,7 +35,7 @@ static const MCPhysReg GPRArgRegs[] = {CSKY::R0, CSKY::R1, CSKY::R2, CSKY::R3};
 
 CSKYTargetLowering::CSKYTargetLowering(const TargetMachine &TM,
                                        const CSKYSubtarget &STI)
-    : TargetLowering(TM), Subtarget(STI) {
+    : TargetLowering(TM, STI), Subtarget(STI) {
   // Register Class
   addRegisterClass(MVT::i32, &CSKY::GPRRegClass);
 

--- a/llvm/lib/Target/M68k/M68kISelLowering.cpp
+++ b/llvm/lib/Target/M68k/M68kISelLowering.cpp
@@ -47,7 +47,7 @@ STATISTIC(NumTailCalls, "Number of tail calls");
 
 M68kTargetLowering::M68kTargetLowering(const M68kTargetMachine &TM,
                                        const M68kSubtarget &STI)
-    : TargetLowering(TM), Subtarget(STI), TM(TM) {
+    : TargetLowering(TM, STI), Subtarget(STI), TM(TM) {
 
   MVT PtrVT = MVT::i32;
 


### PR DESCRIPTION
Those were missing in https://github.com/llvm/llvm-project/pull/168620.