### PR TITLE
[lldb-dap] Add format support for evaluate request

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -988,7 +988,12 @@ class DebugCommunication(object):
         return self._send_recv(command_dict)
 
     def request_evaluate(
-        self, expression, frameIndex=0, threadId=None, context=None, is_hex=None
+        self,
+        expression,
+        frameIndex=0,
+        threadId=None,
+        context=None,
+        is_hex: Optional[bool] = None,
     ):
         stackFrame = self.get_stackFrame(frameIndex=frameIndex, threadId=threadId)
         if stackFrame is None:

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -987,7 +987,9 @@ class DebugCommunication(object):
         }
         return self._send_recv(command_dict)
 
-    def request_evaluate(self, expression, frameIndex=0, threadId=None, context=None):
+    def request_evaluate(
+        self, expression, frameIndex=0, threadId=None, context=None, is_hex=None
+    ):
         stackFrame = self.get_stackFrame(frameIndex=frameIndex, threadId=threadId)
         if stackFrame is None:
             return []
@@ -997,6 +999,8 @@ class DebugCommunication(object):
         }
         if context:
             args_dict["context"] = context
+        if is_hex is not None:
+            args_dict["format"] = {"hex": is_hex}
         command_dict = {
             "command": "evaluate",
             "type": "request",

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -27,8 +27,11 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         want_varref=False,
         want_memref=True,
         want_locref=False,
+        is_hex=None,
     ):
-        resp = self.dap_server.request_evaluate(expression, context=self.context)
+        resp = self.dap_server.request_evaluate(
+            expression, context=self.context, is_hex=is_hex
+        )
         self.assertTrue(
             resp["success"], f"Failed to evaluate expression {expression!r}"
         )
@@ -132,6 +135,12 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         if context == "repl":
             self.assertEvaluate("", "21", want_type="int")
             self.assertEvaluate("", "21", want_type="int")
+        self.assertEvaluate("static_int", "0x0000002a", want_type="int", is_hex=True)
+        self.assertEvaluate(
+            "non_static_int", "0x0000002b", want_type="int", is_hex=True
+        )
+        self.assertEvaluate("struct1.foo", "0x0000000f", want_type="int", is_hex=True)
+        self.assertEvaluate("struct2->foo", "0x00000010", want_type="int", is_hex=True)
         self.assertEvaluate("static_int", "42", want_type="int")
         self.assertEvaluate("non_static_int", "43", want_type="int")
         self.assertEvaluate("struct1.foo", "15", want_type="int")

--- a/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
@@ -84,9 +84,7 @@ EvaluateRequestHandler::Run(const EvaluateArguments &arguments) const {
   if (value.GetError().Fail())
     return ToError(value.GetError(), /*show_user=*/false);
 
-  bool hex = false;
-  if (arguments.format)
-    hex = arguments.format->hex;
+  const bool hex = arguments.format ? arguments.format->hex : false;
 
   VariableDescription desc(value, dap.configuration.enableAutoVariableSummaries,
                            hex);

--- a/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
@@ -84,8 +84,12 @@ EvaluateRequestHandler::Run(const EvaluateArguments &arguments) const {
   if (value.GetError().Fail())
     return ToError(value.GetError(), /*show_user=*/false);
 
-  VariableDescription desc(value,
-                           dap.configuration.enableAutoVariableSummaries);
+  bool hex = false;
+  if (arguments.format)
+    hex = arguments.format->hex;
+
+  VariableDescription desc(value, dap.configuration.enableAutoVariableSummaries,
+                           hex);
 
   body.result = desc.GetResult(arguments.context);
   body.type = desc.display_type_name;
@@ -98,7 +102,7 @@ EvaluateRequestHandler::Run(const EvaluateArguments &arguments) const {
     body.memoryReference = EncodeMemoryReference(addr);
 
   if (ValuePointsToCode(value) &&
-      body.variablesReference != LLDB_DAP_INVALID_VARRERF)
+      body.variablesReference != LLDB_DAP_INVALID_VAR_REF)
     body.valueLocationReference = PackLocation(body.variablesReference, true);
 
   return body;

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
@@ -28,7 +28,7 @@
 #include <optional>
 #include <string>
 
-#define LLDB_DAP_INVALID_VARRERF INT64_MAX
+#define LLDB_DAP_INVALID_VAR_REF INT64_MAX
 #define LLDB_DAP_INVALID_SRC_REF 0
 #define LLDB_DAP_INVALID_VALUE_LOC 0
 
@@ -462,7 +462,7 @@ struct Scope {
   /// remains suspended. See 'Lifetime of Object References' in the Overview
   /// section for details.
   ////
-  uint64_t variablesReference = LLDB_DAP_INVALID_VARRERF;
+  uint64_t variablesReference = LLDB_DAP_INVALID_VAR_REF;
 
   /// The number of named variables in this scope.
   /// The client can use this information to present the variables in a paged UI


### PR DESCRIPTION
This patch adds support for format option in the `evaluate` request according to [DAP](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Evaluate) specification. Also, fixed typo in `LLDB_DAP_INVALID_VARRERF` constant.