### PR TITLE
[libc++][FreeBSD] use copy_file_range() in FreeBSD >= 13.0

### DIFF
--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -50,7 +50,10 @@
 #    define _LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE
 #  endif
 #elif defined(__FreeBSD__)
-#  define _LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE
+#  include <sys/param.h>
+#  if __FreeBSD_version >= 1300000
+#    define _LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE
+#  endif
 #endif
 #if __has_include(<sys/sendfile.h>)
 #  include <sys/sendfile.h>


### PR DESCRIPTION
The copy_file_range() function appeared in FreeBSD 13.0.

https://man.freebsd.org/cgi/man.cgi?copy_file_range