### PR TITLE
[orc-rt] Rename 'Session' variables to avoid ambiguity with type. NFCI.

### DIFF
--- a/orc-rt/include/orc-rt-c/WrapperFunction.h
+++ b/orc-rt/include/orc-rt-c/WrapperFunction.h
@@ -54,7 +54,7 @@ typedef struct {
  * Asynchronous return function for an orc-rt wrapper function.
  */
 typedef void (*orc_rt_WrapperFunctionReturn)(
-    orc_rt_SessionRef Session, uint64_t CallId,
+    orc_rt_SessionRef S, uint64_t CallId,
     orc_rt_WrapperFunctionBuffer ResultBytes);
 
 /**
@@ -65,8 +65,7 @@ typedef void (*orc_rt_WrapperFunctionReturn)(
  * CallId holds a pointer to the context object for this particular call.
  * Return holds a pointer to the return function.
  */
-typedef void (*orc_rt_WrapperFunction)(orc_rt_SessionRef Session,
-                                       uint64_t CallId,
+typedef void (*orc_rt_WrapperFunction)(orc_rt_SessionRef S, uint64_t CallId,
                                        orc_rt_WrapperFunctionReturn Return,
                                        orc_rt_WrapperFunctionBuffer ArgBytes);
 

--- a/orc-rt/include/orc-rt/SPSWrapperFunction.h
+++ b/orc-rt/include/orc-rt/SPSWrapperFunction.h
@@ -124,10 +124,10 @@ template <typename SPSSig> struct SPSWrapperFunction {
   }
 
   template <typename Handler>
-  static void handle(orc_rt_SessionRef Session, uint64_t CallId,
+  static void handle(orc_rt_SessionRef S, uint64_t CallId,
                      orc_rt_WrapperFunctionReturn Return,
                      WrapperFunctionBuffer ArgBytes, Handler &&H) {
-    WrapperFunction::handle(Session, CallId, Return, std::move(ArgBytes),
+    WrapperFunction::handle(S, CallId, Return, std::move(ArgBytes),
                             WrapperFunctionSPSSerializer<SPSSig>(),
                             std::forward<Handler>(H));
   }

--- a/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
+++ b/orc-rt/include/orc-rt/SimpleNativeMemoryMap.h
@@ -114,21 +114,21 @@ private:
 } // namespace orc_rt
 
 ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_reserve_sps_wrapper(
-    orc_rt_SessionRef Session, uint64_t CallId,
-    orc_rt_WrapperFunctionReturn Return, orc_rt_WrapperFunctionBuffer ArgBytes);
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
+    orc_rt_WrapperFunctionBuffer ArgBytes);
 
 ORC_RT_SPS_INTERFACE void
 orc_rt_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper(
-    orc_rt_SessionRef Session, uint64_t CallId,
-    orc_rt_WrapperFunctionReturn Return, orc_rt_WrapperFunctionBuffer ArgBytes);
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
+    orc_rt_WrapperFunctionBuffer ArgBytes);
 
 ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_initialize_sps_wrapper(
-    orc_rt_SessionRef Session, uint64_t CallId,
-    orc_rt_WrapperFunctionReturn Return, orc_rt_WrapperFunctionBuffer ArgBytes);
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
+    orc_rt_WrapperFunctionBuffer ArgBytes);
 
 ORC_RT_SPS_INTERFACE void
 orc_rt_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper(
-    orc_rt_SessionRef Session, uint64_t CallId,
-    orc_rt_WrapperFunctionReturn Return, orc_rt_WrapperFunctionBuffer ArgBytes);
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
+    orc_rt_WrapperFunctionBuffer ArgBytes);
 
 #endif // ORC_RT_SIMPLENATIVEMEMORYMAP_H

--- a/orc-rt/include/orc-rt/WrapperFunction.h
+++ b/orc-rt/include/orc-rt/WrapperFunction.h
@@ -137,16 +137,15 @@ using WFHandlerTraits = CallableTraitsHelper<WFHandlerTraitsImpl, C>;
 
 template <typename Serializer> class StructuredYieldBase {
 public:
-  StructuredYieldBase(orc_rt_SessionRef Session, uint64_t CallId,
-                      orc_rt_WrapperFunctionReturn Return, Serializer &&S)
-      : Session(Session), CallId(CallId), Return(Return),
-        S(std::forward<Serializer>(S)) {}
+  StructuredYieldBase(orc_rt_SessionRef S, uint64_t CallId,
+                      orc_rt_WrapperFunctionReturn Return, Serializer &&Z)
+      : S(S), CallId(CallId), Return(Return), Z(std::forward<Serializer>(Z)) {}
 
 protected:
-  orc_rt_SessionRef Session;
+  orc_rt_SessionRef S;
   uint64_t CallId;
   orc_rt_WrapperFunctionReturn Return;
-  std::decay_t<Serializer> S;
+  std::decay_t<Serializer> Z;
 };
 
 template <typename RetT, typename Serializer> class StructuredYield;
@@ -157,10 +156,10 @@ class StructuredYield<std::tuple<RetT>, Serializer>
 public:
   using StructuredYieldBase<Serializer>::StructuredYieldBase;
   void operator()(RetT &&R) {
-    if (auto ResultBytes = this->S.result().serialize(std::forward<RetT>(R)))
-      this->Return(this->Session, this->CallId, ResultBytes->release());
+    if (auto ResultBytes = this->Z.result().serialize(std::forward<RetT>(R)))
+      this->Return(this->S, this->CallId, ResultBytes->release());
     else
-      this->Return(this->Session, this->CallId,
+      this->Return(this->S, this->CallId,
                    WrapperFunctionBuffer::createOutOfBandError(
                        "Could not serialize wrapper function result data")
                        .release());
@@ -173,8 +172,7 @@ class StructuredYield<std::tuple<>, Serializer>
 public:
   using StructuredYieldBase<Serializer>::StructuredYieldBase;
   void operator()() {
-    this->Return(this->Session, this->CallId,
-                 WrapperFunctionBuffer().release());
+    this->Return(this->S, this->CallId, WrapperFunctionBuffer().release());
   }
 };
 
@@ -251,12 +249,12 @@ struct WrapperFunction {
   ///
   ///
   ///   static void adder_add_async_sps_wrapper(
-  ///       orc_rt_SessionRef Session, uint64_t CallId,
+  ///       orc_rt_SessionRef S, uint64_t CallId,
   ///       orc_rt_WrapperFunctionReturn Return,
   ///       orc_rt_WrapperFunctionBuffer ArgBytes) {
   ///     using SPSSig = SPSString(SPSExecutorAddr, int32_t, bool);
   ///     SPSWrapperFunction<SPSSig>::handle(
-  ///         Session, CallId, Return, ArgBytes,
+  ///         S, CallId, Return, ArgBytes,
   ///         WrapperFunction::handleWithAsyncMethod(&MyClass::myMethod));
   ///   }
   ///   @endcode
@@ -313,12 +311,12 @@ struct WrapperFunction {
   ///
   ///
   ///   static void adder_add_sync_sps_wrapper(
-  ///       orc_rt_SessionRef Session, uint64_t CallId,
+  ///       orc_rt_SessionRef S, uint64_t CallId,
   ///       orc_rt_WrapperFunctionReturn Return,
   ///       orc_rt_WrapperFunctionBuffer ArgBytes) {
   ///     using SPSSig = SPSString(SPSExecutorAddr, int32_t, bool);
   ///     SPSWrapperFunction<SPSSig>::handle(
-  ///         Session, CallId, Return, ArgBytes,
+  ///         S, CallId, Return, ArgBytes,
   ///         WrapperFunction::handleWithSyncMethod(&Adder::addSync));
   ///   }
   ///   @endcode
@@ -336,7 +334,7 @@ struct WrapperFunction {
   /// given Caller object.
   template <typename Caller, typename Serializer, typename ResultHandler,
             typename... ArgTs>
-  static void call(Caller &&C, Serializer &&S, ResultHandler &&RH,
+  static void call(Caller &&C, Serializer &&Z, ResultHandler &&RH,
                    ArgTs &&...Args) {
     typedef CallableArgInfo<ResultHandler> ResultHandlerTraits;
     static_assert(std::is_void_v<typename ResultHandlerTraits::return_type>,
@@ -346,16 +344,15 @@ struct WrapperFunction {
         "Result-handler should have exactly one argument");
     typedef typename ResultHandlerTraits::args_tuple_type ResultTupleType;
 
-    if (auto ArgBytes = S.arguments().serialize(std::forward<ArgTs>(Args)...)) {
+    if (auto ArgBytes = Z.arguments().serialize(std::forward<ArgTs>(Args)...)) {
       C(
-          [RH = std::move(RH),
-           S = std::move(S)](orc_rt_SessionRef Session,
-                             WrapperFunctionBuffer ResultBytes) mutable {
+          [RH = std::move(RH), Z = std::move(Z)](
+              orc_rt_SessionRef S, WrapperFunctionBuffer ResultBytes) mutable {
             if (const char *ErrMsg = ResultBytes.getOutOfBandError())
               RH(make_error<StringError>(ErrMsg));
             else
               RH(detail::ResultDeserializer<ResultTupleType, Serializer>::
-                     deserialize(std::move(ResultBytes), S));
+                     deserialize(std::move(ResultBytes), Z));
           },
           std::move(*ArgBytes));
     } else
@@ -368,9 +365,9 @@ struct WrapperFunction {
   /// This utility deserializes and serializes arguments and return values
   /// (using the given Serializer), and calls the given handler.
   template <typename Serializer, typename Handler>
-  static void handle(orc_rt_SessionRef Session, uint64_t CallId,
+  static void handle(orc_rt_SessionRef S, uint64_t CallId,
                      orc_rt_WrapperFunctionReturn Return,
-                     WrapperFunctionBuffer ArgBytes, Serializer &&S,
+                     WrapperFunctionBuffer ArgBytes, Serializer &&Z,
                      Handler &&H) {
     typedef detail::WFHandlerTraits<Handler> HandlerTraits;
     typedef typename HandlerTraits::ArgTupleType ArgTuple;
@@ -380,16 +377,16 @@ struct WrapperFunction {
     typedef typename CallableArgInfo<Yield>::args_tuple_type RetTupleType;
 
     if (ArgBytes.getOutOfBandError())
-      return Return(Session, CallId, ArgBytes.release());
+      return Return(S, CallId, ArgBytes.release());
 
-    if (auto Args = S.arguments().template deserialize<ArgTuple>(ArgBytes))
+    if (auto Args = Z.arguments().template deserialize<ArgTuple>(ArgBytes))
       std::apply(HandlerTraits::forwardArgsAsRequested(bind_front(
                      std::forward<Handler>(H),
                      detail::StructuredYield<RetTupleType, Serializer>(
-                         Session, CallId, Return, std::move(S)))),
+                         S, CallId, Return, std::move(Z)))),
                  *Args);
     else
-      Return(Session, CallId,
+      Return(S, CallId,
              WrapperFunctionBuffer::createOutOfBandError(
                  "Could not deserialize wrapper function arg data")
                  .release());

--- a/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
+++ b/orc-rt/lib/executor/SimpleNativeMemoryMap.cpp
@@ -367,45 +367,41 @@ Error SimpleNativeMemoryMap::recordDeallocActions(
 }
 
 ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_reserve_sps_wrapper(
-    orc_rt_SessionRef Session, uint64_t CallId,
-    orc_rt_WrapperFunctionReturn Return,
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
     orc_rt_WrapperFunctionBuffer ArgBytes) {
   using Sig = SPSExpected<SPSExecutorAddr>(SPSExecutorAddr, SPSSize);
   SPSWrapperFunction<Sig>::handle(
-      Session, CallId, Return, ArgBytes,
+      S, CallId, Return, ArgBytes,
       WrapperFunction::handleWithAsyncMethod(&SimpleNativeMemoryMap::reserve));
 }
 
 ORC_RT_SPS_INTERFACE void
 orc_rt_SimpleNativeMemoryMap_releaseMultiple_sps_wrapper(
-    orc_rt_SessionRef Session, uint64_t CallId,
-    orc_rt_WrapperFunctionReturn Return,
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
     orc_rt_WrapperFunctionBuffer ArgBytes) {
   using Sig = SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>);
-  SPSWrapperFunction<Sig>::handle(Session, CallId, Return, ArgBytes,
+  SPSWrapperFunction<Sig>::handle(S, CallId, Return, ArgBytes,
                                   WrapperFunction::handleWithAsyncMethod(
                                       &SimpleNativeMemoryMap::releaseMultiple));
 }
 
 ORC_RT_SPS_INTERFACE void orc_rt_SimpleNativeMemoryMap_initialize_sps_wrapper(
-    orc_rt_SessionRef Session, uint64_t CallId,
-    orc_rt_WrapperFunctionReturn Return,
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
     orc_rt_WrapperFunctionBuffer ArgBytes) {
   using Sig = SPSExpected<SPSExecutorAddr>(
       SPSExecutorAddr, SPSSimpleNativeMemoryMapInitializeRequest);
-  SPSWrapperFunction<Sig>::handle(Session, CallId, Return, ArgBytes,
+  SPSWrapperFunction<Sig>::handle(S, CallId, Return, ArgBytes,
                                   WrapperFunction::handleWithAsyncMethod(
                                       &SimpleNativeMemoryMap::initialize));
 }
 
 ORC_RT_SPS_INTERFACE void
 orc_rt_SimpleNativeMemoryMap_deinitializeMultiple_sps_wrapper(
-    orc_rt_SessionRef Session, uint64_t CallId,
-    orc_rt_WrapperFunctionReturn Return,
+    orc_rt_SessionRef S, uint64_t CallId, orc_rt_WrapperFunctionReturn Return,
     orc_rt_WrapperFunctionBuffer ArgBytes) {
   using Sig = SPSError(SPSExecutorAddr, SPSSequence<SPSExecutorAddr>);
   SPSWrapperFunction<Sig>::handle(
-      Session, CallId, Return, ArgBytes,
+      S, CallId, Return, ArgBytes,
       WrapperFunction::handleWithAsyncMethod(
           &SimpleNativeMemoryMap::deinitializeMultiple));
 }

--- a/orc-rt/unittests/DirectCaller.h
+++ b/orc-rt/unittests/DirectCaller.h
@@ -20,14 +20,14 @@ private:
   class DirectResultSender {
   public:
     virtual ~DirectResultSender() {}
-    virtual void send(orc_rt_SessionRef Session,
+    virtual void send(orc_rt_SessionRef S,
                       orc_rt::WrapperFunctionBuffer ResultBytes) = 0;
-    static void send(orc_rt_SessionRef Session, uint64_t CallId,
+    static void send(orc_rt_SessionRef S, uint64_t CallId,
                      orc_rt_WrapperFunctionBuffer ResultBytes) {
       std::unique_ptr<DirectResultSender>(
           reinterpret_cast<DirectResultSender *>(
               static_cast<uintptr_t>(CallId)))
-          ->send(Session, ResultBytes);
+          ->send(S, ResultBytes);
     }
   };
 
@@ -35,9 +35,9 @@ private:
   class DirectResultSenderImpl : public DirectResultSender {
   public:
     DirectResultSenderImpl(ImplFn &&Fn) : Fn(std::forward<ImplFn>(Fn)) {}
-    void send(orc_rt_SessionRef Session,
+    void send(orc_rt_SessionRef S,
               orc_rt::WrapperFunctionBuffer ResultBytes) override {
-      Fn(Session, std::move(ResultBytes));
+      Fn(S, std::move(ResultBytes));
     }
 
   private:
@@ -52,21 +52,19 @@ private:
   }
 
 public:
-  DirectCaller(orc_rt_SessionRef Session, orc_rt_WrapperFunction Fn)
-      : Session(Session), Fn(Fn) {}
+  DirectCaller(orc_rt_SessionRef S, orc_rt_WrapperFunction Fn) : S(S), Fn(Fn) {}
 
   template <typename HandleResultFn>
   void operator()(HandleResultFn &&HandleResult,
                   orc_rt::WrapperFunctionBuffer ArgBytes) {
     auto DR =
         makeDirectResultSender(std::forward<HandleResultFn>(HandleResult));
-    Fn(Session,
-       static_cast<uint64_t>(reinterpret_cast<uintptr_t>(DR.release())),
+    Fn(S, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(DR.release())),
        DirectResultSender::send, ArgBytes.release());
   }
 
 private:
-  orc_rt_SessionRef Session;
+  orc_rt_SessionRef S;
   orc_rt_WrapperFunction Fn;
 };
 

--- a/orc-rt/unittests/SPSWrapperFunctionTest.cpp
+++ b/orc-rt/unittests/SPSWrapperFunctionTest.cpp
@@ -22,11 +22,11 @@
 
 using namespace orc_rt;
 
-static void void_noop_sps_wrapper(orc_rt_SessionRef Session, uint64_t CallId,
+static void void_noop_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                                   orc_rt_WrapperFunctionReturn Return,
                                   orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<void()>::handle(
-      Session, CallId, Return, ArgBytes,
+      S, CallId, Return, ArgBytes,
       [](move_only_function<void()> Return) { Return(); });
 }
 
@@ -40,12 +40,11 @@ TEST(SPSWrapperFunctionUtilsTest, VoidNoop) {
   EXPECT_TRUE(Ran);
 }
 
-static void add_via_lambda_sps_wrapper(orc_rt_SessionRef Session,
-                                       uint64_t CallId,
+static void add_via_lambda_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                                        orc_rt_WrapperFunctionReturn Return,
                                        orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::handle(
-      Session, CallId, Return, ArgBytes,
+      S, CallId, Return, ArgBytes,
       [](move_only_function<void(int32_t)> Return, int32_t X, int32_t Y) {
         Return(X + Y);
       });
@@ -65,11 +64,11 @@ static void add_via_function(move_only_function<void(int32_t)> Return,
 }
 
 static void
-add_via_function_sps_wrapper(orc_rt_SessionRef Session, uint64_t CallId,
+add_via_function_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                              orc_rt_WrapperFunctionReturn Return,
                              orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::handle(
-      Session, CallId, Return, ArgBytes, add_via_function);
+      S, CallId, Return, ArgBytes, add_via_function);
 }
 
 TEST(SPSWrapperFunctionUtilsTest, BinaryOpViaFunction) {
@@ -81,11 +80,11 @@ TEST(SPSWrapperFunctionUtilsTest, BinaryOpViaFunction) {
 }
 
 static void
-add_via_function_pointer_sps_wrapper(orc_rt_SessionRef Session, uint64_t CallId,
+add_via_function_pointer_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                                      orc_rt_WrapperFunctionReturn Return,
                                      orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<int32_t(int32_t, int32_t)>::handle(
-      Session, CallId, Return, ArgBytes, &add_via_function);
+      S, CallId, Return, ArgBytes, &add_via_function);
 }
 
 TEST(SPSWrapperFunctionUtilsTest, BinaryOpViaFunctionPointer) {
@@ -97,12 +96,11 @@ TEST(SPSWrapperFunctionUtilsTest, BinaryOpViaFunctionPointer) {
 }
 
 static void
-round_trip_string_via_span_sps_wrapper(orc_rt_SessionRef Session,
-                                       uint64_t CallId,
+round_trip_string_via_span_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                                        orc_rt_WrapperFunctionReturn Return,
                                        orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<SPSString(SPSString)>::handle(
-      Session, CallId, Return, ArgBytes,
+      S, CallId, Return, ArgBytes,
       [](move_only_function<void(std::string)> Return, span<const char> S) {
         Return({S.data(), S.size()});
       });
@@ -120,12 +118,11 @@ TEST(SPSWrapperFunctionUtilsTest, RoundTripStringViaSpan) {
   EXPECT_EQ(Result, "hello, world!");
 }
 
-static void improbable_feat_sps_wrapper(orc_rt_SessionRef Session,
-                                        uint64_t CallId,
+static void improbable_feat_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                                         orc_rt_WrapperFunctionReturn Return,
                                         orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<SPSError(bool)>::handle(
-      Session, CallId, Return, ArgBytes,
+      S, CallId, Return, ArgBytes,
       [](move_only_function<void(Error)> Return, bool LuckyHat) {
         if (LuckyHat)
           Return(Error::success());
@@ -157,11 +154,11 @@ TEST(SPSWrapperFunctionUtilsTest, TransparentConversionErrorFailureCase) {
   EXPECT_EQ(ErrMsg, "crushed by boulder");
 }
 
-static void halve_number_sps_wrapper(orc_rt_SessionRef Session, uint64_t CallId,
+static void halve_number_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                                      orc_rt_WrapperFunctionReturn Return,
                                      orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<SPSExpected<int32_t>(int32_t)>::handle(
-      Session, CallId, Return, ArgBytes,
+      S, CallId, Return, ArgBytes,
       [](move_only_function<void(Expected<int32_t>)> Return, int N) {
         if (N % 2 == 0)
           Return(N >> 1);
@@ -209,13 +206,12 @@ public:
 } // namespace orc_rt
 
 static void
-handle_with_reference_types_sps_wrapper(orc_rt_SessionRef Session,
-                                        uint64_t CallId,
+handle_with_reference_types_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                                         orc_rt_WrapperFunctionReturn Return,
                                         orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<void(
       SPSOpCounter<0>, SPSOpCounter<1>, SPSOpCounter<2>,
-      SPSOpCounter<3>)>::handle(Session, CallId, Return, ArgBytes,
+      SPSOpCounter<3>)>::handle(S, CallId, Return, ArgBytes,
                                 [](move_only_function<void()> Return,
                                    OpCounter<0>, OpCounter<1> &,
                                    const OpCounter<2> &,
@@ -282,12 +278,11 @@ public:
 };
 } // anonymous namespace
 
-static void adder_add_async_sps_wrapper(orc_rt_SessionRef Session,
-                                        uint64_t CallId,
+static void adder_add_async_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                                         orc_rt_WrapperFunctionReturn Return,
                                         orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<int32_t(SPSExecutorAddr, int32_t, int32_t)>::handle(
-      Session, CallId, Return, ArgBytes,
+      S, CallId, Return, ArgBytes,
       WrapperFunction::handleWithAsyncMethod(&Adder::addAsync));
 }
 
@@ -302,12 +297,11 @@ TEST(SPSWrapperFunctionUtilsTest, HandleWtihAsyncMethod) {
   EXPECT_EQ(Result, 42);
 }
 
-static void adder_add_sync_sps_wrapper(orc_rt_SessionRef Session,
-                                       uint64_t CallId,
+static void adder_add_sync_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
                                        orc_rt_WrapperFunctionReturn Return,
                                        orc_rt_WrapperFunctionBuffer ArgBytes) {
   SPSWrapperFunction<int32_t(SPSExecutorAddr, int32_t, int32_t)>::handle(
-      Session, CallId, Return, ArgBytes,
+      S, CallId, Return, ArgBytes,
       WrapperFunction::handleWithSyncMethod(&Adder::addSync));
 }
 


### PR DESCRIPTION
Re-using Session as a variable name risks confusion with the Session type.