### PR TITLE
Revert "[NFC][bugpoint] Namespace cleanup in `bugpoint`"

### DIFF
--- a/llvm/tools/bugpoint/BugDriver.h
+++ b/llvm/tools/bugpoint/BugDriver.h
@@ -16,7 +16,6 @@
 #define LLVM_TOOLS_BUGPOINT_BUGDRIVER_H
 
 #include "llvm/IR/ValueMap.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
@@ -41,10 +40,6 @@ extern bool DisableSimplifyCFG;
 /// BugpointIsInterrupted - Set to true when the user presses ctrl-c.
 ///
 extern bool BugpointIsInterrupted;
-
-/// Command line options used across files.
-extern cl::list<std::string> InputArgv;
-extern cl::opt<std::string> OutputPrefix;
 
 class BugDriver {
   LLVMContext &Context;

--- a/llvm/tools/bugpoint/CrashDebugger.cpp
+++ b/llvm/tools/bugpoint/CrashDebugger.cpp
@@ -87,9 +87,10 @@ static bool isValidModule(std::unique_ptr<Module> &M,
   return false;
 }
 
+namespace llvm {
 // Note this class needs to be in llvm namespace since its declared as a friend
 // of BugDriver.
-class llvm::ReducePassList : public ListReducer<std::string> {
+class ReducePassList : public ListReducer<std::string> {
   BugDriver &BD;
 
 public:
@@ -101,6 +102,7 @@ public:
   Expected<TestResult> doTest(std::vector<std::string> &Removed,
                               std::vector<std::string> &Kept) override;
 };
+} // namespace llvm
 
 Expected<ReducePassList::TestResult>
 ReducePassList::doTest(std::vector<std::string> &Prefix,

--- a/llvm/tools/bugpoint/ExecutionDriver.cpp
+++ b/llvm/tools/bugpoint/ExecutionDriver.cpp
@@ -13,6 +13,7 @@
 
 #include "BugDriver.h"
 #include "ToolRunner.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/Program.h"
@@ -101,13 +102,15 @@ static cl::opt<std::string> CustomExecCommand(
 
 // Anything specified after the --args option are taken as arguments to the
 // program being debugged.
-cl::list<std::string> llvm::InputArgv("args", cl::Positional,
-                                      cl::desc("<program arguments>..."),
-                                      cl::PositionalEatsArgs);
+namespace llvm {
+cl::list<std::string> InputArgv("args", cl::Positional,
+                                cl::desc("<program arguments>..."),
+                                cl::PositionalEatsArgs);
 
-cl::opt<std::string> llvm::OutputPrefix(
-    "output-prefix", cl::init("bugpoint"),
-    cl::desc("Prefix to use for outputs (default: 'bugpoint')"));
+cl::opt<std::string>
+    OutputPrefix("output-prefix", cl::init("bugpoint"),
+                 cl::desc("Prefix to use for outputs (default: 'bugpoint')"));
+} // namespace llvm
 
 static cl::list<std::string> ToolArgv("tool-args", cl::Positional,
                                       cl::desc("<tool arguments>..."),

--- a/llvm/tools/bugpoint/ExtractFunction.cpp
+++ b/llvm/tools/bugpoint/ExtractFunction.cpp
@@ -36,6 +36,9 @@ using namespace llvm;
 #define DEBUG_TYPE "bugpoint"
 
 bool llvm::DisableSimplifyCFG = false;
+namespace llvm {
+extern cl::opt<std::string> OutputPrefix;
+} // namespace llvm
 
 static cl::opt<bool>
     NoDCE("disable-dce",

--- a/llvm/tools/bugpoint/Miscompilation.cpp
+++ b/llvm/tools/bugpoint/Miscompilation.cpp
@@ -28,6 +28,11 @@
 
 using namespace llvm;
 
+namespace llvm {
+extern cl::opt<std::string> OutputPrefix;
+extern cl::list<std::string> InputArgv;
+} // end namespace llvm
+
 static cl::opt<bool> DisableLoopExtraction(
     "disable-loop-extraction",
     cl::desc("Don't extract loops when searching for miscompilations"),

--- a/llvm/tools/bugpoint/OptimizerDriver.cpp
+++ b/llvm/tools/bugpoint/OptimizerDriver.cpp
@@ -34,6 +34,10 @@ using namespace llvm;
 
 #define DEBUG_TYPE "bugpoint"
 
+namespace llvm {
+extern cl::opt<std::string> OutputPrefix;
+}
+
 static cl::opt<std::string>
     OptCmd("opt-command", cl::init(""),
            cl::desc("Path to opt. (default: search path "


### PR DESCRIPTION
Reverts llvm/llvm-project#168921

Causes build failures.