### PR TITLE
[llvm] Use llvm::equal (NFC)

### DIFF
--- a/llvm/lib/CodeGen/CallingConvLower.cpp
+++ b/llvm/lib/CodeGen/CallingConvLower.cpp
@@ -290,6 +290,5 @@ bool CCState::resultsCompatible(CallingConv::ID CalleeCC,
     llvm_unreachable("Unknown location kind");
   };
 
-  return std::equal(RVLocs1.begin(), RVLocs1.end(), RVLocs2.begin(),
-                    RVLocs2.end(), AreCompatible);
+  return llvm::equal(RVLocs1, RVLocs2, AreCompatible);
 }

--- a/llvm/lib/TextAPI/InterfaceFile.cpp
+++ b/llvm/lib/TextAPI/InterfaceFile.cpp
@@ -421,12 +421,11 @@ bool InterfaceFile::operator==(const InterfaceFile &O) const {
       return false;
   }
 
-  if (!std::equal(Documents.begin(), Documents.end(), O.Documents.begin(),
-                  O.Documents.end(),
-                  [](const std::shared_ptr<InterfaceFile> LHS,
-                     const std::shared_ptr<InterfaceFile> RHS) {
-                    return *LHS == *RHS;
-                  }))
+  if (!llvm::equal(Documents, O.Documents,
+                   [](const std::shared_ptr<InterfaceFile> &LHS,
+                      const std::shared_ptr<InterfaceFile> &RHS) {
+                     return *LHS == *RHS;
+                   }))
     return false;
   return true;
 }


### PR DESCRIPTION
While I am at it, this patch uses const l-value references for
std::shared_ptr.  We don't need to increment the reference count by
passing std::shared_ptr by value.

Identified with llvm-use-ranges.
