### PR TITLE
[clang][Sema] Merge Check[Sizeless]VectorConditionalTypes implementations

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8627,6 +8627,8 @@ def err_conditional_vector_size : Error<
 def err_conditional_vector_element_size : Error<
   "vector condition type %0 and result type %1 do not have elements of the "
   "same size">;
+def err_conditional_vector_scalar_type_unsupported : Error<
+  "scalar type %0 not supported with vector condition type %1">;
 def err_conditional_vector_has_void : Error<
   "GNU vector conditional operand cannot be %select{void|a throw expression}0">;
 def err_conditional_vector_operand_type

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -8699,10 +8699,6 @@ public:
                                        ExprResult &RHS,
                                        SourceLocation QuestionLoc);
 
-  QualType CheckSizelessVectorConditionalTypes(ExprResult &Cond,
-                                               ExprResult &LHS, ExprResult &RHS,
-                                               SourceLocation QuestionLoc);
-
   //// Determines if a type is trivially relocatable
   /// according to the C++26 rules.
   // FIXME: This is in Sema because it requires

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -4512,25 +4512,25 @@ QualType ASTContext::getScalableVectorType(QualType EltTy, unsigned NumElts,
                             ElBits, NF, IsSigned)                              \
   if (EltTy->hasIntegerRepresentation() && !EltTy->isBooleanType() &&          \
       EltTy->hasSignedIntegerRepresentation() == IsSigned &&                   \
-      EltTySize == ElBits && NumElts == (NumEls * NF) && NumFields == 1) {     \
+      EltTySize == ElBits && NumElts == NumEls && NumFields == NF) {           \
     return ScalableVecTyMap[K] = SingletonId;                                  \
   }
 #define SVE_VECTOR_TYPE_FLOAT(Name, MangledName, Id, SingletonId, NumEls,      \
                               ElBits, NF)                                      \
   if (EltTy->hasFloatingRepresentation() && !EltTy->isBFloat16Type() &&        \
-      EltTySize == ElBits && NumElts == (NumEls * NF) && NumFields == 1) {     \
+      EltTySize == ElBits && NumElts == NumEls && NumFields == NF) {           \
     return ScalableVecTyMap[K] = SingletonId;                                  \
   }
 #define SVE_VECTOR_TYPE_BFLOAT(Name, MangledName, Id, SingletonId, NumEls,     \
                                ElBits, NF)                                     \
   if (EltTy->hasFloatingRepresentation() && EltTy->isBFloat16Type() &&         \
-      EltTySize == ElBits && NumElts == (NumEls * NF) && NumFields == 1) {     \
+      EltTySize == ElBits && NumElts == NumEls && NumFields == NF) {           \
     return ScalableVecTyMap[K] = SingletonId;                                  \
   }
 #define SVE_VECTOR_TYPE_MFLOAT(Name, MangledName, Id, SingletonId, NumEls,     \
                                ElBits, NF)                                     \
-  if (EltTy->isMFloat8Type() && EltTySize == ElBits &&                         \
-      NumElts == (NumEls * NF) && NumFields == 1) {                            \
+  if (EltTy->isMFloat8Type() && EltTySize == ElBits && NumElts == NumEls &&    \
+      NumFields == NF) {                                                       \
     return ScalableVecTyMap[K] = SingletonId;                                  \
   }
 #define SVE_PREDICATE_TYPE_ALL(Name, MangledName, Id, SingletonId, NumEls, NF) \

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -4512,25 +4512,25 @@ QualType ASTContext::getScalableVectorType(QualType EltTy, unsigned NumElts,
                             ElBits, NF, IsSigned)                              \
   if (EltTy->hasIntegerRepresentation() && !EltTy->isBooleanType() &&          \
       EltTy->hasSignedIntegerRepresentation() == IsSigned &&                   \
-      EltTySize == ElBits && NumElts == NumEls && NumFields == NF) {           \
+      EltTySize == ElBits && NumElts == (NumEls * NF) && NumFields == 1) {     \
     return ScalableVecTyMap[K] = SingletonId;                                  \
   }
 #define SVE_VECTOR_TYPE_FLOAT(Name, MangledName, Id, SingletonId, NumEls,      \
                               ElBits, NF)                                      \
   if (EltTy->hasFloatingRepresentation() && !EltTy->isBFloat16Type() &&        \
-      EltTySize == ElBits && NumElts == NumEls && NumFields == NF) {           \
+      EltTySize == ElBits && NumElts == (NumEls * NF) && NumFields == 1) {     \
     return ScalableVecTyMap[K] = SingletonId;                                  \
   }
 #define SVE_VECTOR_TYPE_BFLOAT(Name, MangledName, Id, SingletonId, NumEls,     \
                                ElBits, NF)                                     \
   if (EltTy->hasFloatingRepresentation() && EltTy->isBFloat16Type() &&         \
-      EltTySize == ElBits && NumElts == NumEls && NumFields == NF) {           \
+      EltTySize == ElBits && NumElts == (NumEls * NF) && NumFields == 1) {     \
     return ScalableVecTyMap[K] = SingletonId;                                  \
   }
 #define SVE_VECTOR_TYPE_MFLOAT(Name, MangledName, Id, SingletonId, NumEls,     \
                                ElBits, NF)                                     \
-  if (EltTy->isMFloat8Type() && EltTySize == ElBits && NumElts == NumEls &&    \
-      NumFields == NF) {                                                       \
+  if (EltTy->isMFloat8Type() && EltTySize == ElBits &&                         \
+      NumElts == (NumEls * NF) && NumFields == 1) {                            \
     return ScalableVecTyMap[K] = SingletonId;                                  \
   }
 #define SVE_PREDICATE_TYPE_ALL(Name, MangledName, Id, SingletonId, NumEls, NF) \

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -5697,8 +5697,10 @@ QualType Sema::CheckVectorConditionalTypes(ExprResult &Cond, ExprResult &LHS,
       ElementTy = VT->getElementType();
       EC = llvm::ElementCount::getFixed(VT->getNumElements());
     } else {
-      ElementTy = Type->getSizelessVectorEltType(Context);
-      EC = Context.getBuiltinVectorTypeInfo(Type->castAs<BuiltinType>()).EC;
+      ASTContext::BuiltinVectorTypeInfo VectorInfo =
+          Context.getBuiltinVectorTypeInfo(Type->castAs<BuiltinType>());
+      ElementTy = VectorInfo.ElementType;
+      EC = VectorInfo.EC;
     }
     return std::make_pair(ElementTy, EC);
   };

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -5709,7 +5709,7 @@ QualType Sema::CheckVectorConditionalTypes(ExprResult &Cond, ExprResult &LHS,
 
   QualType ResultType;
   if (LHSIsVector && RHSIsVector) {
-    if (isa<ExtVectorType>(CondType) != isa<ExtVectorType>(LHSType)) {
+    if (CondType->isExtVectorType() != LHSType->isExtVectorType()) {
       Diag(QuestionLoc, diag::err_conditional_vector_cond_result_mismatch)
           << /*isExtVector*/ isa<ExtVectorType>(CondType);
       return {};

--- a/clang/test/Sema/AArch64/sve-vector-conditional-op.cpp
+++ b/clang/test/Sema/AArch64/sve-vector-conditional-op.cpp
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 %s -fsyntax-only -triple aarch64-none-linux-gnu -target-feature +sve -verify
+
+typedef int fixed_vector __attribute__((vector_size(4)));
+
+auto error_fixed_vector_result(__SVBool_t svbool, fixed_vector a, fixed_vector b) {
+  // expected-error@+1 {{vector condition type '__SVBool_t' and result type 'fixed_vector' (vector of 1 'int' value) do not have the same number of elements}}
+  return svbool ? a : b;
+}
+
+auto error_void_result(__SVBool_t svbool) {
+  // expected-error@+1 {{GNU vector conditional operand cannot be void}}
+  return svbool ? (void)0 : (void)1;
+}
+
+auto error_sve_splat_result_unsupported(__SVBool_t svbool, long long a, long long b) {
+  // expected-error@+1 {{scalar type 'long long' not supported with vector condition type '__SVBool_t'}}
+  return svbool ? a : b;
+}
+
+auto error_sve_vector_result_matched_element_count(__SVBool_t svbool, __SVUint32_t a, __SVUint32_t b) {
+  // expected-error@+1 {{vector condition type '__SVBool_t' and result type '__SVUint32_t' do not have the same number of elements}}
+  return svbool ? a : b;
+}
+
+// The following cases should be supported:
+
+__SVBool_t cond_svbool(__SVBool_t a, __SVBool_t b) {
+    return a < b ? a : b;
+}
+
+__SVFloat32_t cond_svf32(__SVFloat32_t a, __SVFloat32_t b) {
+    return a < b ? a : b;
+}
+
+__SVUint64_t cond_u64_splat(__SVUint64_t a) {
+    return a < 1ul ? a : 1ul;
+}


### PR DESCRIPTION
These two functions are almost identical, except for the handling different vector types, so merging them eliminates some duplication. This also fixes some bugs, as "sizeless" vector code was missing checks for several cases.

This meant type checking would crash if:

 - The LHS or RHS type was void
 - The LHS or RHS type was a fixed-length vector type
 - There was not a scalable vector type for the result element count/size

These are fixed with this patch and tested in
Sema/AArch64/sve-vector-conditional-op.cpp.

Fixes #169025