### PR TITLE
[LLVM] Add myself to the former maintainers list.

### DIFF
--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -533,6 +533,7 @@ sabre@nondot.org (email), [lattner](https://github.com/lattner) (GitHub), clattn
 ### Inactive or former component maintainers
 
 Paul C. Anagnostopoulos (paul@windfall.com, [Paul-C-Anagnostopoulos](https://github.com/Paul-C-Anagnostopoulos)) -- TableGen \
+Owen Anderson (resistor@mac.com, [resistor](https://github.com/resistor)) -- SelectionDAG \
 Justin Bogner (mail@justinbogner.com, [bogner](https://github.com/bogner)) -- SelectionDAG \
 Chandler Carruth (chandlerc@gmail.com, chandlerc@google.com, [chandlerc](https://github.com/chandlerc)) -- ADT, Support, Inlining, CMake and library layering \
 Peter Collingbourne (peter@pcc.me.uk, [pcc](https://github.com/pcc)) -- LTO \


### PR DESCRIPTION
I was the SelectionDAG maintainer (then called code owner) from aebfacb008246b912e2fc5a454939a3de942303b (requested to take it up by Evan Cheng) and yielded the role to Justin Bogner as of d8ed65dda0b10b5d9fa6ebd2da46e733fbde5512.
