### PR TITLE
[UBSan] Fix test-darwin-interface.c on X86 Darwin with Internal Shell

### DIFF
--- a/compiler-rt/test/ubsan_minimal/TestCases/test-darwin-interface.c
+++ b/compiler-rt/test/ubsan_minimal/TestCases/test-darwin-interface.c
@@ -3,11 +3,19 @@
 //
 // REQUIRES: x86_64-darwin
 
-// RUN: nm -jgU `%clangxx_min_runtime -fsanitize-minimal-runtime -fsanitize=undefined %s -o %t '-###' 2>&1 | grep "libclang_rt.ubsan_minimal_osx_dynamic.dylib" | sed -e 's/.*"\(.*libclang_rt.ubsan_minimal_osx_dynamic.dylib\)".*/\1/'` | grep "^___ubsan_handle" \
+// RUN: %clangxx_min_runtime -fsanitize-minimal-runtime -fsanitize=undefined %s -o %t '-###' 2>&1 | \
+// RUN: grep "libclang_rt.ubsan_minimal_osx_dynamic.dylib" | \
+// RUN: sed -e 's/.*"\(.*libclang_rt.ubsan_minimal_osx_dynamic.dylib\)".*/\1/' | \
+// RUN: tr -d '\n' > %t.dylib_path1
+// RUN: nm -jgU %{readfile:%t.dylib_path1} | grep "^___ubsan_handle" \
 // RUN:  | sed 's/_minimal//g' \
 // RUN:  > %t.minimal.symlist
 //
-// RUN: nm -jgU `%clangxx_min_runtime -fno-sanitize-minimal-runtime -fsanitize=undefined %s -o %t '-###' 2>&1 | grep "libclang_rt.ubsan_osx_dynamic.dylib" | sed -e 's/.*"\(.*libclang_rt.ubsan_osx_dynamic.dylib\)".*/\1/'` | grep "^___ubsan_handle" \
+// RUN: %clangxx_min_runtime -fno-sanitize-minimal-runtime -fsanitize=undefined %s -o %t '-###' 2>&1 | \
+// RUN: grep "libclang_rt.ubsan_osx_dynamic.dylib" | \
+// RUN: sed -e 's/.*"\(.*libclang_rt.ubsan_osx_dynamic.dylib\)".*/\1/' | \
+// RUN: tr -d '\n' > %t.dylib_path2
+// RUN: nm -jgU %{readfile:%t.dylib_path2} | grep "^___ubsan_handle" \
 // RUN:  | grep -vE "^___ubsan_handle_dynamic_type_cache_miss" \
 // RUN:  | grep -vE "^___ubsan_handle_cfi_bad_type" \
 // RUN:  | sed 's/_v1//g' \


### PR DESCRIPTION
This test was failing with the internal shell due to the use of subshells. This was not caught in my initial round of testing due to me only using a M4 Mac for running my tests.