### PR TITLE
[libc] Removed unused flags from baremetal cache files

### DIFF
--- a/libc/cmake/caches/armv6m-none-eabi.cmake
+++ b/libc/cmake/caches/armv6m-none-eabi.cmake
@@ -2,7 +2,7 @@ set(CMAKE_SYSTEM_PROCESSOR arm CACHE STRING "")
 set(RUNTIMES_TARGET_TRIPLE "armv6m-none-eabi" CACHE STRING "")
 
 foreach(lang C;CXX;ASM)
-    set(CMAKE_${lang}_FLAGS "-march=armv6m -mcpu=cortex-m0plus -mfloat-abi=soft -Wno-atomic-alignment \"-Dvfprintf(stream, format, vlist)=vprintf(format, vlist)\" \"-Dfprintf(stream, format, ...)=printf(format)\" \"-Dfputs(string, stream)=puts(string)\" -D_LIBCPP_PRINT=1" CACHE STRING "")
+    set(CMAKE_${lang}_FLAGS "-march=armv6m -mcpu=cortex-m0plus -mfloat-abi=soft -Wno-atomic-alignment" CACHE STRING "")
 endforeach()
 
 include(${CMAKE_CURRENT_LIST_DIR}/baremetal_common.cmake)

--- a/libc/cmake/caches/armv7em-none-eabi.cmake
+++ b/libc/cmake/caches/armv7em-none-eabi.cmake
@@ -2,7 +2,7 @@ set(CMAKE_SYSTEM_PROCESSOR arm CACHE STRING "")
 set(RUNTIMES_TARGET_TRIPLE "armv7em-none-eabi" CACHE STRING "")
 
 foreach(lang C;CXX;ASM)
-    set(CMAKE_${lang}_FLAGS "-march=armv7em -mcpu=cortex-m4 -mfloat-abi=soft -Wno-atomic-alignment \"-Dvfprintf(stream, format, vlist)=vprintf(format, vlist)\" \"-Dfprintf(stream, format, ...)=printf(format)\" \"-Dfputs(string, stream)=puts(string)\" -D_LIBCPP_PRINT=1" CACHE STRING "")
+    set(CMAKE_${lang}_FLAGS "-march=armv7em -mcpu=cortex-m4 -mfloat-abi=soft -Wno-atomic-alignment" CACHE STRING "")
 endforeach()
 
 include(${CMAKE_CURRENT_LIST_DIR}/baremetal_common.cmake)

--- a/libc/cmake/caches/armv7m-none-eabi.cmake
+++ b/libc/cmake/caches/armv7m-none-eabi.cmake
@@ -2,7 +2,7 @@ set(CMAKE_SYSTEM_PROCESSOR arm CACHE STRING "")
 set(RUNTIMES_TARGET_TRIPLE "armv7m-none-eabi" CACHE STRING "")
 
 foreach(lang C;CXX;ASM)
-    set(CMAKE_${lang}_FLAGS "-march=armv7m -mcpu=cortex-m4 -mfloat-abi=soft -Wno-atomic-alignment \"-Dvfprintf(stream, format, vlist)=vprintf(format, vlist)\" \"-Dfprintf(stream, format, ...)=printf(format)\" \"-Dfputs(string, stream)=puts(string)\" -D_LIBCPP_PRINT=1" CACHE STRING "")
+    set(CMAKE_${lang}_FLAGS "-march=armv7m -mcpu=cortex-m4 -mfloat-abi=soft -Wno-atomic-alignment" CACHE STRING "")
 endforeach()
 
 include(${CMAKE_CURRENT_LIST_DIR}/baremetal_common.cmake)


### PR DESCRIPTION
These flags are not needed for building libc.