### PR TITLE
Really fix tysan test failing on unsupported arches

### DIFF
--- a/clang/test/CodeGen/sanitize-type-outlined.cpp
+++ b/clang/test/CodeGen/sanitize-type-outlined.cpp
@@ -1,9 +1,7 @@
-// REQUIRES: target=x86_64-linux-gnu
-
-// RUN: %clang -S -fsanitize=type -emit-llvm -o - -fsanitize=type %s \
+// RUN: %clang --target=x86_64-linux-gnu -S -fsanitize=type -emit-llvm -o - %s \
 // RUN:     -fno-sanitize-type-outline-instrumentation \
 // RUN:     | FileCheck %s --check-prefixes=CHECK-NO-OUTLINE
-// RUN: %clang -S -fsanitize=type -emit-llvm -o - -fsanitize=type %s \
+// RUN: %clang --target=x86_64-linux-gnu -S -fsanitize=type -emit-llvm -o - %s \
 // RUN:     -fsanitize-type-outline-instrumentation \
 // RUN:     | FileCheck %s --check-prefixes=CHECK-OUTLINE
 


### PR DESCRIPTION
'target' is not one of the features recognized by clang tests, and the test doesn't require X86 backend to be built. Specify the target explicitly instead. Remove duplicate `-fsanitize=type` as well.