### PR TITLE
[MLIR][IRDL] Support camelCase segment size attributes in IRDL verifier

### DIFF
--- a/mlir/lib/Dialect/IRDL/IRDLLoading.cpp
+++ b/mlir/lib/Dialect/IRDL/IRDLLoading.cpp
@@ -169,8 +169,11 @@ LogicalResult getSegmentSizes(Operation *op, StringRef elemName,
 LogicalResult getOperandSegmentSizes(Operation *op,
                                      ArrayRef<Variadicity> variadicities,
                                      SmallVectorImpl<int> &segmentSizes) {
-  return getSegmentSizes(op, "operand", "operand_segment_sizes",
-                         op->getNumOperands(), variadicities, segmentSizes);
+  StringRef attrName = op->getAttr("operandSegmentSizes")
+                           ? "operandSegmentSizes"
+                           : "operand_segment_sizes";
+  return getSegmentSizes(op, "operand", attrName, op->getNumOperands(),
+                         variadicities, segmentSizes);
 }
 
 /// Compute the segment sizes of the given results.
@@ -180,8 +183,11 @@ LogicalResult getOperandSegmentSizes(Operation *op,
 LogicalResult getResultSegmentSizes(Operation *op,
                                     ArrayRef<Variadicity> variadicities,
                                     SmallVectorImpl<int> &segmentSizes) {
-  return getSegmentSizes(op, "result", "result_segment_sizes",
-                         op->getNumResults(), variadicities, segmentSizes);
+  StringRef attrName = op->getAttr("resultSegmentSizes")
+                           ? "resultSegmentSizes"
+                           : "result_segment_sizes";
+  return getSegmentSizes(op, "result", attrName, op->getNumResults(),
+                         variadicities, segmentSizes);
 }
 
 /// Verify that the given operation satisfies the given constraints.

--- a/mlir/lib/Dialect/IRDL/IRDLLoading.cpp
+++ b/mlir/lib/Dialect/IRDL/IRDLLoading.cpp
@@ -169,11 +169,8 @@ LogicalResult getSegmentSizes(Operation *op, StringRef elemName,
 LogicalResult getOperandSegmentSizes(Operation *op,
                                      ArrayRef<Variadicity> variadicities,
                                      SmallVectorImpl<int> &segmentSizes) {
-  StringRef attrName = op->getAttr("operandSegmentSizes")
-                           ? "operandSegmentSizes"
-                           : "operand_segment_sizes";
-  return getSegmentSizes(op, "operand", attrName, op->getNumOperands(),
-                         variadicities, segmentSizes);
+  return getSegmentSizes(op, "operand", "operandSegmentSizes",
+                         op->getNumOperands(), variadicities, segmentSizes);
 }
 
 /// Compute the segment sizes of the given results.
@@ -183,11 +180,8 @@ LogicalResult getOperandSegmentSizes(Operation *op,
 LogicalResult getResultSegmentSizes(Operation *op,
                                     ArrayRef<Variadicity> variadicities,
                                     SmallVectorImpl<int> &segmentSizes) {
-  StringRef attrName = op->getAttr("resultSegmentSizes")
-                           ? "resultSegmentSizes"
-                           : "result_segment_sizes";
-  return getSegmentSizes(op, "result", attrName, op->getNumResults(),
-                         variadicities, segmentSizes);
+  return getSegmentSizes(op, "result", "resultSegmentSizes",
+                         op->getNumResults(), variadicities, segmentSizes);
 }
 
 /// Verify that the given operation satisfies the given constraints.

--- a/mlir/test/Dialect/IRDL/variadics.mlir
+++ b/mlir/test/Dialect/IRDL/variadics.mlir
@@ -161,6 +161,18 @@ func.func @testMultOperands(%x: i16, %y: i32, %z: i64) {
   // CHECK-NEXT: "testvar.var_and_opt_operand"(%{{.*}}, %{{.*}}) {operand_segment_sizes = array<i32: 0, 1, 1>} : (i32, i64) -> ()
   return
 }
+// -----
+
+// Check that attribute 'operandSegmentSizes' can work well as 'operand_segment_sizes'
+func.func @testMultOperands(%x: i16, %y: i32, %z: i64) {
+  "testvar.var_and_opt_operand"(%x, %x, %z) {operandSegmentSizes = array<i32: 2, 0, 1>} : (i16, i16, i64) -> ()
+  // CHECK: "testvar.var_and_opt_operand"(%{{.*}}, %{{.*}}, %{{.*}}) {operandSegmentSizes = array<i32: 2, 0, 1>} : (i16, i16, i64) -> ()
+  "testvar.var_and_opt_operand"(%x, %x, %y, %z) {operandSegmentSizes = array<i32: 2, 1, 1>} : (i16, i16, i32, i64) -> ()
+  // CHECK-NEXT: "testvar.var_and_opt_operand"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {operandSegmentSizes = array<i32: 2, 1, 1>} : (i16, i16, i32, i64) -> ()
+  "testvar.var_and_opt_operand"(%y, %z) {operandSegmentSizes = array<i32: 0, 1, 1>} : (i32, i64) -> ()
+  // CHECK-NEXT: "testvar.var_and_opt_operand"(%{{.*}}, %{{.*}}) {operandSegmentSizes = array<i32: 0, 1, 1>} : (i32, i64) -> ()
+  return
+}
 
 // -----
 
@@ -360,6 +372,19 @@ func.func @testMultResults() {
   // CHECK-NEXT: "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 2, 1, 1>} : () -> (i16, i16, i32, i64)
   "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 0, 1, 1>} : () -> (i32, i64)
   // CHECK-NEXT: "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 0, 1, 1>} : () -> (i32, i64)
+  return
+}
+
+// -----
+
+// Check that attribute 'resultSegmentSizes' can work well as 'result_segment_sizes'
+func.func @testMultResults() {
+  "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 2, 0, 1>} : () -> (i16, i16, i64)
+  // CHECK: "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 2, 0, 1>} : () -> (i16, i16, i64)
+  "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 2, 1, 1>} : () -> (i16, i16, i32, i64)
+  // CHECK-NEXT: "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 2, 1, 1>} : () -> (i16, i16, i32, i64)
+  "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 0, 1, 1>} : () -> (i32, i64)
+  // CHECK-NEXT: "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 0, 1, 1>} : () -> (i32, i64)
   return
 }
 

--- a/mlir/test/Dialect/IRDL/variadics.mlir
+++ b/mlir/test/Dialect/IRDL/variadics.mlir
@@ -133,7 +133,7 @@ func.func @testOptOperandFail(%x: i16) {
 // Check that an operation with multiple variadics expects the segment size
 // attribute
 func.func @testMultOperandsMissingSegment(%x: i16, %z: i64) {
-  // expected-error@+1 {{'operand_segment_sizes' attribute is expected but not provided}}
+  // expected-error@+1 {{'operandSegmentSizes' attribute is expected but not provided}}
   "testvar.var_and_opt_operand"(%x, %x, %z) : (i16, i16, i64) -> ()
   return
 }
@@ -143,8 +143,8 @@ func.func @testMultOperandsMissingSegment(%x: i16, %z: i64) {
 // Check that an operation with multiple variadics expects the segment size
 // attribute of the right type
 func.func @testMultOperandsWrongSegmentType(%x: i16, %z: i64) {
-  // expected-error@+1 {{'operand_segment_sizes' attribute is expected to be a dense i32 array}}
-  "testvar.var_and_opt_operand"(%x, %x, %z) {operand_segment_sizes = i32} : (i16, i16, i64) -> ()
+  // expected-error@+1 {{'operandSegmentSizes' attribute is expected to be a dense i32 array}}
+  "testvar.var_and_opt_operand"(%x, %x, %z) {operandSegmentSizes = i32} : (i16, i16, i64) -> ()
   return
 }
 
@@ -152,18 +152,6 @@ func.func @testMultOperandsWrongSegmentType(%x: i16, %z: i64) {
 
 // Check that an operation with multiple variadics with the right segment size
 // verifies.
-func.func @testMultOperands(%x: i16, %y: i32, %z: i64) {
-  "testvar.var_and_opt_operand"(%x, %x, %z) {operand_segment_sizes = array<i32: 2, 0, 1>} : (i16, i16, i64) -> ()
-  // CHECK: "testvar.var_and_opt_operand"(%{{.*}}, %{{.*}}, %{{.*}}) {operand_segment_sizes = array<i32: 2, 0, 1>} : (i16, i16, i64) -> ()
-  "testvar.var_and_opt_operand"(%x, %x, %y, %z) {operand_segment_sizes = array<i32: 2, 1, 1>} : (i16, i16, i32, i64) -> ()
-  // CHECK-NEXT: "testvar.var_and_opt_operand"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {operand_segment_sizes = array<i32: 2, 1, 1>} : (i16, i16, i32, i64) -> ()
-  "testvar.var_and_opt_operand"(%y, %z) {operand_segment_sizes = array<i32: 0, 1, 1>} : (i32, i64) -> ()
-  // CHECK-NEXT: "testvar.var_and_opt_operand"(%{{.*}}, %{{.*}}) {operand_segment_sizes = array<i32: 0, 1, 1>} : (i32, i64) -> ()
-  return
-}
-// -----
-
-// Check that attribute 'operandSegmentSizes' can work well as 'operand_segment_sizes'
 func.func @testMultOperands(%x: i16, %y: i32, %z: i64) {
   "testvar.var_and_opt_operand"(%x, %x, %z) {operandSegmentSizes = array<i32: 2, 0, 1>} : (i16, i16, i64) -> ()
   // CHECK: "testvar.var_and_opt_operand"(%{{.*}}, %{{.*}}, %{{.*}}) {operandSegmentSizes = array<i32: 2, 0, 1>} : (i16, i16, i64) -> ()
@@ -178,8 +166,8 @@ func.func @testMultOperands(%x: i16, %y: i32, %z: i64) {
 
 // Check that the segment sizes expects non-negative values
 func.func @testMultOperandsSegmentNegative() {
-  // expected-error@+1 {{'operand_segment_sizes' attribute for specifying operand segments must have non-negative values}}
-  "testvar.var_and_opt_operand"() {operand_segment_sizes = array<i32: 2, -1, 1>} : () -> ()
+  // expected-error@+1 {{'operandSegmentSizes' attribute for specifying operand segments must have non-negative values}}
+  "testvar.var_and_opt_operand"() {operandSegmentSizes = array<i32: 2, -1, 1>} : () -> ()
   return
 }
 
@@ -187,8 +175,8 @@ func.func @testMultOperandsSegmentNegative() {
 
 // Check that the segment sizes expects 1 for single values
 func.func @testMultOperandsSegmentWrongSingle() {
-  // expected-error@+1 {{element 2 in 'operand_segment_sizes' attribute must be equal to 1}}
-  "testvar.var_and_opt_operand"() {operand_segment_sizes = array<i32: 0, 0, 0>} : () -> ()
+  // expected-error@+1 {{element 2 in 'operandSegmentSizes' attribute must be equal to 1}}
+  "testvar.var_and_opt_operand"() {operandSegmentSizes = array<i32: 0, 0, 0>} : () -> ()
   return
 }
 
@@ -196,8 +184,8 @@ func.func @testMultOperandsSegmentWrongSingle() {
 
 // Check that the segment sizes expects not more than 1 for optional values
 func.func @testMultOperandsSegmentWrongOptional() {
-  // expected-error@+1 {{element 1 in 'operand_segment_sizes' attribute must be equal to 0 or 1}}
-  "testvar.var_and_opt_operand"() {operand_segment_sizes = array<i32: 0, 2, 0>} : () -> ()
+  // expected-error@+1 {{element 1 in 'operandSegmentSizes' attribute must be equal to 0 or 1}}
+  "testvar.var_and_opt_operand"() {operandSegmentSizes = array<i32: 0, 2, 0>} : () -> ()
   return
 }
 
@@ -205,8 +193,8 @@ func.func @testMultOperandsSegmentWrongOptional() {
 
 // Check that the sum of the segment sizes should be equal to the number of operands
 func.func @testMultOperandsSegmentWrongOptional(%y: i32, %z: i64) {
-  // expected-error@+1 {{sum of elements in 'operand_segment_sizes' attribute must be equal to the number of operands}}
-  "testvar.var_and_opt_operand"(%y, %z) {operand_segment_sizes = array<i32: 0, 0, 1>} : (i32, i64) -> ()
+  // expected-error@+1 {{sum of elements in 'operandSegmentSizes' attribute must be equal to the number of operands}}
+  "testvar.var_and_opt_operand"(%y, %z) {operandSegmentSizes = array<i32: 0, 0, 1>} : (i32, i64) -> ()
   return
 }
 
@@ -346,7 +334,7 @@ func.func @testOptResultFail() {
 // Check that an operation with multiple variadics expects the segment size
 // attribute
 func.func @testMultResultsMissingSegment() {
-  // expected-error@+1 {{'result_segment_sizes' attribute is expected but not provided}}
+  // expected-error@+1 {{'resultSegmentSizes' attribute is expected but not provided}}
   "testvar.var_and_opt_result"() : () -> (i16, i16, i64)
   return
 }
@@ -356,8 +344,8 @@ func.func @testMultResultsMissingSegment() {
 // Check that an operation with multiple variadics expects the segment size
 // attribute of the right type
 func.func @testMultResultsWrongSegmentType() {
-  // expected-error@+1 {{'result_segment_sizes' attribute is expected to be a dense i32 array}}
-  "testvar.var_and_opt_result"() {result_segment_sizes = i32} : () -> (i16, i16, i64)
+  // expected-error@+1 {{'resultSegmentSizes' attribute is expected to be a dense i32 array}}
+  "testvar.var_and_opt_result"() {resultSegmentSizes = i32} : () -> (i16, i16, i64)
   return
 }
 
@@ -365,19 +353,6 @@ func.func @testMultResultsWrongSegmentType() {
 
 // Check that an operation with multiple variadics with the right segment size
 // verifies.
-func.func @testMultResults() {
-  "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 2, 0, 1>} : () -> (i16, i16, i64)
-  // CHECK: "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 2, 0, 1>} : () -> (i16, i16, i64)
-  "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 2, 1, 1>} : () -> (i16, i16, i32, i64)
-  // CHECK-NEXT: "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 2, 1, 1>} : () -> (i16, i16, i32, i64)
-  "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 0, 1, 1>} : () -> (i32, i64)
-  // CHECK-NEXT: "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 0, 1, 1>} : () -> (i32, i64)
-  return
-}
-
-// -----
-
-// Check that attribute 'resultSegmentSizes' can work well as 'result_segment_sizes'
 func.func @testMultResults() {
   "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 2, 0, 1>} : () -> (i16, i16, i64)
   // CHECK: "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 2, 0, 1>} : () -> (i16, i16, i64)
@@ -392,8 +367,8 @@ func.func @testMultResults() {
 
 // Check that the segment sizes expects non-negative values
 func.func @testMultResultsSegmentNegative() {
-  // expected-error@+1 {{'result_segment_sizes' attribute for specifying result segments must have non-negative values}}
-  "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 2, -1, 1>} : () -> ()
+  // expected-error@+1 {{'resultSegmentSizes' attribute for specifying result segments must have non-negative values}}
+  "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 2, -1, 1>} : () -> ()
   return
 }
 
@@ -401,8 +376,8 @@ func.func @testMultResultsSegmentNegative() {
 
 // Check that the segment sizes expects 1 for single values
 func.func @testMultResultsSegmentWrongSingle() {
-  // expected-error@+1 {{element 2 in 'result_segment_sizes' attribute must be equal to 1}}
-  "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 0, 0, 0>} : () -> ()
+  // expected-error@+1 {{element 2 in 'resultSegmentSizes' attribute must be equal to 1}}
+  "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 0, 0, 0>} : () -> ()
   return
 }
 
@@ -410,8 +385,8 @@ func.func @testMultResultsSegmentWrongSingle() {
 
 // Check that the segment sizes expects not more than 1 for optional values
 func.func @testMultResultsSegmentWrongOptional() {
-  // expected-error@+1 {{element 1 in 'result_segment_sizes' attribute must be equal to 0 or 1}}
-  "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 0, 2, 0>} : () -> ()
+  // expected-error@+1 {{element 1 in 'resultSegmentSizes' attribute must be equal to 0 or 1}}
+  "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 0, 2, 0>} : () -> ()
   return
 }
 
@@ -419,7 +394,7 @@ func.func @testMultResultsSegmentWrongOptional() {
 
 // Check that the sum of the segment sizes should be equal to the number of results
 func.func @testMultResultsSegmentWrongOptional() {
-  // expected-error@+1 {{sum of elements in 'result_segment_sizes' attribute must be equal to the number of results}}
-  "testvar.var_and_opt_result"() {result_segment_sizes = array<i32: 0, 0, 1>} : () -> (i32, i64)
+  // expected-error@+1 {{sum of elements in 'resultSegmentSizes' attribute must be equal to the number of results}}
+  "testvar.var_and_opt_result"() {resultSegmentSizes = array<i32: 0, 0, 1>} : () -> (i32, i64)
   return
 }


### PR DESCRIPTION
Two years ago, `operand_segment_sizes` and `result_segment_sizes` were renamed to `operandSegmentSizes` and `resultSegmentSizes` (check related commits, e.g. https://github.com/llvm/llvm-project/commit/363b655920c49a4bcb0869f820ed40aac834eebd).

However, the op verifiers in IRDL loading phase is still using old attributes like `operand_segment_sizes` and `result_segment_sizes`, which causes some conflict, e.g. it is not compatible with the OpView builder in MLIR python bindings (which generates camelCase segment attributes).

This PR is to support to use camelCase segment size attributes in IRDL verifier. Note that support of  `operand_segment_sizes` and `result_segment_sizes` is dropped.

I found this issue since I'm working on a new IRDL wrapper in the MLIR python bindings.
