### PR TITLE
[llc][NPM] Use buffer_ostream support for non-seekable streams

### DIFF
--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -101,6 +101,13 @@ int llvm::compileModuleWithNewPM(
 
   raw_pwrite_stream *OS = &Out->os();
 
+  std::unique_ptr<buffer_ostream> BOS;
+  if (codegen::getFileType() != CodeGenFileType::AssemblyFile &&
+      !Out->os().supportsSeeking()) {
+    BOS = std::make_unique<buffer_ostream>(Out->os());
+    OS = BOS.get();
+  }
+
   // Fetch options from TargetPassConfig
   CGPassBuilderOption Opt = getCGPassBuilderOption();
   Opt.DisableVerify = VK != VerifierKind::InputOutput;


### PR DESCRIPTION
NPM was missing buffering for non-seekable output streams (stdout, pipes), causing assertion failures when generating object files with `-o -`.

Use buffer_ostream to provide seekable buffering, matching legacy PM behavior.