### PR TITLE
[ASAN] Disable broken __SANITIZER_DISABLE_CONTAINER_OVERFLOW__ tests on iOS/Android

### DIFF
--- a/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.cpp
+++ b/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.cpp
@@ -12,6 +12,7 @@
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -O %s -o %t-no-overflow
 // RUN: %run %t-no-overflow 2>&1 | FileCheck --check-prefix=CHECK-NOCRASH %s
 //
+// UNSUPPORTED: ios, android
 
 #include <assert.h>
 #include <stdio.h>

--- a/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.cpp
+++ b/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.cpp
@@ -12,7 +12,7 @@
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -O %s -o %t-no-overflow
 // RUN: %run %t-no-overflow 2>&1 | FileCheck --check-prefix=CHECK-NOCRASH %s
 //
-// UNSUPPORTED: ios, android
+// UNSUPPORTED: *
 
 #include <assert.h>
 #include <stdio.h>

--- a/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.cpp
+++ b/compiler-rt/test/asan/TestCases/disable_container_overflow_checks.cpp
@@ -12,7 +12,7 @@
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -O %s -o %t-no-overflow
 // RUN: %run %t-no-overflow 2>&1 | FileCheck --check-prefix=CHECK-NOCRASH %s
 //
-// UNSUPPORTED: *
+// UNSUPPORTED: true
 
 #include <assert.h>
 #include <stdio.h>

--- a/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
+++ b/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
@@ -19,6 +19,8 @@
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ %s -c -o %t-main.o
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -o %t %t-main.o %t-object.o %libdl
 // RUN: %run %t 2>&1 | FileCheck --check-prefix=CHECK-NO-CONTAINER-OVERFLOW %s
+//
+// UNSUPPORTED: ios, android
 
 #include <assert.h>
 #include <sanitizer/common_interface_defs.h>

--- a/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
+++ b/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
@@ -20,7 +20,7 @@
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -o %t %t-main.o %t-object.o %libdl
 // RUN: %run %t 2>&1 | FileCheck --check-prefix=CHECK-NO-CONTAINER-OVERFLOW %s
 //
-// UNSUPPORTED: *
+// UNSUPPORTED: true
 
 #include <assert.h>
 #include <sanitizer/common_interface_defs.h>

--- a/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
+++ b/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
@@ -20,7 +20,7 @@
 // RUN: %clangxx_asan -D__SANITIZER_DISABLE_CONTAINER_OVERFLOW__ -o %t %t-main.o %t-object.o %libdl
 // RUN: %run %t 2>&1 | FileCheck --check-prefix=CHECK-NO-CONTAINER-OVERFLOW %s
 //
-// UNSUPPORTED: ios, android
+// UNSUPPORTED: *
 
 #include <assert.h>
 #include <sanitizer/common_interface_defs.h>


### PR DESCRIPTION
The tests added by #163468 appear to be broken on iOS (sim) and android. I have no idea if this works on iOS (devices) or not, so I'm just marking UNSUPPORTED rather than XFAIL.

Android: https://lab.llvm.org/buildbot/#/builders/186/builds/14106