### PR TITLE
[clang-doc] Fix `</section>` mismatch in the namespace template

### DIFF
--- a/clang-tools-extra/clang-doc/assets/namespace-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/namespace-template.mustache
@@ -97,8 +97,8 @@
                             </li>
                         {{/Records}}
                         </ul>
-                    {{/HasRecords}}
                     </section>
+                    {{/HasRecords}}
                 </div>
             </div>
         </main>

--- a/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: clang-doc --format=mustache --output=%t --executor=standalone %s 
 // RUN: FileCheck %s < %t/html/MyNamespace/index.html
+// RUN: FileCheck %s < %t/html/GlobalNamespace/index.html --check-prefix=CHECK-GLOBAL
 
 namespace MyNamespace {
   class Foo;
@@ -13,3 +14,18 @@ namespace MyNamespace {
 // CHECK-NEXT:        </a>
 // CHECK-NEXT:    </li>
 // CHECK-NEXT: </ul>
+
+// COM: Check that the empty global namespace doesn't contain tag mismatches.
+// CHECK-GLOBAL:             <main>
+// CHECK-GLOBAL-NEXT:            <div class="container">
+// CHECK-GLOBAL-NEXT:                <div class="sidebar">
+// CHECK-GLOBAL-NEXT:                    <h2> </h2>
+// CHECK-GLOBAL-NEXT:                    <ul>
+// CHECK-GLOBAL-NEXT:                    </ul>
+// CHECK-GLOBAL-NEXT:                </div>
+// CHECK-GLOBAL-NEXT:                <div class="resizer" id="resizer"></div>
+// CHECK-GLOBAL-NEXT:                <div class="content">
+// CHECK-GLOBAL-EMPTY:
+// CHECK-GLOBAL-NEXT:                </div>
+// CHECK-GLOBAL-NEXT:            </div>
+// CHECK-GLOBAL-NEXT:        </main>


### PR DESCRIPTION
A `</section>` tag wasn't inside the `{{#HasRecords}}` Mustache tag, which caused a
mismatch if there weren't any records to render.