### PR TITLE
Add a filegroup containing _all_ sources to the libc build rules

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -247,6 +247,12 @@ def libc_header_library(name, hdrs, deps = [], **kwargs):
         **kwargs
     )
 
+    _libc_srcs_filegroup(
+        name = name + "_hdrs",
+        libs = [":" + name],
+        enforce_headers_only = True,
+    )
+
 def libc_generated_header(name, hdr, yaml_template, other_srcs = []):
     """Generates a libc header file from YAML template.
 

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -247,6 +247,8 @@ def libc_header_library(name, hdrs, deps = [], **kwargs):
         **kwargs
     )
 
+    # Also generate a filegroup that contains _all_ of the headers for use in
+    # systems like Carbon's where runtime sources are shipped outside of Bazel.
     _libc_srcs_filegroup(
         name = name + "_hdrs",
         libs = [":" + name],


### PR DESCRIPTION
These rules already expose a filegroup containing the _dependencies_, but that misses the source files directly in the top level library.

Without this filegroup, there isn't a way to access the source files used by libcxx when building it, etc.