### PR TITLE
Desugar complex element types for promoted complex division

### DIFF
--- a/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/clang/lib/CodeGen/CGExprComplex.cpp
@@ -320,7 +320,8 @@ public:
   QualType getPromotionType(FPOptionsOverride Features, QualType Ty,
                             bool IsComplexDivisor) {
     if (auto *CT = Ty->getAs<ComplexType>()) {
-      QualType ElementType = CT->getElementType();
+      QualType ElementType =
+          CT->getElementType().getDesugaredType(CGF.getContext());
       bool IsFloatingType = ElementType->isFloatingType();
       bool IsComplexRangePromoted = CGF.getLangOpts().getComplexRange() ==
                                     LangOptions::ComplexRangeKind::CX_Promoted;

--- a/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/clang/lib/CodeGen/CGExprComplex.cpp
@@ -320,8 +320,7 @@ public:
   QualType getPromotionType(FPOptionsOverride Features, QualType Ty,
                             bool IsComplexDivisor) {
     if (auto *CT = Ty->getAs<ComplexType>()) {
-      QualType ElementType =
-          CT->getElementType().getDesugaredType(CGF.getContext());
+      QualType ElementType = CT->getElementType().getCanonicalType();
       bool IsFloatingType = ElementType->isFloatingType();
       bool IsComplexRangePromoted = CGF.getLangOpts().getComplexRange() ==
                                     LangOptions::ComplexRangeKind::CX_Promoted;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -10726,13 +10726,13 @@ static void DetectPrecisionLossInComplexDivision(Sema &S, QualType DivisorTy,
   if (!CT)
     return;
 
-  ASTContext &Ctx = S.getASTContext();
-  QualType ElementType = CT->getElementType().getDesugaredType(Ctx);
+  QualType ElementType = CT->getElementType().getCanonicalType();
   bool IsComplexRangePromoted = S.getLangOpts().getComplexRange() ==
                                 LangOptions::ComplexRangeKind::CX_Promoted;
   if (!ElementType->isFloatingType() || !IsComplexRangePromoted)
     return;
 
+  ASTContext &Ctx = S.getASTContext();
   QualType HigherElementType = Ctx.GetHigherPrecisionFPType(ElementType);
   const llvm::fltSemantics &ElementTypeSemantics =
       Ctx.getFloatTypeSemantics(ElementType);

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -10726,13 +10726,13 @@ static void DetectPrecisionLossInComplexDivision(Sema &S, QualType DivisorTy,
   if (!CT)
     return;
 
-  QualType ElementType = CT->getElementType();
+  ASTContext &Ctx = S.getASTContext();
+  QualType ElementType = CT->getElementType().getDesugaredType(Ctx);
   bool IsComplexRangePromoted = S.getLangOpts().getComplexRange() ==
                                 LangOptions::ComplexRangeKind::CX_Promoted;
   if (!ElementType->isFloatingType() || !IsComplexRangePromoted)
     return;
 
-  ASTContext &Ctx = S.getASTContext();
   QualType HigherElementType = Ctx.GetHigherPrecisionFPType(ElementType);
   const llvm::fltSemantics &ElementTypeSemantics =
       Ctx.getFloatTypeSemantics(ElementType);


### PR DESCRIPTION
This patch fixes a crash in Clang that occurs when the compiler retrieves the element type of a complex type but receives a sugared type. See example here: https://godbolt.org/z/cdbdeMcaT 
This patch fixes the crash.