### PR TITLE
[SPIRV] Error in backend for vararg functions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -464,7 +464,7 @@ private:
   SPIRVType *getOpTypeForwardPointer(SPIRV::StorageClass::StorageClass SC,
                                      MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeFunction(SPIRVType *RetType,
+  SPIRVType *getOpTypeFunction(const FunctionType *Ty, SPIRVType *RetType,
                                const SmallVectorImpl<SPIRVType *> &ArgTypes,
                                MachineIRBuilder &MIRBuilder);
 

--- a/llvm/test/CodeGen/SPIRV/function/vararg.ll
+++ b/llvm/test/CodeGen/SPIRV/function/vararg.ll
@@ -1,0 +1,17 @@
+; RUN: not llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - 2>&1 | FileCheck %s
+
+@glob = addrspace(1) global ptr null, align 8
+
+; Function Attrs: mustprogress noinline norecurse optnone
+define noundef i32 @main() {
+entry:
+  %retval = alloca i32, align 4
+  %retval.ascast = addrspacecast ptr %retval to ptr addrspace(4)
+  store i32 0, ptr addrspace(4) %retval.ascast, align 4
+  store ptr @_Z3fooiz, ptr addrspace(4) addrspacecast (ptr addrspace(1) @glob to ptr addrspace(4)), align 8
+  call spir_func void (i32, ...) @_Z3fooiz(i32 noundef 5, i32 noundef 3)
+  ret i32 0
+}
+
+; CHECK: SPIR-V does not support variadic functions
+declare spir_func void @_Z3fooiz(i32 noundef, ...)

--- a/llvm/test/CodeGen/SPIRV/function/vararg.ll
+++ b/llvm/test/CodeGen/SPIRV/function/vararg.ll
@@ -1,17 +1,11 @@
 ; RUN: not llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - 2>&1 | FileCheck %s
 
-@glob = addrspace(1) global ptr null, align 8
-
 ; Function Attrs: mustprogress noinline norecurse optnone
-define noundef i32 @main() {
+define void @bar() {
 entry:
-  %retval = alloca i32, align 4
-  %retval.ascast = addrspacecast ptr %retval to ptr addrspace(4)
-  store i32 0, ptr addrspace(4) %retval.ascast, align 4
-  store ptr @_Z3fooiz, ptr addrspace(4) addrspacecast (ptr addrspace(1) @glob to ptr addrspace(4)), align 8
-  call spir_func void (i32, ...) @_Z3fooiz(i32 noundef 5, i32 noundef 3)
-  ret i32 0
+  call spir_func void (i32, ...) @_Z3fooiz(i32 5, i32 3)
+  ret void
 }
 
-; CHECK: SPIR-V does not support variadic functions
-declare spir_func void @_Z3fooiz(i32 noundef, ...)
+; CHECK:error: {{.*}} in function bar void (): SPIR-V does not support variadic functions
+declare spir_func void @_Z3fooiz(i32, ...)

--- a/llvm/test/CodeGen/SPIRV/function/vararg.ll
+++ b/llvm/test/CodeGen/SPIRV/function/vararg.ll
@@ -1,6 +1,5 @@
-; RUN: not llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - 2>&1 | FileCheck %s
+; RUN: not llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers < %s 2>&1 | FileCheck %s
 
-; Function Attrs: mustprogress noinline norecurse optnone
 define void @bar() {
 entry:
   call spir_func void (i32, ...) @_Z3fooiz(i32 5, i32 3)


### PR DESCRIPTION
SPIR-V doesn't support variadic functions, though we make an exception for `printf`.

If we don't error, we generate invalid SPIR-V because the backend has no idea how to codegen vararg functions as it is not described in the spec. We get asm like this:

```
%27 = OpFunction %6 None %7
%28 = OpFunctionParameter %4
                                        ; -- End function
```

The above asm is totally invalid, there's no `OpFunctionEnd` and it causes crashes in downstream tools like `spirv-as` and `spirv-link`.

We already have many `printf` tests locking down that this doesn't break `printf`, it was already handled elsewhere at the time the error check runs.

Note the SPIR-V Translator does the same thing, see [here](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2703).