### PR TITLE
[ORC] Fix obj-imageinfo.S on X86 Darwin with Internal Shell

### DIFF
--- a/compiler-rt/test/orc/TestCases/Darwin/x86-64/objc-imageinfo.S
+++ b/compiler-rt/test/orc/TestCases/Darwin/x86-64/objc-imageinfo.S
@@ -5,7 +5,9 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: (cd %t; %clang -c *.S)
+// RUN: pushd %t
+// RUN: %clang -c *.S
+// RUN: popd
 
 // Check individual versions are loadable.
 


### PR DESCRIPTION
d464c99f595b69d3a34b361b6a935e803c60d308 fixes this test on AArch64 Darwin, but I did not realize that there was another X86 version of the test. This patch also updates the X86 version of the test in a similar manner.