### PR TITLE
[libc++][NFC] Refactor __request_unbuffered_mode

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -419,14 +419,12 @@ private:
   // If the file is already open, switch to unbuffered mode. Otherwise, record
   // the request to use unbuffered mode so that we use that mode when we
   // eventually open the file.
-  _LIBCPP_HIDE_FROM_ABI void __request_unbuffered_mode(char_type* __s, streamsize __n) {
-    if (__cm_ == __no_io_operations && __s == nullptr && __n == 0) {
-      if (__file_) {
-        std::setbuf(__file_, nullptr);
-        __cm_ = 0;
-      } else {
-        __cm_ = __no_io_operations | __use_unbuffered_io;
-      }
+  _LIBCPP_HIDE_FROM_ABI void __request_unbuffered_mode() {
+    if (__file_) {
+      std::setbuf(__file_, nullptr);
+      __cm_ = 0;
+    } else {
+      __cm_ = __no_io_operations | __use_unbuffered_io;
     }
   }
 
@@ -934,7 +932,9 @@ template <class _CharT, class _Traits>
 basic_streambuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::setbuf(char_type* __s, streamsize __n) {
   this->setg(nullptr, nullptr, nullptr);
   this->setp(nullptr, nullptr);
-  __request_unbuffered_mode(__s, __n);
+  // Calling setbuf(nullptr, 0) before any i/o operation switches the stream to unbuffered mode
+  if (__cm_ == __no_io_operations && __s == nullptr && __n == 0)
+    __request_unbuffered_mode();
   if (__owns_eb_)
     delete[] __extbuf_;
   if (__owns_ib_)


### PR DESCRIPTION
It's a bit awkward to pass the char* and the size to the function, which then only decides whether it should be a no-op with it. Instead, only call the function when the pointer is null and n is 0, which matches more closely what the standard says with respect to calling pubsetbuf(0, 0).