### PR TITLE
[clang-format] Handle `&&` in requires clause in requires requires

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3129,8 +3129,11 @@ private:
 
     // It is very unlikely that we are going to find a pointer or reference type
     // definition on the RHS of an assignment.
-    if (IsExpression && !Contexts.back().CaretFound)
+    if (IsExpression && !Contexts.back().CaretFound &&
+        Line.getFirstNonComment()->isNot(
+            TT_RequiresClauseInARequiresExpression)) {
       return TT_BinaryOperator;
+    }
 
     // Opeartors at class scope are likely pointer or reference members.
     if (!Scopes.empty() && Scopes.back() == ST_Class)

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1392,6 +1392,15 @@ TEST_F(TokenAnnotatorTest, UnderstandsRequiresClausesAndConcepts) {
   EXPECT_TOKEN(Tokens[19], tok::l_brace, TT_RequiresExpressionLBrace);
 
   Tokens =
+      annotate("template <typename... Ts>\n"
+               "  requires requires {\n"
+               "    requires std::same_as<int, SomeTemplate<void(Ts &&...)>>;\n"
+               "  }\n"
+               "void Foo();");
+  ASSERT_EQ(Tokens.size(), 34u) << Tokens;
+  EXPECT_TOKEN(Tokens[21], tok::ampamp, TT_PointerOrReference);
+
+  Tokens =
       annotate("template <class A, class B> concept C ="
                "std::same_as<std::iter_value_t<A>, std::iter_value_t<B>>;");
   ASSERT_EQ(Tokens.size(), 31u) << Tokens;


### PR DESCRIPTION
Fixes #152266