### PR TITLE
[TSan] [Darwin] Fix off by one in TSAN init due to MemoryRangeIsAvailable

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_platform_mac.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_mac.cpp
@@ -235,7 +235,7 @@ void InitializePlatformEarly() {
   }
   // In some configurations, the max_vm is expanded, but much of this space is
   // already mapped. TSAN will not work in this configuration.
-  if (!MemoryRangeIsAvailable(HiAppMemEnd() - 1, HiAppMemEnd())) {
+  if (!MemoryRangeIsAvailable(HiAppMemEnd() - 1, HiAppMemEnd() - 1)) {
     Report(
         "ThreadSanitizer: Unsupported virtual memory layout: Address %p is "
         "already mapped.\n",


### PR DESCRIPTION
This fixes a bug in https://github.com/llvm/llvm-project/pull/167797 where an upper-bound was mistaken to be exclusive when it was actually inclusive. MemoryRangeIsAvailable takes an inclusive upper bound, and if beginning == end it will check for overlap with a range of size 1.

Here, we want to check if `HiAppMemEnd() - 1` is mapped. If it is, the memory layout should be marked unsupported.

rdar://164815619