### PR TITLE
[clang-format] Allow custom pointer/ref alignment in return types

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5668,31 +5668,54 @@ the configuration (without a prefix: ``Auto``).
 
 .. _PointerAlignment:
 
-**PointerAlignment** (``PointerAlignmentStyle``) :versionbadge:`clang-format 3.7` :ref:`¶ <PointerAlignment>`
+**PointerAlignment** (``PointerAlignmentOptions``) :versionbadge:`clang-format 3.7` :ref:`¶ <PointerAlignment>`
   Pointer and reference alignment style.
 
-  Possible values:
+  Acceptable values (configured as a single string or with suboptions):
+  * ``Left``
+  * ``Right``
+  * ``Middle``
 
-  * ``PAS_Left`` (in configuration: ``Left``)
-    Align pointer to the left.
+  For example, to configure left pointer alignment:
 
-    .. code-block:: c++
+  .. code-block:: yaml
 
-      int* a;
+    PointerAlignment: Left
 
-  * ``PAS_Right`` (in configuration: ``Right``)
-    Align pointer to the right.
+    # or
 
-    .. code-block:: c++
+    PointerAlignment:
+      Default: Left
 
-      int *a;
+  Nested configuration flags:
 
-  * ``PAS_Middle`` (in configuration: ``Middle``)
-    Align pointer in the middle.
+  Pointer and reference alignment options.
 
-    .. code-block:: c++
+  * ``PointerAlignmentStyle Default``
+    The default alignment for pointers and references.
 
-      int * a;
+    Possible values:
+
+    * ``PAS_Left`` (in configuration: ``Left``)
+      Align pointer to the left.
+
+      .. code-block:: c++
+
+        int* a;
+
+    * ``PAS_Right`` (in configuration: ``Right``)
+      Align pointer to the right.
+
+      .. code-block:: c++
+
+        int *a;
+
+    * ``PAS_Middle`` (in configuration: ``Middle``)
+      Align pointer in the middle.
+
+      .. code-block:: c++
+
+        int * a;
 
 
 
@@ -5824,34 +5847,58 @@ the configuration (without a prefix: ``Auto``).
 
 .. _ReferenceAlignment:
 
-**ReferenceAlignment** (``ReferenceAlignmentStyle``) :versionbadge:`clang-format 13` :ref:`¶ <ReferenceAlignment>`
+**ReferenceAlignment** (``ReferenceAlignmentOptions``) :versionbadge:`clang-format 13` :ref:`¶ <ReferenceAlignment>`
   Reference alignment style (overrides ``PointerAlignment`` for references).
 
-  Possible values:
+  Acceptable values (configured as a single string or with suboptions):
+  * ``Pointer``
+  * ``Left``
+  * ``Right``
+  * ``Middle``
 
-  * ``RAS_Pointer`` (in configuration: ``Pointer``)
-    Align reference like ``PointerAlignment``.
+  For example, to configure right reference alignment:
 
-  * ``RAS_Left`` (in configuration: ``Left``)
-    Align reference to the left.
+  .. code-block:: yaml
 
-    .. code-block:: c++
+    ReferenceAlignment: Right
 
-      int& a;
+    # or
 
-  * ``RAS_Right`` (in configuration: ``Right``)
-    Align reference to the right.
+    ReferenceAlignment:
+      Default: Right
 
-    .. code-block:: c++
+  Nested configuration flags:
 
-      int &a;
+  Reference alignment options.
 
-  * ``RAS_Middle`` (in configuration: ``Middle``)
-    Align reference in the middle.
+  * ``ReferenceAlignmentStyle Default``
+    The default alignment for references.
 
-    .. code-block:: c++
+    Possible values:
 
-      int & a;
+    * ``RAS_Pointer`` (in configuration: ``Pointer``)
+      Align reference like ``PointerAlignment``.
+
+    * ``RAS_Left`` (in configuration: ``Left``)
+      Align reference to the left.
+
+      .. code-block:: c++
+
+        int& a;
+
+    * ``RAS_Right`` (in configuration: ``Right``)
+      Align reference to the right.
+
+      .. code-block:: c++
+
+        int &a;
+
+    * ``RAS_Middle`` (in configuration: ``Middle``)
+      Align reference in the middle.
+
+      .. code-block:: c++
+
+        int & a;
 
 
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5748,6 +5748,29 @@ the configuration (without a prefix: ``Auto``).
         int * a(void);
 
 
+  * ``CastAlignmentStyle CStyleCast``
+    The alignment for pointers in C-style casts.
+
+    Possible values:
+
+    * ``CAS_Default`` (in configuration: ``Default``)
+      Use default alignment.
+
+    * ``CAS_Left`` (in configuration: ``Left``)
+      Align pointer/reference to the left.
+
+      .. code-block:: c++
+
+        (char*)s;
+
+    * ``CAS_Right`` (in configuration: ``Right``)
+      Align pointer/reference to the right.
+
+      .. code-block:: c++
+
+        (char *)s;
+
+
 
 .. _QualifierAlignment:
 
@@ -5959,6 +5982,29 @@ the configuration (without a prefix: ``Auto``).
       .. code-block:: c++
 
         int * a(void);
+
+
+  * ``CastAlignmentStyle CStyleCast``
+    The alignment for references in C-style casts.
+
+    Possible values:
+
+    * ``CAS_Default`` (in configuration: ``Default``)
+      Use default alignment.
+
+    * ``CAS_Left`` (in configuration: ``Left``)
+      Align pointer/reference to the left.
+
+      .. code-block:: c++
+
+        (char*)s;
+
+    * ``CAS_Right`` (in configuration: ``Right``)
+      Align pointer/reference to the right.
+
+      .. code-block:: c++
+
+        (char *)s;
 
 
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5718,6 +5718,36 @@ the configuration (without a prefix: ``Auto``).
         int * a;
 
 
+  * ``ReturnTypeAlignmentStyle ReturnType``
+    The alignment for pointers in function return types.
+
+    Possible values:
+
+    * ``RTAS_Default`` (in configuration: ``Default``)
+      Use default alignment.
+
+    * ``RTAS_Left`` (in configuration: ``Left``)
+      Align pointer/reference to the left.
+
+      .. code-block:: c++
+
+        int* a(void);
+
+    * ``RTAS_Right`` (in configuration: ``Right``)
+      Align pointer/reference to the right.
+
+      .. code-block:: c++
+
+        int *a(void);
+
+    * ``RTAS_Middle`` (in configuration: ``Middle``)
+      Align pointer/reference in the middle.
+
+      .. code-block:: c++
+
+        int * a(void);
+
+
 
 .. _QualifierAlignment:
 
@@ -5899,6 +5929,36 @@ the configuration (without a prefix: ``Auto``).
       .. code-block:: c++
 
         int & a;
+
+
+  * ``ReturnTypeAlignmentStyle ReturnType``
+    The alignment for references in function return types.
+
+    Possible values:
+
+    * ``RTAS_Default`` (in configuration: ``Default``)
+      Use default alignment.
+
+    * ``RTAS_Left`` (in configuration: ``Left``)
+      Align pointer/reference to the left.
+
+      .. code-block:: c++
+
+        int* a(void);
+
+    * ``RTAS_Right`` (in configuration: ``Right``)
+      Align pointer/reference to the right.
+
+      .. code-block:: c++
+
+        int *a(void);
+
+    * ``RTAS_Middle`` (in configuration: ``Middle``)
+      Align pointer/reference in the middle.
+
+      .. code-block:: c++
+
+        int * a(void);
 
 
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -4057,14 +4057,33 @@ struct FormatStyle {
     RTAS_Middle
   };
 
+  /// \brief The pointer/reference alignment style for C-style casts.
+  enum CastAlignmentStyle : int8_t {
+    /// Use default alignment.
+    CAS_Default,
+    /// Align pointer/reference to the left.
+    /// \code
+    ///   (char*)s;
+    /// \endcode
+    CAS_Left,
+    /// Align pointer/reference to the right.
+    /// \code
+    ///   (char *)s;
+    /// \endcode
+    CAS_Right,
+  };
+
   /// Pointer and reference alignment options.
   struct PointerAlignmentOptions {
     /// The default alignment for pointers and references.
     PointerAlignmentStyle Default;
     /// The alignment for pointers in function return types.
     ReturnTypeAlignmentStyle ReturnType;
+    /// The alignment for pointers in C-style casts.
+    CastAlignmentStyle CStyleCast;
     bool operator==(const PointerAlignmentOptions &R) const {
-      return Default == R.Default && ReturnType == R.ReturnType;
+      return Default == R.Default && ReturnType == R.ReturnType &&
+             CStyleCast == R.CStyleCast;
     }
     bool operator!=(const PointerAlignmentOptions &R) const {
       return !(*this == R);
@@ -4264,8 +4283,11 @@ struct FormatStyle {
     ReferenceAlignmentStyle Default;
     /// The alignment for references in function return types.
     ReturnTypeAlignmentStyle ReturnType;
+    /// The alignment for references in C-style casts.
+    CastAlignmentStyle CStyleCast;
     bool operator==(const ReferenceAlignmentOptions &R) const {
-      return Default == R.Default && ReturnType == R.ReturnType;
+      return Default == R.Default && ReturnType == R.ReturnType &&
+             CStyleCast == R.CStyleCast;
     }
     bool operator!=(const ReferenceAlignmentOptions &R) const {
       return !(*this == R);

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -4036,9 +4036,36 @@ struct FormatStyle {
     PAS_Middle
   };
 
+  /// Pointer and reference alignment options.
+  struct PointerAlignmentOptions {
+    /// The default alignment for pointers and references.
+    PointerAlignmentStyle Default;
+    bool operator==(const PointerAlignmentOptions &R) const {
+      return Default == R.Default;
+    }
+    bool operator!=(const PointerAlignmentOptions &R) const {
+      return !(*this == R);
+    }
+  };
+
   /// Pointer and reference alignment style.
+  ///
+  /// Acceptable values (configured as a single string or with suboptions):
+  /// * ``Left``
+  /// * ``Right``
+  /// * ``Middle``
+  ///
+  /// For example, to configure left pointer alignment:
+  /// \code{.yaml}
+  ///   PointerAlignment: Left
+  ///
+  ///   # or
+  ///
+  ///   PointerAlignment:
+  ///     Default: Left
+  /// \endcode
   /// \version 3.7
-  PointerAlignmentStyle PointerAlignment;
+  PointerAlignmentOptions PointerAlignment;
 
   /// The number of columns to use for indentation of preprocessor statements.
   /// When set to -1 (default) ``IndentWidth`` is used also for preprocessor
@@ -4208,9 +4235,37 @@ struct FormatStyle {
     RAS_Middle
   };
 
+  /// Reference alignment options.
+  struct ReferenceAlignmentOptions {
+    /// The default alignment for references.
+    ReferenceAlignmentStyle Default;
+    bool operator==(const ReferenceAlignmentOptions &R) const {
+      return Default == R.Default;
+    }
+    bool operator!=(const ReferenceAlignmentOptions &R) const {
+      return !(*this == R);
+    }
+  };
+
   /// Reference alignment style (overrides ``PointerAlignment`` for references).
+  ///
+  /// Acceptable values (configured as a single string or with suboptions):
+  /// * ``Pointer``
+  /// * ``Left``
+  /// * ``Right``
+  /// * ``Middle``
+  ///
+  /// For example, to configure right reference alignment:
+  /// \code{.yaml}
+  ///   ReferenceAlignment: Right
+  ///
+  ///   # or
+  ///
+  ///   ReferenceAlignment:
+  ///     Default: Right
+  /// \endcode
   /// \version 13
-  ReferenceAlignmentStyle ReferenceAlignment;
+  ReferenceAlignmentOptions ReferenceAlignment;
 
   // clang-format off
   /// Types of comment reflow style.

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -4036,12 +4036,35 @@ struct FormatStyle {
     PAS_Middle
   };
 
+  /// \brief The pointer/reference alignment style for function return types.
+  enum ReturnTypeAlignmentStyle : int8_t {
+    /// Use default alignment.
+    RTAS_Default,
+    /// Align pointer/reference to the left.
+    /// \code
+    ///   int* a(void);
+    /// \endcode
+    RTAS_Left,
+    /// Align pointer/reference to the right.
+    /// \code
+    ///   int *a(void);
+    /// \endcode
+    RTAS_Right,
+    /// Align pointer/reference in the middle.
+    /// \code
+    ///   int * a(void);
+    /// \endcode
+    RTAS_Middle
+  };
+
   /// Pointer and reference alignment options.
   struct PointerAlignmentOptions {
     /// The default alignment for pointers and references.
     PointerAlignmentStyle Default;
+    /// The alignment for pointers in function return types.
+    ReturnTypeAlignmentStyle ReturnType;
     bool operator==(const PointerAlignmentOptions &R) const {
-      return Default == R.Default;
+      return Default == R.Default && ReturnType == R.ReturnType;
     }
     bool operator!=(const PointerAlignmentOptions &R) const {
       return !(*this == R);
@@ -4239,8 +4262,10 @@ struct FormatStyle {
   struct ReferenceAlignmentOptions {
     /// The default alignment for references.
     ReferenceAlignmentStyle Default;
+    /// The alignment for references in function return types.
+    ReturnTypeAlignmentStyle ReturnType;
     bool operator==(const ReferenceAlignmentOptions &R) const {
-      return Default == R.Default;
+      return Default == R.Default && ReturnType == R.ReturnType;
     }
     bool operator!=(const ReferenceAlignmentOptions &R) const {
       return !(*this == R);

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -541,10 +541,32 @@ template <> struct ScalarEnumerationTraits<FormatStyle::PointerAlignmentStyle> {
     IO.enumCase(Value, "Middle", FormatStyle::PAS_Middle);
     IO.enumCase(Value, "Left", FormatStyle::PAS_Left);
     IO.enumCase(Value, "Right", FormatStyle::PAS_Right);
+  }
+};
+
+template <> struct MappingTraits<FormatStyle::PointerAlignmentOptions> {
+  static void enumInput(IO &IO, FormatStyle::PointerAlignmentOptions &Value) {
+    IO.enumCase(Value, "Middle",
+                FormatStyle::PointerAlignmentOptions(
+                    {/*Default=*/FormatStyle::PAS_Middle}));
+    IO.enumCase(Value, "Left",
+                FormatStyle::PointerAlignmentOptions(
+                    {/*Default=*/FormatStyle::PAS_Left}));
+    IO.enumCase(Value, "Right",
+                FormatStyle::PointerAlignmentOptions(
+                    {/*Default=*/FormatStyle::PAS_Right}));
 
     // For backward compatibility.
-    IO.enumCase(Value, "true", FormatStyle::PAS_Left);
-    IO.enumCase(Value, "false", FormatStyle::PAS_Right);
+    IO.enumCase(Value, "true",
+                FormatStyle::PointerAlignmentOptions(
+                    {/*Default=*/FormatStyle::PAS_Left}));
+    IO.enumCase(Value, "false",
+                FormatStyle::PointerAlignmentOptions(
+                    {/*Default=*/FormatStyle::PAS_Right}));
+  }
+
+  static void mapping(IO &IO, FormatStyle::PointerAlignmentOptions &Value) {
+    IO.mapOptional("Default", Value.Default);
   }
 };
 
@@ -586,6 +608,27 @@ template <> struct ScalarEnumerationTraits<FormatStyle::ReflowCommentsStyle> {
     // For backward compatibility:
     IO.enumCase(Value, "false", FormatStyle::RCS_Never);
     IO.enumCase(Value, "true", FormatStyle::RCS_Always);
+  }
+};
+
+template <> struct MappingTraits<FormatStyle::ReferenceAlignmentOptions> {
+  static void enumInput(IO &IO, FormatStyle::ReferenceAlignmentOptions &Value) {
+    IO.enumCase(Value, "Pointer",
+                FormatStyle::ReferenceAlignmentOptions(
+                    {/*Default=*/FormatStyle::RAS_Pointer}));
+    IO.enumCase(Value, "Middle",
+                FormatStyle::ReferenceAlignmentOptions(
+                    {/*Default=*/FormatStyle::RAS_Middle}));
+    IO.enumCase(Value, "Left",
+                FormatStyle::ReferenceAlignmentOptions(
+                    {/*Default=*/FormatStyle::RAS_Left}));
+    IO.enumCase(Value, "Right",
+                FormatStyle::ReferenceAlignmentOptions(
+                    {/*Default=*/FormatStyle::RAS_Right}));
+  }
+
+  static void mapping(IO &IO, FormatStyle::ReferenceAlignmentOptions &Value) {
+    IO.mapOptional("Default", Value.Default);
   }
 };
 
@@ -1785,10 +1828,10 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.ObjCSpaceAfterProperty = false;
   LLVMStyle.ObjCSpaceBeforeProtocolList = true;
   LLVMStyle.PackConstructorInitializers = FormatStyle::PCIS_BinPack;
-  LLVMStyle.PointerAlignment = FormatStyle::PAS_Right;
+  LLVMStyle.PointerAlignment = {/*Default=*/FormatStyle::PAS_Right};
   LLVMStyle.PPIndentWidth = -1;
   LLVMStyle.QualifierAlignment = FormatStyle::QAS_Leave;
-  LLVMStyle.ReferenceAlignment = FormatStyle::RAS_Pointer;
+  LLVMStyle.ReferenceAlignment = {/*Default=*/FormatStyle::RAS_Pointer};
   LLVMStyle.ReflowComments = FormatStyle::RCS_Always;
   LLVMStyle.RemoveBracesLLVM = false;
   LLVMStyle.RemoveEmptyLinesInUnwrappedLines = false;
@@ -1910,7 +1953,7 @@ FormatStyle getGoogleStyle(FormatStyle::LanguageKind Language) {
   GoogleStyle.ObjCSpaceAfterProperty = false;
   GoogleStyle.ObjCSpaceBeforeProtocolList = true;
   GoogleStyle.PackConstructorInitializers = FormatStyle::PCIS_NextLine;
-  GoogleStyle.PointerAlignment = FormatStyle::PAS_Left;
+  GoogleStyle.PointerAlignment.Default = FormatStyle::PAS_Left;
   GoogleStyle.RawStringFormats = {
       {
           FormatStyle::LK_Cpp,
@@ -2105,7 +2148,7 @@ FormatStyle getMozillaStyle() {
   MozillaStyle.ObjCSpaceAfterProperty = true;
   MozillaStyle.ObjCSpaceBeforeProtocolList = false;
   MozillaStyle.PenaltyReturnTypeOnItsOwnLine = 200;
-  MozillaStyle.PointerAlignment = FormatStyle::PAS_Left;
+  MozillaStyle.PointerAlignment.Default = FormatStyle::PAS_Left;
   MozillaStyle.SpaceAfterTemplateKeyword = false;
   return MozillaStyle;
 }
@@ -2128,7 +2171,7 @@ FormatStyle getWebKitStyle() {
   Style.NamespaceIndentation = FormatStyle::NI_Inner;
   Style.ObjCBlockIndentWidth = 4;
   Style.ObjCSpaceAfterProperty = true;
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   Style.SpaceBeforeCpp11BracedList = true;
   Style.SpaceInEmptyBraces = FormatStyle::SIEB_Always;
   return Style;
@@ -2862,10 +2905,10 @@ private:
     if (Style.DerivePointerAlignment) {
       const auto NetRightCount = countVariableAlignments(AnnotatedLines);
       if (NetRightCount > 0)
-        Style.PointerAlignment = FormatStyle::PAS_Right;
+        Style.PointerAlignment.Default = FormatStyle::PAS_Right;
       else if (NetRightCount < 0)
-        Style.PointerAlignment = FormatStyle::PAS_Left;
-      Style.ReferenceAlignment = FormatStyle::RAS_Pointer;
+        Style.PointerAlignment.Default = FormatStyle::PAS_Left;
+      Style.ReferenceAlignment.Default = FormatStyle::RAS_Pointer;
     }
     if (Style.Standard == FormatStyle::LS_Auto) {
       Style.Standard = hasCpp03IncompatibleFormat(AnnotatedLines)

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -544,29 +544,46 @@ template <> struct ScalarEnumerationTraits<FormatStyle::PointerAlignmentStyle> {
   }
 };
 
+template <>
+struct ScalarEnumerationTraits<FormatStyle::ReturnTypeAlignmentStyle> {
+  static void enumeration(IO &IO,
+                          FormatStyle::ReturnTypeAlignmentStyle &Value) {
+    IO.enumCase(Value, "Default", FormatStyle::RTAS_Default);
+    IO.enumCase(Value, "Middle", FormatStyle::RTAS_Middle);
+    IO.enumCase(Value, "Left", FormatStyle::RTAS_Left);
+    IO.enumCase(Value, "Right", FormatStyle::RTAS_Right);
+  }
+};
+
 template <> struct MappingTraits<FormatStyle::PointerAlignmentOptions> {
   static void enumInput(IO &IO, FormatStyle::PointerAlignmentOptions &Value) {
     IO.enumCase(Value, "Middle",
                 FormatStyle::PointerAlignmentOptions(
-                    {/*Default=*/FormatStyle::PAS_Middle}));
+                    {/*Default=*/FormatStyle::PAS_Middle,
+                     /*ReturnType=*/FormatStyle::RTAS_Default}));
     IO.enumCase(Value, "Left",
                 FormatStyle::PointerAlignmentOptions(
-                    {/*Default=*/FormatStyle::PAS_Left}));
+                    {/*Default=*/FormatStyle::PAS_Left,
+                     /*ReturnType=*/FormatStyle::RTAS_Default}));
     IO.enumCase(Value, "Right",
                 FormatStyle::PointerAlignmentOptions(
-                    {/*Default=*/FormatStyle::PAS_Right}));
+                    {/*Default=*/FormatStyle::PAS_Right,
+                     /*ReturnType=*/FormatStyle::RTAS_Default}));
 
     // For backward compatibility.
     IO.enumCase(Value, "true",
                 FormatStyle::PointerAlignmentOptions(
-                    {/*Default=*/FormatStyle::PAS_Left}));
+                    {/*Default=*/FormatStyle::PAS_Left,
+                     /*ReturnType=*/FormatStyle::RTAS_Default}));
     IO.enumCase(Value, "false",
                 FormatStyle::PointerAlignmentOptions(
-                    {/*Default=*/FormatStyle::PAS_Right}));
+                    {/*Default=*/FormatStyle::PAS_Right,
+                     /*ReturnType=*/FormatStyle::RTAS_Default}));
   }
 
   static void mapping(IO &IO, FormatStyle::PointerAlignmentOptions &Value) {
     IO.mapOptional("Default", Value.Default);
+    IO.mapOptional("ReturnType", Value.ReturnType);
   }
 };
 
@@ -615,20 +632,25 @@ template <> struct MappingTraits<FormatStyle::ReferenceAlignmentOptions> {
   static void enumInput(IO &IO, FormatStyle::ReferenceAlignmentOptions &Value) {
     IO.enumCase(Value, "Pointer",
                 FormatStyle::ReferenceAlignmentOptions(
-                    {/*Default=*/FormatStyle::RAS_Pointer}));
+                    {/*Default=*/FormatStyle::RAS_Pointer,
+                     /*ReturnType=*/FormatStyle::RTAS_Default}));
     IO.enumCase(Value, "Middle",
                 FormatStyle::ReferenceAlignmentOptions(
-                    {/*Default=*/FormatStyle::RAS_Middle}));
+                    {/*Default=*/FormatStyle::RAS_Middle,
+                     /*ReturnType=*/FormatStyle::RTAS_Default}));
     IO.enumCase(Value, "Left",
                 FormatStyle::ReferenceAlignmentOptions(
-                    {/*Default=*/FormatStyle::RAS_Left}));
+                    {/*Default=*/FormatStyle::RAS_Left,
+                     /*ReturnType=*/FormatStyle::RTAS_Default}));
     IO.enumCase(Value, "Right",
                 FormatStyle::ReferenceAlignmentOptions(
-                    {/*Default=*/FormatStyle::RAS_Right}));
+                    {/*Default=*/FormatStyle::RAS_Right,
+                     /*ReturnType=*/FormatStyle::RTAS_Default}));
   }
 
   static void mapping(IO &IO, FormatStyle::ReferenceAlignmentOptions &Value) {
     IO.mapOptional("Default", Value.Default);
+    IO.mapOptional("ReturnType", Value.ReturnType);
   }
 };
 
@@ -1828,10 +1850,12 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.ObjCSpaceAfterProperty = false;
   LLVMStyle.ObjCSpaceBeforeProtocolList = true;
   LLVMStyle.PackConstructorInitializers = FormatStyle::PCIS_BinPack;
-  LLVMStyle.PointerAlignment = {/*Default=*/FormatStyle::PAS_Right};
+  LLVMStyle.PointerAlignment = {/*Default=*/FormatStyle::PAS_Right,
+                                /*ReturnType=*/FormatStyle::RTAS_Default};
   LLVMStyle.PPIndentWidth = -1;
   LLVMStyle.QualifierAlignment = FormatStyle::QAS_Leave;
-  LLVMStyle.ReferenceAlignment = {/*Default=*/FormatStyle::RAS_Pointer};
+  LLVMStyle.ReferenceAlignment = {/*Default=*/FormatStyle::RAS_Pointer,
+                                  /*ReturnType=*/FormatStyle::RTAS_Default};
   LLVMStyle.ReflowComments = FormatStyle::RCS_Always;
   LLVMStyle.RemoveBracesLLVM = false;
   LLVMStyle.RemoveEmptyLinesInUnwrappedLines = false;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -555,35 +555,49 @@ struct ScalarEnumerationTraits<FormatStyle::ReturnTypeAlignmentStyle> {
   }
 };
 
+template <> struct ScalarEnumerationTraits<FormatStyle::CastAlignmentStyle> {
+  static void enumeration(IO &IO, FormatStyle::CastAlignmentStyle &Value) {
+    IO.enumCase(Value, "Default", FormatStyle::CAS_Default);
+    IO.enumCase(Value, "Left", FormatStyle::CAS_Left);
+    IO.enumCase(Value, "Right", FormatStyle::CAS_Right);
+  }
+};
+
 template <> struct MappingTraits<FormatStyle::PointerAlignmentOptions> {
   static void enumInput(IO &IO, FormatStyle::PointerAlignmentOptions &Value) {
     IO.enumCase(Value, "Middle",
                 FormatStyle::PointerAlignmentOptions(
                     {/*Default=*/FormatStyle::PAS_Middle,
-                     /*ReturnType=*/FormatStyle::RTAS_Default}));
+                     /*ReturnType=*/FormatStyle::RTAS_Default,
+                     /*CStyleCast=*/FormatStyle::CAS_Default}));
     IO.enumCase(Value, "Left",
                 FormatStyle::PointerAlignmentOptions(
                     {/*Default=*/FormatStyle::PAS_Left,
-                     /*ReturnType=*/FormatStyle::RTAS_Default}));
+                     /*ReturnType=*/FormatStyle::RTAS_Default,
+                     /*CStyleCast=*/FormatStyle::CAS_Default}));
     IO.enumCase(Value, "Right",
                 FormatStyle::PointerAlignmentOptions(
                     {/*Default=*/FormatStyle::PAS_Right,
-                     /*ReturnType=*/FormatStyle::RTAS_Default}));
+                     /*ReturnType=*/FormatStyle::RTAS_Default,
+                     /*CStyleCast=*/FormatStyle::CAS_Default}));
 
     // For backward compatibility.
     IO.enumCase(Value, "true",
                 FormatStyle::PointerAlignmentOptions(
                     {/*Default=*/FormatStyle::PAS_Left,
-                     /*ReturnType=*/FormatStyle::RTAS_Default}));
+                     /*ReturnType=*/FormatStyle::RTAS_Default,
+                     /*CStyleCast=*/FormatStyle::CAS_Default}));
     IO.enumCase(Value, "false",
                 FormatStyle::PointerAlignmentOptions(
                     {/*Default=*/FormatStyle::PAS_Right,
-                     /*ReturnType=*/FormatStyle::RTAS_Default}));
+                     /*ReturnType=*/FormatStyle::RTAS_Default,
+                     /*CStyleCast=*/FormatStyle::CAS_Default}));
   }
 
   static void mapping(IO &IO, FormatStyle::PointerAlignmentOptions &Value) {
     IO.mapOptional("Default", Value.Default);
     IO.mapOptional("ReturnType", Value.ReturnType);
+    IO.mapOptional("CStyleCast", Value.CStyleCast);
   }
 };
 
@@ -633,24 +647,29 @@ template <> struct MappingTraits<FormatStyle::ReferenceAlignmentOptions> {
     IO.enumCase(Value, "Pointer",
                 FormatStyle::ReferenceAlignmentOptions(
                     {/*Default=*/FormatStyle::RAS_Pointer,
-                     /*ReturnType=*/FormatStyle::RTAS_Default}));
+                     /*ReturnType=*/FormatStyle::RTAS_Default,
+                     /*CStyleCast=*/FormatStyle::CAS_Default}));
     IO.enumCase(Value, "Middle",
                 FormatStyle::ReferenceAlignmentOptions(
                     {/*Default=*/FormatStyle::RAS_Middle,
-                     /*ReturnType=*/FormatStyle::RTAS_Default}));
+                     /*ReturnType=*/FormatStyle::RTAS_Default,
+                     /*CStyleCast=*/FormatStyle::CAS_Default}));
     IO.enumCase(Value, "Left",
                 FormatStyle::ReferenceAlignmentOptions(
                     {/*Default=*/FormatStyle::RAS_Left,
-                     /*ReturnType=*/FormatStyle::RTAS_Default}));
+                     /*ReturnType=*/FormatStyle::RTAS_Default,
+                     /*CStyleCast=*/FormatStyle::CAS_Default}));
     IO.enumCase(Value, "Right",
                 FormatStyle::ReferenceAlignmentOptions(
                     {/*Default=*/FormatStyle::RAS_Right,
-                     /*ReturnType=*/FormatStyle::RTAS_Default}));
+                     /*ReturnType=*/FormatStyle::RTAS_Default,
+                     /*CStyleCast=*/FormatStyle::CAS_Default}));
   }
 
   static void mapping(IO &IO, FormatStyle::ReferenceAlignmentOptions &Value) {
     IO.mapOptional("Default", Value.Default);
     IO.mapOptional("ReturnType", Value.ReturnType);
+    IO.mapOptional("CStyleCast", Value.CStyleCast);
   }
 };
 
@@ -1851,11 +1870,13 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.ObjCSpaceBeforeProtocolList = true;
   LLVMStyle.PackConstructorInitializers = FormatStyle::PCIS_BinPack;
   LLVMStyle.PointerAlignment = {/*Default=*/FormatStyle::PAS_Right,
-                                /*ReturnType=*/FormatStyle::RTAS_Default};
+                                /*ReturnType=*/FormatStyle::RTAS_Default,
+                                /*CStyleCast=*/FormatStyle::CAS_Default};
   LLVMStyle.PPIndentWidth = -1;
   LLVMStyle.QualifierAlignment = FormatStyle::QAS_Leave;
   LLVMStyle.ReferenceAlignment = {/*Default=*/FormatStyle::RAS_Pointer,
-                                  /*ReturnType=*/FormatStyle::RTAS_Default};
+                                  /*ReturnType=*/FormatStyle::RTAS_Default,
+                                  /*CStyleCast=*/FormatStyle::CAS_Default};
   LLVMStyle.ReflowComments = FormatStyle::RCS_Always;
   LLVMStyle.RemoveBracesLLVM = false;
   LLVMStyle.RemoveEmptyLinesInUnwrappedLines = false;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -4732,7 +4732,7 @@ bool TokenAnnotator::spaceRequiredBetween(const AnnotatedLine &Line,
     if (BeforeLeft->is(tok::coloncolon)) {
       if (Left.isNot(tok::star))
         return false;
-      assert(Style.PointerAlignment != FormatStyle::PAS_Right);
+      assert(Style.PointerAlignment.Default != FormatStyle::PAS_Right);
       if (!Right.startsSequence(tok::identifier, tok::r_paren))
         return true;
       assert(Right.Next);
@@ -4744,7 +4744,7 @@ bool TokenAnnotator::spaceRequiredBetween(const AnnotatedLine &Line,
   // Ensure right pointer alignment with ellipsis e.g. int *...P
   if (Left.is(tok::ellipsis) && BeforeLeft &&
       BeforeLeft->isPointerOrReference()) {
-    return Style.PointerAlignment != FormatStyle::PAS_Right;
+    return Style.PointerAlignment.Default != FormatStyle::PAS_Right;
   }
 
   if (Right.is(tok::star) && Left.is(tok::l_paren))
@@ -4782,9 +4782,9 @@ bool TokenAnnotator::spaceRequiredBetween(const AnnotatedLine &Line,
     // dependent on PointerAlignment style.
     if (Previous) {
       if (Previous->endsSequence(tok::kw_operator))
-        return Style.PointerAlignment != FormatStyle::PAS_Left;
+        return Style.PointerAlignment.Default != FormatStyle::PAS_Left;
       if (Previous->isOneOf(tok::kw_const, tok::kw_volatile)) {
-        return (Style.PointerAlignment != FormatStyle::PAS_Left) ||
+        return (Style.PointerAlignment.Default != FormatStyle::PAS_Left) ||
                (Style.SpaceAroundPointerQualifiers ==
                 FormatStyle::SAPQ_After) ||
                (Style.SpaceAroundPointerQualifiers == FormatStyle::SAPQ_Both);
@@ -6543,9 +6543,9 @@ void TokenAnnotator::printDebugInfo(const AnnotatedLine &Line) const {
 FormatStyle::PointerAlignmentStyle
 TokenAnnotator::getTokenReferenceAlignment(const FormatToken &Reference) const {
   assert(Reference.isOneOf(tok::amp, tok::ampamp));
-  switch (Style.ReferenceAlignment) {
+  switch (Style.ReferenceAlignment.Default) {
   case FormatStyle::RAS_Pointer:
-    return Style.PointerAlignment;
+    return Style.PointerAlignment.Default;
   case FormatStyle::RAS_Left:
     return FormatStyle::PAS_Left;
   case FormatStyle::RAS_Right:
@@ -6554,7 +6554,7 @@ TokenAnnotator::getTokenReferenceAlignment(const FormatToken &Reference) const {
     return FormatStyle::PAS_Middle;
   }
   assert(0); //"Unhandled value of ReferenceAlignment"
-  return Style.PointerAlignment;
+  return Style.PointerAlignment.Default;
 }
 
 FormatStyle::PointerAlignmentStyle
@@ -6563,7 +6563,7 @@ TokenAnnotator::getTokenPointerOrReferenceAlignment(
   if (PointerOrReference.isOneOf(tok::amp, tok::ampamp))
     return getTokenReferenceAlignment(PointerOrReference);
   assert(PointerOrReference.is(tok::star));
-  return Style.PointerAlignment;
+  return Style.PointerAlignment.Default;
 }
 
 } // namespace format

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -384,14 +384,14 @@ AlignTokenSequence(const FormatStyle &Style, unsigned Start, unsigned End,
 
     // If PointerAlignment is PAS_Right, keep *s or &s next to the token,
     // except if the token is equal, then a space is needed.
-    if ((Style.PointerAlignment == FormatStyle::PAS_Right ||
-         Style.ReferenceAlignment == FormatStyle::RAS_Right) &&
+    if ((Style.PointerAlignment.Default == FormatStyle::PAS_Right ||
+         Style.ReferenceAlignment.Default == FormatStyle::RAS_Right) &&
         CurrentChange.Spaces != 0 &&
         CurrentChange.Tok->isNoneOf(tok::equal, tok::r_paren,
                                     TT_TemplateCloser)) {
       const bool ReferenceNotRightAligned =
-          Style.ReferenceAlignment != FormatStyle::RAS_Right &&
-          Style.ReferenceAlignment != FormatStyle::RAS_Pointer;
+          Style.ReferenceAlignment.Default != FormatStyle::RAS_Right &&
+          Style.ReferenceAlignment.Default != FormatStyle::RAS_Pointer;
       for (int Previous = i - 1;
            Previous >= 0 && Changes[Previous].Tok->is(TT_PointerOrReference);
            --Previous) {
@@ -399,7 +399,7 @@ AlignTokenSequence(const FormatStyle &Style, unsigned Start, unsigned End,
         if (Changes[Previous].Tok->isNot(tok::star)) {
           if (ReferenceNotRightAligned)
             continue;
-        } else if (Style.PointerAlignment != FormatStyle::PAS_Right) {
+        } else if (Style.PointerAlignment.Default != FormatStyle::PAS_Right) {
           continue;
         }
         Changes[Previous + 1].Spaces -= Shift;

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -391,29 +391,39 @@ TEST(ConfigParseTest, ParsesConfiguration) {
 
 #undef CHECK_ALIGN_CONSECUTIVE
 
-  Style.PointerAlignment = FormatStyle::PAS_Middle;
+  Style.PointerAlignment = {/*Default=*/FormatStyle::PAS_Middle};
   CHECK_PARSE("PointerAlignment: Left", PointerAlignment,
-              FormatStyle::PAS_Left);
+              FormatStyle::PointerAlignmentOptions(
+                  {/*Default=*/FormatStyle::PAS_Left}));
   CHECK_PARSE("PointerAlignment: Right", PointerAlignment,
-              FormatStyle::PAS_Right);
+              FormatStyle::PointerAlignmentOptions(
+                  {/*Default=*/FormatStyle::PAS_Right}));
   CHECK_PARSE("PointerAlignment: Middle", PointerAlignment,
-              FormatStyle::PAS_Middle);
-  Style.ReferenceAlignment = FormatStyle::RAS_Middle;
+              FormatStyle::PointerAlignmentOptions(
+                  {/*Default=*/FormatStyle::PAS_Middle}));
+  Style.ReferenceAlignment = {/*Default=*/FormatStyle::RAS_Middle};
   CHECK_PARSE("ReferenceAlignment: Pointer", ReferenceAlignment,
-              FormatStyle::RAS_Pointer);
+              FormatStyle::ReferenceAlignmentOptions(
+                  {/*Default=*/FormatStyle::RAS_Pointer}));
   CHECK_PARSE("ReferenceAlignment: Left", ReferenceAlignment,
-              FormatStyle::RAS_Left);
+              FormatStyle::ReferenceAlignmentOptions(
+                  {/*Default=*/FormatStyle::RAS_Left}));
   CHECK_PARSE("ReferenceAlignment: Right", ReferenceAlignment,
-              FormatStyle::RAS_Right);
+              FormatStyle::ReferenceAlignmentOptions(
+                  {/*Default=*/FormatStyle::RAS_Right}));
   CHECK_PARSE("ReferenceAlignment: Middle", ReferenceAlignment,
-              FormatStyle::RAS_Middle);
+              FormatStyle::ReferenceAlignmentOptions(
+                  {/*Default=*/FormatStyle::RAS_Middle}));
   // For backward compatibility:
   CHECK_PARSE("PointerBindsToType: Left", PointerAlignment,
-              FormatStyle::PAS_Left);
+              FormatStyle::PointerAlignmentOptions(
+                  {/*Default=*/FormatStyle::PAS_Left}));
   CHECK_PARSE("PointerBindsToType: Right", PointerAlignment,
-              FormatStyle::PAS_Right);
+              FormatStyle::PointerAlignmentOptions(
+                  {/*Default=*/FormatStyle::PAS_Right}));
   CHECK_PARSE("PointerBindsToType: Middle", PointerAlignment,
-              FormatStyle::PAS_Middle);
+              FormatStyle::PointerAlignmentOptions(
+                  {/*Default=*/FormatStyle::PAS_Middle}));
 
   Style.ReflowComments = FormatStyle::RCS_Always;
   CHECK_PARSE("ReflowComments: Never", ReflowComments, FormatStyle::RCS_Never);

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -392,66 +392,96 @@ TEST(ConfigParseTest, ParsesConfiguration) {
 #undef CHECK_ALIGN_CONSECUTIVE
 
   Style.PointerAlignment = {/*Default=*/FormatStyle::PAS_Middle,
-                            /*ReturnType=*/FormatStyle::RTAS_Default};
+                            /*ReturnType=*/FormatStyle::RTAS_Default,
+                            /*CStyleCast=*/FormatStyle::CAS_Default};
   CHECK_PARSE("PointerAlignment: Left", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
                   {/*Default=*/FormatStyle::PAS_Left,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
   CHECK_PARSE("PointerAlignment: Right", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
                   {/*Default=*/FormatStyle::PAS_Right,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
   CHECK_PARSE("PointerAlignment: Middle", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
                   {/*Default=*/FormatStyle::PAS_Middle,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
   CHECK_PARSE("PointerAlignment:\n"
               "  Default: Right\n"
               "  ReturnType: Left",
               PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
                   {/*Default=*/FormatStyle::PAS_Right,
-                   /*ReturnType=*/FormatStyle::RTAS_Left}));
+                   /*ReturnType=*/FormatStyle::RTAS_Left,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
+  CHECK_PARSE("PointerAlignment:\n"
+              "  Default: Right\n"
+              "  CStyleCast: Left",
+              PointerAlignment,
+              FormatStyle::PointerAlignmentOptions(
+                  {/*Default=*/FormatStyle::PAS_Right,
+                   /*ReturnType=*/FormatStyle::RTAS_Left,
+                   /*CStyleCast=*/FormatStyle::CAS_Left}));
 
   Style.ReferenceAlignment = {/*Default=*/FormatStyle::RAS_Middle,
-                              /*ReturnType=*/FormatStyle::RTAS_Default};
+                              /*ReturnType=*/FormatStyle::RTAS_Default,
+                              /*CStyleCast=*/FormatStyle::CAS_Default};
   CHECK_PARSE("ReferenceAlignment: Pointer", ReferenceAlignment,
               FormatStyle::ReferenceAlignmentOptions(
                   {/*Default=*/FormatStyle::RAS_Pointer,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
   CHECK_PARSE("ReferenceAlignment: Left", ReferenceAlignment,
               FormatStyle::ReferenceAlignmentOptions(
                   {/*Default=*/FormatStyle::RAS_Left,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
   CHECK_PARSE("ReferenceAlignment: Right", ReferenceAlignment,
               FormatStyle::ReferenceAlignmentOptions(
                   {/*Default=*/FormatStyle::RAS_Right,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
   CHECK_PARSE("ReferenceAlignment: Middle", ReferenceAlignment,
               FormatStyle::ReferenceAlignmentOptions(
                   {/*Default=*/FormatStyle::RAS_Middle,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
   CHECK_PARSE("ReferenceAlignment:\n"
               "  Default: Right\n"
               "  ReturnType: Left",
               ReferenceAlignment,
               FormatStyle::ReferenceAlignmentOptions(
                   {/*Default=*/FormatStyle::RAS_Right,
-                   /*ReturnType=*/FormatStyle::RTAS_Left}));
+                   /*ReturnType=*/FormatStyle::RTAS_Left,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
+  CHECK_PARSE("ReferenceAlignment:\n"
+              "  Default: Right\n"
+              "  CStyleCast: Left",
+              ReferenceAlignment,
+              FormatStyle::ReferenceAlignmentOptions(
+                  {/*Default=*/FormatStyle::RAS_Right,
+                   /*ReturnType=*/FormatStyle::RTAS_Left,
+                   /*CStyleCast=*/FormatStyle::CAS_Left}));
 
   // For backward compatibility:
   CHECK_PARSE("PointerBindsToType: Left", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
                   {/*Default=*/FormatStyle::PAS_Left,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
   CHECK_PARSE("PointerBindsToType: Right", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
                   {/*Default=*/FormatStyle::PAS_Right,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
   CHECK_PARSE("PointerBindsToType: Middle", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
                   {/*Default=*/FormatStyle::PAS_Middle,
-                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+                   /*ReturnType=*/FormatStyle::RTAS_Default,
+                   /*CStyleCast=*/FormatStyle::CAS_Default}));
 
   Style.ReflowComments = FormatStyle::RCS_Always;
   CHECK_PARSE("ReflowComments: Never", ReflowComments, FormatStyle::RCS_Never);

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -391,39 +391,67 @@ TEST(ConfigParseTest, ParsesConfiguration) {
 
 #undef CHECK_ALIGN_CONSECUTIVE
 
-  Style.PointerAlignment = {/*Default=*/FormatStyle::PAS_Middle};
+  Style.PointerAlignment = {/*Default=*/FormatStyle::PAS_Middle,
+                            /*ReturnType=*/FormatStyle::RTAS_Default};
   CHECK_PARSE("PointerAlignment: Left", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
-                  {/*Default=*/FormatStyle::PAS_Left}));
+                  {/*Default=*/FormatStyle::PAS_Left,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
   CHECK_PARSE("PointerAlignment: Right", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
-                  {/*Default=*/FormatStyle::PAS_Right}));
+                  {/*Default=*/FormatStyle::PAS_Right,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
   CHECK_PARSE("PointerAlignment: Middle", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
-                  {/*Default=*/FormatStyle::PAS_Middle}));
-  Style.ReferenceAlignment = {/*Default=*/FormatStyle::RAS_Middle};
+                  {/*Default=*/FormatStyle::PAS_Middle,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+  CHECK_PARSE("PointerAlignment:\n"
+              "  Default: Right\n"
+              "  ReturnType: Left",
+              PointerAlignment,
+              FormatStyle::PointerAlignmentOptions(
+                  {/*Default=*/FormatStyle::PAS_Right,
+                   /*ReturnType=*/FormatStyle::RTAS_Left}));
+
+  Style.ReferenceAlignment = {/*Default=*/FormatStyle::RAS_Middle,
+                              /*ReturnType=*/FormatStyle::RTAS_Default};
   CHECK_PARSE("ReferenceAlignment: Pointer", ReferenceAlignment,
               FormatStyle::ReferenceAlignmentOptions(
-                  {/*Default=*/FormatStyle::RAS_Pointer}));
+                  {/*Default=*/FormatStyle::RAS_Pointer,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
   CHECK_PARSE("ReferenceAlignment: Left", ReferenceAlignment,
               FormatStyle::ReferenceAlignmentOptions(
-                  {/*Default=*/FormatStyle::RAS_Left}));
+                  {/*Default=*/FormatStyle::RAS_Left,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
   CHECK_PARSE("ReferenceAlignment: Right", ReferenceAlignment,
               FormatStyle::ReferenceAlignmentOptions(
-                  {/*Default=*/FormatStyle::RAS_Right}));
+                  {/*Default=*/FormatStyle::RAS_Right,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
   CHECK_PARSE("ReferenceAlignment: Middle", ReferenceAlignment,
               FormatStyle::ReferenceAlignmentOptions(
-                  {/*Default=*/FormatStyle::RAS_Middle}));
+                  {/*Default=*/FormatStyle::RAS_Middle,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
+  CHECK_PARSE("ReferenceAlignment:\n"
+              "  Default: Right\n"
+              "  ReturnType: Left",
+              ReferenceAlignment,
+              FormatStyle::ReferenceAlignmentOptions(
+                  {/*Default=*/FormatStyle::RAS_Right,
+                   /*ReturnType=*/FormatStyle::RTAS_Left}));
+
   // For backward compatibility:
   CHECK_PARSE("PointerBindsToType: Left", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
-                  {/*Default=*/FormatStyle::PAS_Left}));
+                  {/*Default=*/FormatStyle::PAS_Left,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
   CHECK_PARSE("PointerBindsToType: Right", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
-                  {/*Default=*/FormatStyle::PAS_Right}));
+                  {/*Default=*/FormatStyle::PAS_Right,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
   CHECK_PARSE("PointerBindsToType: Middle", PointerAlignment,
               FormatStyle::PointerAlignmentOptions(
-                  {/*Default=*/FormatStyle::PAS_Middle}));
+                  {/*Default=*/FormatStyle::PAS_Middle,
+                   /*ReturnType=*/FormatStyle::RTAS_Default}));
 
   Style.ReflowComments = FormatStyle::RCS_Always;
   CHECK_PARSE("ReflowComments: Never", ReflowComments, FormatStyle::RCS_Never);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -2047,8 +2047,8 @@ TEST_F(FormatTest, ElseIf) {
 
 TEST_F(FormatTest, SeparatePointerReferenceAlignment) {
   FormatStyle Style = getLLVMStyle();
-  EXPECT_EQ(Style.PointerAlignment, FormatStyle::PAS_Right);
-  EXPECT_EQ(Style.ReferenceAlignment, FormatStyle::RAS_Pointer);
+  EXPECT_EQ(Style.PointerAlignment.Default, FormatStyle::PAS_Right);
+  EXPECT_EQ(Style.ReferenceAlignment.Default, FormatStyle::RAS_Pointer);
   verifyFormat("int *f1(int *a, int &b, int &&c);", Style);
   verifyFormat("int &f2(int &&c, int *a, int &b);", Style);
   verifyFormat("int &&f3(int &b, int &&c, int *a);", Style);
@@ -2104,7 +2104,7 @@ TEST_F(FormatTest, SeparatePointerReferenceAlignment) {
                "Const unsigned   h;",
                Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("int* f1(int* a, int& b, int&& c);", Style);
   verifyFormat("int& f2(int&& c, int* a, int& b);", Style);
   verifyFormat("int&& f3(int& b, int&& c, int* a);", Style);
@@ -2162,8 +2162,8 @@ TEST_F(FormatTest, SeparatePointerReferenceAlignment) {
                "Const unsigned   h;",
                Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Right;
-  Style.ReferenceAlignment = FormatStyle::RAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Right;
+  Style.ReferenceAlignment.Default = FormatStyle::RAS_Left;
   verifyFormat("int *f1(int *a, int& b, int&& c);", Style);
   verifyFormat("int& f2(int&& c, int *a, int& b);", Style);
   verifyFormat("int&& f3(int& b, int&& c, int *a);", Style);
@@ -2200,8 +2200,8 @@ TEST_F(FormatTest, SeparatePointerReferenceAlignment) {
                "Const unsigned   h;",
                Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Left;
-  Style.ReferenceAlignment = FormatStyle::RAS_Middle;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
+  Style.ReferenceAlignment.Default = FormatStyle::RAS_Middle;
   verifyFormat("int* f1(int* a, int & b, int && c);", Style);
   verifyFormat("int & f2(int && c, int* a, int & b);", Style);
   verifyFormat("int && f3(int & b, int && c, int* a);", Style);
@@ -2253,8 +2253,8 @@ TEST_F(FormatTest, SeparatePointerReferenceAlignment) {
                "Const unsigned    h;",
                Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Middle;
-  Style.ReferenceAlignment = FormatStyle::RAS_Right;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Middle;
+  Style.ReferenceAlignment.Default = FormatStyle::RAS_Right;
   verifyFormat("int * f1(int * a, int &b, int &&c);", Style);
   verifyFormat("int &f2(int &&c, int * a, int &b);", Style);
   verifyFormat("int &&f3(int &b, int &&c, int * a);", Style);
@@ -2376,7 +2376,7 @@ TEST_F(FormatTest, FormatsForLoop) {
       NoBinPacking);
 
   FormatStyle AlignLeft = getLLVMStyle();
-  AlignLeft.PointerAlignment = FormatStyle::PAS_Left;
+  AlignLeft.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("for (A* a = start; a < end; ++a, ++value) {\n}", AlignLeft);
 }
 
@@ -8638,7 +8638,7 @@ TEST_F(FormatTest, BreaksFunctionDeclarations) {
                "    void f();");
 
   auto Style = getLLVMStyle();
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("void aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(\n"
                "    aaaaaaaaaaaaaaaaaaaaaaaaa* const aaaaaaaaaaaa) {}",
                Style);
@@ -9975,7 +9975,7 @@ TEST_F(FormatTest, DeclarationsOfMultipleVariables) {
                "          ***c = ccccccccccccccccccc, ***d = ddddddddddddddd;");
 
   FormatStyle Style = getGoogleStyle();
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   Style.DerivePointerAlignment = false;
   verifyFormat("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
                "    *aaaaaaaaaaaaaaaaaaaaaaaaaaaaa = aaaaaaaaaaaaaaaaaaa,\n"
@@ -11465,15 +11465,15 @@ TEST_F(FormatTest, UnderstandsPointersToMembers) {
       "    aaaaaaaaaaaaaaaaaaaaaaaaaaa(aaaaaaaaaaaaaaaaaaaaaaaaaaa));");
 
   FormatStyle Style = getLLVMStyle();
-  EXPECT_EQ(Style.PointerAlignment, FormatStyle::PAS_Right);
+  EXPECT_EQ(Style.PointerAlignment.Default, FormatStyle::PAS_Right);
   verifyFormat("typedef bool *(Class::*Member)() const;", Style);
   verifyFormat("void f(int A::*p) { int A::*v = &A::B; }", Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("typedef bool* (Class::*Member)() const;", Style);
   verifyFormat("void f(int A::* p) { int A::* v = &A::B; }", Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Middle;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("typedef bool * (Class::*Member)() const;", Style);
   verifyFormat("void f(int A::* p) { int A::* v = &A::B; }", Style);
 }
@@ -11533,7 +11533,7 @@ TEST_F(FormatTest, UnderstandsUnaryOperators) {
   // Check that * is not treated as a binary operator when we set
   // PointerAlignment as PAS_Left after a keyword and not a declaration.
   FormatStyle PASLeftStyle = getLLVMStyle();
-  PASLeftStyle.PointerAlignment = FormatStyle::PAS_Left;
+  PASLeftStyle.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("co_return *a;", PASLeftStyle);
   verifyFormat("co_await *a;", PASLeftStyle);
   verifyFormat("co_yield *a", PASLeftStyle);
@@ -11661,7 +11661,7 @@ TEST_F(FormatTest, UnderstandsFunctionRefQualification) {
   verifyFormat("template <typename T> void operator=(T) && {}");
 
   FormatStyle AlignLeft = getLLVMStyle();
-  AlignLeft.PointerAlignment = FormatStyle::PAS_Left;
+  AlignLeft.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("void A::b() && {}", AlignLeft);
   verifyFormat("void A::b() && noexcept {}", AlignLeft);
   verifyFormat("Deleted& operator=(const Deleted&) & = default;", AlignLeft);
@@ -11693,7 +11693,7 @@ TEST_F(FormatTest, UnderstandsFunctionRefQualification) {
   verifyFormat("for (foo<void() &&>& cb : X)", AlignLeft);
 
   FormatStyle AlignMiddle = getLLVMStyle();
-  AlignMiddle.PointerAlignment = FormatStyle::PAS_Middle;
+  AlignMiddle.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("void A::b() && {}", AlignMiddle);
   verifyFormat("void A::b() && noexcept {}", AlignMiddle);
   verifyFormat("Deleted & operator=(const Deleted &) & = default;",
@@ -11776,7 +11776,7 @@ TEST_F(FormatTest, UnderstandsFunctionRefQualification) {
 
   FormatStyle AlignLeftBreakTemplate = getLLVMStyle();
   AlignLeftBreakTemplate.BreakTemplateDeclarations = FormatStyle::BTDS_Yes;
-  AlignLeftBreakTemplate.PointerAlignment = FormatStyle::PAS_Left;
+  AlignLeftBreakTemplate.PointerAlignment.Default = FormatStyle::PAS_Left;
 
   verifyFormat("struct f {\n"
                "  template <class T>\n"
@@ -11860,19 +11860,19 @@ TEST_F(FormatTest, PointerAlignmentFallback) {
                            "int *q;\n"
                            "int * r;");
 
-  EXPECT_EQ(Style.PointerAlignment, FormatStyle::PAS_Right);
+  EXPECT_EQ(Style.PointerAlignment.Default, FormatStyle::PAS_Right);
   verifyFormat("int *p;\n"
                "int *q;\n"
                "int *r;",
                Code, Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("int* p;\n"
                "int* q;\n"
                "int* r;",
                Code, Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Middle;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("int * p;\n"
                "int * q;\n"
                "int * r;",
@@ -12068,7 +12068,7 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
                      "void f(int i = 0, SomeType** temps = NULL);");
 
   FormatStyle Left = getLLVMStyle();
-  Left.PointerAlignment = FormatStyle::PAS_Left;
+  Left.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("x = *a(x) = *a(y);", Left);
   verifyFormat("for (;; *a = b) {\n}", Left);
   verifyFormat("return *this += 1;", Left);
@@ -12214,7 +12214,7 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
       getGoogleStyleWithColumns(68));
 
   FormatStyle Style = getLLVMStyle();
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("struct {\n"
                "}* ptr;",
                Style);
@@ -12238,7 +12238,7 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
                Style);
   verifyFormat("bool b = 3 == int{3} && true;");
 
-  Style.PointerAlignment = FormatStyle::PAS_Middle;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("struct {\n"
                "} * ptr;",
                Style);
@@ -12258,7 +12258,7 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
                "} && ptr = {};",
                Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Right;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Right;
   verifyFormat("struct {\n"
                "} *ptr;",
                Style);
@@ -12278,7 +12278,7 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
                "} &&ptr = {};",
                Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("delete[] *ptr;", Style);
   verifyFormat("delete[] **ptr;", Style);
   verifyFormat("delete[] *(ptr);", Style);
@@ -12369,7 +12369,7 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   verifyFormat("foo<a<b && c> d> v;");
 
   FormatStyle PointerMiddle = getLLVMStyle();
-  PointerMiddle.PointerAlignment = FormatStyle::PAS_Middle;
+  PointerMiddle.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("delete *x;", PointerMiddle);
   verifyFormat("int * x;", PointerMiddle);
   verifyFormat("int *[] x;", PointerMiddle);
@@ -12476,7 +12476,7 @@ TEST_F(FormatTest, UnderstandsAttributes) {
 
   auto Style = getLLVMStyleWithColumns(60);
   Style.AttributeMacros.push_back("my_fancy_attr");
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("void foo(const MyLongTypeNameeeeeeeeeeeee* my_fancy_attr\n"
                "             testttttttttt);",
                Style);
@@ -12504,7 +12504,7 @@ TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
   // determine that the expression is a cast to a pointer type.
   FormatStyle LongPointerRight = getLLVMStyleWithColumns(999);
   FormatStyle LongPointerLeft = getLLVMStyleWithColumns(999);
-  LongPointerLeft.PointerAlignment = FormatStyle::PAS_Left;
+  LongPointerLeft.PointerAlignment.Default = FormatStyle::PAS_Left;
   StringRef AllQualifiers =
       "const volatile restrict __attribute__((foo)) _Nonnull _Null_unspecified "
       "_Nullable [[clang::attr]] __ptr32 __ptr64 __capability";
@@ -12640,12 +12640,12 @@ TEST_F(FormatTest, UnderstandsEllipsis) {
 
   verifyFormat("template <int *...PP> a;", Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("template <class... Ts> void Foo(Ts*... ts) {}", Style);
 
   verifyFormat("template <int*... PP> a;", Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Middle;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("template <int *... PP> a;", Style);
 }
 
@@ -16253,15 +16253,15 @@ TEST_F(FormatTest, ConfigurableUseOfTab) {
 
   FormatStyle TabAlignment = Tab;
   TabAlignment.AlignConsecutiveDeclarations.Enabled = true;
-  TabAlignment.PointerAlignment = FormatStyle::PAS_Left;
+  TabAlignment.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("unsigned long long big;\n"
                "char*\t\t   ptr;",
                TabAlignment);
-  TabAlignment.PointerAlignment = FormatStyle::PAS_Middle;
+  TabAlignment.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("unsigned long long big;\n"
                "char *\t\t   ptr;",
                TabAlignment);
-  TabAlignment.PointerAlignment = FormatStyle::PAS_Right;
+  TabAlignment.PointerAlignment.Default = FormatStyle::PAS_Right;
   verifyFormat("unsigned long long big;\n"
                "char\t\t  *ptr;",
                TabAlignment);
@@ -16309,19 +16309,19 @@ TEST_F(FormatTest, ConfigurableUseOfTab) {
                Tab);
 
   TabAlignment.UseTab = FormatStyle::UT_ForIndentation;
-  TabAlignment.PointerAlignment = FormatStyle::PAS_Left;
+  TabAlignment.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("void f() {\n"
                "\tunsigned long long big;\n"
                "\tchar*              ptr;\n"
                "}",
                TabAlignment);
-  TabAlignment.PointerAlignment = FormatStyle::PAS_Middle;
+  TabAlignment.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("void f() {\n"
                "\tunsigned long long big;\n"
                "\tchar *             ptr;\n"
                "}",
                TabAlignment);
-  TabAlignment.PointerAlignment = FormatStyle::PAS_Right;
+  TabAlignment.PointerAlignment.Default = FormatStyle::PAS_Right;
   verifyFormat("void f() {\n"
                "\tunsigned long long big;\n"
                "\tchar              *ptr;\n"
@@ -18227,13 +18227,13 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeColon) {
 TEST_F(FormatTest, ConfigurableSpaceAroundPointerQualifiers) {
   FormatStyle Style = getLLVMStyle();
 
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   Style.SpaceAroundPointerQualifiers = FormatStyle::SAPQ_Default;
   verifyFormat("void* const* x = NULL;", Style);
 
 #define verifyQualifierSpaces(Code, Pointers, Qualifiers)                      \
   do {                                                                         \
-    Style.PointerAlignment = FormatStyle::Pointers;                            \
+    Style.PointerAlignment.Default = FormatStyle::Pointers;                    \
     Style.SpaceAroundPointerQualifiers = FormatStyle::Qualifiers;              \
     verifyFormat(Code, Style);                                                 \
   } while (false)
@@ -18279,7 +18279,7 @@ TEST_F(FormatTest, ConfigurableSpaceAroundPointerQualifiers) {
 
   FormatStyle Spaces = getLLVMStyle();
   Spaces.AttributeMacros.push_back("qualified");
-  Spaces.PointerAlignment = FormatStyle::PAS_Right;
+  Spaces.PointerAlignment.Default = FormatStyle::PAS_Right;
   Spaces.SpaceAroundPointerQualifiers = FormatStyle::SAPQ_Default;
   verifyFormat("SomeType *volatile *a = NULL;", Spaces);
   verifyFormat("SomeType *__attribute__((attr)) *a = NULL;", Spaces);
@@ -18294,7 +18294,7 @@ TEST_F(FormatTest, ConfigurableSpaceAroundPointerQualifiers) {
   verifyFormat("std::vector<SomeVar * NotAQualifier> x;", Spaces);
 
   // Check that SAPQ_Before doesn't result in extra spaces for PAS_Left.
-  Spaces.PointerAlignment = FormatStyle::PAS_Left;
+  Spaces.PointerAlignment.Default = FormatStyle::PAS_Left;
   Spaces.SpaceAroundPointerQualifiers = FormatStyle::SAPQ_Before;
   verifyFormat("SomeType* volatile* a = NULL;", Spaces);
   verifyFormat("SomeType* __attribute__((attr))* a = NULL;", Spaces);
@@ -18310,7 +18310,7 @@ TEST_F(FormatTest, ConfigurableSpaceAroundPointerQualifiers) {
   verifyFormat("std::vector<SomeVar * NotAQualifier> x;", Spaces);
 
   // PAS_Middle should not have any noticeable changes even for SAPQ_Both
-  Spaces.PointerAlignment = FormatStyle::PAS_Middle;
+  Spaces.PointerAlignment.Default = FormatStyle::PAS_Middle;
   Spaces.SpaceAroundPointerQualifiers = FormatStyle::SAPQ_After;
   verifyFormat("SomeType * volatile * a = NULL;", Spaces);
   verifyFormat("SomeType * __attribute__((attr)) * a = NULL;", Spaces);
@@ -19756,7 +19756,7 @@ TEST_F(FormatTest, AlignConsecutiveBitFields) {
 TEST_F(FormatTest, AlignConsecutiveDeclarations) {
   FormatStyle Alignment = getLLVMStyle();
   Alignment.AlignConsecutiveMacros.Enabled = true;
-  Alignment.PointerAlignment = FormatStyle::PAS_Right;
+  Alignment.PointerAlignment.Default = FormatStyle::PAS_Right;
   verifyFormat("float const a = 5;\n"
                "int oneTwoThree = 123;",
                Alignment);
@@ -20023,7 +20023,7 @@ TEST_F(FormatTest, AlignConsecutiveDeclarations) {
 
   // PAS_Left
   FormatStyle AlignmentLeft = Alignment;
-  AlignmentLeft.PointerAlignment = FormatStyle::PAS_Left;
+  AlignmentLeft.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("void SomeFunction(int parameter = 0) {\n"
                "  int const i   = 1;\n"
                "  int*      j   = 2;\n"
@@ -20097,7 +20097,7 @@ TEST_F(FormatTest, AlignConsecutiveDeclarations) {
 
   // PAS_Middle
   FormatStyle AlignmentMiddle = Alignment;
-  AlignmentMiddle.PointerAlignment = FormatStyle::PAS_Middle;
+  AlignmentMiddle.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("void SomeFunction(int parameter = 0) {\n"
                "  int const i   = 1;\n"
                "  int *     j   = 2;\n"
@@ -20313,14 +20313,14 @@ TEST_F(FormatTest, AlignConsecutiveDeclarations) {
   Alignment.ColumnLimit = 80;
 
   // Bug 33507
-  Alignment.PointerAlignment = FormatStyle::PAS_Middle;
+  Alignment.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat(
       "auto found = range::find_if(vsProducts, [&](auto * aProduct) {\n"
       "  static const Version verVs2017;\n"
       "  return true;\n"
       "});",
       Alignment);
-  Alignment.PointerAlignment = FormatStyle::PAS_Right;
+  Alignment.PointerAlignment.Default = FormatStyle::PAS_Right;
 
   // See llvm.org/PR35641
   Alignment.AlignConsecutiveDeclarations.Enabled = true;
@@ -20337,7 +20337,7 @@ TEST_F(FormatTest, AlignConsecutiveDeclarations) {
                "foo(int a);",
                "DECOR1 /**/ int8_t /**/ DECOR2 /**/ foo (int a);", Style);
 
-  Alignment.PointerAlignment = FormatStyle::PAS_Left;
+  Alignment.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("unsigned int*       a;\n"
                "int*                b;\n"
                "unsigned int Const* c;\n"
@@ -20353,7 +20353,7 @@ TEST_F(FormatTest, AlignConsecutiveDeclarations) {
                "Const unsigned      h;",
                Alignment);
 
-  Alignment.PointerAlignment = FormatStyle::PAS_Middle;
+  Alignment.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("unsigned int *       a;\n"
                "int *                b;\n"
                "unsigned int Const * c;\n"
@@ -25086,7 +25086,7 @@ TEST_F(FormatTest, StructuredBindings) {
 
   // Make sure we don't mistake structured bindings for lambdas.
   FormatStyle PointerMiddle = getLLVMStyle();
-  PointerMiddle.PointerAlignment = FormatStyle::PAS_Middle;
+  PointerMiddle.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyGoogleFormat("auto [a1, b]{A * i};");
   verifyFormat("auto [a2, b]{A * i};");
   verifyFormat("auto [a3, b]{A * i};", PointerMiddle);
@@ -25330,7 +25330,7 @@ TEST_F(FormatTest, TypenameMacros) {
   verifyFormat("vector<LIST(uint64_t) *attr> x;", Macros);
   verifyFormat("vector<LIST(uint64_t) *const> f(LIST(uint64_t) *arg);", Macros);
 
-  Macros.PointerAlignment = FormatStyle::PAS_Left;
+  Macros.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("STACK_OF(int)* a;", Macros);
   verifyFormat("STACK_OF(int*)* a;", Macros);
   verifyFormat("x = (STACK_OF(uint64_t))*a;", Macros);
@@ -25361,7 +25361,7 @@ TEST_F(FormatTest, AtomicQualifier) {
   verifyFormat("_Atomic(uint64_t) *s(InitValue);");
   verifyFormat("_Atomic(uint64_t) *s{InitValue};");
   FormatStyle Style = getLLVMStyle();
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("_Atomic(uint64_t)* s(InitValue);", Style);
   verifyFormat("_Atomic(uint64_t)* s{InitValue};", Style);
   verifyFormat("_Atomic(int)* a;", Style);
@@ -25424,9 +25424,9 @@ TEST_F(FormatTest, C11Generic) {
 TEST_F(FormatTest, AmbersandInLamda) {
   // Test case reported in https://bugs.llvm.org/show_bug.cgi?id=41899
   FormatStyle AlignStyle = getLLVMStyle();
-  AlignStyle.PointerAlignment = FormatStyle::PAS_Left;
+  AlignStyle.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("auto lambda = [&a = a]() { a = 2; };", AlignStyle);
-  AlignStyle.PointerAlignment = FormatStyle::PAS_Right;
+  AlignStyle.PointerAlignment.Default = FormatStyle::PAS_Right;
   verifyFormat("auto lambda = [&a = a]() { a = 2; };", AlignStyle);
 }
 
@@ -25554,7 +25554,7 @@ TEST_F(FormatTest, STLWhileNotDefineChed) {
 
 TEST_F(FormatTest, OperatorSpacing) {
   FormatStyle Style = getLLVMStyle();
-  Style.PointerAlignment = FormatStyle::PAS_Right;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Right;
   verifyFormat("Foo::operator*();", Style);
   verifyFormat("Foo::operator void *();", Style);
   verifyFormat("Foo::operator void **();", Style);
@@ -25610,7 +25610,7 @@ TEST_F(FormatTest, OperatorSpacing) {
   verifyFormat("operator const FooRight<Object> *&()", Style);
   verifyFormat("operator const FooRight<Object> *&&()", Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Left;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Left;
   verifyFormat("Foo::operator*();", Style);
   verifyFormat("Foo::operator**();", Style);
   verifyFormat("Foo::operator void*();", Style);
@@ -25681,7 +25681,7 @@ TEST_F(FormatTest, OperatorSpacing) {
   verifyFormat("operator/*a*/ const /*b*/ Foo /*c*/<X> /*d*/ ::Bar<Y>*();",
                Style);
 
-  Style.PointerAlignment = FormatStyle::PAS_Middle;
+  Style.PointerAlignment.Default = FormatStyle::PAS_Middle;
   verifyFormat("Foo::operator*();", Style);
   verifyFormat("Foo::operator void *();", Style);
   verifyFormat("Foo::operator()(void *);", Style);
@@ -27940,7 +27940,7 @@ TEST_F(FormatTest, BreakAfterAttributes) {
                "Foo &operator-(Foo &);",
                Style);
 
-  Style.ReferenceAlignment = FormatStyle::RAS_Left;
+  Style.ReferenceAlignment.Default = FormatStyle::RAS_Left;
   verifyFormat("[[nodiscard]]\n"
                "Foo& operator-(Foo&);",
                Style);


### PR DESCRIPTION
I would like to adopt clang-format in systemd
(https://github.com/systemd/systemd). One major blocker is that
systemd right-aligns pointers by default, except in function return
types, where they are left-aligned.

Let's introduce a ReturnType customization for PointerAlignment and
ReferenceAlignment that allows overriding the alignment used in return
types.

Fixes https://github.com/llvm/llvm-project/issues/136597