### PR TITLE
[TableGen] Use MVT instead of MVT::SimpleValueType. NFC

### DIFF
--- a/llvm/utils/TableGen/CallingConvEmitter.cpp
+++ b/llvm/utils/TableGen/CallingConvEmitter.cpp
@@ -271,9 +271,9 @@ void CallingConvEmitter::emitAction(const Record *Action, indent Indent,
     O << Indent << "return false;\n";
   } else if (Action->isSubClassOf("CCPromoteToType")) {
     const Record *DestTy = Action->getValueAsDef("DestTy");
-    MVT::SimpleValueType DestVT = getValueType(DestTy);
+    MVT DestVT = getValueType(DestTy);
     O << Indent << "LocVT = " << getEnumName(DestVT) << ";\n";
-    if (MVT(DestVT).isFloatingPoint()) {
+    if (DestVT.isFloatingPoint()) {
       O << Indent << "LocInfo = CCValAssign::FPExt;\n";
     } else {
       O << Indent << "if (ArgFlags.isSExt())\n"
@@ -285,9 +285,9 @@ void CallingConvEmitter::emitAction(const Record *Action, indent Indent,
     }
   } else if (Action->isSubClassOf("CCPromoteToUpperBitsInType")) {
     const Record *DestTy = Action->getValueAsDef("DestTy");
-    MVT::SimpleValueType DestVT = getValueType(DestTy);
+    MVT DestVT = getValueType(DestTy);
     O << Indent << "LocVT = " << getEnumName(DestVT) << ";\n";
-    if (MVT(DestVT).isFloatingPoint()) {
+    if (DestVT.isFloatingPoint()) {
       PrintFatalError(Action->getLoc(),
                       "CCPromoteToUpperBitsInType does not handle floating "
                       "point");

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -1921,8 +1921,8 @@ SDNodeInfo::SDNodeInfo(const Record *R, const CodeGenHwModes &CGH) : Def(R) {
 
 /// getKnownType - If the type constraints on this node imply a fixed type
 /// (e.g. all stores return void, etc), then return it as an
-/// MVT::SimpleValueType.  Otherwise, return EEVT::Other.
-MVT::SimpleValueType SDNodeInfo::getKnownType(unsigned ResNo) const {
+/// MVT.  Otherwise, return EEVT::Other.
+MVT SDNodeInfo::getKnownType(unsigned ResNo) const {
   unsigned NumResults = getNumResults();
   assert(NumResults <= 1 &&
          "We only work with nodes with zero or one result so far!");
@@ -2585,14 +2585,14 @@ bool TreePatternNode::ApplyTypeConstraints(TreePattern &TP, bool NotRegisters) {
 
       ValueTypeByHwMode VVT = TP.getInfer().getConcrete(Types[0], false);
       for (auto &P : VVT) {
-        MVT::SimpleValueType VT = P.second.SimpleTy;
+        MVT VT = P.second;
         // Can only check for types of a known size
         if (VT == MVT::iPTR)
           continue;
 
         // Check that the value doesn't use more bits than we have. It must
         // either be a sign- or zero-extended equivalent of the original.
-        unsigned Width = MVT(VT).getFixedSizeInBits();
+        unsigned Width = VT.getFixedSizeInBits();
         int64_t Val = II->getValue();
         if (!isIntN(Width, Val) && !isUIntN(Width, Val)) {
           TP.error("Integer value '" + Twine(Val) +
@@ -2629,8 +2629,7 @@ bool TreePatternNode::ApplyTypeConstraints(TreePattern &TP, bool NotRegisters) {
     for (unsigned i = 0, e = getNumChildren() - 1; i != e; ++i) {
       MadeChange |= getChild(i + 1).ApplyTypeConstraints(TP, NotRegisters);
 
-      MVT::SimpleValueType OpVT =
-          getValueType(Int->IS.ParamTys[i]->getValueAsDef("VT"));
+      MVT OpVT = getValueType(Int->IS.ParamTys[i]->getValueAsDef("VT"));
       assert(getChild(i + 1).getNumTypes() == 1 && "Unhandled case");
       MadeChange |= getChild(i + 1).UpdateNodeType(0, OpVT, TP);
     }
@@ -2676,8 +2675,7 @@ bool TreePatternNode::ApplyTypeConstraints(TreePattern &TP, bool NotRegisters) {
 
       // FIXME: Generalize to multiple possible types and multiple possible
       // ImplicitDefs.
-      MVT::SimpleValueType VT =
-          InstInfo.HasOneImplicitDefWithKnownVT(CDP.getTargetInfo());
+      MVT VT = InstInfo.HasOneImplicitDefWithKnownVT(CDP.getTargetInfo());
 
       if (VT != MVT::Other)
         MadeChange |= UpdateNodeType(ResNo, VT, TP);

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
@@ -191,8 +191,7 @@ struct TypeSetByHwMode : public InfoByHwMode<MachineValueTypeSet> {
   TypeSetByHwMode() = default;
   TypeSetByHwMode(const TypeSetByHwMode &VTS) = default;
   TypeSetByHwMode &operator=(const TypeSetByHwMode &) = default;
-  TypeSetByHwMode(MVT::SimpleValueType VT)
-      : TypeSetByHwMode(ValueTypeByHwMode(VT)) {}
+  TypeSetByHwMode(MVT VT) : TypeSetByHwMode(ValueTypeByHwMode(VT)) {}
   TypeSetByHwMode(ArrayRef<ValueTypeByHwMode> VTList);
 
   SetType &getOrCreate(unsigned Mode) { return Map[Mode]; }
@@ -259,7 +258,7 @@ struct TypeInfer {
   /// otherwise.
 
   bool MergeInTypeInfo(TypeSetByHwMode &Out, const TypeSetByHwMode &In) const;
-  bool MergeInTypeInfo(TypeSetByHwMode &Out, MVT::SimpleValueType InVT) const {
+  bool MergeInTypeInfo(TypeSetByHwMode &Out, MVT InVT) const {
     return MergeInTypeInfo(Out, TypeSetByHwMode(InVT));
   }
   bool MergeInTypeInfo(TypeSetByHwMode &Out,
@@ -451,8 +450,8 @@ public:
 
   /// getKnownType - If the type constraints on this node imply a fixed type
   /// (e.g. all stores return void, etc), then return it as an
-  /// MVT::SimpleValueType.  Otherwise, return MVT::Other.
-  MVT::SimpleValueType getKnownType(unsigned ResNo) const;
+  /// MVT.  Otherwise, return MVT::Other.
+  MVT getKnownType(unsigned ResNo) const;
 
   unsigned getProperties() const { return Properties; }
 
@@ -698,8 +697,8 @@ public:
   }
   TypeSetByHwMode &getExtType(unsigned ResNo) { return Types[ResNo]; }
   void setType(unsigned ResNo, const TypeSetByHwMode &T) { Types[ResNo] = T; }
-  MVT::SimpleValueType getSimpleType(unsigned ResNo) const {
-    return Types[ResNo].getMachineValueType().SimpleTy;
+  MVT getSimpleType(unsigned ResNo) const {
+    return Types[ResNo].getMachineValueType();
   }
 
   bool hasConcreteType(unsigned ResNo) const {
@@ -850,8 +849,7 @@ public: // Higher level manipulation routines.
   ///
   bool UpdateNodeType(unsigned ResNo, const TypeSetByHwMode &InTy,
                       TreePattern &TP);
-  bool UpdateNodeType(unsigned ResNo, MVT::SimpleValueType InTy,
-                      TreePattern &TP);
+  bool UpdateNodeType(unsigned ResNo, MVT InTy, TreePattern &TP);
   bool UpdateNodeType(unsigned ResNo, const ValueTypeByHwMode &InTy,
                       TreePattern &TP);
 
@@ -1001,8 +999,7 @@ inline bool TreePatternNode::UpdateNodeType(unsigned ResNo,
   return TP.getInfer().MergeInTypeInfo(Types[ResNo], VTS);
 }
 
-inline bool TreePatternNode::UpdateNodeType(unsigned ResNo,
-                                            MVT::SimpleValueType InTy,
+inline bool TreePatternNode::UpdateNodeType(unsigned ResNo, MVT InTy,
                                             TreePattern &TP) {
   TypeSetByHwMode VTS(InTy);
   TP.getInfer().expandOverloads(VTS);

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
@@ -499,7 +499,7 @@ CodeGenInstruction::CodeGenInstruction(const Record *R)
 /// HasOneImplicitDefWithKnownVT - If the instruction has at least one
 /// implicit def and it has a known VT, return the VT, otherwise return
 /// MVT::Other.
-MVT::SimpleValueType CodeGenInstruction::HasOneImplicitDefWithKnownVT(
+MVT CodeGenInstruction::HasOneImplicitDefWithKnownVT(
     const CodeGenTarget &TargetInfo) const {
   if (ImplicitDefs.empty())
     return MVT::Other;
@@ -510,7 +510,7 @@ MVT::SimpleValueType CodeGenInstruction::HasOneImplicitDefWithKnownVT(
   const std::vector<ValueTypeByHwMode> &RegVTs =
       TargetInfo.getRegisterVTs(FirstImplicitDef);
   if (RegVTs.size() == 1 && RegVTs[0].isSimple())
-    return RegVTs[0].getSimple().SimpleTy;
+    return RegVTs[0].getSimple();
   return MVT::Other;
 }
 

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.h
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.h
@@ -289,8 +289,7 @@ public:
   /// HasOneImplicitDefWithKnownVT - If the instruction has at least one
   /// implicit def and it has a known VT, return the VT, otherwise return
   /// MVT::Other.
-  MVT::SimpleValueType
-  HasOneImplicitDefWithKnownVT(const CodeGenTarget &TargetInfo) const;
+  MVT HasOneImplicitDefWithKnownVT(const CodeGenTarget &TargetInfo) const;
 
   /// FlattenAsmStringVariants - Flatten the specified AsmString to only
   /// include text from the specified variant, returning the new string.

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -39,7 +39,7 @@ static cl::opt<unsigned>
                  cl::desc("Make -gen-asm-writer emit assembly writer #N"),
                  cl::cat(AsmWriterCat));
 
-/// getValueType - Return the MVT::SimpleValueType that the specified TableGen
+/// Returns the MVT that the specified TableGen
 /// record corresponds to.
 MVT llvm::getValueType(const Record *Rec) {
   return (MVT::SimpleValueType)Rec->getValueAsInt("Value");

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -41,13 +41,13 @@ static cl::opt<unsigned>
 
 /// getValueType - Return the MVT::SimpleValueType that the specified TableGen
 /// record corresponds to.
-MVT::SimpleValueType llvm::getValueType(const Record *Rec) {
+MVT llvm::getValueType(const Record *Rec) {
   return (MVT::SimpleValueType)Rec->getValueAsInt("Value");
 }
 
-StringRef llvm::getEnumName(MVT::SimpleValueType T) {
+StringRef llvm::getEnumName(MVT T) {
   // clang-format off
-  switch (T) {
+  switch (T.SimpleTy) {
 #define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)   \
   case MVT::Ty: return "MVT::" # Ty;
 #include "llvm/CodeGen/GenVT.inc"

--- a/llvm/utils/TableGen/Common/CodeGenTarget.h
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.h
@@ -41,7 +41,7 @@ class CodeGenRegisterClass;
 class CodeGenSchedModels;
 class CodeGenSubRegIndex;
 
-/// getValueType - Return the MVT::SimpleValueType that the specified TableGen
+/// Returns the MVT that the specified TableGen
 /// record corresponds to.
 MVT getValueType(const Record *Rec);
 

--- a/llvm/utils/TableGen/Common/CodeGenTarget.h
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.h
@@ -43,9 +43,9 @@ class CodeGenSubRegIndex;
 
 /// getValueType - Return the MVT::SimpleValueType that the specified TableGen
 /// record corresponds to.
-MVT::SimpleValueType getValueType(const Record *Rec);
+MVT getValueType(const Record *Rec);
 
-StringRef getEnumName(MVT::SimpleValueType T);
+StringRef getEnumName(MVT T);
 
 /// getQualifiedName - Return the name of the specified record, with a
 /// namespace qualifier if the record contains one.

--- a/llvm/utils/TableGen/Common/DAGISelMatcher.cpp
+++ b/llvm/utils/TableGen/Common/DAGISelMatcher.cpp
@@ -286,7 +286,7 @@ void EmitNodeMatcherCommon::printImpl(raw_ostream &OS, indent Indent) const {
   OS << (isa<MorphNodeToMatcher>(this) ? "MorphNodeTo: " : "EmitNode: ")
      << CGI.Namespace << "::" << CGI.getName() << ": <todo flags> ";
 
-  for (MVT::SimpleValueType VT : VTs)
+  for (MVT VT : VTs)
     OS << ' ' << getEnumName(VT);
   OS << '(';
   for (unsigned Operand : Operands)
@@ -321,8 +321,7 @@ void MorphNodeToMatcher::anchor() {}
 
 // isContradictoryImpl Implementations.
 
-static bool TypesAreContradictory(MVT::SimpleValueType T1,
-                                  MVT::SimpleValueType T2) {
+static bool TypesAreContradictory(MVT T1, MVT T2) {
   // If the two types are the same, then they are the same, so they don't
   // contradict.
   if (T1 == T2)
@@ -339,16 +338,16 @@ static bool TypesAreContradictory(MVT::SimpleValueType T1,
   // If either type is about iPtr, then they don't conflict unless the other
   // one is not a scalar integer type.
   if (T1 == MVT::iPTR)
-    return !MVT(T2).isInteger() || MVT(T2).isVector();
+    return !T2.isInteger() || T2.isVector();
 
   if (T2 == MVT::iPTR)
-    return !MVT(T1).isInteger() || MVT(T1).isVector();
+    return !T1.isInteger() || T1.isVector();
 
   if (T1 == MVT::cPTR)
-    return !MVT(T2).isCheriCapability() || MVT(T2).isVector();
+    return !T2.isCheriCapability() || T2.isVector();
 
   if (T2 == MVT::cPTR)
-    return !MVT(T1).isCheriCapability() || MVT(T1).isVector();
+    return !T1.isCheriCapability() || T1.isVector();
 
   // Otherwise, they are two different non-iPTR/cPTR types, they conflict.
   return true;
@@ -370,7 +369,7 @@ bool CheckOpcodeMatcher::isContradictoryImpl(const Matcher *M) const {
     if (CT->getResNo() >= getOpcode().getNumResults())
       return true;
 
-    MVT::SimpleValueType NodeType = getOpcode().getKnownType(CT->getResNo());
+    MVT NodeType = getOpcode().getKnownType(CT->getResNo());
     if (NodeType != MVT::Other)
       return TypesAreContradictory(NodeType, CT->getType());
   }

--- a/llvm/utils/TableGen/Common/DAGISelMatcher.h
+++ b/llvm/utils/TableGen/Common/DAGISelMatcher.h
@@ -517,14 +517,14 @@ private:
 /// CheckTypeMatcher - This checks to see if the current node has the
 /// specified type at the specified result, if not it fails to match.
 class CheckTypeMatcher : public Matcher {
-  MVT::SimpleValueType Type;
+  MVT Type;
   unsigned ResNo;
 
 public:
-  CheckTypeMatcher(MVT::SimpleValueType type, unsigned resno)
+  CheckTypeMatcher(MVT type, unsigned resno)
       : Matcher(CheckType), Type(type), ResNo(resno) {}
 
-  MVT::SimpleValueType getType() const { return Type; }
+  MVT getType() const { return Type; }
   unsigned getResNo() const { return ResNo; }
 
   static bool classof(const Matcher *N) { return N->getKind() == CheckType; }
@@ -542,11 +542,10 @@ private:
 /// then the match fails.  This is semantically equivalent to a Scope node where
 /// every child does a CheckType, but is much faster.
 class SwitchTypeMatcher : public Matcher {
-  SmallVector<std::pair<MVT::SimpleValueType, Matcher *>, 8> Cases;
+  SmallVector<std::pair<MVT, Matcher *>, 8> Cases;
 
 public:
-  SwitchTypeMatcher(
-      SmallVectorImpl<std::pair<MVT::SimpleValueType, Matcher *>> &&cases)
+  SwitchTypeMatcher(SmallVectorImpl<std::pair<MVT, Matcher *>> &&cases)
       : Matcher(SwitchType), Cases(std::move(cases)) {}
   ~SwitchTypeMatcher() override;
 
@@ -554,7 +553,7 @@ public:
 
   unsigned getNumCases() const { return Cases.size(); }
 
-  MVT::SimpleValueType getCaseType(unsigned i) const { return Cases[i].first; }
+  MVT getCaseType(unsigned i) const { return Cases[i].first; }
   Matcher *getCaseMatcher(unsigned i) { return Cases[i].second; }
   const Matcher *getCaseMatcher(unsigned i) const { return Cases[i].second; }
 
@@ -567,14 +566,14 @@ private:
 /// specified type, if not it fails to match.
 class CheckChildTypeMatcher : public Matcher {
   unsigned ChildNo;
-  MVT::SimpleValueType Type;
+  MVT Type;
 
 public:
-  CheckChildTypeMatcher(unsigned childno, MVT::SimpleValueType type)
+  CheckChildTypeMatcher(unsigned childno, MVT type)
       : Matcher(CheckChildType), ChildNo(childno), Type(type) {}
 
   unsigned getChildNo() const { return ChildNo; }
-  MVT::SimpleValueType getType() const { return Type; }
+  MVT getType() const { return Type; }
 
   static bool classof(const Matcher *N) {
     return N->getKind() == CheckChildType;
@@ -684,13 +683,12 @@ private:
 /// CheckValueTypeMatcher - This checks to see if the current node is a
 /// VTSDNode with the specified type, if not it fails to match.
 class CheckValueTypeMatcher : public Matcher {
-  MVT::SimpleValueType VT;
+  MVT VT;
 
 public:
-  CheckValueTypeMatcher(MVT::SimpleValueType SimpleVT)
-      : Matcher(CheckValueType), VT(SimpleVT) {}
+  CheckValueTypeMatcher(MVT SimpleVT) : Matcher(CheckValueType), VT(SimpleVT) {}
 
-  MVT::SimpleValueType getVT() const { return VT; }
+  MVT getVT() const { return VT; }
 
   static bool classof(const Matcher *N) {
     return N->getKind() == CheckValueType;
@@ -832,18 +830,18 @@ private:
 /// EmitIntegerMatcher - This creates a new TargetConstant.
 class EmitIntegerMatcher : public Matcher {
   int64_t Val;
-  MVT::SimpleValueType VT;
+  MVT VT;
 
   unsigned ResultNo;
 
 public:
-  EmitIntegerMatcher(int64_t val, MVT::SimpleValueType vt, unsigned resultNo)
+  EmitIntegerMatcher(int64_t val, MVT vt, unsigned resultNo)
       : Matcher(EmitInteger),
         Val(SignExtend64(val, MVT(vt).getFixedSizeInBits())), VT(vt),
         ResultNo(resultNo) {}
 
   int64_t getValue() const { return Val; }
-  MVT::SimpleValueType getVT() const { return VT; }
+  MVT getVT() const { return VT; }
   unsigned getResultNo() const { return ResultNo; }
 
   static bool classof(const Matcher *N) { return N->getKind() == EmitInteger; }
@@ -860,17 +858,16 @@ private:
 /// by a string.
 class EmitStringIntegerMatcher : public Matcher {
   std::string Val;
-  MVT::SimpleValueType VT;
+  MVT VT;
 
   unsigned ResultNo;
 
 public:
-  EmitStringIntegerMatcher(const std::string &val, MVT::SimpleValueType vt,
-                           unsigned resultNo)
+  EmitStringIntegerMatcher(const std::string &val, MVT vt, unsigned resultNo)
       : Matcher(EmitStringInteger), Val(val), VT(vt), ResultNo(resultNo) {}
 
   const std::string &getValue() const { return Val; }
-  MVT::SimpleValueType getVT() const { return VT; }
+  MVT getVT() const { return VT; }
   unsigned getResultNo() const { return ResultNo; }
 
   static bool classof(const Matcher *N) {
@@ -890,17 +887,16 @@ class EmitRegisterMatcher : public Matcher {
   /// Reg - The def for the register that we're emitting.  If this is null, then
   /// this is a reference to zero_reg.
   const CodeGenRegister *Reg;
-  MVT::SimpleValueType VT;
+  MVT VT;
 
   unsigned ResultNo;
 
 public:
-  EmitRegisterMatcher(const CodeGenRegister *reg, MVT::SimpleValueType vt,
-                      unsigned resultNo)
+  EmitRegisterMatcher(const CodeGenRegister *reg, MVT vt, unsigned resultNo)
       : Matcher(EmitRegister), Reg(reg), VT(vt), ResultNo(resultNo) {}
 
   const CodeGenRegister *getReg() const { return Reg; }
-  MVT::SimpleValueType getVT() const { return VT; }
+  MVT getVT() const { return VT; }
   unsigned getResultNo() const { return ResultNo; }
 
   static bool classof(const Matcher *N) { return N->getKind() == EmitRegister; }
@@ -1028,7 +1024,7 @@ private:
 /// MorphNodeTo.
 class EmitNodeMatcherCommon : public Matcher {
   const CodeGenInstruction &CGI;
-  const SmallVector<MVT::SimpleValueType, 3> VTs;
+  const SmallVector<MVT, 3> VTs;
   const SmallVector<unsigned, 6> Operands;
   bool HasChain, HasInGlue, HasOutGlue, HasMemRefs;
 
@@ -1038,8 +1034,7 @@ class EmitNodeMatcherCommon : public Matcher {
   int NumFixedArityOperands;
 
 public:
-  EmitNodeMatcherCommon(const CodeGenInstruction &cgi,
-                        ArrayRef<MVT::SimpleValueType> vts,
+  EmitNodeMatcherCommon(const CodeGenInstruction &cgi, ArrayRef<MVT> vts,
                         ArrayRef<unsigned> operands, bool hasChain,
                         bool hasInGlue, bool hasOutGlue, bool hasmemrefs,
                         int numfixedarityoperands, bool isMorphNodeTo)
@@ -1051,7 +1046,7 @@ public:
   const CodeGenInstruction &getInstruction() const { return CGI; }
 
   unsigned getNumVTs() const { return VTs.size(); }
-  MVT::SimpleValueType getVT(unsigned i) const {
+  MVT getVT(unsigned i) const {
     assert(i < VTs.size());
     return VTs[i];
   }
@@ -1062,7 +1057,7 @@ public:
     return Operands[i];
   }
 
-  const SmallVectorImpl<MVT::SimpleValueType> &getVTList() const { return VTs; }
+  const SmallVectorImpl<MVT> &getVTList() const { return VTs; }
   const SmallVectorImpl<unsigned> &getOperandList() const { return Operands; }
 
   bool hasChain() const { return HasChain; }
@@ -1086,8 +1081,7 @@ class EmitNodeMatcher : public EmitNodeMatcherCommon {
   unsigned FirstResultSlot;
 
 public:
-  EmitNodeMatcher(const CodeGenInstruction &cgi,
-                  ArrayRef<MVT::SimpleValueType> vts,
+  EmitNodeMatcher(const CodeGenInstruction &cgi, ArrayRef<MVT> vts,
                   ArrayRef<unsigned> operands, bool hasChain, bool hasInGlue,
                   bool hasOutGlue, bool hasmemrefs, int numfixedarityoperands,
                   unsigned firstresultslot)
@@ -1106,8 +1100,7 @@ class MorphNodeToMatcher : public EmitNodeMatcherCommon {
   const PatternToMatch &Pattern;
 
 public:
-  MorphNodeToMatcher(const CodeGenInstruction &cgi,
-                     ArrayRef<MVT::SimpleValueType> vts,
+  MorphNodeToMatcher(const CodeGenInstruction &cgi, ArrayRef<MVT> vts,
                      ArrayRef<unsigned> operands, bool hasChain, bool hasInGlue,
                      bool hasOutGlue, bool hasmemrefs,
                      int numfixedarityoperands, const PatternToMatch &pattern)

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -440,9 +440,7 @@ bool LLTCodeGen::operator<(const LLTCodeGen &Other) const {
 
 //===- LLTCodeGen Helpers -------------------------------------------------===//
 
-std::optional<LLTCodeGen> llvm::gi::MVTToLLT(MVT::SimpleValueType SVT) {
-  MVT VT(SVT);
-
+std::optional<LLTCodeGen> llvm::gi::MVTToLLT(MVT VT) {
   if (VT.isVector() && !VT.getVectorElementCount().isScalar())
     return LLTCodeGen(
         LLT::vector(VT.getVectorElementCount(), VT.getScalarSizeInBits()));

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
@@ -267,7 +267,7 @@ extern std::set<LLTCodeGen> KnownTypes;
 
 /// Convert an MVT to an equivalent LLT if possible, or the invalid LLT() for
 /// MVTs that don't map cleanly to an LLT (e.g., iPTR, *any, ...).
-std::optional<LLTCodeGen> MVTToLLT(MVT::SimpleValueType SVT);
+std::optional<LLTCodeGen> MVTToLLT(MVT VT);
 
 using TempTypeIdx = int64_t;
 class LLTCodeGenOrTempType {

--- a/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
@@ -339,8 +339,9 @@ unsigned MatcherTableEmitter::SizeMatcher(Matcher *N, raw_ostream &OS) {
         Size += 2; // Count the child's opcode.
       } else {
         Child = cast<SwitchTypeMatcher>(N)->getCaseMatcher(i);
-        Size += GetVBRSize(cast<SwitchTypeMatcher>(N)->getCaseType(
-            i)); // Count the child's type.
+        Size += GetVBRSize(cast<SwitchTypeMatcher>(N)
+                               ->getCaseType(i)
+                               .SimpleTy); // Count the child's type.
       }
       const unsigned ChildSize = SizeMatcherList(Child, OS);
       assert(ChildSize != 0 && "Matcher cannot have child of size 0");
@@ -604,8 +605,10 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
         IdxSize = 2; // size of opcode in table is 2 bytes.
       } else {
         Child = cast<SwitchTypeMatcher>(N)->getCaseMatcher(i);
-        IdxSize = GetVBRSize(cast<SwitchTypeMatcher>(N)->getCaseType(
-            i)); // size of type in table is sizeof(VBR(MVT)) byte.
+        IdxSize = GetVBRSize(
+            cast<SwitchTypeMatcher>(N)
+                ->getCaseType(i)
+                .SimpleTy); // size of type in table is sizeof(VBR(MVT)) byte.
       }
 
       if (i != 0) {
@@ -625,8 +628,7 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
         if (!OmitComments)
           OS << "/*" << getEnumName(cast<SwitchTypeMatcher>(N)->getCaseType(i))
              << "*/";
-        EmitVBRValue(cast<SwitchTypeMatcher>(N)->getCaseType(i),
-                     OS);
+        EmitVBRValue(cast<SwitchTypeMatcher>(N)->getCaseType(i).SimpleTy, OS);
       }
       if (!OmitComments)
         OS << "// ->" << CurrentIdx + ChildSize;
@@ -652,8 +654,8 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
 
   case Matcher::CheckType: {
     if (cast<CheckTypeMatcher>(N)->getResNo() == 0) {
-      MVT::SimpleValueType VT = cast<CheckTypeMatcher>(N)->getType();
-      switch (VT) {
+      MVT VT = cast<CheckTypeMatcher>(N)->getType();
+      switch (VT.SimpleTy) {
       case MVT::i32:
       case MVT::i64:
         OS << "OPC_CheckTypeI" << MVT(VT).getSizeInBits() << ",\n";
@@ -662,7 +664,7 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
         OS << "OPC_CheckType, ";
         if (!OmitComments)
           OS << "/*" << getEnumName(VT) << "*/";
-        unsigned NumBytes = EmitVBRValue(VT, OS);
+        unsigned NumBytes = EmitVBRValue(VT.SimpleTy, OS);
         OS << "\n";
         return NumBytes + 1;
       }
@@ -670,14 +672,15 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
     OS << "OPC_CheckTypeRes, " << cast<CheckTypeMatcher>(N)->getResNo() << ", ";
     if (!OmitComments)
       OS << "/*" << getEnumName(cast<CheckTypeMatcher>(N)->getType()) << "*/";
-    unsigned NumBytes = EmitVBRValue(cast<CheckTypeMatcher>(N)->getType(), OS);
+    unsigned NumBytes =
+        EmitVBRValue(cast<CheckTypeMatcher>(N)->getType().SimpleTy, OS);
     OS << "\n";
     return NumBytes + 2;
   }
 
   case Matcher::CheckChildType: {
-    MVT::SimpleValueType VT = cast<CheckChildTypeMatcher>(N)->getType();
-    switch (VT) {
+    MVT VT = cast<CheckChildTypeMatcher>(N)->getType();
+    switch (VT.SimpleTy) {
     case MVT::i32:
     case MVT::i64:
       OS << "OPC_CheckChild" << cast<CheckChildTypeMatcher>(N)->getChildNo()
@@ -688,7 +691,7 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
          << "Type, ";
       if (!OmitComments)
         OS << "/*" << getEnumName(VT) << "*/";
-      unsigned NumBytes = EmitVBRValue(VT, OS);
+      unsigned NumBytes = EmitVBRValue(VT.SimpleTy, OS);
       OS << "\n";
       return NumBytes + 1;
     }
@@ -725,7 +728,7 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
       OS << "/*" << getEnumName(cast<CheckValueTypeMatcher>(N)->getVT())
          << "*/";
     unsigned NumBytes =
-        EmitVBRValue(cast<CheckValueTypeMatcher>(N)->getVT(), OS);
+        EmitVBRValue(cast<CheckValueTypeMatcher>(N)->getVT().SimpleTy, OS);
     OS << "\n";
     return NumBytes + 1;
   }
@@ -784,21 +787,21 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
 
   case Matcher::EmitInteger: {
     int64_t Val = cast<EmitIntegerMatcher>(N)->getValue();
-    MVT::SimpleValueType VT = cast<EmitIntegerMatcher>(N)->getVT();
+    MVT VT = cast<EmitIntegerMatcher>(N)->getVT();
     unsigned OpBytes;
-    switch (VT) {
+    switch (VT.SimpleTy) {
     case MVT::i8:
     case MVT::i16:
     case MVT::i32:
     case MVT::i64:
       OpBytes = 1;
-      OS << "OPC_EmitInteger" << MVT(VT).getSizeInBits() << ", ";
+      OS << "OPC_EmitInteger" << VT.getSizeInBits() << ", ";
       break;
     default:
       OS << "OPC_EmitInteger, ";
       if (!OmitComments)
         OS << "/*" << getEnumName(VT) << "*/";
-      OpBytes = EmitVBRValue(VT, OS) + 1;
+      OpBytes = EmitVBRValue(VT.SimpleTy, OS) + 1;
       break;
     }
     unsigned Bytes = OpBytes + EmitSignedVBRValue(Val, OS);
@@ -809,19 +812,19 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
   }
   case Matcher::EmitStringInteger: {
     const std::string &Val = cast<EmitStringIntegerMatcher>(N)->getValue();
-    MVT::SimpleValueType VT = cast<EmitStringIntegerMatcher>(N)->getVT();
+    MVT VT = cast<EmitStringIntegerMatcher>(N)->getVT();
     // These should always fit into 7 bits.
     unsigned OpBytes;
-    switch (VT) {
+    switch (VT.SimpleTy) {
     case MVT::i32:
       OpBytes = 1;
-      OS << "OPC_EmitStringInteger" << MVT(VT).getSizeInBits() << ", ";
+      OS << "OPC_EmitStringInteger" << VT.getSizeInBits() << ", ";
       break;
     default:
       OS << "OPC_EmitStringInteger, ";
       if (!OmitComments)
         OS << "/*" << getEnumName(VT) << "*/";
-      OpBytes = EmitVBRValue(VT, OS) + 1;
+      OpBytes = EmitVBRValue(VT.SimpleTy, OS) + 1;
       break;
     }
     OS << Val << ',';
@@ -834,7 +837,7 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
   case Matcher::EmitRegister: {
     const EmitRegisterMatcher *Matcher = cast<EmitRegisterMatcher>(N);
     const CodeGenRegister *Reg = Matcher->getReg();
-    MVT::SimpleValueType VT = Matcher->getVT();
+    MVT VT = Matcher->getVT();
     unsigned OpBytes;
     // If the enum value of the register is larger than one byte can handle,
     // use EmitRegister2.
@@ -842,21 +845,21 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
       OS << "OPC_EmitRegister2, ";
       if (!OmitComments)
         OS << "/*" << getEnumName(VT) << "*/";
-      OpBytes = EmitVBRValue(VT, OS);
+      OpBytes = EmitVBRValue(VT.SimpleTy, OS);
       OS << "TARGET_VAL(" << getQualifiedName(Reg->TheDef) << "),\n";
       return OpBytes + 3;
     }
-    switch (VT) {
+    switch (VT.SimpleTy) {
     case MVT::i32:
     case MVT::i64:
       OpBytes = 1;
-      OS << "OPC_EmitRegisterI" << MVT(VT).getSizeInBits() << ", ";
+      OS << "OPC_EmitRegisterI" << VT.getSizeInBits() << ", ";
       break;
     default:
       OS << "OPC_EmitRegister, ";
       if (!OmitComments)
         OS << "/*" << getEnumName(VT) << "*/";
-      OpBytes = EmitVBRValue(VT, OS) + 1;
+      OpBytes = EmitVBRValue(VT.SimpleTy, OS) + 1;
       break;
     }
     if (Reg) {
@@ -1014,7 +1017,7 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
     for (unsigned i = 0, e = EN->getNumVTs(); i != e; ++i) {
       if (!OmitComments)
         OS << "/*" << getEnumName(EN->getVT(i)) << "*/";
-      NumTypeBytes += EmitVBRValue(EN->getVT(i), OS);
+      NumTypeBytes += EmitVBRValue(EN->getVT(i).SimpleTy, OS);
     }
 
     OS << EN->getNumOperands();

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -23,10 +23,9 @@ using namespace llvm;
 /// getRegisterValueType - Look up and return the ValueType of the specified
 /// register. If the register is a member of multiple register classes, they
 /// must all have the same type.
-static MVT::SimpleValueType getRegisterValueType(const Record *R,
-                                                 const CodeGenTarget &T) {
+static MVT getRegisterValueType(const Record *R, const CodeGenTarget &T) {
   bool FoundRC = false;
-  MVT::SimpleValueType VT = MVT::Other;
+  MVT VT = MVT::Other;
   const CodeGenRegister *Reg = T.getRegBank().getReg(R);
 
   for (const auto &RC : T.getRegBank().getRegClasses()) {
@@ -37,14 +36,14 @@ static MVT::SimpleValueType getRegisterValueType(const Record *R,
       FoundRC = true;
       const ValueTypeByHwMode &VVT = RC.getValueTypeNum(0);
       assert(VVT.isSimple());
-      VT = VVT.getSimple().SimpleTy;
+      VT = VVT.getSimple();
       continue;
     }
 
 #ifndef NDEBUG
     // If this occurs in multiple register classes, they all have to agree.
     const ValueTypeByHwMode &VVT = RC.getValueTypeNum(0);
-    assert(VVT.isSimple() && VVT.getSimple().SimpleTy == VT &&
+    assert(VVT.isSimple() && VVT.getSimple() == VT &&
            "ValueType mismatch between register classes for this register");
 #endif
   }
@@ -687,7 +686,7 @@ void MatcherGen::EmitResultLeafAsOperand(const TreePatternNode &N,
     }
 
     if (Def->getName() == "undef_tied_input") {
-      MVT::SimpleValueType ResultVT = N.getSimpleType(0);
+      MVT ResultVT = N.getSimpleType(0);
       auto IDOperandNo = NextRecordedOperandNo++;
       const Record *ImpDef = Def->getRecords().getDef("IMPLICIT_DEF");
       CodeGenInstruction &II = CGP.getTargetInfo().getInstruction(ImpDef);
@@ -896,7 +895,7 @@ void MatcherGen::EmitResultInstructionAsOperand(
   // Result order: node results, chain, glue
 
   // Determine the result types.
-  SmallVector<MVT::SimpleValueType, 4> ResultVTs;
+  SmallVector<MVT, 4> ResultVTs;
   for (unsigned i = 0, e = N.getNumTypes(); i != e; ++i)
     ResultVTs.push_back(N.getSimpleType(i));
 
@@ -973,7 +972,7 @@ void MatcherGen::EmitResultInstructionAsOperand(
                                  NumFixedArityOperands, NextRecordedOperandNo));
 
   // The non-chain and non-glue results of the newly emitted node get recorded.
-  for (MVT::SimpleValueType ResultVT : ResultVTs) {
+  for (MVT ResultVT : ResultVTs) {
     if (ResultVT == MVT::Other || ResultVT == MVT::Glue)
       break;
     OutputOps.push_back(NextRecordedOperandNo++);

--- a/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
@@ -282,7 +282,7 @@ static void ContractNodes(std::unique_ptr<Matcher> &InputMatcherPtr,
 #endif
 
         if (ResultsMatch) {
-          ArrayRef<MVT::SimpleValueType> VTs = EN->getVTList();
+          ArrayRef<MVT> VTs = EN->getVTList();
           ArrayRef<unsigned> Operands = EN->getOperandList();
           MatcherPtr->reset(new MorphNodeToMatcher(
               EN->getInstruction(), VTs, Operands, EN->hasChain(),
@@ -556,17 +556,17 @@ static void FactorScope(std::unique_ptr<Matcher> &MatcherPtr) {
   // If all the options are CheckType's, we can form the SwitchType, woot.
   if (AllTypeChecks) {
     DenseMap<unsigned, unsigned> TypeEntry;
-    SmallVector<std::pair<MVT::SimpleValueType, Matcher *>, 8> Cases;
+    SmallVector<std::pair<MVT, Matcher *>, 8> Cases;
     for (Matcher *Optn : OptionsToMatch) {
       Matcher *M = FindNodeWithKind(Optn, Matcher::CheckType);
       assert(M && isa<CheckTypeMatcher>(M) && "Unknown Matcher type");
 
       auto *CTM = cast<CheckTypeMatcher>(M);
       Matcher *MatcherWithoutCTM = Optn->unlinkNode(CTM);
-      MVT::SimpleValueType CTMTy = CTM->getType();
+      MVT CTMTy = CTM->getType();
       delete CTM;
 
-      unsigned &Entry = TypeEntry[CTMTy];
+      unsigned &Entry = TypeEntry[CTMTy.SimpleTy];
       if (Entry != 0) {
         // If we have unfactored duplicate types, then we should factor them.
         Matcher *PrevMatcher = Cases[Entry - 1].second;

--- a/llvm/utils/TableGen/FastISelEmitter.cpp
+++ b/llvm/utils/TableGen/FastISelEmitter.cpp
@@ -189,7 +189,7 @@ struct OperandsSignature {
   /// are supported, false otherwise.
   ///
   bool initialize(TreePatternNode &InstPatNode, const CodeGenTarget &Target,
-                  MVT::SimpleValueType VT, ImmPredicateSet &ImmediatePredicates,
+                  MVT VT, ImmPredicateSet &ImmediatePredicates,
                   const CodeGenRegisterClass *OrigDstRC) {
     if (InstPatNode.isLeaf())
       return false;
@@ -367,8 +367,8 @@ class FastISelMap {
   // A multimap is needed instead of a "plain" map because the key is
   // the instruction's complexity (an int) and they are not unique.
   using PredMap = std::multimap<int, InstructionMemo>;
-  using RetPredMap = std::map<MVT::SimpleValueType, PredMap>;
-  using TypeRetPredMap = std::map<MVT::SimpleValueType, RetPredMap>;
+  using RetPredMap = std::map<MVT, PredMap>;
+  using TypeRetPredMap = std::map<MVT, RetPredMap>;
   using OpcodeTypeRetPredMap = std::map<StringRef, TypeRetPredMap>;
   using OperandsOpcodeTypeRetPredMap =
       std::map<OperandsSignature, OpcodeTypeRetPredMap>;
@@ -376,8 +376,7 @@ class FastISelMap {
   OperandsOpcodeTypeRetPredMap SimplePatterns;
 
   // This is used to check that there are no duplicate predicates
-  std::set<std::tuple<OperandsSignature, StringRef, MVT::SimpleValueType,
-                      MVT::SimpleValueType, std::string>>
+  std::set<std::tuple<OperandsSignature, StringRef, MVT, MVT, std::string>>
       SimplePatternsCheck;
 
   std::map<OperandsSignature, std::vector<OperandsSignature>>
@@ -501,10 +500,10 @@ void FastISelMap::collectPatterns(const CodeGenDAGPatterns &CGP) {
 
     const Record *InstPatOp = InstPatNode.getOperator();
     StringRef OpcodeName = CGP.getSDNodeInfo(InstPatOp).getEnumName();
-    MVT::SimpleValueType RetVT = MVT::isVoid;
+    MVT RetVT = MVT::isVoid;
     if (InstPatNode.getNumTypes())
       RetVT = InstPatNode.getSimpleType(0);
-    MVT::SimpleValueType VT = RetVT;
+    MVT VT = RetVT;
     if (InstPatNode.getNumChildren()) {
       assert(InstPatNode.getChild(0).getNumTypes() == 1);
       VT = InstPatNode.getChild(0).getSimpleType(0);

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -1034,8 +1034,8 @@ Error GlobalISelEmitter::importChildMatcher(
     if (ChildRec->isSubClassOf("ValueType") && !SrcChild.hasName()) {
       // An unnamed ValueType as in (sext_inreg GPR:$foo, i8). GISel represents
       // this as a literal constant with the scalar size.
-      MVT::SimpleValueType VT = llvm::getValueType(ChildRec);
-      OM.addPredicate<LiteralIntOperandMatcher>(MVT(VT).getScalarSizeInBits());
+      MVT VT = llvm::getValueType(ChildRec);
+      OM.addPredicate<LiteralIntOperandMatcher>(VT.getScalarSizeInBits());
       return Error::success();
     }
   }

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -616,7 +616,7 @@ public:
   void print(raw_ostream &OS) { printBitVectorAsHex(OS, Values, 8); }
 };
 
-static void printSimpleValueType(raw_ostream &OS, MVT::SimpleValueType VT) {
+static void printSimpleValueType(raw_ostream &OS, MVT VT) {
   OS << getEnumName(VT);
 }
 
@@ -1260,14 +1260,14 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
   unsigned NumModes = CGH.getNumModeIds();
 
   // Build a shared array of value types.
-  SequenceToOffsetTable<std::vector<MVT::SimpleValueType>> VTSeqs(
+  SequenceToOffsetTable<std::vector<MVT>> VTSeqs(
       /*Terminator=*/MVT::Other);
   for (unsigned M = 0; M < NumModes; ++M) {
     for (const auto &RC : RegisterClasses) {
-      std::vector<MVT::SimpleValueType> S;
+      std::vector<MVT> S;
       for (const ValueTypeByHwMode &VVT : RC.VTs)
         if (VVT.hasDefault() || VVT.hasMode(M))
-          S.push_back(VVT.get(M).SimpleTy);
+          S.push_back(VVT.get(M));
       VTSeqs.add(S);
     }
   }
@@ -1328,10 +1328,10 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
         const RegSizeInfo &RI = RC.RSI.get(M);
         OS << "  { " << RI.RegSize << ", " << RI.SpillSize << ", "
            << RI.SpillAlignment;
-        std::vector<MVT::SimpleValueType> VTs;
+        std::vector<MVT> VTs;
         for (const ValueTypeByHwMode &VVT : RC.VTs)
           if (VVT.hasDefault() || VVT.hasMode(M))
-            VTs.push_back(VVT.get(M).SimpleTy);
+            VTs.push_back(VVT.get(M));
         OS << ", /*VTLists+*/" << VTSeqs.get(VTs) << " },    // "
            << RC.getName() << '\n';
       }

--- a/llvm/utils/TableGen/SDNodeInfoEmitter.cpp
+++ b/llvm/utils/TableGen/SDNodeInfoEmitter.cpp
@@ -201,7 +201,7 @@ static void emitTypeConstraint(
   unsigned OtherOpNo = 0;
   unsigned NumHwModes = 0;
   unsigned VTByHwModeOffset = 0;
-  MVT::SimpleValueType VT = MVT::INVALID_SIMPLE_VALUE_TYPE;
+  MVT VT = MVT::INVALID_SIMPLE_VALUE_TYPE;
 
   switch (C.ConstraintType) {
   case SDTypeConstraint::SDTCisVT:
@@ -212,7 +212,7 @@ static void emitTypeConstraint(
     [[fallthrough]];
   case SDTypeConstraint::SDTCVecEltisVT:
     if (C.VVT.isSimple()) {
-      VT = C.VVT.getSimple().SimpleTy;
+      VT = C.VVT.getSimple();
     } else {
       NumHwModes = C.VVT.size();
       assert(NumHwModes && "Empty type set?");


### PR DESCRIPTION
This improves type safety and is less verbose. Use SimpleTy only where an integer is needed like switches or emitting a VBR.