### PR TITLE
[test][Support] Disable SignalsTest.PrintsSymbolizerMarkup

### DIFF
--- a/llvm/unittests/Support/SignalsTest.cpp
+++ b/llvm/unittests/Support/SignalsTest.cpp
@@ -32,6 +32,11 @@ using testing::Not;
 #if defined(HAVE_BACKTRACE) && ENABLE_BACKTRACES &&                            \
     (defined(__linux__) || defined(__FreeBSD__) ||                             \
      defined(__FreeBSD_kernel__) || defined(__NetBSD__))
+// Test relies on the binary this test is linked into having a GNU build ID
+// note, which is not universally enabled by default (even when using Clang).
+// Disable until we can reliably detect whether this is the case and skip it if
+// not. See https://github.com/llvm/llvm-project/issues/168891.
+#if 0
 TEST(SignalsTest, PrintsSymbolizerMarkup) {
   auto Exit =
       make_scope_exit([]() { unsetenv("LLVM_ENABLE_SYMBOLIZER_MARKUP"); });
@@ -51,6 +56,7 @@ TEST(SignalsTest, PrintsSymbolizerMarkup) {
   // Backtrace line
   EXPECT_THAT(Res, MatchesRegex(".*" TAG_BEGIN "bt:0:" P_REGEX ".*"));
 }
+#endif
 
 TEST(SignalsTest, SymbolizerMarkupDisabled) {
   auto Exit = make_scope_exit([]() { unsetenv("LLVM_DISABLE_SYMBOLIZATION"); });


### PR DESCRIPTION
This test checks that DSOMarkupPrinter::printDSOMarkup prints the module
and segment mappings, but that is only done if we can determine the GNU
build ID for the given object, and in many environments that is not
enabled by default (e.g. the FreeBSD Clang driver never enables it, and
various other Clang drivers only do so when ENABLE_LINKER_BUILD_ID is
opted into at configure time). GCC tends to enable it by default, and
many distributions enable it for Clang, so this has gone unnoticed for a
while, but this test has been failing on FreeBSD since its creation.

Fixes: 22b9404f09dc ("Optionally print symbolizer markup backtraces.")
See: https://github.com/llvm/llvm-project/issues/168891
