### PR TITLE
[NVVM] Move print functions from NVVMIntrinsicUtils.h to cpp file

### DIFF
--- a/llvm/include/llvm/IR/NVVMIntrinsicUtils.h
+++ b/llvm/include/llvm/IR/NVVMIntrinsicUtils.h
@@ -662,50 +662,9 @@ inline APFloat::roundingMode GetFMARoundingMode(Intrinsic::ID IntrinsicID) {
   llvm_unreachable("Invalid FP instrinsic rounding mode for NVVM fma");
 }
 
-inline void printTcgen05MMAKind(raw_ostream &OS, const Constant *ImmArgVal) {
-  if (const auto *CI = dyn_cast<ConstantInt>(ImmArgVal)) {
-    uint64_t Val = CI->getZExtValue();
-    switch (static_cast<Tcgen05MMAKind>(Val)) {
-    case Tcgen05MMAKind::F16:
-      OS << "f16";
-      return;
-    case Tcgen05MMAKind::TF32:
-      OS << "tf32";
-      return;
-    case Tcgen05MMAKind::F8F6F4:
-      OS << "f8f6f4";
-      return;
-    case Tcgen05MMAKind::I8:
-      OS << "i8";
-      return;
-    }
-  }
-  llvm_unreachable(
-      "printTcgen05MMAKind called with invalid value for immediate argument");
-}
+void printTcgen05MMAKind(raw_ostream &OS, const Constant *ImmArgVal);
 
-inline void printTcgen05CollectorUsageOp(raw_ostream &OS,
-                                         const Constant *ImmArgVal) {
-  if (const auto *CI = dyn_cast<ConstantInt>(ImmArgVal)) {
-    uint64_t Val = CI->getZExtValue();
-    switch (static_cast<Tcgen05CollectorUsageOp>(Val)) {
-    case Tcgen05CollectorUsageOp::DISCARD:
-      OS << "discard";
-      return;
-    case Tcgen05CollectorUsageOp::LASTUSE:
-      OS << "lastuse";
-      return;
-    case Tcgen05CollectorUsageOp::FILL:
-      OS << "fill";
-      return;
-    case Tcgen05CollectorUsageOp::USE:
-      OS << "use";
-      return;
-    }
-  }
-  llvm_unreachable("printTcgen05CollectorUsageOp called with invalid value for "
-                   "immediate argument");
-}
+void printTcgen05CollectorUsageOp(raw_ostream &OS, const Constant *ImmArgVal);
 
 } // namespace nvvm
 } // namespace llvm

--- a/llvm/include/llvm/IR/NVVMIntrinsicUtils.h
+++ b/llvm/include/llvm/IR/NVVMIntrinsicUtils.h
@@ -59,6 +59,10 @@ enum class Tcgen05CollectorUsageOp : uint8_t {
   USE = 3,
 };
 
+void printTcgen05MMAKind(raw_ostream &OS, const Constant *ImmArgVal);
+
+void printTcgen05CollectorUsageOp(raw_ostream &OS, const Constant *ImmArgVal);
+
 inline bool FPToIntegerIntrinsicShouldFTZ(Intrinsic::ID IntrinsicID) {
   switch (IntrinsicID) {
   case Intrinsic::nvvm_f2i_rm_ftz:
@@ -661,10 +665,6 @@ inline APFloat::roundingMode GetFMARoundingMode(Intrinsic::ID IntrinsicID) {
   }
   llvm_unreachable("Invalid FP instrinsic rounding mode for NVVM fma");
 }
-
-void printTcgen05MMAKind(raw_ostream &OS, const Constant *ImmArgVal);
-
-void printTcgen05CollectorUsageOp(raw_ostream &OS, const Constant *ImmArgVal);
 
 } // namespace nvvm
 } // namespace llvm

--- a/llvm/lib/IR/CMakeLists.txt
+++ b/llvm/lib/IR/CMakeLists.txt
@@ -35,6 +35,7 @@ add_llvm_component_library(LLVMCore
   GVMaterializer.cpp
   Globals.cpp
   Intrinsics.cpp
+  NVVMIntrinsicUtils.cpp
   IRBuilder.cpp
   IRPrintingPasses.cpp
   SSAContext.cpp

--- a/llvm/lib/IR/NVVMIntrinsicUtils.cpp
+++ b/llvm/lib/IR/NVVMIntrinsicUtils.cpp
@@ -38,7 +38,7 @@ void nvvm::printTcgen05MMAKind(raw_ostream &OS, const Constant *ImmArgVal) {
 }
 
 void nvvm::printTcgen05CollectorUsageOp(raw_ostream &OS,
-                                  const Constant *ImmArgVal) {
+                                        const Constant *ImmArgVal) {
   if (const auto *CI = dyn_cast<ConstantInt>(ImmArgVal)) {
     uint64_t Val = CI->getZExtValue();
     switch (static_cast<Tcgen05CollectorUsageOp>(Val)) {

--- a/llvm/lib/IR/NVVMIntrinsicUtils.cpp
+++ b/llvm/lib/IR/NVVMIntrinsicUtils.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements functions associated with NVVM Intrinsics.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/NVVMIntrinsicUtils.h"
+
+using namespace llvm;
+using namespace nvvm;
+
+void nvvm::printTcgen05MMAKind(raw_ostream &OS, const Constant *ImmArgVal) {
+  if (const auto *CI = dyn_cast<ConstantInt>(ImmArgVal)) {
+    uint64_t Val = CI->getZExtValue();
+    switch (static_cast<Tcgen05MMAKind>(Val)) {
+    case Tcgen05MMAKind::F16:
+      OS << "f16";
+      return;
+    case Tcgen05MMAKind::TF32:
+      OS << "tf32";
+      return;
+    case Tcgen05MMAKind::F8F6F4:
+      OS << "f8f6f4";
+      return;
+    case Tcgen05MMAKind::I8:
+      OS << "i8";
+      return;
+    }
+  }
+  llvm_unreachable(
+      "printTcgen05MMAKind called with invalid value for immediate argument");
+}
+
+void nvvm::printTcgen05CollectorUsageOp(raw_ostream &OS,
+                                  const Constant *ImmArgVal) {
+  if (const auto *CI = dyn_cast<ConstantInt>(ImmArgVal)) {
+    uint64_t Val = CI->getZExtValue();
+    switch (static_cast<Tcgen05CollectorUsageOp>(Val)) {
+    case Tcgen05CollectorUsageOp::DISCARD:
+      OS << "discard";
+      return;
+    case Tcgen05CollectorUsageOp::LASTUSE:
+      OS << "lastuse";
+      return;
+    case Tcgen05CollectorUsageOp::FILL:
+      OS << "fill";
+      return;
+    case Tcgen05CollectorUsageOp::USE:
+      OS << "use";
+      return;
+    }
+  }
+  llvm_unreachable("printTcgen05CollectorUsageOp called with invalid value for "
+                   "immediate argument");
+}


### PR DESCRIPTION
This patch moves the print functions from `NVVMIntrinsicUtils.h` to `NVVMIntrinsicUtils.cpp`, a file created in the `llvm/lib/IR` directory.