### PR TITLE
[lldb] Remove Base::unique from NonNullSharedPtr

### DIFF
--- a/lldb/include/lldb/Utility/NonNullSharedPtr.h
+++ b/lldb/include/lldb/Utility/NonNullSharedPtr.h
@@ -56,7 +56,6 @@ public:
   using Base::operator*;
   using Base::operator->;
   using Base::get;
-  using Base::unique;
   using Base::use_count;
   using Base::operator bool;
 


### PR DESCRIPTION
It seems like this fails on macOS with C++20
