### PR TITLE
[mlir] Fix GCC compilation warning in TuneExtensionOps.cpp

### DIFF
--- a/mlir/lib/Dialect/Transform/TuneExtension/TuneExtensionOps.cpp
+++ b/mlir/lib/Dialect/Transform/TuneExtension/TuneExtensionOps.cpp
@@ -156,7 +156,7 @@ DiagnosedSilenceableFailure
 transform::tune::AlternativesOp::apply(transform::TransformRewriter &rewriter,
                                        transform::TransformResults &results,
                                        transform::TransformState &state) {
-  std::optional<size_t> selectedRegionIdx;
+  std::optional<int64_t> selectedRegionIdx;
 
   if (auto selectedRegionAttr = getSelectedRegionAttr())
     selectedRegionIdx = selectedRegionAttr->getSExtValue();
@@ -232,7 +232,7 @@ LogicalResult transform::tune::AlternativesOp::verify() {
   }
 
   if (auto selectedRegionAttr = getSelectedRegionAttr()) {
-    size_t regionIdx = selectedRegionAttr->getSExtValue();
+    int64_t regionIdx = selectedRegionAttr->getSExtValue();
     if (regionIdx < 0 || regionIdx >= getNumRegions())
       return emitOpError()
              << "'selected_region' attribute specifies region at index "

--- a/mlir/lib/Dialect/Transform/TuneExtension/TuneExtensionOps.cpp
+++ b/mlir/lib/Dialect/Transform/TuneExtension/TuneExtensionOps.cpp
@@ -177,7 +177,7 @@ transform::tune::AlternativesOp::apply(transform::TransformRewriter &rewriter,
                                  << " is only resolved through providing a "
                                     "`selected_region` attr/param";
 
-  if (*selectedRegionIdx >= getNumRegions())
+  if (*selectedRegionIdx < 0 || *selectedRegionIdx >= getNumRegions())
     return emitDefiniteFailure()
            << "'selected_region' attribute/param specifies region at index "
            << *selectedRegionIdx << " while op has only " << getNumRegions()
@@ -233,7 +233,7 @@ LogicalResult transform::tune::AlternativesOp::verify() {
 
   if (auto selectedRegionAttr = getSelectedRegionAttr()) {
     size_t regionIdx = selectedRegionAttr->getSExtValue();
-    if (regionIdx >= getNumRegions())
+    if (regionIdx < 0 || regionIdx >= getNumRegions())
       return emitOpError()
              << "'selected_region' attribute specifies region at index "
              << regionIdx << " while op has only " << getNumRegions()

--- a/mlir/lib/Dialect/Transform/TuneExtension/TuneExtensionOps.cpp
+++ b/mlir/lib/Dialect/Transform/TuneExtension/TuneExtensionOps.cpp
@@ -177,7 +177,7 @@ transform::tune::AlternativesOp::apply(transform::TransformRewriter &rewriter,
                                  << " is only resolved through providing a "
                                     "`selected_region` attr/param";
 
-  if (*selectedRegionIdx < 0 || *selectedRegionIdx >= getNumRegions())
+  if (*selectedRegionIdx >= getNumRegions())
     return emitDefiniteFailure()
            << "'selected_region' attribute/param specifies region at index "
            << *selectedRegionIdx << " while op has only " << getNumRegions()
@@ -233,7 +233,7 @@ LogicalResult transform::tune::AlternativesOp::verify() {
 
   if (auto selectedRegionAttr = getSelectedRegionAttr()) {
     size_t regionIdx = selectedRegionAttr->getSExtValue();
-    if (regionIdx < 0 || regionIdx >= getNumRegions())
+    if (regionIdx >= getNumRegions())
       return emitOpError()
              << "'selected_region' attribute specifies region at index "
              << regionIdx << " while op has only " << getNumRegions()


### PR DESCRIPTION
Building with GCC produces:
```
<...>/TuneExtensionOps.cpp:180:26: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
  180 |   if (*selectedRegionIdx < 0 || *selectedRegionIdx >= getNumRegions())
      |       ~~~~~~~~~~~~~~~~~~~^~~
<...>/TuneExtensionOps.cpp: In member function ‘llvm::LogicalResult mlir::transform::tune::AlternativesOp::verify()’:
/home/david.spickett/llvm-project/mlir/lib/Dialect/Transform/TuneExtension/TuneExtensionOps.cpp:236:19: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
  236 |     if (regionIdx < 0 || regionIdx >= getNumRegions())
      |         ~~~~~~~~~~^~~
```

As we are sign extending these variables, use int64_t instead of size_t for their type.