### PR TITLE
[LLVM] Remove the requirement for named pipe in jobserver

### DIFF
--- a/llvm/lib/Support/Unix/Jobserver.inc
+++ b/llvm/lib/Support/Unix/Jobserver.inc
@@ -19,14 +19,6 @@
 #include <unistd.h>
 
 namespace {
-/// Returns true if the given file descriptor is a FIFO (named pipe).
-bool isFifo(int FD) {
-  struct stat StatBuf;
-  if (::fstat(FD, &StatBuf) != 0)
-    return false;
-  return S_ISFIFO(StatBuf.st_mode);
-}
-
 /// Returns true if the given file descriptors are valid.
 bool areFdsValid(int ReadFD, int WriteFD) {
   if (ReadFD == -1 || WriteFD == -1)
@@ -75,7 +67,7 @@ JobserverClientImpl::JobserverClientImpl(const JobserverConfig &Config) {
   case JobserverConfig::PosixFifo:
     // Open the FIFO for reading. It must be non-blocking and close-on-exec.
     ReadFD = ::open(Config.Path.c_str(), O_RDONLY | O_NONBLOCK | O_CLOEXEC);
-    if (ReadFD < 0 || !isFifo(ReadFD)) {
+    if (ReadFD < 0) {
       if (ReadFD >= 0)
         ::close(ReadFD);
       ReadFD = -1;


### PR DESCRIPTION
Remove the requirement that the jobserver "fifo" is actually a named pipe.  Named pipes are essentially stateless, and therefore carry a high risk of a killed process leaving the server with no tokens left, and no clear way to reclaim them.  Therefore, multiple jobserver implementations use FUSE instead:

- [nixos-jobserver](https://github.com/NixOS/nixpkgs/pull/314888) (WIP) uses simple file on FUSE

- [steve](https://gitweb.gentoo.org/proj/steve.git) uses a character device via CUSE

- [guildmaster](https://codeberg.org/amonakov/guildmaster) uses a character device via CUSE

This is compatible with GNU make and Ninja, since they do not check the file type, and seems to be the only solution that can achieve state tracking while preserving compatibility.

CC @amonakov