### PR TITLE
[clang] Use llvm::equal (NFC)

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -852,10 +852,9 @@ static bool RoundTrip(ParseFn Parse, GenerateFn Generate,
   // Compares two lists of arguments.
   auto Equal = [](const ArrayRef<const char *> A,
                   const ArrayRef<const char *> B) {
-    return std::equal(A.begin(), A.end(), B.begin(), B.end(),
-                      [](const char *AElem, const char *BElem) {
-                        return StringRef(AElem) == StringRef(BElem);
-                      });
+    return llvm::equal(A, B, [](const char *AElem, const char *BElem) {
+      return StringRef(AElem) == StringRef(BElem);
+    });
   };
 
   // If we generated different arguments from what we assume are two

--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -2233,13 +2233,10 @@ NeonEmitter::areRangeChecksCompatible(const ArrayRef<ImmCheck> ChecksA,
   // the same. The element types may differ as they will be resolved
   // per-intrinsic as overloaded types by SemaArm.cpp, though the vector sizes
   // are not and so must be the same.
-  bool compat =
-      std::equal(ChecksA.begin(), ChecksA.end(), ChecksB.begin(), ChecksB.end(),
-                 [](const auto &A, const auto &B) {
-                   return A.getImmArgIdx() == B.getImmArgIdx() &&
-                          A.getKind() == B.getKind() &&
-                          A.getVecSizeInBits() == B.getVecSizeInBits();
-                 });
+  bool compat = llvm::equal(ChecksA, ChecksB, [](const auto &A, const auto &B) {
+    return A.getImmArgIdx() == B.getImmArgIdx() && A.getKind() == B.getKind() &&
+           A.getVecSizeInBits() == B.getVecSizeInBits();
+  });
 
   return compat;
 }


### PR DESCRIPTION
Identified with llvm-use-ranges.
