### PR TITLE
[OpenMP][libomp] Add transparent task flag bit to kmp_tasking_flags

### DIFF
--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -2731,7 +2731,7 @@ typedef struct kmp_tasking_flags { /* Total struct must be exactly 32 bits */
   unsigned detachable : 1; /* 1 == can detach */
   unsigned free_agent_eligible : 1; /* set if task can be executed by a
                                        free-agent thread */
-  unsigned transparent: 1; /* transparent task support (compiler uses this) */
+  unsigned transparent : 1; /* transparent task support (compiler uses this) */
   unsigned reserved : 7; /* reserved for compiler use */
 
   /* Library flags */ /* Total library flags must be 16 bits */

--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -2731,7 +2731,8 @@ typedef struct kmp_tasking_flags { /* Total struct must be exactly 32 bits */
   unsigned detachable : 1; /* 1 == can detach */
   unsigned free_agent_eligible : 1; /* set if task can be executed by a
                                        free-agent thread */
-  unsigned reserved : 8; /* reserved for compiler use */
+  unsigned transparent: 1; /* transparent task support (compiler uses this) */
+  unsigned reserved : 7; /* reserved for compiler use */
 
   /* Library flags */ /* Total library flags must be 16 bits */
   unsigned tasktype : 1; /* task is either explicit(1) or implicit (0) */

--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -2707,9 +2707,9 @@ typedef struct kmp_tasking_flags { /* Total struct must be exactly 32 bits */
   unsigned tasking_ser : 1;
   unsigned task_serial : 1;
   unsigned tasktype : 1;
-  unsigned reserved : 8;
-  unsigned free_agent_eligible : 1;
+  unsigned reserved : 7;
   unsigned transparent : 1;
+  unsigned free_agent_eligible : 1;
   unsigned detachable : 1;
   unsigned priority_specified : 1;
   unsigned proxy : 1;

--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -2709,6 +2709,7 @@ typedef struct kmp_tasking_flags { /* Total struct must be exactly 32 bits */
   unsigned tasktype : 1;
   unsigned reserved : 8;
   unsigned free_agent_eligible : 1;
+  unsigned transparent : 1;
   unsigned detachable : 1;
   unsigned priority_specified : 1;
   unsigned proxy : 1;


### PR DESCRIPTION
Clang is adding support for the new `OpenMP transparent` clause on `task` and `taskloop` directives.
The parsing and semantic handling for this clause is introduced in https://github.com/llvm/llvm-project/pull/166810 .
To allow the compiler to communicate this clause to the `OpenMP` runtime, a dedicated bit in `kmp_tasking_flags` is required.
This patch adds a new compiler-reserved bit `transparent` to the` kmp_tasking_flags` structure.