### PR TITLE
[BoundsSafety][LLDB] Implement instrumentation plugin for -fbounds-safety soft traps

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -542,6 +542,7 @@ enum InstrumentationRuntimeType {
   eInstrumentationRuntimeTypeMainThreadChecker = 0x0003,
   eInstrumentationRuntimeTypeSwiftRuntimeReporting = 0x0004,
   eInstrumentationRuntimeTypeLibsanitizersAsan = 0x0005,
+  eInstrumentationRuntimeTypeBoundsSafety = 0x0006,
   eNumInstrumentationRuntimeTypes
 };
 

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/CMakeLists.txt
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_lldb_library(lldbPluginInstrumentationRuntimeBoundsSafety PLUGIN
+  InstrumentationRuntimeBoundsSafety.cpp
+
+  LINK_LIBS
+    lldbBreakpoint
+    lldbCore
+    lldbSymbol
+    lldbTarget
+    lldbPluginInstrumentationRuntimeUtility
+
+  CLANG_LIBS
+    clangCodeGen
+  )

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
@@ -135,10 +135,9 @@ InstrumentationBoundsSafetyStopInfo::ComputeStopReasonAndSuggestedStackFrame(
     return {};
   }
 
-  if (parent_sf->HasDebugInformation()) {
+  if (parent_sf->HasDebugInformation()) 
     return ComputeStopReasonAndSuggestedStackFrameWithDebugInfo(
         parent_sf, debugger_id, warning_emitted_for_failure);
-  }
 
   // If the debug info is missing we can still get some information
   // from the parameter in the soft trap runtime call.

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
@@ -279,7 +279,7 @@ InstrumentationBoundsSafetyStopInfo::
   }
   };
 
-  // Examine the register for the first argument
+  // Examine the register for the first argument.
   auto *arg0_info = rc->GetRegisterInfo(
       lldb::RegisterKind::eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1);
   if (!arg0_info) {

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
@@ -104,7 +104,7 @@ InstrumentationBoundsSafetyStopInfo::InstrumentationBoundsSafetyStopInfo(
     m_value = MaybeSuggestedStackIndex.value();
 
   // Emit warning about the failure to compute the stop info if one wasn't
-  // already emitted
+  // already emitted.
   if ((!Description.has_value()) && !warning_emitted_for_failure) {
     if (auto thread_sp = GetThread()) {
       lldb::user_id_t debugger_id =

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
@@ -123,8 +123,7 @@ InstrumentationBoundsSafetyStopInfo::InstrumentationBoundsSafetyStopInfo(
 // Helper functions to make it convenient to log a failure and then return.
 template <typename T, typename... ArgTys>
 [[nodiscard]] T LogBeforeReturn(ArgTys &&...Args) {
-  Log *log_category = GetLog(LLDBLog::InstrumentationRuntime);
-  LLDB_LOG(log_category, Args...);
+  LLDB_LOG(GetLog(LLDBLog::InstrumentationRuntime), Args...);
   return T();
 }
 

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
@@ -91,7 +91,7 @@ private:
 InstrumentationBoundsSafetyStopInfo::InstrumentationBoundsSafetyStopInfo(
     Thread &thread)
     : StopInfo(thread, 0) {
-  // No additional data describing the reason for stopping
+  // No additional data describing the reason for stopping.
   m_extended_info = nullptr;
   m_description = SOFT_TRAP_FALLBACK_CATEGORY;
 

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
@@ -1,4 +1,4 @@
-//===-- InstrumentationRuntimeBoundsSafety.cpp -----------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
@@ -137,7 +137,7 @@ InstrumentationBoundsSafetyStopInfo::ComputeStopReasonAndSuggestedStackFrame(
     return {};
   }
 
-  if (parent_sf->HasDebugInformation()) 
+  if (parent_sf->HasDebugInformation())
     return ComputeStopReasonAndSuggestedStackFrameWithDebugInfo(
         parent_sf, debugger_id, warning_emitted_for_failure);
 

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.h
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.h
@@ -1,4 +1,4 @@
-//===-- InstrumentationRuntimeBoundsSafetySoftTrap.h-------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.h
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.h
@@ -1,0 +1,61 @@
+//===-- InstrumentationRuntimeBoundsSafetySoftTrap.h-------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_INSTRUMENTATIONRUNTIME_BOUNDS_SAFETY_SOFT_TRAP_H
+#define LLDB_SOURCE_PLUGINS_INSTRUMENTATIONRUNTIME_BOUNDS_SAFETY_SOFT_TRAP_H
+
+#include "lldb/Target/ABI.h"
+#include "lldb/Target/InstrumentationRuntime.h"
+#include "lldb/Utility/StructuredData.h"
+#include "lldb/lldb-private.h"
+
+namespace lldb_private {
+
+class InstrumentationRuntimeBoundsSafety
+    : public lldb_private::InstrumentationRuntime {
+public:
+  ~InstrumentationRuntimeBoundsSafety() override;
+
+  static lldb::InstrumentationRuntimeSP
+  CreateInstance(const lldb::ProcessSP &process_sp);
+
+  static void Initialize();
+
+  static void Terminate();
+
+  static llvm::StringRef GetPluginNameStatic() { return "BoundsSafety"; }
+
+  static lldb::InstrumentationRuntimeType GetTypeStatic();
+
+  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
+
+  virtual lldb::InstrumentationRuntimeType GetType() { return GetTypeStatic(); }
+
+private:
+  InstrumentationRuntimeBoundsSafety(const lldb::ProcessSP &process_sp)
+      : lldb_private::InstrumentationRuntime(process_sp) {}
+
+  const RegularExpression &GetPatternForRuntimeLibrary() override;
+
+  bool CheckIfRuntimeIsValid(const lldb::ModuleSP module_sp) override;
+
+  void Activate() override;
+
+  void Deactivate();
+
+  static bool NotifyBreakpointHit(void *baton,
+                                  StoppointCallbackContext *context,
+                                  lldb::user_id_t break_id,
+                                  lldb::user_id_t break_loc_id);
+
+  bool MatchAllModules() override { return true; }
+};
+
+} // namespace lldb_private
+
+#endif

--- a/lldb/source/Plugins/InstrumentationRuntime/CMakeLists.txt
+++ b/lldb/source/Plugins/InstrumentationRuntime/CMakeLists.txt
@@ -2,6 +2,7 @@ set_property(DIRECTORY PROPERTY LLDB_PLUGIN_KIND InstrumentationRuntime)
 
 add_subdirectory(ASan)
 add_subdirectory(ASanLibsanitizers)
+add_subdirectory(BoundsSafety)
 add_subdirectory(MainThreadChecker)
 add_subdirectory(TSan)
 add_subdirectory(UBSan)

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/Makefile
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/Makefile
@@ -1,0 +1,10 @@
+# FIXME: mockSoftTrapRuntime.c shouldn't really be built with -fbounds-safety
+C_SOURCES := main.c mockSoftTrapRuntime.c
+
+soft-trap-test-minimal: CFLAGS_EXTRAS := -fbounds-safety -fbounds-safety-soft-traps=call-minimal
+soft-trap-test-minimal: all
+
+soft-trap-test-with-str: CFLAGS_EXTRAS := -fbounds-safety -fbounds-safety-soft-traps=call-with-str
+soft-trap-test-with-str: all
+
+include Makefile.rules

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
@@ -1,0 +1,148 @@
+"""
+Test the BoundsSafety instrumentation plugin
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+STOP_REASON_MAX_LEN = 100
+SOFT_TRAP_FUNC_MINIMAL = "__bounds_safety_soft_trap"
+SOFT_TRAP_FUNC_WITH_STR = "__bounds_safety_soft_trap_s"
+
+
+class BoundsSafetyTestSoftTrapPlugin(TestBase):
+    def _check_stop_reason_impl(
+        self,
+        expected_soft_trap_func: str,
+        expected_stop_reason: str,
+        expected_func_name: str,
+        expected_file_name: str,
+        expected_line_num: int,
+    ):
+        process = self.test_target.process
+        thread = process.GetSelectedThread()
+        self.assertEqual(
+            thread.GetStopReason(),
+            lldb.eStopReasonInstrumentation,
+        )
+
+        stop_reason = thread.GetStopDescription(STOP_REASON_MAX_LEN)
+        self.assertEqual(stop_reason, expected_stop_reason)
+
+        soft_trap_func_frame = thread.GetFrameAtIndex(0)
+        self.assertEqual(soft_trap_func_frame.name, expected_soft_trap_func)
+
+        stop_frame = thread.GetSelectedFrame()
+        self.assertEqual(stop_frame.name, expected_func_name)
+        # The stop frame isn't frame 1 because that frame is the artificial
+        # frame containing the trap reason.
+        self.assertEqual(stop_frame.idx, 2)
+        file_name = stop_frame.GetLineEntry().GetFileSpec().basename
+        self.assertEqual(file_name, expected_file_name)
+        line = stop_frame.GetLineEntry().line
+        self.assertEqual(line, expected_line_num)
+
+    def check_state_soft_trap_minimal(
+        self, stop_reason: str, func_name: str, file_name: str, line_num: int
+    ):
+        """
+        Check the program state is as expected when hitting
+        a soft trap from -fbounds-safety-soft-traps=call-minimal
+        """
+        self._check_stop_reason_impl(
+            SOFT_TRAP_FUNC_MINIMAL,
+            expected_stop_reason=stop_reason,
+            expected_func_name=func_name,
+            expected_file_name=file_name,
+            expected_line_num=line_num,
+        )
+
+    def check_state_soft_trap_with_str(
+        self, stop_reason: str, func_name: str, file_name: str, line_num: int
+    ):
+        """
+        Check the program state is as expected when hitting
+        a soft trap from -fbounds-safety-soft-traps=call-with_str
+        """
+        self._check_stop_reason_impl(
+            SOFT_TRAP_FUNC_WITH_STR,
+            expected_stop_reason=stop_reason,
+            expected_func_name=func_name,
+            expected_file_name=file_name,
+            expected_line_num=line_num,
+        )
+
+    # Skip the tests on Windows because they fail due to the stop reason
+    # being `eStopReasonNon` instead of the expected
+    # `eStopReasonInstrumentation`.
+    @skipIfWindows
+    @skipUnlessBoundsSafety
+    def test_call_minimal(self):
+        """
+        Test the plugin on code built with
+        -fbounds-safety-soft-traps=call-minimal
+        """
+        self.build(make_targets=["soft-trap-test-minimal"])
+        self.test_target = self.createTestTarget()
+        self.runCmd("run")
+
+        process = self.test_target.process
+
+        # First soft trap hit
+        self.check_state_soft_trap_minimal(
+            "Soft Bounds check failed: indexing above upper bound in 'buffer[2]'",
+            "main",
+            "main.c",
+            7,
+        )
+
+        process.Continue()
+
+        # Second soft trap hit
+        self.check_state_soft_trap_minimal(
+            "Soft Bounds check failed: indexing below lower bound in 'buffer[-1]'",
+            "main",
+            "main.c",
+            8,
+        )
+
+        process.Continue()
+        self.assertEqual(process.GetState(), lldb.eStateExited)
+        self.assertEqual(process.GetExitStatus(), 0)
+
+    @skipIfWindows
+    @skipUnlessBoundsSafety
+    def test_call_with_str(self):
+        """
+        Test the plugin on code built with
+        -fbounds-safety-soft-traps=call-with-str
+        """
+        self.build(make_targets=["soft-trap-test-with-str"])
+        self.test_target = self.createTestTarget()
+        self.runCmd("run")
+
+        process = self.test_target.process
+
+        # First soft trap hit
+        self.check_state_soft_trap_with_str(
+            "Soft Bounds check failed: indexing above upper bound in 'buffer[2]'",
+            "main",
+            "main.c",
+            7,
+        )
+
+        process.Continue()
+
+        # Second soft trap hit
+        self.check_state_soft_trap_with_str(
+            "Soft Bounds check failed: indexing below lower bound in 'buffer[-1]'",
+            "main",
+            "main.c",
+            8,
+        )
+
+        process.Continue()
+        self.assertEqual(process.GetState(), lldb.eStateExited)
+        self.assertEqual(process.GetExitStatus(), 0)

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/main.c
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/main.c
@@ -1,0 +1,10 @@
+#include <ptrcheck.h>
+
+int main(void) {
+  int pad;
+  int buffer[] = {0, 1};
+  int pad2;
+  int tmp = buffer[2]; // access past upper bound
+  tmp = buffer[-1];    // access below lower bound
+  return 0;
+}

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/mockSoftTrapRuntime.c
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/mockSoftTrapRuntime.c
@@ -1,0 +1,17 @@
+#include <bounds_safety_soft_traps.h>
+#include <ptrcheck.h>
+#include <stdio.h>
+
+#if __CLANG_BOUNDS_SAFETY_SOFT_TRAP_API_VERSION > 0
+#error API version changed
+#endif
+
+// FIXME: The runtimes really shouldn't be built with `-fbounds-safety` in
+// soft trap mode because of the risk of infinite recursion. However,
+// there's currently no way to have source files built with different flags
+
+void __bounds_safety_soft_trap_s(const char *reason) {
+  printf("BoundsSafety check FAILED: message:\"%s\"\n", reason ? reason : "");
+}
+
+void __bounds_safety_soft_trap(void) { printf("BoundsSafety check FAILED\n"); }

--- a/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetyMockCallSoftTrapRuntime.c
+++ b/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetyMockCallSoftTrapRuntime.c
@@ -1,0 +1,8 @@
+#include <bounds_safety_soft_traps.h>
+#include <stdio.h>
+
+int main(void) {
+  __bounds_safety_soft_trap_s(0);
+  printf("Execution continued\n");
+  return 0;
+}

--- a/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetyMockSoftTrapRuntime.c
+++ b/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetyMockSoftTrapRuntime.c
@@ -1,0 +1,15 @@
+#include <bounds_safety_soft_traps.h>
+#include <ptrcheck.h>
+#include <stdio.h>
+
+#if __CLANG_BOUNDS_SAFETY_SOFT_TRAP_API_VERSION > 0
+#error API version changed
+#endif
+
+#if __has_ptrcheck
+#error Do not compile the runtime with -fbounds-safety enabled due to potential for infinite recursion
+#endif
+
+void __bounds_safety_soft_trap_s(const char *reason) { printf("BoundsSafety check FAILED: message:\"%s\"\n", reason ? reason : ""); }
+
+void __bounds_safety_soft_trap(void) { printf("BoundsSafety check FAILED\n"); }

--- a/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTraps.c
+++ b/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTraps.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+int bad_read(int index) {
+  int array[] = {0, 1, 2};
+  return array[index];
+}
+
+int main(int argc, char **argv) {
+  bad_read(10);
+  printf("Execution continued\n");
+  return 0;
+}

--- a/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTrapsMissingReason.c
+++ b/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTrapsMissingReason.c
@@ -1,0 +1,20 @@
+#include <ptrcheck.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int bad_call(int *__counted_by(count) ptr, int count) {}
+
+int main(int argc, char **argv) {
+  const int num_bytes = sizeof(int) * 2;
+  int *array = (int *)malloc(num_bytes);
+  memset(array, 0, num_bytes);
+
+  // The count argument is too large and will cause a trap.
+  // This code pattern is currently missing a trap reason (rdar://100346924) and
+  // so we can use it to test how `InstrumentationRuntimeBoundsSafety` handles
+  // this.
+  bad_call(array, 3);
+  printf("Execution continued\n");
+  return 0;
+}

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal.test
@@ -10,6 +10,9 @@
 plugin list instrumentation-runtime.BoundsSafety
 # CHECK: [+] BoundsSafety
 
+# Emit logging so that the code has test coverage
+log enable lldb instrumentation-runtime
+
 run
 
 # CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed: indexing above upper bound in 'array[index]'{{$}}

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal.test
@@ -1,0 +1,28 @@
+# UNSUPPORTED: system-windows
+# REQUIRES: clang-bounds-safety
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-minimal -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out | FileCheck %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed: indexing above upper bound in 'array[index]'{{$}}
+
+# Check that the `bad_read` frame is selected
+bt
+# CHECK: frame #{{.*}}`__bounds_safety_soft_trap{{$}}
+# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
+# CHECK-NEXT: * frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_missing_reason.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_missing_reason.test
@@ -12,6 +12,9 @@
 plugin list instrumentation-runtime.BoundsSafety
 # CHECK: [+] BoundsSafety
 
+# Emit logging so that the code has test coverage
+log enable lldb instrumentation-runtime
+
 run
 
 # CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_missing_reason.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_missing_reason.test
@@ -1,0 +1,31 @@
+# UNSUPPORTED: system-windows
+# REQUIRES: clang-bounds-safety
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-minimal -g -O0 %S/Inputs/boundsSafetySoftTrapsMissingReason.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out 2> %t.warnings | FileCheck %s
+# Warnings are checked separately because their order in the output is not guaranteed.
+# RUN: FileCheck --input-file=%t.warnings --check-prefix=WARN %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}
+# WARN: warning: specific BoundsSafety trap reason is not available because the compiler omitted it from the debug info
+
+# Check that the `bad_read` frame is selected
+bt
+# CHECK: frame #{{.*}}`__bounds_safety_soft_trap{{$}}
+# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$
+# CHECK-NEXT: * frame #{{.*}}`main({{.+}}) at boundsSafetySoftTrapsMissingReason.c:17
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_dbg_info.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_dbg_info.test
@@ -12,6 +12,9 @@
 plugin list instrumentation-runtime.BoundsSafety
 # CHECK: [+] BoundsSafety
 
+# Emit logging so that the code has test coverage
+log enable lldb instrumentation-runtime
+
 run
 
 # CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_dbg_info.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_dbg_info.test
@@ -1,0 +1,30 @@
+# UNSUPPORTED: system-windows
+# REQUIRES: clang-bounds-safety
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-minimal -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out 2> %t.warnings | FileCheck %s
+# Warnings are checked separately because their order in the output is not guaranteed.
+# RUN: FileCheck --input-file=%t.warnings --check-prefix=WARN %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}
+# WARN: warning: specific BoundsSafety trap reason is not available because debug info is missing on the caller of '__bounds_safety_soft_trap'
+
+# Check that the `__bounds_safety_soft_trap` frame is selected
+bt
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap{{$}}
+# CHECK-NEXT: frame #{{.*}}`bad_read
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_plugin.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_plugin.test
@@ -1,0 +1,30 @@
+# UNSUPPORTED: system-windows
+# REQUIRES: clang-bounds-safety
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-minimal -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out | FileCheck %s
+
+# Run without the plugin. A user might want to do this so they can set their
+# own custom breakpoint with custom stopping behavior (e.g. stop after n hits).
+plugin disable instrumentation-runtime.BoundsSafety
+# CHECK: [-] BoundsSafety
+
+b __bounds_safety_soft_trap
+run
+
+# CHECK: * thread #{{.*}} stop reason = breakpoint 1.1
+
+# Check that reason for bounds check failing can be seen in the stacktrace
+bt
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap{{$}}
+# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
+# CHECK-NEXT: frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_str.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_str.test
@@ -1,0 +1,28 @@
+# UNSUPPORTED: system-windows
+# REQUIRES: clang-bounds-safety
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-with-str -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out | FileCheck %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed: indexing above upper bound in 'array[index]'{{$}}
+
+# Check that the `bad_read` frame is selected
+bt
+# CHECK: frame #{{.*}}`__bounds_safety_soft_trap_s{{$}}
+# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
+# CHECK-NEXT: * frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_str.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_str.test
@@ -10,6 +10,9 @@
 plugin list instrumentation-runtime.BoundsSafety
 # CHECK: [+] BoundsSafety
 
+# Emit logging so that the code has test coverage
+log enable lldb instrumentation-runtime
+
 run
 
 # CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed: indexing above upper bound in 'array[index]'{{$}}

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_missing_reason.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_missing_reason.test
@@ -12,6 +12,9 @@
 plugin list instrumentation-runtime.BoundsSafety
 # CHECK: [+] BoundsSafety
 
+# Emit logging so that the code has test coverage
+log enable lldb instrumentation-runtime
+
 run
 
 # CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_missing_reason.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_missing_reason.test
@@ -1,0 +1,31 @@
+# UNSUPPORTED: system-windows
+# REQUIRES: clang-bounds-safety
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-with-str -g -O0 %S/Inputs/boundsSafetySoftTrapsMissingReason.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out 2> %t.warnings | FileCheck %s
+# Warnings are checked separately because their order in the output is not guaranteed.
+# RUN: FileCheck --input-file=%t.warnings --check-prefix=WARN %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}
+# WARN: warning: specific BoundsSafety trap reason is not available because the compiler omitted it from the debug info
+
+# Check that the `bad_read` frame is selected
+bt
+# CHECK: frame #{{.*}}`__bounds_safety_soft_trap_s{{$}}
+# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$
+# CHECK-NEXT: * frame #{{.*}}`main({{.+}}) at boundsSafetySoftTrapsMissingReason.c:17
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info.test
@@ -10,6 +10,9 @@
 plugin list instrumentation-runtime.BoundsSafety
 # CHECK: [+] BoundsSafety
 
+# Emit logging so that the code has test coverage
+log enable lldb instrumentation-runtime
+
 run
 
 # CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed: indexing above upper bound in 'array[index]'{{$}}

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info.test
@@ -1,0 +1,27 @@
+# UNSUPPORTED: system-windows
+# REQUIRES: clang-bounds-safety
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-with-str -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out | FileCheck %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed: indexing above upper bound in 'array[index]'{{$}}
+
+# Check that the `__bounds_safety_soft_trap_s` frame is selected
+bt
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap_s{{$}}
+# CHECK-NEXT: frame #{{.*}}`bad_read
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info_null_str.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info_null_str.test
@@ -12,6 +12,9 @@
 plugin list instrumentation-runtime.BoundsSafety
 # CHECK: [+] BoundsSafety
 
+# Emit logging so that the code has test coverage
+log enable lldb instrumentation-runtime
+
 run
 
 # This exists to check that the instrumentation correctly handles

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info_null_str.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info_null_str.test
@@ -1,0 +1,33 @@
+# UNSUPPORTED: system-windows
+# REQUIRES: clang-bounds-safety
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockCallSoftTrapRuntime.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out 2> %t.warnings | FileCheck %s
+# Warnings are checked separately because their order in the output is not guaranteed.
+# RUN: FileCheck --input-file=%t.warnings --check-prefix=WARN %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# This exists to check that the instrumentation correctly handles
+# `__bounds_safety_soft_trap_s()` being called with a nullptr argument.
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}
+# WARN: warning: specific BoundsSafety trap reason cannot be inferred because the compiler omitted the reason
+
+# Check that the `__bounds_safety_soft_trap_s` frame is selected
+bt
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap_s{{$}}
+# CHECK-NEXT: frame #{{.*}}`main
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_plugin.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_plugin.test
@@ -1,0 +1,30 @@
+# UNSUPPORTED: system-windows
+# REQUIRES: clang-bounds-safety
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-with-str -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out | FileCheck %s
+
+# Run without the plugin. A user might want to do this so they can set their
+# own custom breakpoint with custom stopping behavior (e.g. stop after n hits).
+plugin disable instrumentation-runtime.BoundsSafety
+# CHECK: [-] BoundsSafety
+
+b __bounds_safety_soft_trap_s
+run
+
+# CHECK: * thread #{{.*}} stop reason = breakpoint 1.1
+
+# Check that reason for bounds check failing can be seen in the stacktrace
+bt
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap_s
+# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
+# CHECK-NEXT: frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED: message:"indexing above upper bound in 'array[index]'"
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q


### PR DESCRIPTION
[BoundsSafety][LLDB] Implement instrumentation plugin for -fbounds-safety soft traps

This patch tries to upstream code landed downstream in
https://github.com/swiftlang/llvm-project/pull/11835.

This patch implements an instrumentation plugin for the
`-fbounds-safety` soft trap mode first implemented in
https://github.com/swiftlang/llvm-project/pull/11645 (rdar://158088757).
That functionality isn't supported in upstream Clang yet, however the
instrumented plugin can be compiled without issue so this patch tries to
upstream it. The included tests are all disabled when the clang used for
testing doesn't support `-fbounds-safety`. This means the tests will be
skipped. However, it's fairly easy to point LLDB at a clang that does
support `-fbounds-safety. I've done this and confirmed the tests pass.
To use a custom clang the following can be done:

* For API tests set the `LLDB_TEST_COMPILER` CMake cache variable to
  point to appropriate compiler.
* For shell tests applying a patch like this can be used to set the
  appropriate compiler:

```
--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -271,6 +271,7 @@ def use_support_substitutions(config):
     if config.lldb_lit_tools_dir:
         additional_tool_dirs.append(config.lldb_lit_tools_dir)

+    config.environment['CLANG'] = '/path/to/clang'
     llvm_config.use_clang(
```

The current implementation of -fbounds-safety traps works by emitting
calls to runtime functions intended to log the occurrence of a soft trap.
While the user could just set a breakpoint of these functions the
instrumentation plugin sets it automatically and provides several
additional features:

When debug info is available:

* It adjusts the stop reason to be the reason for trapping. This is
  extracted from the artificial frame in the debug info (similar to
  -fbounds-safety hard traps).
* It adjusts the selected frame to be the frame where the soft trap
  occurred.

When debug info is not available:

* For the `call-with-str` soft trap mode the soft trap reason is
  read from the first argument register.
* For the `call-minimal` soft trap mode the stop reason is adjusted
  to note its a bounds check failure but does not give further
  information because none is available.
* In this situation the selected frame is not adjusted because in
  this mode the user will be looking at assembly and adjusting the
  frame makes things confusing.

This patch includes shell and api tests. The shell tests seemed like the
best way to test behavior when debug info is missing because those tests
make it easy to disable building with debug info completely.

rdar://163230807

