### PR TITLE
[libc] Add missing dependencies for arpa/inet.h header.

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -200,6 +200,8 @@ add_header_macro(
   DEPENDS
     .llvm_libc_common_h
     .inttypes
+    .llvm-libc-types.in_addr
+    .llvm-libc-types.in_addr_t
 )
 
 file(MAKE_DIRECTORY ${LIBC_INCLUDE_DIR}/netinet)


### PR DESCRIPTION
Add dependency on headers with `in_addr` and `in_addr_t` type definitions to ensure that these headers will be properly installed by "install-libc" CMake target.