### PR TITLE
[lldb] Fix help/pydoc output when the statusline is enabled

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -416,6 +416,14 @@ ScriptInterpreterPythonImpl::ScriptInterpreterPythonImpl(Debugger &debugger)
   RunSimpleString(run_string.GetData());
   run_string.Clear();
 
+  // Configure pydoc (built-in module) to use the "plain" pager. The default one
+  // doesn't play nice with the statusline.
+  run_string.Printf("run_one_line (%s, 'import pydoc; pydoc.pager = "
+                    "pydoc.plainpager')",
+                    m_dictionary_name.c_str());
+  RunSimpleString(run_string.GetData());
+  run_string.Clear();
+
   run_string.Printf("run_one_line (%s, 'lldb.debugger_unique_id = %" PRIu64
                     "')",
                     m_dictionary_name.c_str(), m_debugger.GetID());


### PR DESCRIPTION
Using Python's built-in help shows an empty screen when the statusline is enabled. The issue is the pydoc pager (e.g. less) which doesn't play nice with the statusline. Use the "plain" pager instead.

I considered making this conditional on the statusline, but to do that right you would need to register a callback that toggles it every time the setting changes and that doesn't seem worth the complexity.

Fixes #166610