### PR TITLE
[llvm-21][MC] Fix fragments for sections bigger than 4G

### DIFF
--- a/llvm/lib/MC/MCSection.cpp
+++ b/llvm/lib/MC/MCSection.cpp
@@ -84,11 +84,11 @@ LLVM_DUMP_METHOD void MCSection::dump(
 
 void MCEncodedFragment::setContents(ArrayRef<char> Contents) {
   auto &S = getParent()->ContentStorage;
-  if (ContentStart + Contents.size() > ContentEnd) {
+  if (Contents.size() > ContentSize) {
     ContentStart = S.size();
     S.resize_for_overwrite(S.size() + Contents.size());
   }
-  ContentEnd = ContentStart + Contents.size();
+  ContentSize = Contents.size();
   llvm::copy(Contents, S.begin() + ContentStart);
 }
 


### PR DESCRIPTION
An OOM situation occurs in llvm-dwp when running big builds where sections are >4 GB. The problem is addressed in this post: https://github.com/llvm/llvm-project/issues/168923

Problem: 
When `ContentStorage` exceeds 4GB, the `uint32_t ContentEnd` field overflows when assigned in `doneAppending()`. Later in `getContentsForAppending()`, the calculation `Size = ContentEnd - ContentStart` causes unsigned integer underflow, producing large arbitrary memory allocations.

To address the OOM issue while keeping MCEncodedFragment size minimal, this solution transitions from a begin/end representation (`uint32_t ContentStart`, `uint32_t ContentEnd`) to a begin/size representation (`uint64_t ContentStart`, `uint32_t ContentSize`). The new approach changes `ContentStart` to 64-bit to support positions beyond 4GB, while `ContentSize` remains 32-bit, limiting individual fragments to 4GB.

This problem only exists in the llvm-21 branch. The recent refactoring in main branch makes this unnecessary there.

Fixes #168923