### PR TITLE
[bazel] Remove old config option

### DIFF
--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -46,9 +46,6 @@ build --incompatible_no_implicit_file_export
 # eventually become the default
 common --incompatible_disallow_empty_glob
 
-# TODO: Remove once we move to bazel 7.x
-build --experimental_cc_shared_library
-
 # Disabling runfiles links drastically increases performance in slow disk IO
 # situations Do not build runfile trees by default. If an execution strategy
 # relies on runfile symlink tree, the tree is created on-demand. See:


### PR DESCRIPTION
The default of this has been flipped since we're on 8.x
