### PR TITLE
[lldb] Fix SWIG bug detection in CMake

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -182,7 +182,12 @@ if (LLDB_ENABLE_PYTHON)
 
   # Enable targeting the Python Limited C API.
   set(PYTHON_LIMITED_API_MIN_SWIG_VERSION "4.2")
-  set(AFFECTED_BY_SWIG_BUG SWIG_VERSION VERSION_EQUAL "4.4.0" AND Python3_VERSION VERSION_GREATER_EQUAL "3.13")
+  if (SWIG_VERSION VERSION_EQUAL "4.4.0" AND Python3_VERSION VERSION_GREATER_EQUAL "3.13")
+    set(AFFECTED_BY_SWIG_BUG TRUE)
+  else()
+    set(AFFECTED_BY_SWIG_BUG FALSE)
+  endif()
+
   if (SWIG_VERSION VERSION_GREATER_EQUAL PYTHON_LIMITED_API_MIN_SWIG_VERSION
       AND NOT LLDB_EMBED_PYTHON_HOME AND NOT AFFECTED_BY_SWIG_BUG)
     set(default_enable_python_limited_api ON)
@@ -195,7 +200,7 @@ if (LLDB_ENABLE_PYTHON)
 
   # Diagnose unsupported configurations.
   if (LLDB_ENABLE_PYTHON_LIMITED_API AND AFFECTED_BY_SWIG_BUG)
-    message(SEND_ERROR "LLDB_ENABLE_PYTHON_LIMITED_API is not compatible with SWIG 4.4.0 and Python 3.13 due to a bug in SWIG: https://github.com/swig/swig/issues/3283")
+    message(SEND_ERROR "LLDB_ENABLE_PYTHON_LIMITED_API is not compatible with SWIG 4.4.0 and Python >= 3.13 due to a bug in SWIG: https://github.com/swig/swig/issues/3283")
   endif()
   if (LLDB_ENABLE_PYTHON_LIMITED_API AND LLDB_EMBED_PYTHON_HOME)
     message(SEND_ERROR "LLDB_ENABLE_PYTHON_LIMITED_API is not compatible with LLDB_EMBED_PYTHON_HOME")


### PR DESCRIPTION
The CMake [`set()`](https://cmake.org/cmake/help/latest/command/set.html) command does not accept a conditional expression as a value. As a result, AFFECTED_BY_SWIG_BUG was being set to a string representation of the condition rather than a boolean value, causing it to always evaluate as truthy in subsequent if-checks.

Fixes #168363