### PR TITLE
[bazel] Replace --experimental_guard_against_concurrent_changes usage

### DIFF
--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -13,7 +13,7 @@ common --enable_bzlmod --noenable_workspace
 common --legacy_external_runfiles
 
 # Prevent invalid caching if input files are modified during a build.
-build --experimental_guard_against_concurrent_changes
+build --guard_against_concurrent_changes
 
 # Automatically enable --config=(linux|macos|windows) based on the host
 build --enable_platform_specific_config


### PR DESCRIPTION
On startup, bazel prints: `WARNING: Option 'experimental_guard_against_concurrent_changes' is deprecated: Use --guard_against_concurrent_changes instead`
