### PR TITLE
[LLDB] Add empty Microsoft ABI language runtime

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CMakeLists.txt
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CMakeLists.txt
@@ -11,4 +11,4 @@ add_lldb_library(lldbPluginCPPRuntime
 )
 
 add_subdirectory(ItaniumABI)
-#add_subdirectory(MicrosoftABI)
+add_subdirectory(MicrosoftABI)

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -491,3 +491,10 @@ bool CPPLanguageRuntime::IsSymbolARuntimeThunk(const Symbol &symbol) {
   return mangled_name.starts_with("_ZTh") || mangled_name.starts_with("_ZTv") ||
          mangled_name.starts_with("_ZTc");
 }
+
+bool CPPLanguageRuntime::ShouldUseMicrosoftABI(Process *process) {
+  return process->GetTarget()
+      .GetArchitecture()
+      .GetTriple()
+      .isWindowsMSVCEnvironment();
+}

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h
@@ -81,6 +81,8 @@ public:
 
   bool IsSymbolARuntimeThunk(const Symbol &symbol) override;
 
+  static bool ShouldUseMicrosoftABI(Process *process);
+
 protected:
   // Classes that inherit from CPPLanguageRuntime can see and modify these
   CPPLanguageRuntime(Process *process);

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
@@ -397,9 +397,9 @@ TypeAndOrName ItaniumABILanguageRuntime::FixUpDynamicType(
 LanguageRuntime *
 ItaniumABILanguageRuntime::CreateInstance(Process *process,
                                           lldb::LanguageType language) {
-  // FIXME: We have to check the process and make sure we actually know that
-  // this process supports
-  // the Itanium ABI.
+  if (ShouldUseMicrosoftABI(process))
+    return nullptr;
+
   if (language == eLanguageTypeC_plus_plus ||
       language == eLanguageTypeC_plus_plus_03 ||
       language == eLanguageTypeC_plus_plus_11 ||

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/MicrosoftABI/CMakeLists.txt
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/MicrosoftABI/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_lldb_library(lldbPluginCXXMicrosoftABI PLUGIN
+  MicrosoftABILanguageRuntime.cpp
+
+  LINK_LIBS
+    lldbPluginCPPRuntime
+)

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/MicrosoftABI/MicrosoftABILanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/MicrosoftABI/MicrosoftABILanguageRuntime.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MicrosoftABILanguageRuntime.h"
+
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Target/Process.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+LLDB_PLUGIN_DEFINE_ADV(MicrosoftABILanguageRuntime, CXXMicrosoftABI)
+
+char MicrosoftABILanguageRuntime::ID = 0;
+
+void MicrosoftABILanguageRuntime::Initialize() {
+  PluginManager::RegisterPlugin(GetPluginNameStatic(),
+                                "Microsoft ABI for the C++ language",
+                                CreateInstance);
+}
+
+void MicrosoftABILanguageRuntime::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
+
+LanguageRuntime *
+MicrosoftABILanguageRuntime::CreateInstance(Process *process,
+                                            lldb::LanguageType language) {
+  if (!ShouldUseMicrosoftABI(process))
+    return nullptr;
+
+  if (!(language == eLanguageTypeC_plus_plus ||
+        language == eLanguageTypeC_plus_plus_03 ||
+        language == eLanguageTypeC_plus_plus_11 ||
+        language == eLanguageTypeC_plus_plus_14))
+    return nullptr;
+
+  return new MicrosoftABILanguageRuntime(process);
+}
+
+llvm::Expected<LanguageRuntime::VTableInfo>
+MicrosoftABILanguageRuntime::GetVTableInfo(ValueObject &in_value,
+                                           bool check_type) {
+  return llvm::createStringError("Not implemented");
+}
+
+bool MicrosoftABILanguageRuntime::GetDynamicTypeAndAddress(
+    ValueObject &in_value, lldb::DynamicValueType use_dynamic,
+    TypeAndOrName &class_type_or_name, Address &address,
+    Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) {
+  return false;
+}
+
+TypeAndOrName MicrosoftABILanguageRuntime::FixUpDynamicType(
+    const TypeAndOrName &type_and_or_name, ValueObject &static_value) {
+  return type_and_or_name;
+}
+
+bool MicrosoftABILanguageRuntime::CouldHaveDynamicValue(ValueObject &in_value) {
+  return false;
+}
+
+lldb::BreakpointResolverSP MicrosoftABILanguageRuntime::CreateExceptionResolver(
+    const lldb::BreakpointSP &bkpt, bool catch_bp, bool throw_bp) {
+  return nullptr;
+}

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/MicrosoftABI/MicrosoftABILanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/MicrosoftABI/MicrosoftABILanguageRuntime.h
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_LANGUAGERUNTIME_CPLUSPLUS_MICROSOFTABI_MICROSOFTABILANGUAGERUNTIME_H
+#define LLDB_SOURCE_PLUGINS_LANGUAGERUNTIME_CPLUSPLUS_MICROSOFTABI_MICROSOFTABILANGUAGERUNTIME_H
+
+#include "lldb/Core/Value.h"
+#include "lldb/Symbol/Type.h"
+#include "lldb/Target/LanguageRuntime.h"
+
+#include "Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h"
+
+namespace lldb_private {
+
+class MicrosoftABILanguageRuntime : public CPPLanguageRuntime {
+public:
+  static void Initialize();
+
+  static void Terminate();
+
+  static lldb_private::LanguageRuntime *
+  CreateInstance(Process *process, lldb::LanguageType language);
+
+  static llvm::StringRef GetPluginNameStatic() { return "microsoft-abi"; }
+
+  static char ID;
+
+  bool isA(const void *ClassID) const override {
+    return ClassID == &ID || CPPLanguageRuntime::isA(ClassID);
+  }
+
+  static bool classof(const LanguageRuntime *runtime) {
+    return runtime->isA(&ID);
+  }
+
+  llvm::Expected<LanguageRuntime::VTableInfo>
+  GetVTableInfo(ValueObject &in_value, bool check_type) override;
+
+  bool GetDynamicTypeAndAddress(ValueObject &in_value,
+                                lldb::DynamicValueType use_dynamic,
+                                TypeAndOrName &class_type_or_name,
+                                Address &address, Value::ValueType &value_type,
+                                llvm::ArrayRef<uint8_t> &local_buffer) override;
+
+  TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,
+                                 ValueObject &static_value) override;
+
+  bool CouldHaveDynamicValue(ValueObject &in_value) override;
+
+  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
+
+  lldb::BreakpointResolverSP
+  CreateExceptionResolver(const lldb::BreakpointSP &bkpt, bool catch_bp,
+                          bool throw_bp) override;
+
+private:
+  MicrosoftABILanguageRuntime(Process *process) : CPPLanguageRuntime(process) {}
+};
+
+} // namespace lldb_private
+
+#endif


### PR DESCRIPTION
To support dynamic values and C++ exception breakpoints with the MSVC/Microsoft ABI in the future, this PR adds a minimal/empty language runtime. Since the Itanium ABI didn't resolve any types or create exception breakpoints on windows-msvc, it shouldn't change any behavior.

The Microsoft ABI is used in processes with the windows-msvc target. MinGW uses windows-gnu, so it should be unaffected.