### PR TITLE
[CFIInserter] Improve `CSRSavedLocation` struct.

### DIFF
--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -102,7 +102,7 @@ class CFIInstrInserter : public MachineFunctionPass {
     } U;
 
   public:
-    CSRSavedLocation() { K = Kind::Invalid; }
+    CSRSavedLocation() {}
 
     static CSRSavedLocation createCFAOffset(int64_t Offset) {
       CSRSavedLocation Loc;
@@ -135,7 +135,7 @@ class CFIInstrInserter : public MachineFunctionPass {
         return false;
       switch (K) {
       case Kind::Invalid:
-        return !RHS.isValid();
+        return true;
       case Kind::Register:
         return getRegister() == RHS.getRegister();
       case Kind::CFAOffset:

--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -121,12 +121,12 @@ class CFIInstrInserter : public MachineFunctionPass {
     bool isValid() const { return K != Kind::Invalid; }
 
     unsigned getRegister() const {
-      assert(K == Register);
+      assert(K == Kind::Register);
       return U.Reg;
     }
 
     int64_t getOffset() const {
-      assert(K == Register);
+      assert(K == Kind::CFAOffset);
       return U.Offset;
     }
 

--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -99,7 +99,7 @@ class CFIInstrInserter : public MachineFunctionPass {
       unsigned Reg;
       // CFA offset
       int64_t Offset;
-    }
+    };
 
   public:
     CSRSavedLocation() {}

--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -99,7 +99,7 @@ class CFIInstrInserter : public MachineFunctionPass {
       unsigned Reg;
       // CFA offset
       int64_t Offset;
-    } U;
+    }
 
   public:
     CSRSavedLocation() {}
@@ -107,14 +107,14 @@ class CFIInstrInserter : public MachineFunctionPass {
     static CSRSavedLocation createCFAOffset(int64_t Offset) {
       CSRSavedLocation Loc;
       Loc.K = Kind::CFAOffset;
-      Loc.U.Offset = Offset;
+      Loc.Offset = Offset;
       return Loc;
     }
 
     static CSRSavedLocation createRegister(unsigned Reg) {
       CSRSavedLocation Loc;
       Loc.K = Kind::Register;
-      Loc.U.Reg = Reg;
+      Loc.Reg = Reg;
       return Loc;
     }
 
@@ -122,12 +122,12 @@ class CFIInstrInserter : public MachineFunctionPass {
 
     unsigned getRegister() const {
       assert(K == Kind::Register);
-      return U.Reg;
+      return Reg;
     }
 
     int64_t getOffset() const {
       assert(K == Kind::CFAOffset);
-      return U.Offset;
+      return Offset;
     }
 
     bool operator==(const CSRSavedLocation &RHS) const {

--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -319,10 +319,13 @@ void CFIInstrInserter::calculateOutgoingCFAInfo(MBBCFAInfo &MBBInfo) {
       case MCCFIInstruction::OpValOffset:
         break;
       }
+      assert((bool)CSRReg + (bool)CSROffset <= 1 &&
+             "A register can only be at an offset from CFA or in another "
+             "register, but not both!");
       CSRSavedLocation CSRLoc;
       if (CSRReg)
         CSRLoc = CSRSavedLocation::createRegister(*CSRReg);
-      if (CSROffset)
+      else if (CSROffset)
         CSRLoc = CSRSavedLocation::createCFAOffset(*CSROffset);
       if (CSRLoc.isValid()) {
         auto It = CSRLocMap.find(CFI.getRegister());


### PR DESCRIPTION
(1) Define `CSRSavedLocation::Kind` and use it in the code. This makes the code more readable and allows to extend it to new kinds. For example, soon I want to add "scalable offset from a given register" kind.

(2) Store the contents in a union. This should reduce memory usage.