### PR TITLE
[clang][deps] Use the caching VFS even in the 'preprocess' mode

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScannerImpl.cpp
@@ -524,8 +524,8 @@ bool dependencies::initializeScanCompilerInstance(
   // Create a new FileManager to match the invocation's FileSystemOptions.
   ScanInstance.createFileManager();
 
-  // Use the dependency scanning optimized file system if requested to do so.
-  if (DepFS) {
+  // Use DepFS for getting the dependency directives if requested to do so.
+  if (Service.getMode() == ScanningMode::DependencyDirectivesScan) {
     DepFS->resetBypassedPathPrefix();
     SmallString<256> ModulesCachePath;
     normalizeModuleCachePath(ScanInstance.getFileManager(),
@@ -717,7 +717,7 @@ bool CompilerInstanceWithContext::initialize(DiagnosticConsumer *DC) {
   }
 
   std::tie(OverlayFS, CommandLine) = initVFSForByNameScanning(
-      Worker.BaseFS, CommandLine, CWD, "ScanningByName");
+      Worker.DepFS, CommandLine, CWD, "ScanningByName");
 
   DiagEngineWithCmdAndOpts = std::make_unique<DignosticsEngineWithDiagOpts>(
       CommandLine, OverlayFS, *DiagConsumer);


### PR DESCRIPTION
The dependency scanner worker's VFS originally unconditionally did two things: file system access caching and dependency directives extraction. That's why `clang-scan-deps -mode preprocess` avoided using the VFS entirely. Since then, the dependency directives extraction was made lazy/on-demand/optional, meaning it should be possible to use only the caching parts of the VFS. This PR does exactly that, speeding up `clang-scan-deps -mode preprocess` on my config of Clang/LLVM from ~80s to ~38s. (For comparison, `clang-scan-deps -mode preprocess-dependency-directives` runs in ~13s.)

(The real motivation was to simplify the VFS handling in the scanner, this is just a nice side-effect.)