### PR TITLE
Fix build breakage when using modules

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -10,7 +10,6 @@ module LLVM_Analysis {
 
   // This is intended for (repeated) textual inclusion.
   textual header "llvm/Analysis/ScalarFuncs.def"
-  textual header "llvm/Analysis/TargetLibraryInfo.def"
   textual header "llvm/Analysis/VecFuncs.def"
 }
 


### PR DESCRIPTION
Commit c9f573463ebd7b4e46da4877802f2364f700e54a removed the file TargetLibraryInfo.def but did not remove it from the module map.