### PR TITLE
[NVPTX] Use correct `mul.wide` operand type when matching on `shl` in `combineMulWide`

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -5896,8 +5896,8 @@ static SDValue combineMulWide(SDNode *N, TargetLowering::DAGCombinerInfo &DCI,
   SDValue RHS = Op.getOperand(1);
   if (Op.getOpcode() == ISD::SHL) {
     const auto ShiftAmt = Op.getConstantOperandVal(1);
-    const auto MulVal = APInt(ToVT.getSizeInBits(), 1) << ShiftAmt;
-    RHS = DCI.DAG.getConstant(MulVal, DL, ToVT);
+    const auto MulVal = APInt(FromVT.getSizeInBits(), 1) << ShiftAmt;
+    RHS = DCI.DAG.getConstant(MulVal, DL, FromVT);
   }
   return DCI.DAG.getNode(Opcode, DL, ToVT, Op.getOperand(0), RHS);
 }

--- a/llvm/test/CodeGen/NVPTX/combine-mul-wide-type.ll
+++ b/llvm/test/CodeGen/NVPTX/combine-mul-wide-type.ll
@@ -1,0 +1,35 @@
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_20 -O3 -debug-only=dagcombine 2>&1 | FileCheck %s
+; REQUIRES: asserts
+
+; Test that combineMulWide creates the constant with the correct type (FromVT).
+; This catches a bug where ToVT was incorrectly used instead of FromVT,
+; resulting in a type mismatch (e.g., i32 constant instead of i16).
+
+; CHECK: MUL_WIDE_SIGNED {{.*}}, Constant:i16<16384>
+define i32 @shl_sext_i16(i16 %a) {
+  %shl = shl nsw i16 %a, 14
+  %conv = sext i16 %shl to i32
+  ret i32 %conv
+}
+
+; CHECK: MUL_WIDE_UNSIGNED {{.*}}, Constant:i16<16384>
+define i32 @shl_zext_i16(i16 %a) {
+  %shl = shl nuw i16 %a, 14
+  %conv = zext i16 %shl to i32
+  ret i32 %conv
+}
+
+; CHECK: MUL_WIDE_SIGNED {{.*}}, Constant:i32<1073741824>
+define i64 @shl_sext_i32(i32 %a) {
+  %shl = shl nsw i32 %a, 30
+  %conv = sext i32 %shl to i64
+  ret i64 %conv
+}
+
+; CHECK: MUL_WIDE_UNSIGNED {{.*}}, Constant:i32<1073741824>
+define i64 @shl_zext_i32(i32 %a) {
+  %shl = shl nuw i32 %a, 30
+  %conv = zext i32 %shl to i64
+  ret i64 %conv
+}
+

--- a/llvm/test/CodeGen/NVPTX/combine-mul-wide-type.ll
+++ b/llvm/test/CodeGen/NVPTX/combine-mul-wide-type.ll
@@ -5,28 +5,28 @@
 ; This catches a bug where ToVT was incorrectly used instead of FromVT,
 ; resulting in a type mismatch (e.g., i32 constant instead of i16).
 
-; CHECK: MUL_WIDE_SIGNED {{.*}}, Constant:i16<16384>
+; CHECK: i32 = NVPTXISD::MUL_WIDE_SIGNED {{.*}}, Constant:i16<16384>
 define i32 @shl_sext_i16(i16 %a) {
   %shl = shl nsw i16 %a, 14
   %conv = sext i16 %shl to i32
   ret i32 %conv
 }
 
-; CHECK: MUL_WIDE_UNSIGNED {{.*}}, Constant:i16<16384>
+; CHECK: i32 = NVPTXISD::MUL_WIDE_UNSIGNED {{.*}}, Constant:i16<16384>
 define i32 @shl_zext_i16(i16 %a) {
   %shl = shl nuw i16 %a, 14
   %conv = zext i16 %shl to i32
   ret i32 %conv
 }
 
-; CHECK: MUL_WIDE_SIGNED {{.*}}, Constant:i32<1073741824>
+; CHECK: i64 = NVPTXISD::MUL_WIDE_SIGNED {{.*}}, Constant:i32<1073741824>
 define i64 @shl_sext_i32(i32 %a) {
   %shl = shl nsw i32 %a, 30
   %conv = sext i32 %shl to i64
   ret i64 %conv
 }
 
-; CHECK: MUL_WIDE_UNSIGNED {{.*}}, Constant:i32<1073741824>
+; CHECK: i64 = NVPTXISD::MUL_WIDE_UNSIGNED {{.*}}, Constant:i32<1073741824>
 define i64 @shl_zext_i32(i32 %a) {
   %shl = shl nuw i32 %a, 30
   %conv = zext i32 %shl to i64

--- a/llvm/test/CodeGen/NVPTX/combine-mul-wide-type.ll
+++ b/llvm/test/CodeGen/NVPTX/combine-mul-wide-type.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_20 -O3 -debug-only=dagcombine 2>&1 | FileCheck %s
+; RUN: llc < %s -mtriple=nvptx64 -O3 -debug-only=dagcombine 2>&1 | FileCheck %s
 ; REQUIRES: asserts
 
 ; Test that combineMulWide creates the constant with the correct type (FromVT).


### PR DESCRIPTION
The operand types of a `mul.wide` are half the size of the output type. `combineMulWide` incorrectly uses the output type of the `mul.wide` for the operand type. 