### PR TITLE
[windows] improve python3.dll load check

### DIFF
--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -477,18 +477,17 @@ bool AddPythonDLLToSearchPath() {
 #endif
 
 #ifdef LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
-/// Returns whether `python3x.dll` is in the DLL search path.
+/// Returns true if `python3x.dll` can be loaded.
 bool IsPythonDLLInPath() {
 #define WIDEN2(x) L##x
 #define WIDEN(x) WIDEN2(x)
-  WCHAR foundPath[MAX_PATH];
-  DWORD result =
-      SearchPathW(nullptr, WIDEN(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME), nullptr,
-                  MAX_PATH, foundPath, nullptr);
+  HMODULE h = LoadLibraryW(WIDEN(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME));
+  if (!h)
+    return false;
+  FreeLibrary(h);
+  return true;
 #undef WIDEN2
 #undef WIDEN
-
-  return result > 0;
 }
 #endif
 


### PR DESCRIPTION
This patch improves the detection of `python3x.dll`.

`SearchPathW` does not account for `SetDllDirectoryW`. Therefore, when manually adding `python3x.dll` to the search path, `SearchPathW` will still return that it has not been found, resulting in a false negative.

This patch ensures that the driver uses the same mechanism as the loader to attempt to load `python3x.dll` using `LoadLibraryW`.

rdar://165123628