### PR TITLE
[LLDB] Make sure FILE* is valid before trying to flush it.

### DIFF
--- a/lldb/source/Host/common/File.cpp
+++ b/lldb/source/Host/common/File.cpp
@@ -378,7 +378,10 @@ Status NativeFile::Close() {
           m_options & (File::eOpenOptionReadOnly | File::eOpenOptionWriteOnly |
                        File::eOpenOptionReadWrite);
 
-      if (rw == eOpenOptionWriteOnly || rw == eOpenOptionReadWrite) {
+      // If the stream is writable, and has not already been closed, flush
+      // it.
+      if ((rw == eOpenOptionWriteOnly || rw == eOpenOptionReadWrite) &&
+          (m_stream->_flags != m_stream->_fileno)) {
         if (::fflush(m_stream) == EOF)
           error = Status::FromErrno();
       }


### PR DESCRIPTION
PR/167764 makes sure the access mode for newly created Native files is writable. This uncovered a bug in NativeFile::Close where it tries to flush a writable file without first checking to make sure the file hasn't already been closed. This triggers a bug in some of our code, where it closes a file by ovewriting the fields with nonsense values rather than deleting the pointer. This PR now checks to make sure this has not been done before trying to flush it.