### PR TITLE
[lldb] Fix testErrorMessages test cases in commands/trace/

### DIFF
--- a/lldb/test/API/commands/trace/TestTraceDumpInfo.py
+++ b/lldb/test/API/commands/trace/TestTraceDumpInfo.py
@@ -34,7 +34,7 @@ class TestTraceDumpInfo(TraceIntelPTTestCaseBase):
 
         self.expect(
             "thread trace dump info",
-            substrs=["error: Process is not being traced"],
+            substrs=["error: process is not being traced"],
             error=True,
         )
 

--- a/lldb/test/API/commands/trace/TestTraceExport.py
+++ b/lldb/test/API/commands/trace/TestTraceExport.py
@@ -38,7 +38,7 @@ class TestTraceExport(TraceIntelPTTestCaseBase):
 
         self.expect(
             f"thread trace export ctf --file {ctf_test_file}",
-            substrs=["error: Process is not being traced"],
+            substrs=["error: process is not being traced"],
             error=True,
         )
 

--- a/lldb/test/API/commands/trace/TestTraceSave.py
+++ b/lldb/test/API/commands/trace/TestTraceSave.py
@@ -40,7 +40,7 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
         self.expect("run")
 
         self.expect(
-            "trace save", substrs=["error: Process is not being traced"], error=True
+            "trace save", substrs=["error: process is not being traced"], error=True
         )
 
     @skipIfNoIntelPT


### PR DESCRIPTION
This patch fix the assertion text in `testErrorMessages` in some IntelPT test cases. 

Test: 
Enable intel-pt test plygin with cmake flag: `-DLLDB_BUILD_INTEL_PT=ON` and together with `DLIBIPT_INCLUDE_PATH` `DLIBIPT_LIBRARY_PATH` and `DLIBIPT_LIBRARY` 

build lldb 
 
lldb-dotest -p TestTraceDumpInfo
lldb-dotest -p TestTraceExport 
lldb-dotest -p TestTraceSave