### PR TITLE
[compiler-rt] [test] Generalize an UNSUPPORTED marking

### DIFF
--- a/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
+++ b/compiler-rt/test/asan/TestCases/stack_container_dynamic_lib.cpp
@@ -1,6 +1,6 @@
 // Test to demonstrate compile-time disabling of container-overflow checks
 // in order to handle uninstrumented libraries
-// UNSUPPORTED: target={{.*windows-msvc.*}}
+// UNSUPPORTED: target={{.*windows-.*}}
 
 // Mimic a closed-source library compiled without ASan
 // RUN: %clangxx_asan -fno-sanitize=address -DSHARED_LIB %s %fPIC -shared -o %t-so.so


### PR DESCRIPTION
Don't specifically target windows-msvc - the same goes for any windows target; mingw doesn't have dlfcn.h either.