### PR TITLE
[Clang] Refactor getOptimizationLevel and getOptimizationLevelSize to non-static. NFC.

### DIFF
--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -67,6 +67,11 @@ bool ParseDiagnosticArgs(DiagnosticOptions &Opts, llvm::opt::ArgList &Args,
                          DiagnosticsEngine *Diags = nullptr,
                          bool DefaultDiagColor = true);
 
+unsigned getOptimizationLevel(llvm::opt::ArgList &Args, InputKind IK,
+                              DiagnosticsEngine &Diags);
+
+unsigned getOptimizationLevelSize(llvm::opt::ArgList &Args);
+
 /// The base class of CompilerInvocation. It keeps individual option objects
 /// behind reference-counted pointers, which is useful for clients that want to
 /// keep select option objects alive (even after CompilerInvocation gets


### PR DESCRIPTION
So that we can reuse these functions in few place, such as in clang/lib/Driver/ToolChains/CommonArgs.cpp. Part of the code there is currently copied from getOptimizationLevel.