### PR TITLE
[MLIR][CODEOWNERS] Add XeGPU transform ops code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,8 @@
 /mlir/lib/Conversion/*XeGPU* @charithaintc @Jianhui-Li
 /mlir/include/mlir/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li
 /mlir/lib/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li
+/mlir/include/mlir/Dialect/XeGPU/TransformOps @charithaintc @Jianhui-Li @tkarna
+/mlir/lib/Dialect/XeGPU/TransformOps @charithaintc @Jianhui-Li @tkarna
 /mlir/include/mlir/Dialect/LLVMIR/XeVM* @silee2
 /mlir/lib/Dialect/LLVMIR/IR/XeVM @silee2
 /mlir/lib/Conversion/*XeVM* @silee2


### PR DESCRIPTION
Add charithaintc, Jianhui-Li and tkarna as code owners of XeGPU/TransformOps directories.

Extends #166971