### PR TITLE
[include-cleaner] Use lit internal shell by default for tests

### DIFF
--- a/clang-tools-extra/include-cleaner/test/lit.cfg.py
+++ b/clang-tools-extra/include-cleaner/test/lit.cfg.py
@@ -1,12 +1,25 @@
+import os
+
 import lit.llvm
 
 lit.llvm.initialize(lit_config, config)
 lit.llvm.llvm_config.use_default_substitutions()
 
+# TODO: Consolidate the logic for turning on the internal shell by default for all LLVM test suites.
+# See https://github.com/llvm/llvm-project/issues/106636 for more details.
+#
+# We prefer the lit internal shell which provides a better user experience on failures
+# and is faster unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0
+# env var.
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+
 config.name = "ClangIncludeCleaner"
 config.suffixes = [".test", ".c", ".cpp"]
 config.excludes = ["Inputs"]
-config.test_format = lit.formats.ShTest(not lit.llvm.llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest(not use_lit_shell)
 config.test_source_root = config.clang_include_cleaner_source_dir + "/test"
 config.test_exec_root = config.clang_include_cleaner_binary_dir + "/test"
 


### PR DESCRIPTION
All of the tests seem to be compatible with the internal shell and the internal shell is typically faster by 10-15% on top of providing a better debugging experience.