### PR TITLE
[llvm] Replace `OwningArrayRef` with `SmallVector` in `BTFParser`

### DIFF
--- a/llvm/include/llvm/DebugInfo/BTF/BTFParser.h
+++ b/llvm/include/llvm/DebugInfo/BTF/BTFParser.h
@@ -46,7 +46,7 @@ class BTFParser {
   // A copy of types table from the object file but using native byte
   // order. Should not be too big in practice, e.g. for ~250MiB vmlinux
   // image it is ~4MiB.
-  OwningArrayRef<uint8_t> TypesBuffer;
+  SmallVector<uint8_t, 0> TypesBuffer;
 
   // Maps ELF section number to instruction line number information.
   // Each BTFLinesVector is sorted by `InsnOffset` to allow fast lookups.

--- a/llvm/lib/DebugInfo/BTF/BTFParser.cpp
+++ b/llvm/lib/DebugInfo/BTF/BTFParser.cpp
@@ -206,8 +206,7 @@ Error BTFParser::parseTypesInfo(ParseContext &Ctx, uint64_t TypesInfoStart,
                                 StringRef RawData) {
   using support::endian::byte_swap;
 
-  auto RawDataAsBytes = arrayRefFromStringRef(RawData);
-  TypesBuffer.assign(RawDataAsBytes.begin(), RawDataAsBytes.end());
+  TypesBuffer.assign(arrayRefFromStringRef(RawData));
   // Switch endianness if necessary.
   endianness Endianness = Ctx.Obj.isLittleEndian() ? llvm::endianness::little
                                                    : llvm::endianness::big;

--- a/llvm/lib/DebugInfo/BTF/BTFParser.cpp
+++ b/llvm/lib/DebugInfo/BTF/BTFParser.cpp
@@ -206,7 +206,8 @@ Error BTFParser::parseTypesInfo(ParseContext &Ctx, uint64_t TypesInfoStart,
                                 StringRef RawData) {
   using support::endian::byte_swap;
 
-  TypesBuffer = OwningArrayRef<uint8_t>(arrayRefFromStringRef(RawData));
+  auto RawDataAsBytes = arrayRefFromStringRef(RawData);
+  TypesBuffer.assign(RawDataAsBytes.begin(), RawDataAsBytes.end());
   // Switch endianness if necessary.
   endianness Endianness = Ctx.Obj.isLittleEndian() ? llvm::endianness::little
                                                    : llvm::endianness::big;
@@ -380,7 +381,7 @@ Error BTFParser::parse(const ObjectFile &Obj, const ParseOptions &Opts) {
   SectionLines.clear();
   SectionRelocs.clear();
   Types.clear();
-  TypesBuffer = OwningArrayRef<uint8_t>();
+  TypesBuffer.clear();
 
   ParseContext Ctx(Obj, Opts);
   std::optional<SectionRef> BTF;


### PR DESCRIPTION
`OwningArrayRef` requires that the size and the capacity are the same. This prevents reusing memory allocations unless the size happens to be exactly the same (which is rare enough we don't even try). Switch to `SmallVector` instead so that we're not repeatedly calling `new[]` and `delete[]`.