### PR TITLE
[llvm] Remove unused local variables (NFC)

### DIFF
--- a/llvm/lib/Transforms/Utils/DebugSSAUpdater.cpp
+++ b/llvm/lib/Transforms/Utils/DebugSSAUpdater.cpp
@@ -291,7 +291,6 @@ void DbgValueRangeTable::addVariable(Function *F, DebugVariableAggregate DVA) {
 
   // We don't have a single location for the variable's entire scope, so instead
   // we must now perform a liveness analysis to create a location list.
-  DenseMap<BasicBlock *, DbgValueDef> LiveInMap;
   SmallVector<DbgSSAPhi *> HypotheticalPHIs;
   DebugSSAUpdater SSAUpdater(&HypotheticalPHIs);
   SSAUpdater.initialize();

--- a/llvm/utils/TableGen/Basic/TargetLibraryInfoEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/TargetLibraryInfoEmitter.cpp
@@ -146,7 +146,6 @@ void TargetLibraryInfoEmitter::emitTargetLibraryInfoSignatureTable(
     }
     return Sig;
   };
-  DenseMap<unsigned, Signature> SignatureMap;
   Signature NoFuncSig({StringRef("Void")});
   SignatureTable.add(NoFuncSig);
   for (const auto *R : AllTargetLibcalls)


### PR DESCRIPTION
Identified with bugprone-unused-local-non-trivial-variable.
