### PR TITLE
[flang] Handle assumed-type dummy arguments in ExtractDataRef

### DIFF
--- a/flang/lib/Evaluate/tools.cpp
+++ b/flang/lib/Evaluate/tools.cpp
@@ -63,7 +63,11 @@ Expr<SomeType> Parenthesize(Expr<SomeType> &&expr) {
 
 std::optional<DataRef> ExtractDataRef(
     const ActualArgument &arg, bool intoSubstring, bool intoComplexPart) {
-  return ExtractDataRef(arg.UnwrapExpr(), intoSubstring, intoComplexPart);
+  if (const Symbol *assumedType{arg.GetAssumedTypeDummy()}) {
+    return DataRef{*assumedType};
+  } else {
+    return ExtractDataRef(arg.UnwrapExpr(), intoSubstring, intoComplexPart);
+  }
 }
 
 std::optional<DataRef> ExtractSubstringBase(const Substring &substring) {

--- a/flang/test/Evaluate/bug168978.f90
+++ b/flang/test/Evaluate/bug168978.f90
@@ -1,0 +1,6 @@
+!RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+subroutine sub(dd)
+  type(*)::dd(..)
+  !CHECK: PRINT *, size(lbound(dd))
+  print *, size(lbound(dd)) ! do not fold
+end


### PR DESCRIPTION
Assumed-type dummy argument symbols s are never packaged in DataRefs since the only way they can be used in Fortran is by forwarded as actual arguments to other calls.  When an ActualArgument comprising a forwarded assumed-type dummy argument is presented to ExtractDataRef, it fails, because ExtractDataRef for ActualArgument only handles actual argument expressions (including variable references).  Add support for actual arguments that are assumed-type dummy arguments.

Fixes https://github.com/llvm/llvm-project/issues/168978.