### PR TITLE
[MLIR] Drop use of REQUIRES:shell from tests

### DIFF
--- a/mlir/test/Target/SPIRV/mlir-translate.mlir
+++ b/mlir/test/Target/SPIRV/mlir-translate.mlir
@@ -1,7 +1,6 @@
 // Check that `--spirv-save-validation-files-with-prefix` generates
 // a correct number of files.
 
-// REQUIRES: shell
 // RUN: rm -rf %t
 // RUN: mkdir %t && mlir-translate --serialize-spirv --no-implicit-module \
 // RUN: --split-input-file --spirv-save-validation-files-with-prefix=%t/foo %s \

--- a/mlir/test/Target/SPIRV/module.mlir
+++ b/mlir/test/Target/SPIRV/module.mlir
@@ -1,6 +1,5 @@
 // RUN: mlir-translate --no-implicit-module --test-spirv-roundtrip --split-input-file %s | FileCheck %s
 
-// REQUIRES: shell
 // RUN: %if spirv-tools %{ rm -rf %t %}
 // RUN: %if spirv-tools %{ mkdir %t %}
 // RUN: %if spirv-tools %{ mlir-translate --no-implicit-module --serialize-spirv --split-input-file --spirv-save-validation-files-with-prefix=%t/module %s %}


### PR DESCRIPTION
This patch drops two instances of REQUIRES: shell from MLIR tests. This feature does not mean much given the internal shell is the default for MLIR. It does prevent these tests from running on Windows, but it does not seem like there is anything inherent to these tests preventing them from running on Windows (minus maybe the lack of spirv-tools, which is explicitly required anyways.