### PR TITLE
[compiler-rt] [test] Avoid error printouts if os.sysconf is missing

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -971,7 +971,7 @@ def target_page_size():
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
         )
-        out, err = proc.communicate(b'import os; print(os.sysconf("SC_PAGESIZE"))')
+        out, err = proc.communicate(b'import os; print(os.sysconf("SC_PAGESIZE") if hasattr(os, "sysconf") else "")')
         return int(out)
     except:
         return 4096

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -971,7 +971,9 @@ def target_page_size():
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
         )
-        out, err = proc.communicate(b'import os; print(os.sysconf("SC_PAGESIZE") if hasattr(os, "sysconf") else "")')
+        out, err = proc.communicate(
+            b'import os; print(os.sysconf("SC_PAGESIZE") if hasattr(os, "sysconf") else "")'
+        )
         return int(out)
     except:
         return 4096


### PR DESCRIPTION
This avoids dozens of instances of benign error messages being printed when running the tests on e.g. Windows:

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    AttributeError: module 'os' has no attribute 'sysconf'