### PR TITLE
[GitHub] Add review instructions for commit access requests

### DIFF
--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -526,7 +526,10 @@ Most commonly these reviewers will provide the necessary approval, but approvals
 from other LLVM committers are also acceptable. Those reviewing the application are
 confirming that you have indeed had three patches committed, and that based on interactions
 on those reviews and elsewhere in the LLVM community they have no concern about you
-adhering to our Developer Policy and Code of Conduct.
+adhering to our Developer Policy and Code of Conduct. Reviewers should clearly state their
+reasoning for accepting or rejecting the request, and finish with a clear statement such
+as "I approve of this request" or "I do not approve of this request".
+
 
 If approved, a GitHub invitation will be sent to your
 GitHub account. In case you don't get notification from GitHub, go to

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -528,7 +528,7 @@ confirming that you have indeed had three patches committed, and that based on i
 on those reviews and elsewhere in the LLVM community they have no concern about you
 adhering to our Developer Policy and Code of Conduct. Reviewers should clearly state their
 reasoning for accepting or rejecting the request, and finish with a clear statement such
-as "I approve of this request" or "I do not approve of this request".
+as "I approve of this request", "LGTM", or "I do not approve of this request".
 
 
 If approved, a GitHub invitation will be sent to your

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -306,7 +306,7 @@ class CommitRequestGreeter:
             * Top 3 Committers: {get_user_values_str(get_top_values(merged_by))}
             * Top 3 Reviewers: {get_user_values_str(get_top_values(reviewed_by))}
 
-            Reviewers should clearly state their reasoning for accepting or rejecting this request, and finish with a clear statement such as \"I approve of this request\" or \"I do not approve of this request\". Please review the instructions for [obtaining commit access](https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access).
+            Reviewers should clearly state their reasoning for accepting or rejecting this request, and finish with a clear statement such as \"I approve of this request\", \"LGTM\", or \"I do not approve of this request\". Please review the instructions for [obtaining commit access](https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access).
         """
         self.issue.create_comment(textwrap.dedent(comment))
 

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -305,6 +305,8 @@ class CommitRequestGreeter:
             * [{merged_prs} Merged Pull Requests]({merged_prs_url})
             * Top 3 Committers: {get_user_values_str(get_top_values(merged_by))}
             * Top 3 Reviewers: {get_user_values_str(get_top_values(reviewed_by))}
+
+            Reviewers should clearly state their reasoning for accepting or rejecting this request, and finish with a clear statement such as \"I approve of this request\" or \"I do not approve of this request\". Please review the instructions for [obtaining commit access](https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access).
         """
         self.issue.create_comment(textwrap.dedent(comment))
 


### PR DESCRIPTION
As discussed in https://discourse.llvm.org/t/clarification-on-how-to-accept-commit-access-requests/88728, clarify reviewer instructions for how to accept commit access requests.