### PR TITLE
[NFC][LLDB] Make it possible to detect if the compiler used in tests supports -fbounds-safety

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1059,6 +1059,16 @@ def skipUnlessAddressSanitizer(func):
     return skipTestIfFn(is_compiler_with_address_sanitizer)(func)
 
 
+def skipUnlessBoundsSafety(func):
+    """Decorate the item to skip test unless Clang -fbounds-safety is supported."""
+
+    def is_compiler_with_bounds_safety():
+        if not _compiler_supports(lldbplatformutil.getCompiler(), "-fbounds-safety"):
+            return "Compiler cannot compile with -fbounds-safety"
+        return None
+
+    return skipTestIfFn(is_compiler_with_bounds_safety)(func)
+
 def skipIfAsan(func):
     """Skip this test if the environment is set up to run LLDB *itself* under ASAN."""
     return skipTestIfFn(is_running_under_asan)(func)

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -277,6 +277,9 @@ def use_support_substitutions(config):
         required=True,
         use_installed=True,
     )
+    if llvm_config.clang_has_bounds_safety():
+        llvm_config.lit_config.note("clang has -fbounds-safety support")
+        config.available_features.add("clang-bounds-safety")
 
     if sys.platform == "win32":
         _use_msvc_substitutions(config)


### PR DESCRIPTION
This patch makes it possible to detect in LLDB shell and API tests if `-fbounds-safety` is supported by the compiler used for testing. The motivation behind this is to allow upstreaming https://github.com/swiftlang/llvm-project/pull/11835 but with the tests disabled in upstream because the full implementation of -fbounds-safety isn't available in Clang yet.

For shell tests when -fbounds-safety is available the `clang-bounds-safety` feature is available which means tests can be annotated with `# REQUIRES: clang-bounds-safety`.

API tests that need -fbounds-safety support in the compiler can use the new `@skipUnlessBoundsSafety` decorator.

rdar://165225507