### PR TITLE
[libc++] Reformat `optional` constructor tests

### DIFF
--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/U.pass.cpp
@@ -13,25 +13,28 @@
 // template <class U>
 //   constexpr EXPLICIT optional(U&& u);
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 #include "archetypes.h"
 #include "test_convertible.h"
 
-
 using std::optional;
 
-struct ImplicitThrow
-{
-    constexpr ImplicitThrow(int x) { if (x != -1) TEST_THROW(6);}
+struct ImplicitThrow {
+  constexpr ImplicitThrow(int x) {
+    if (x != -1)
+      TEST_THROW(6);
+  }
 };
 
-struct ExplicitThrow
-{
-    constexpr explicit ExplicitThrow(int x) { if (x != -1) TEST_THROW(6);}
+struct ExplicitThrow {
+  constexpr explicit ExplicitThrow(int x) {
+    if (x != -1)
+      TEST_THROW(6);
+  }
 };
 
 struct ImplicitAny {
@@ -39,56 +42,52 @@ struct ImplicitAny {
   constexpr ImplicitAny(U&&) {}
 };
 
-
 template <class To, class From>
-constexpr bool implicit_conversion(optional<To>&& opt, const From& v)
-{
-    using O = optional<To>;
-    static_assert(test_convertible<O, From>(), "");
-    static_assert(!test_convertible<O, void*>(), "");
-    static_assert(!test_convertible<O, From, int>(), "");
-    return opt && *opt == static_cast<To>(v);
+constexpr bool implicit_conversion(optional<To>&& opt, const From& v) {
+  using O = optional<To>;
+  static_assert(test_convertible<O, From>(), "");
+  static_assert(!test_convertible<O, void*>(), "");
+  static_assert(!test_convertible<O, From, int>(), "");
+  return opt && *opt == static_cast<To>(v);
 }
 
 template <class To, class Input, class Expect>
-constexpr bool explicit_conversion(Input&& in, const Expect& v)
-{
-    using O = optional<To>;
-    static_assert(std::is_constructible<O, Input>::value, "");
-    static_assert(!std::is_convertible<Input, O>::value, "");
-    static_assert(!std::is_constructible<O, void*>::value, "");
-    static_assert(!std::is_constructible<O, Input, int>::value, "");
-    optional<To> opt(std::forward<Input>(in));
-    optional<To> opt2{std::forward<Input>(in)};
-    return opt && *opt == static_cast<To>(v) && (opt2 && *opt2 == static_cast<To>(v));
+constexpr bool explicit_conversion(Input&& in, const Expect& v) {
+  using O = optional<To>;
+  static_assert(std::is_constructible<O, Input>::value, "");
+  static_assert(!std::is_convertible<Input, O>::value, "");
+  static_assert(!std::is_constructible<O, void*>::value, "");
+  static_assert(!std::is_constructible<O, Input, int>::value, "");
+  optional<To> opt(std::forward<Input>(in));
+  optional<To> opt2{std::forward<Input>(in)};
+  return opt && *opt == static_cast<To>(v) && (opt2 && *opt2 == static_cast<To>(v));
 }
 
-void test_implicit()
-{
-    {
-        static_assert(implicit_conversion<long long>(42, 42), "");
-    }
-    {
-        static_assert(implicit_conversion<long double>(3.14, 3.14), "");
-    }
-    {
-        int x = 42;
-        optional<void* const> o(&x);
-        assert(*o == &x);
-    }
-    {
-        using T = TrivialTestTypes::TestType;
-        static_assert(implicit_conversion<T>(42, 42), "");
-    }
-    {
-        using T = TestTypes::TestType;
-        assert(implicit_conversion<T>(3, T(3)));
-    }
-    {
-      using T = TestTypes::TestType;
-      optional<T> opt({3});
-      assert(opt && *opt == static_cast<T>(3));
-    }
+void test_implicit() {
+  {
+    static_assert(implicit_conversion<long long>(42, 42), "");
+  }
+  {
+    static_assert(implicit_conversion<long double>(3.14, 3.14), "");
+  }
+  {
+    int x = 42;
+    optional<void* const> o(&x);
+    assert(*o == &x);
+  }
+  {
+    using T = TrivialTestTypes::TestType;
+    static_assert(implicit_conversion<T>(42, 42), "");
+  }
+  {
+    using T = TestTypes::TestType;
+    assert(implicit_conversion<T>(3, T(3)));
+  }
+  {
+    using T = TestTypes::TestType;
+    optional<T> opt({3});
+    assert(opt && *opt == static_cast<T>(3));
+  }
   {
     using O = optional<ImplicitAny>;
     static_assert(!test_convertible<O, std::in_place_t>(), "");
@@ -96,64 +95,63 @@ void test_implicit()
     static_assert(!test_convertible<O, const std::in_place_t&>(), "");
     static_assert(!test_convertible<O, std::in_place_t&&>(), "");
     static_assert(!test_convertible<O, const std::in_place_t&&>(), "");
-
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    {
-        try {
-            using T = ImplicitThrow;
-            optional<T> t = 42;
-            assert(false);
-            ((void)t);
-        } catch (int) {
-        }
+  {
+    try {
+      using T       = ImplicitThrow;
+      optional<T> t = 42;
+      assert(false);
+      ((void)t);
+    } catch (int) {
     }
+  }
 #endif
 }
 
 void test_explicit() {
+  {
+    using T = ExplicitTrivialTestTypes::TestType;
+    static_assert(explicit_conversion<T>(42, 42), "");
+  }
+  {
+    using T = ExplicitConstexprTestTypes::TestType;
+    static_assert(explicit_conversion<T>(42, 42), "");
+    static_assert(!std::is_convertible<int, T>::value, "");
+  }
+  {
+    using T = ExplicitTestTypes::TestType;
+    T::reset();
     {
-        using T = ExplicitTrivialTestTypes::TestType;
-        static_assert(explicit_conversion<T>(42, 42), "");
+      assert(explicit_conversion<T>(42, 42));
+      assert(T::alive == 0);
     }
+    T::reset();
     {
-        using T = ExplicitConstexprTestTypes::TestType;
-        static_assert(explicit_conversion<T>(42, 42), "");
-        static_assert(!std::is_convertible<int, T>::value, "");
+      optional<T> t(42);
+      assert(T::alive == 1);
+      assert(T::value_constructed == 1);
+      assert(T::move_constructed == 0);
+      assert(T::copy_constructed == 0);
+      assert(t.value().value == 42);
     }
-    {
-        using T = ExplicitTestTypes::TestType;
-        T::reset();
-        {
-            assert(explicit_conversion<T>(42, 42));
-            assert(T::alive == 0);
-        }
-        T::reset();
-        {
-            optional<T> t(42);
-            assert(T::alive == 1);
-            assert(T::value_constructed == 1);
-            assert(T::move_constructed == 0);
-            assert(T::copy_constructed == 0);
-            assert(t.value().value == 42);
-        }
-        assert(T::alive == 0);
-    }
+    assert(T::alive == 0);
+  }
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    {
-        try {
-            using T = ExplicitThrow;
-            optional<T> t(42);
-            assert(false);
-        } catch (int) {
-        }
+  {
+    try {
+      using T = ExplicitThrow;
+      optional<T> t(42);
+      assert(false);
+    } catch (int) {
     }
+  }
 #endif
 }
 
 int main(int, char**) {
-    test_implicit();
-    test_explicit();
+  test_implicit();
+  test_explicit();
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/const_T.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/const_T.pass.cpp
@@ -12,117 +12,102 @@
 
 // constexpr optional(const T& v);
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 #include "archetypes.h"
 
 using std::optional;
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        constexpr T t(5);
-        constexpr optional<T> opt(t);
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(*opt == 5, "");
+int main(int, char**) {
+  {
+    typedef int T;
+    constexpr T t(5);
+    constexpr optional<T> opt(t);
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(*opt == 5, "");
 
-        struct test_constexpr_ctor
-            : public optional<T>
-        {
-            constexpr test_constexpr_ctor(const T&) {}
-        };
+    struct test_constexpr_ctor : public optional<T> {
+      constexpr test_constexpr_ctor(const T&) {}
+    };
+  }
+  {
+    typedef double T;
+    constexpr T t(3);
+    constexpr optional<T> opt(t);
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(*opt == 3, "");
 
-    }
-    {
-        typedef double T;
-        constexpr T t(3);
-        constexpr optional<T> opt(t);
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(*opt == 3, "");
+    struct test_constexpr_ctor : public optional<T> {
+      constexpr test_constexpr_ctor(const T&) {}
+    };
+  }
+  {
+    const int x = 42;
+    optional<const int> o(x);
+    assert(*o == x);
+  }
+  {
+    typedef TestTypes::TestType T;
+    T::reset();
+    const T t(3);
+    optional<T> opt = t;
+    assert(T::alive == 2);
+    assert(T::copy_constructed == 1);
+    assert(static_cast<bool>(opt) == true);
+    assert(opt.value().value == 3);
+  }
+  {
+    typedef ExplicitTestTypes::TestType T;
+    static_assert(!std::is_convertible<T const&, optional<T>>::value, "");
+    T::reset();
+    const T t(3);
+    optional<T> opt(t);
+    assert(T::alive == 2);
+    assert(T::copy_constructed == 1);
+    assert(static_cast<bool>(opt) == true);
+    assert(opt.value().value == 3);
+  }
+  {
+    typedef ConstexprTestTypes::TestType T;
+    constexpr T t(3);
+    constexpr optional<T> opt = {t};
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(opt.value().value == 3, "");
 
-        struct test_constexpr_ctor
-            : public optional<T>
-        {
-            constexpr test_constexpr_ctor(const T&) {}
-        };
+    struct test_constexpr_ctor : public optional<T> {
+      constexpr test_constexpr_ctor(const T&) {}
+    };
+  }
+  {
+    typedef ExplicitConstexprTestTypes::TestType T;
+    static_assert(!std::is_convertible<const T&, optional<T>>::value, "");
+    constexpr T t(3);
+    constexpr optional<T> opt(t);
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(opt.value().value == 3, "");
 
-    }
-    {
-        const int x = 42;
-        optional<const int> o(x);
-        assert(*o == x);
-    }
-    {
-        typedef TestTypes::TestType T;
-        T::reset();
-        const T t(3);
-        optional<T> opt = t;
-        assert(T::alive == 2);
-        assert(T::copy_constructed == 1);
-        assert(static_cast<bool>(opt) == true);
-        assert(opt.value().value == 3);
-    }
-    {
-        typedef ExplicitTestTypes::TestType T;
-        static_assert(!std::is_convertible<T const&, optional<T>>::value, "");
-        T::reset();
-        const T t(3);
-        optional<T> opt(t);
-        assert(T::alive == 2);
-        assert(T::copy_constructed == 1);
-        assert(static_cast<bool>(opt) == true);
-        assert(opt.value().value == 3);
-    }
-    {
-        typedef ConstexprTestTypes::TestType T;
-        constexpr T t(3);
-        constexpr optional<T> opt = {t};
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(opt.value().value == 3, "");
-
-        struct test_constexpr_ctor
-            : public optional<T>
-        {
-            constexpr test_constexpr_ctor(const T&) {}
-        };
-    }
-    {
-        typedef ExplicitConstexprTestTypes::TestType T;
-        static_assert(!std::is_convertible<const T&, optional<T>>::value, "");
-        constexpr T t(3);
-        constexpr optional<T> opt(t);
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(opt.value().value == 3, "");
-
-        struct test_constexpr_ctor
-            : public optional<T>
-        {
-            constexpr test_constexpr_ctor(const T&) {}
-        };
-
-    }
+    struct test_constexpr_ctor : public optional<T> {
+      constexpr test_constexpr_ctor(const T&) {}
+    };
+  }
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    {
-        struct Z {
-            Z(int) {}
-            Z(const Z&) {throw 6;}
-        };
-        typedef Z T;
-        try
-        {
-            const T t(3);
-            optional<T> opt(t);
-            assert(false);
-        }
-        catch (int i)
-        {
-            assert(i == 6);
-        }
+  {
+    struct Z {
+      Z(int) {}
+      Z(const Z&) { throw 6; }
+    };
+    typedef Z T;
+    try {
+      const T t(3);
+      optional<T> opt(t);
+      assert(false);
+    } catch (int i) {
+      assert(i == 6);
     }
+  }
 #endif
 
   return 0;

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/const_optional_U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/const_optional_U.pass.cpp
@@ -12,74 +12,69 @@
 // template <class U>
 //   optional(const optional<U>& rhs);
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 
 using std::optional;
 
 template <class T, class U>
-TEST_CONSTEXPR_CXX20 void
-test(const optional<U>& rhs, bool is_going_to_throw = false)
-{
-    bool rhs_engaged = static_cast<bool>(rhs);
+TEST_CONSTEXPR_CXX20 void test(const optional<U>& rhs, bool is_going_to_throw = false) {
+  bool rhs_engaged = static_cast<bool>(rhs);
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    try
-    {
-        optional<T> lhs = rhs;
-        assert(is_going_to_throw == false);
-        assert(static_cast<bool>(lhs) == rhs_engaged);
-        if (rhs_engaged)
-            assert(*lhs == *rhs);
-    }
-    catch (int i)
-    {
-        assert(i == 6);
-    }
-#else
-    if (is_going_to_throw) return;
+  try {
     optional<T> lhs = rhs;
+    assert(is_going_to_throw == false);
     assert(static_cast<bool>(lhs) == rhs_engaged);
     if (rhs_engaged)
-        assert(*lhs == *rhs);
+      assert(*lhs == *rhs);
+  } catch (int i) {
+    assert(i == 6);
+  }
+#else
+  if (is_going_to_throw)
+    return;
+  optional<T> lhs = rhs;
+  assert(static_cast<bool>(lhs) == rhs_engaged);
+  if (rhs_engaged)
+    assert(*lhs == *rhs);
 #endif
 }
 
-class X
-{
-    int i_;
+class X {
+  int i_;
+
 public:
-    constexpr X(int i) : i_(i) {}
-    constexpr X(const X& x) : i_(x.i_) {}
-    TEST_CONSTEXPR_CXX20 ~X() {i_ = 0;}
-    friend constexpr bool operator==(const X& x, const X& y) {return x.i_ == y.i_;}
+  constexpr X(int i) : i_(i) {}
+  constexpr X(const X& x) : i_(x.i_) {}
+  TEST_CONSTEXPR_CXX20 ~X() { i_ = 0; }
+  friend constexpr bool operator==(const X& x, const X& y) { return x.i_ == y.i_; }
 };
 
-class Y
-{
-    int i_;
-public:
-    constexpr Y(int i) : i_(i) {}
+class Y {
+  int i_;
 
-    friend constexpr bool operator==(const Y& x, const Y& y) {return x.i_ == y.i_;}
+public:
+  constexpr Y(int i) : i_(i) {}
+
+  friend constexpr bool operator==(const Y& x, const Y& y) { return x.i_ == y.i_; }
 };
 
 int count = 0;
 
-class Z
-{
-    int i_;
-public:
-    Z(int i) : i_(i) {TEST_THROW(6);}
+class Z {
+  int i_;
 
-    friend bool operator==(const Z& x, const Z& y) {return x.i_ == y.i_;}
+public:
+  Z(int i) : i_(i) { TEST_THROW(6); }
+
+  friend bool operator==(const Z& x, const Z& y) { return x.i_ == y.i_; }
 };
 
-template<class T, class U>
-constexpr bool test_all()
-{
+template <class T, class U>
+constexpr bool test_all() {
   {
     optional<U> rhs;
     test<T>(rhs);
@@ -91,30 +86,29 @@ constexpr bool test_all()
   return true;
 }
 
-int main(int, char**)
-{
-    test_all<int, short>();
-    test_all<X, int>();
-    test_all<Y, int>();
+int main(int, char**) {
+  test_all<int, short>();
+  test_all<X, int>();
+  test_all<Y, int>();
 #if TEST_STD_VER > 17
-    static_assert(test_all<int, short>());
-    static_assert(test_all<X, int>());
-    static_assert(test_all<Y, int>());
+  static_assert(test_all<int, short>());
+  static_assert(test_all<X, int>());
+  static_assert(test_all<Y, int>());
 #endif
-    {
-        typedef Z T;
-        typedef int U;
-        optional<U> rhs;
-        test<T>(rhs);
-    }
-    {
-        typedef Z T;
-        typedef int U;
-        optional<U> rhs(U{3});
-        test<T>(rhs, true);
-    }
+  {
+    typedef Z T;
+    typedef int U;
+    optional<U> rhs;
+    test<T>(rhs);
+  }
+  {
+    typedef Z T;
+    typedef int U;
+    optional<U> rhs(U{3});
+    test<T>(rhs, true);
+  }
 
-    static_assert(!(std::is_constructible<optional<X>, const optional<Y>&>::value), "");
+  static_assert(!(std::is_constructible<optional<X>, const optional<Y>&>::value), "");
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/copy.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/copy.pass.cpp
@@ -11,173 +11,165 @@
 
 // constexpr optional(const optional<T>& rhs);
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 #include "archetypes.h"
 
 using std::optional;
 
-template <class T, class ...InitArgs>
-void test(InitArgs&&... args)
-{
-    const optional<T> rhs(std::forward<InitArgs>(args)...);
-    bool rhs_engaged = static_cast<bool>(rhs);
-    optional<T> lhs = rhs;
-    assert(static_cast<bool>(lhs) == rhs_engaged);
-    if (rhs_engaged)
-        assert(*lhs == *rhs);
+template <class T, class... InitArgs>
+void test(InitArgs&&... args) {
+  const optional<T> rhs(std::forward<InitArgs>(args)...);
+  bool rhs_engaged = static_cast<bool>(rhs);
+  optional<T> lhs  = rhs;
+  assert(static_cast<bool>(lhs) == rhs_engaged);
+  if (rhs_engaged)
+    assert(*lhs == *rhs);
 }
 
-template <class T, class ...InitArgs>
-constexpr bool constexpr_test(InitArgs&&... args)
-{
-    static_assert( std::is_trivially_copy_constructible_v<T>, ""); // requirement
-    const optional<T> rhs(std::forward<InitArgs>(args)...);
-    optional<T> lhs = rhs;
-    return (lhs.has_value() == rhs.has_value()) &&
-           (lhs.has_value() ? *lhs == *rhs : true);
+template <class T, class... InitArgs>
+constexpr bool constexpr_test(InitArgs&&... args) {
+  static_assert(std::is_trivially_copy_constructible_v<T>, ""); // requirement
+  const optional<T> rhs(std::forward<InitArgs>(args)...);
+  optional<T> lhs = rhs;
+  return (lhs.has_value() == rhs.has_value()) && (lhs.has_value() ? *lhs == *rhs : true);
 }
 
 void test_throwing_ctor() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    struct Z {
-        Z() : count(0) {}
-        Z(Z const& o) : count(o.count + 1)
-        { if (count == 2) throw 6; }
-        int count;
-    };
-    const Z z;
-    const optional<Z> rhs(z);
-    try
-    {
-        optional<Z> lhs(rhs);
-        assert(false);
+  struct Z {
+    Z() : count(0) {}
+    Z(Z const& o) : count(o.count + 1) {
+      if (count == 2)
+        throw 6;
     }
-    catch (int i)
-    {
-        assert(i == 6);
-    }
+    int count;
+  };
+  const Z z;
+  const optional<Z> rhs(z);
+  try {
+    optional<Z> lhs(rhs);
+    assert(false);
+  } catch (int i) {
+    assert(i == 6);
+  }
 #endif
 }
 
-template <class T, class ...InitArgs>
-void test_ref(InitArgs&&... args)
-{
-    const optional<T> rhs(std::forward<InitArgs>(args)...);
-    bool rhs_engaged = static_cast<bool>(rhs);
-    optional<T> lhs = rhs;
-    assert(static_cast<bool>(lhs) == rhs_engaged);
-    if (rhs_engaged)
-        assert(&(*lhs) == &(*rhs));
+template <class T, class... InitArgs>
+void test_ref(InitArgs&&... args) {
+  const optional<T> rhs(std::forward<InitArgs>(args)...);
+  bool rhs_engaged = static_cast<bool>(rhs);
+  optional<T> lhs  = rhs;
+  assert(static_cast<bool>(lhs) == rhs_engaged);
+  if (rhs_engaged)
+    assert(&(*lhs) == &(*rhs));
 }
 
-
-void test_reference_extension()
-{
+void test_reference_extension() {
 #if defined(_LIBCPP_VERSION) && 0 // FIXME these extensions are currently disabled.
+  using T = TestTypes::TestType;
+  T::reset();
+  {
+    T t;
+    T::reset_constructors();
+    test_ref<T&>();
+    test_ref<T&>(t);
+    assert(T::alive == 1);
+    assert(T::constructed == 0);
+    assert(T::assigned == 0);
+    assert(T::destroyed == 0);
+  }
+  assert(T::destroyed == 1);
+  assert(T::alive == 0);
+  {
+    T t;
+    const T& ct = t;
+    T::reset_constructors();
+    test_ref<T const&>();
+    test_ref<T const&>(t);
+    test_ref<T const&>(ct);
+    assert(T::alive == 1);
+    assert(T::constructed == 0);
+    assert(T::assigned == 0);
+    assert(T::destroyed == 0);
+  }
+  assert(T::alive == 0);
+  assert(T::destroyed == 1);
+  {
+    static_assert(!std::is_copy_constructible<std::optional<T&&>>::value, "");
+    static_assert(!std::is_copy_constructible<std::optional<T const&&>>::value, "");
+  }
+#endif
+}
+
+int main(int, char**) {
+  test<int>();
+  test<int>(3);
+  static_assert(constexpr_test<int>(), "");
+  static_assert(constexpr_test<int>(3), "");
+
+  {
+    const optional<const int> o(42);
+    optional<const int> o2(o);
+    assert(*o2 == 42);
+  }
+  {
     using T = TestTypes::TestType;
     T::reset();
-    {
-        T t;
-        T::reset_constructors();
-        test_ref<T&>();
-        test_ref<T&>(t);
-        assert(T::alive == 1);
-        assert(T::constructed == 0);
-        assert(T::assigned == 0);
-        assert(T::destroyed == 0);
-    }
-    assert(T::destroyed == 1);
+    const optional<T> rhs;
     assert(T::alive == 0);
-    {
-        T t;
-        const T& ct = t;
-        T::reset_constructors();
-        test_ref<T const&>();
-        test_ref<T const&>(t);
-        test_ref<T const&>(ct);
-        assert(T::alive == 1);
-        assert(T::constructed == 0);
-        assert(T::assigned == 0);
-        assert(T::destroyed == 0);
-    }
+    const optional<T> lhs(rhs);
+    assert(lhs.has_value() == false);
     assert(T::alive == 0);
-    assert(T::destroyed == 1);
-    {
-        static_assert(!std::is_copy_constructible<std::optional<T&&>>::value, "");
-        static_assert(!std::is_copy_constructible<std::optional<T const&&>>::value, "");
-    }
-#endif
-}
+  }
+  TestTypes::TestType::reset();
+  {
+    using T = TestTypes::TestType;
+    T::reset();
+    const optional<T> rhs(42);
+    assert(T::alive == 1);
+    assert(T::value_constructed == 1);
+    assert(T::copy_constructed == 0);
+    const optional<T> lhs(rhs);
+    assert(lhs.has_value());
+    assert(T::copy_constructed == 1);
+    assert(T::alive == 2);
+  }
+  TestTypes::TestType::reset();
+  {
+    using namespace ConstexprTestTypes;
+    test<TestType>();
+    test<TestType>(42);
+  }
+  {
+    using namespace TrivialTestTypes;
+    test<TestType>();
+    test<TestType>(42);
+  }
+  {
+    test_throwing_ctor();
+  }
+  {
+    test_reference_extension();
+  }
+  {
+    constexpr std::optional<int> o1{4};
+    constexpr std::optional<int> o2 = o1;
+    static_assert(*o2 == 4, "");
+  }
 
-int main(int, char**)
-{
-    test<int>();
-    test<int>(3);
-    static_assert(constexpr_test<int>(), "" );
-    static_assert(constexpr_test<int>(3), "" );
-
-    {
-        const optional<const int> o(42);
-        optional<const int> o2(o);
-        assert(*o2 == 42);
-    }
-    {
-        using T = TestTypes::TestType;
-        T::reset();
-        const optional<T> rhs;
-        assert(T::alive == 0);
-        const optional<T> lhs(rhs);
-        assert(lhs.has_value() == false);
-        assert(T::alive == 0);
-    }
-    TestTypes::TestType::reset();
-    {
-        using T = TestTypes::TestType;
-        T::reset();
-        const optional<T> rhs(42);
-        assert(T::alive == 1);
-        assert(T::value_constructed == 1);
-        assert(T::copy_constructed == 0);
-        const optional<T> lhs(rhs);
-        assert(lhs.has_value());
-        assert(T::copy_constructed == 1);
-        assert(T::alive == 2);
-    }
-    TestTypes::TestType::reset();
-    {
-        using namespace ConstexprTestTypes;
-        test<TestType>();
-        test<TestType>(42);
-    }
-    {
-        using namespace TrivialTestTypes;
-        test<TestType>();
-        test<TestType>(42);
-    }
-    {
-        test_throwing_ctor();
-    }
-    {
-        test_reference_extension();
-    }
-    {
-        constexpr std::optional<int> o1{4};
-        constexpr std::optional<int> o2 = o1;
-        static_assert( *o2 == 4, "" );
-    }
-
-    // LWG3836 https://wg21.link/LWG3836
-    // std::optional<bool> conversion constructor optional(const optional<U>&)
-    // should take precedence over optional(U&&) with operator bool
-    {
-        std::optional<bool> o1(false);
-        std::optional<bool> o2(o1);
-        assert(!o2.value());
-    }
+  // LWG3836 https://wg21.link/LWG3836
+  // std::optional<bool> conversion constructor optional(const optional<U>&)
+  // should take precedence over optional(U&&) with operator bool
+  {
+    std::optional<bool> o1(false);
+    std::optional<bool> o2(o1);
+    assert(!o2.value());
+  }
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ctor.verify.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ctor.verify.cpp
@@ -13,16 +13,17 @@
 //   and shall satisfy the Cpp17Destructible requirements.
 // Note: array types do not satisfy the Cpp17Destructible requirements.
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 
-struct NonDestructible { ~NonDestructible() = delete; };
+struct NonDestructible {
+  ~NonDestructible() = delete;
+};
 
-int main(int, char**)
-{
+int main(int, char**) {
   {
 #if TEST_STD_VER >= 26
     std::optional<int&&>
@@ -38,18 +39,26 @@ int main(int, char**)
   }
 
   {
-    std::optional<               std::in_place_t> o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
-    std::optional<const          std::in_place_t> o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
-    std::optional<      volatile std::in_place_t> o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
-    std::optional<const volatile std::in_place_t> o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional< std::in_place_t>
+        o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<const std::in_place_t>
+        o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional< volatile std::in_place_t>
+        o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<const volatile std::in_place_t>
+        o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
   }
 
-    {
-    std::optional<               std::nullopt_t> o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    std::optional<const          std::nullopt_t> o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    std::optional<      volatile std::nullopt_t> o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    std::optional<const volatile std::nullopt_t> o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    }
+  {
+    std::optional< std::nullopt_t>
+        o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<const std::nullopt_t>
+        o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional< volatile std::nullopt_t>
+        o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<const volatile std::nullopt_t>
+        o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+  }
 
-    return 0;
+  return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ctor.verify.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/ctor.verify.cpp
@@ -15,7 +15,6 @@
 
 #include <cassert>
 #include <optional>
-#include <type_traits>
 
 #include "test_macros.h"
 
@@ -24,41 +23,30 @@ struct NonDestructible {
 };
 
 int main(int, char**) {
+  // clang-format off
   {
 #if TEST_STD_VER >= 26
-    std::optional<int&&>
-        opt2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with an rvalue reference type is ill-formed}}
+    std::optional<int&&> opt2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with an rvalue reference type is ill-formed}}
 #else
-    std::optional<char&>
-        o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a reference type is ill-formed}}
+    std::optional<char&> o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a reference type is ill-formed}}
 #endif
-    std::optional<NonDestructible>
-        o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
-    std::optional<char[20]>
-        o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with an array type is ill-formed}}
+    std::optional<NonDestructible> o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with a non-destructible type is ill-formed}}
+    std::optional<char[20]> o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with an array type is ill-formed}}
   }
 
   {
-    std::optional< std::in_place_t>
-        o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
-    std::optional<const std::in_place_t>
-        o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
-    std::optional< volatile std::in_place_t>
-        o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
-    std::optional<const volatile std::in_place_t>
-        o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<               std::in_place_t> o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<const          std::in_place_t> o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<      volatile std::in_place_t> o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
+    std::optional<const volatile std::in_place_t> o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with in_place_t is ill-formed}}
   }
 
   {
-    std::optional< std::nullopt_t>
-        o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    std::optional<const std::nullopt_t>
-        o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    std::optional< volatile std::nullopt_t>
-        o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    std::optional<const volatile std::nullopt_t>
-        o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<               std::nullopt_t> o1; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<const          std::nullopt_t> o2; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<      volatile std::nullopt_t> o3; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional<const volatile std::nullopt_t> o4; // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
   }
-
+  // clang-format on
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/deduct.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/deduct.pass.cpp
@@ -12,67 +12,66 @@
 // template<class T>
 //   optional(T) -> optional<T>;
 
-#include <optional>
 #include <cassert>
+#include <optional>
 
 #include "test_macros.h"
 
 struct A {};
 
-int main(int, char**)
-{
-//  Test the explicit deduction guides
-    {
-//  optional(T)
+int main(int, char**) {
+  //  Test the explicit deduction guides
+  {
+    //  optional(T)
     std::optional opt(5);
     ASSERT_SAME_TYPE(decltype(opt), std::optional<int>);
     assert(static_cast<bool>(opt));
     assert(*opt == 5);
-    }
+  }
 
-    {
-//  optional(T)
+  {
+    //  optional(T)
     std::optional opt(A{});
     ASSERT_SAME_TYPE(decltype(opt), std::optional<A>);
     assert(static_cast<bool>(opt));
-    }
+  }
 
-    {
-//  optional(const T&);
+  {
+    //  optional(const T&);
     const int& source = 5;
     std::optional opt(source);
     ASSERT_SAME_TYPE(decltype(opt), std::optional<int>);
     assert(static_cast<bool>(opt));
     assert(*opt == 5);
-    }
+  }
 
-    {
-//  optional(T*);
+  {
+    //  optional(T*);
     const int* source = nullptr;
     std::optional opt(source);
     ASSERT_SAME_TYPE(decltype(opt), std::optional<const int*>);
     assert(static_cast<bool>(opt));
     assert(*opt == nullptr);
-    }
+  }
 
-    {
-//  optional(T[]);
+  {
+    //  optional(T[]);
     int source[] = {1, 2, 3};
     std::optional opt(source);
     ASSERT_SAME_TYPE(decltype(opt), std::optional<int*>);
     assert(static_cast<bool>(opt));
     assert((*opt)[0] == 1);
-    }
+  }
 
-//  Test the implicit deduction guides
-    {
-//  optional(optional);
+  //  Test the implicit deduction guides
+  {
+    //  optional(optional);
     std::optional<char> source('A');
     std::optional opt(source);
     ASSERT_SAME_TYPE(decltype(opt), std::optional<char>);
     assert(static_cast<bool>(opt) == static_cast<bool>(source));
     assert(*opt == *source);
-    }
+  }
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/deduct.verify.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/deduct.verify.cpp
@@ -22,18 +22,17 @@ int main(int, char**) {
   //  Test the explicit deduction guides
 
   //  Test the implicit deduction guides
+
+  // clang-format off
   {
     //  optional()
-    std::optional
-        opt; // expected-error-re {{no viable constructor or deduction guide for deduction of template arguments of '{{(std::)?}}optional'}}
+    std::optional opt; // expected-error-re {{no viable constructor or deduction guide for deduction of template arguments of '{{(std::)?}}optional'}}
   }
 
   {
     //  optional(nullopt_t)
-    std::optional opt(
-        std::
-            nullopt); // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+    std::optional opt(std::nullopt); // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
   }
-
+  // clang-format on
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/deduct.verify.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/deduct.verify.cpp
@@ -13,25 +13,27 @@
 // template<class T>
 //   optional(T) -> optional<T>;
 
-#include <optional>
 #include <cassert>
+#include <optional>
 
 struct A {};
 
-int main(int, char**)
-{
-//  Test the explicit deduction guides
+int main(int, char**) {
+  //  Test the explicit deduction guides
 
-//  Test the implicit deduction guides
-    {
-//  optional()
-    std::optional opt;   // expected-error-re {{no viable constructor or deduction guide for deduction of template arguments of '{{(std::)?}}optional'}}
-    }
+  //  Test the implicit deduction guides
+  {
+    //  optional()
+    std::optional
+        opt; // expected-error-re {{no viable constructor or deduction guide for deduction of template arguments of '{{(std::)?}}optional'}}
+  }
 
-    {
-//  optional(nullopt_t)
-    std::optional opt(std::nullopt);   // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
-    }
+  {
+    //  optional(nullopt_t)
+    std::optional opt(
+        std::
+            nullopt); // expected-error-re@optional:* {{static assertion failed{{.*}}instantiation of optional with nullopt_t is ill-formed}}
+  }
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/default.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/default.pass.cpp
@@ -11,9 +11,9 @@
 
 // constexpr optional() noexcept;
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 #include "archetypes.h"
@@ -21,61 +21,52 @@
 using std::optional;
 
 template <class Opt>
-void
-test_constexpr()
-{
-    static_assert(std::is_nothrow_default_constructible<Opt>::value, "");
-    static_assert(std::is_trivially_destructible<Opt>::value, "");
-    static_assert(std::is_trivially_destructible<typename Opt::value_type>::value, "");
+void test_constexpr() {
+  static_assert(std::is_nothrow_default_constructible<Opt>::value, "");
+  static_assert(std::is_trivially_destructible<Opt>::value, "");
+  static_assert(std::is_trivially_destructible<typename Opt::value_type>::value, "");
 
-    constexpr Opt opt;
-    static_assert(static_cast<bool>(opt) == false, "");
+  constexpr Opt opt;
+  static_assert(static_cast<bool>(opt) == false, "");
 
-    struct test_constexpr_ctor
-        : public Opt
-    {
-        constexpr test_constexpr_ctor() {}
-    };
+  struct test_constexpr_ctor : public Opt {
+    constexpr test_constexpr_ctor() {}
+  };
 }
 
 template <class Opt>
-void
-test()
-{
-    static_assert(std::is_nothrow_default_constructible<Opt>::value, "");
-    static_assert(!std::is_trivially_destructible<Opt>::value, "");
-    static_assert(!std::is_trivially_destructible<typename Opt::value_type>::value, "");
-    {
-        Opt opt;
-        assert(static_cast<bool>(opt) == false);
-    }
-    {
-        const Opt opt;
-        assert(static_cast<bool>(opt) == false);
-    }
+void test() {
+  static_assert(std::is_nothrow_default_constructible<Opt>::value, "");
+  static_assert(!std::is_trivially_destructible<Opt>::value, "");
+  static_assert(!std::is_trivially_destructible<typename Opt::value_type>::value, "");
+  {
+    Opt opt;
+    assert(static_cast<bool>(opt) == false);
+  }
+  {
+    const Opt opt;
+    assert(static_cast<bool>(opt) == false);
+  }
 
-    struct test_constexpr_ctor
-        : public Opt
-    {
-        constexpr test_constexpr_ctor() {}
-    };
+  struct test_constexpr_ctor : public Opt {
+    constexpr test_constexpr_ctor() {}
+  };
 }
 
-int main(int, char**)
-{
-    test_constexpr<optional<int>>();
-    test_constexpr<optional<int*>>();
-    test_constexpr<optional<ImplicitTypes::NoCtors>>();
-    test_constexpr<optional<NonTrivialTypes::NoCtors>>();
-    test_constexpr<optional<NonConstexprTypes::NoCtors>>();
-    test<optional<NonLiteralTypes::NoCtors>>();
-    // EXTENSIONS
+int main(int, char**) {
+  test_constexpr<optional<int>>();
+  test_constexpr<optional<int*>>();
+  test_constexpr<optional<ImplicitTypes::NoCtors>>();
+  test_constexpr<optional<NonTrivialTypes::NoCtors>>();
+  test_constexpr<optional<NonConstexprTypes::NoCtors>>();
+  test<optional<NonLiteralTypes::NoCtors>>();
+  // EXTENSIONS
 #if defined(_LIBCPP_VERSION) && 0 // FIXME these extensions are currently disabled.
-    test_constexpr<optional<int&>>();
-    test_constexpr<optional<const int&>>();
-    test_constexpr<optional<int&>>();
-    test_constexpr<optional<NonLiteralTypes::NoCtors&>>();
-    test_constexpr<optional<NonLiteralTypes::NoCtors&&>>();
+  test_constexpr<optional<int&>>();
+  test_constexpr<optional<const int&>>();
+  test_constexpr<optional<int&>>();
+  test_constexpr<optional<NonLiteralTypes::NoCtors&>>();
+  test_constexpr<optional<NonLiteralTypes::NoCtors&&>>();
 #endif
 
   return 0;

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/empty_in_place_t_does_not_clobber.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/empty_in_place_t_does_not_clobber.pass.cpp
@@ -15,9 +15,9 @@
 // in_place_t constructor with no arguments when the Clang is trying to check
 // copy constructor.
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 #include "archetypes.h"

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/explicit_const_optional_U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/explicit_const_optional_U.pass.cpp
@@ -12,75 +12,70 @@
 // template <class U>
 //   explicit optional(const optional<U>& rhs);
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 
 using std::optional;
 
 template <class T, class U>
-TEST_CONSTEXPR_CXX20 void
-test(const optional<U>& rhs, bool is_going_to_throw = false)
-{
-    static_assert(!(std::is_convertible<const optional<U>&, optional<T>>::value), "");
-    bool rhs_engaged = static_cast<bool>(rhs);
+TEST_CONSTEXPR_CXX20 void test(const optional<U>& rhs, bool is_going_to_throw = false) {
+  static_assert(!(std::is_convertible<const optional<U>&, optional<T>>::value), "");
+  bool rhs_engaged = static_cast<bool>(rhs);
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    try
-    {
-        optional<T> lhs(rhs);
-        assert(is_going_to_throw == false);
-        assert(static_cast<bool>(lhs) == rhs_engaged);
-        if (rhs_engaged)
-            assert(*lhs == T(*rhs));
-    }
-    catch (int i)
-    {
-        assert(i == 6);
-    }
-#else
-    if (is_going_to_throw) return;
+  try {
     optional<T> lhs(rhs);
+    assert(is_going_to_throw == false);
     assert(static_cast<bool>(lhs) == rhs_engaged);
     if (rhs_engaged)
-        assert(*lhs == T(*rhs));
+      assert(*lhs == T(*rhs));
+  } catch (int i) {
+    assert(i == 6);
+  }
+#else
+  if (is_going_to_throw)
+    return;
+  optional<T> lhs(rhs);
+  assert(static_cast<bool>(lhs) == rhs_engaged);
+  if (rhs_engaged)
+    assert(*lhs == T(*rhs));
 #endif
 }
 
-class X
-{
-    int i_;
+class X {
+  int i_;
+
 public:
-    constexpr explicit X(int i) : i_(i) {}
-    constexpr X(const X& x) : i_(x.i_) {}
-    TEST_CONSTEXPR_CXX20 ~X() {i_ = 0;}
-    friend constexpr bool operator==(const X& x, const X& y) {return x.i_ == y.i_;}
+  constexpr explicit X(int i) : i_(i) {}
+  constexpr X(const X& x) : i_(x.i_) {}
+  TEST_CONSTEXPR_CXX20 ~X() { i_ = 0; }
+  friend constexpr bool operator==(const X& x, const X& y) { return x.i_ == y.i_; }
 };
 
-class Y
-{
-    int i_;
-public:
-    constexpr explicit Y(int i) : i_(i) {}
+class Y {
+  int i_;
 
-    friend constexpr bool operator==(const Y& x, const Y& y) {return x.i_ == y.i_;}
+public:
+  constexpr explicit Y(int i) : i_(i) {}
+
+  friend constexpr bool operator==(const Y& x, const Y& y) { return x.i_ == y.i_; }
 };
 
 int count = 0;
 
-class Z
-{
-    int i_;
-public:
-    explicit Z(int i) : i_(i) {TEST_THROW(6);}
+class Z {
+  int i_;
 
-    friend bool operator==(const Z& x, const Z& y) {return x.i_ == y.i_;}
+public:
+  explicit Z(int i) : i_(i) { TEST_THROW(6); }
+
+  friend bool operator==(const Z& x, const Z& y) { return x.i_ == y.i_; }
 };
 
-template<class T, class U>
-constexpr bool test_all()
-{
+template <class T, class U>
+constexpr bool test_all() {
   {
     optional<U> rhs;
     test<T>(rhs);
@@ -92,27 +87,25 @@ constexpr bool test_all()
   return true;
 }
 
-
-int main(int, char**)
-{
-    test_all<X, int>();
-    test_all<Y, int>();
+int main(int, char**) {
+  test_all<X, int>();
+  test_all<Y, int>();
 #if TEST_STD_VER > 17
-    static_assert(test_all<X, int>());
-    static_assert(test_all<Y, int>());
+  static_assert(test_all<X, int>());
+  static_assert(test_all<Y, int>());
 #endif
-    {
-        typedef Z T;
-        typedef int U;
-        optional<U> rhs;
-        test<T>(rhs);
-    }
-    {
-        typedef Z T;
-        typedef int U;
-        optional<U> rhs(3);
-        test<T>(rhs, true);
-    }
+  {
+    typedef Z T;
+    typedef int U;
+    optional<U> rhs;
+    test<T>(rhs);
+  }
+  {
+    typedef Z T;
+    typedef int U;
+    optional<U> rhs(3);
+    test<T>(rhs, true);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/explicit_optional_U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/explicit_optional_U.pass.cpp
@@ -12,83 +12,77 @@
 // template <class U>
 //   explicit optional(optional<U>&& rhs);
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 
 using std::optional;
 
 template <class T, class U>
-TEST_CONSTEXPR_CXX20 void test(optional<U>&& rhs, bool is_going_to_throw = false)
-{
-    static_assert(!(std::is_convertible<optional<U>&&, optional<T>>::value), "");
-    bool rhs_engaged = static_cast<bool>(rhs);
+TEST_CONSTEXPR_CXX20 void test(optional<U>&& rhs, bool is_going_to_throw = false) {
+  static_assert(!(std::is_convertible<optional<U>&&, optional<T>>::value), "");
+  bool rhs_engaged = static_cast<bool>(rhs);
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    try
-    {
-        optional<T> lhs(std::move(rhs));
-        assert(is_going_to_throw == false);
-        assert(static_cast<bool>(lhs) == rhs_engaged);
-    }
-    catch (int i)
-    {
-        assert(i == 6);
-    }
-#else
-    if (is_going_to_throw) return;
+  try {
     optional<T> lhs(std::move(rhs));
+    assert(is_going_to_throw == false);
     assert(static_cast<bool>(lhs) == rhs_engaged);
+  } catch (int i) {
+    assert(i == 6);
+  }
+#else
+  if (is_going_to_throw)
+    return;
+  optional<T> lhs(std::move(rhs));
+  assert(static_cast<bool>(lhs) == rhs_engaged);
 #endif
 }
 
-class X
-{
-    int i_;
+class X {
+  int i_;
+
 public:
-    constexpr explicit X(int i) : i_(i) {}
-    constexpr X(X&& x) : i_(x.i_) { x.i_ = 0; }
-    TEST_CONSTEXPR_CXX20 ~X() {i_ = 0;}
-    friend constexpr bool operator==(const X& x, const X& y) {return x.i_ == y.i_;}
+  constexpr explicit X(int i) : i_(i) {}
+  constexpr X(X&& x) : i_(x.i_) { x.i_ = 0; }
+  TEST_CONSTEXPR_CXX20 ~X() { i_ = 0; }
+  friend constexpr bool operator==(const X& x, const X& y) { return x.i_ == y.i_; }
 };
 
 int count = 0;
 
-class Z
-{
+class Z {
 public:
-    explicit Z(int) { TEST_THROW(6); }
+  explicit Z(int) { TEST_THROW(6); }
 };
 
-TEST_CONSTEXPR_CXX20 bool test()
-{
-    {
-        optional<int> rhs;
-        test<X>(std::move(rhs));
-    }
-    {
-        optional<int> rhs(3);
-        test<X>(std::move(rhs));
-    }
+TEST_CONSTEXPR_CXX20 bool test() {
+  {
+    optional<int> rhs;
+    test<X>(std::move(rhs));
+  }
+  {
+    optional<int> rhs(3);
+    test<X>(std::move(rhs));
+  }
 
-    return true;
+  return true;
 }
 
-int main(int, char**)
-{
+int main(int, char**) {
 #if TEST_STD_VER > 17
-    static_assert(test());
+  static_assert(test());
 #endif
-    test();
-    {
-        optional<int> rhs;
-        test<Z>(std::move(rhs));
-    }
-    {
-        optional<int> rhs(3);
-        test<Z>(std::move(rhs), true);
-    }
+  test();
+  {
+    optional<int> rhs;
+    test<Z>(std::move(rhs));
+  }
+  {
+    optional<int> rhs(3);
+    test<Z>(std::move(rhs), true);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/in_place_t.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/in_place_t.pass.cpp
@@ -13,136 +13,112 @@
 // template <class... Args>
 //   constexpr explicit optional(in_place_t, Args&&... args);
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 
-using std::optional;
-using std::in_place_t;
 using std::in_place;
+using std::in_place_t;
+using std::optional;
 
-class X
-{
-    int i_;
-    int j_ = 0;
+class X {
+  int i_;
+  int j_ = 0;
+
 public:
-    X() : i_(0) {}
-    X(int i) : i_(i) {}
-    X(int i, int j) : i_(i), j_(j) {}
+  X() : i_(0) {}
+  X(int i) : i_(i) {}
+  X(int i, int j) : i_(i), j_(j) {}
 
-    ~X() {}
+  ~X() {}
 
-    friend bool operator==(const X& x, const X& y)
-        {return x.i_ == y.i_ && x.j_ == y.j_;}
+  friend bool operator==(const X& x, const X& y) { return x.i_ == y.i_ && x.j_ == y.j_; }
 };
 
-class Y
-{
-    int i_;
-    int j_ = 0;
-public:
-    constexpr Y() : i_(0) {}
-    constexpr Y(int i) : i_(i) {}
-    constexpr Y(int i, int j) : i_(i), j_(j) {}
+class Y {
+  int i_;
+  int j_ = 0;
 
-    friend constexpr bool operator==(const Y& x, const Y& y)
-        {return x.i_ == y.i_ && x.j_ == y.j_;}
+public:
+  constexpr Y() : i_(0) {}
+  constexpr Y(int i) : i_(i) {}
+  constexpr Y(int i, int j) : i_(i), j_(j) {}
+
+  friend constexpr bool operator==(const Y& x, const Y& y) { return x.i_ == y.i_ && x.j_ == y.j_; }
 };
 
-class Z
-{
+class Z {
 public:
-    Z(int) {TEST_THROW(6);}
+  Z(int) { TEST_THROW(6); }
 };
 
+int main(int, char**) {
+  {
+    constexpr optional<int> opt(in_place, 5);
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(*opt == 5, "");
 
-int main(int, char**)
-{
-    {
-        constexpr optional<int> opt(in_place, 5);
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(*opt == 5, "");
+    struct test_constexpr_ctor : public optional<int> {
+      constexpr test_constexpr_ctor(in_place_t, int i) : optional<int>(in_place, i) {}
+    };
+  }
+  {
+    optional<const int> opt(in_place, 5);
+    assert(*opt == 5);
+  }
+  {
+    const optional<X> opt(in_place);
+    assert(static_cast<bool>(opt) == true);
+    assert(*opt == X());
+  }
+  {
+    const optional<X> opt(in_place, 5);
+    assert(static_cast<bool>(opt) == true);
+    assert(*opt == X(5));
+  }
+  {
+    const optional<X> opt(in_place, 5, 4);
+    assert(static_cast<bool>(opt) == true);
+    assert(*opt == X(5, 4));
+  }
+  {
+    constexpr optional<Y> opt(in_place);
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(*opt == Y(), "");
 
-        struct test_constexpr_ctor
-            : public optional<int>
-        {
-            constexpr test_constexpr_ctor(in_place_t, int i)
-                : optional<int>(in_place, i) {}
-        };
+    struct test_constexpr_ctor : public optional<Y> {
+      constexpr test_constexpr_ctor(in_place_t) : optional<Y>(in_place) {}
+    };
+  }
+  {
+    constexpr optional<Y> opt(in_place, 5);
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(*opt == Y(5), "");
 
-    }
-    {
-        optional<const int> opt(in_place, 5);
-        assert(*opt == 5);
-    }
-    {
-        const optional<X> opt(in_place);
-        assert(static_cast<bool>(opt) == true);
-        assert(*opt == X());
-    }
-    {
-        const optional<X> opt(in_place, 5);
-        assert(static_cast<bool>(opt) == true);
-        assert(*opt == X(5));
-    }
-    {
-        const optional<X> opt(in_place, 5, 4);
-        assert(static_cast<bool>(opt) == true);
-        assert(*opt == X(5, 4));
-    }
-    {
-        constexpr optional<Y> opt(in_place);
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(*opt == Y(), "");
+    struct test_constexpr_ctor : public optional<Y> {
+      constexpr test_constexpr_ctor(in_place_t, int i) : optional<Y>(in_place, i) {}
+    };
+  }
+  {
+    constexpr optional<Y> opt(in_place, 5, 4);
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(*opt == Y(5, 4), "");
 
-        struct test_constexpr_ctor
-            : public optional<Y>
-        {
-            constexpr test_constexpr_ctor(in_place_t)
-                : optional<Y>(in_place) {}
-        };
-
-    }
-    {
-        constexpr optional<Y> opt(in_place, 5);
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(*opt == Y(5), "");
-
-        struct test_constexpr_ctor
-            : public optional<Y>
-        {
-            constexpr test_constexpr_ctor(in_place_t, int i)
-                : optional<Y>(in_place, i) {}
-        };
-
-    }
-    {
-        constexpr optional<Y> opt(in_place, 5, 4);
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(*opt == Y(5, 4), "");
-
-        struct test_constexpr_ctor
-            : public optional<Y>
-        {
-            constexpr test_constexpr_ctor(in_place_t, int i, int j)
-                : optional<Y>(in_place, i, j) {}
-        };
-
-    }
+    struct test_constexpr_ctor : public optional<Y> {
+      constexpr test_constexpr_ctor(in_place_t, int i, int j) : optional<Y>(in_place, i, j) {}
+    };
+  }
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    {
-        try
-        {
-            const optional<Z> opt(in_place, 1);
-            assert(false);
-        }
-        catch (int i)
-        {
-            assert(i == 6);
-        }
+  {
+    try {
+      const optional<Z> opt(in_place, 1);
+      assert(false);
+    } catch (int i) {
+      assert(i == 6);
     }
+  }
 #endif
 
   return 0;

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/initializer_list.pass.cpp
@@ -13,105 +13,93 @@
 //     constexpr
 //     explicit optional(in_place_t, initializer_list<U> il, Args&&... args);
 
+#include <cassert>
+#include <memory>
 #include <optional>
 #include <type_traits>
-#include <memory>
 #include <vector>
-#include <cassert>
 
 #include "test_macros.h"
 
-using std::optional;
-using std::in_place_t;
 using std::in_place;
+using std::in_place_t;
+using std::optional;
 
-class X
-{
-    int i_;
-    int j_ = 0;
+class X {
+  int i_;
+  int j_ = 0;
+
 public:
-    X() : i_(0) {}
-    X(int i) : i_(i) {}
-    X(int i, int j) : i_(i), j_(j) {}
+  X() : i_(0) {}
+  X(int i) : i_(i) {}
+  X(int i, int j) : i_(i), j_(j) {}
 
-    ~X() {}
+  ~X() {}
 
-    friend bool operator==(const X& x, const X& y)
-        {return x.i_ == y.i_ && x.j_ == y.j_;}
+  friend bool operator==(const X& x, const X& y) { return x.i_ == y.i_ && x.j_ == y.j_; }
 };
 
-class Y
-{
-    int i_;
-    int j_ = 0;
-public:
-    constexpr Y() : i_(0) {}
-    constexpr Y(int i) : i_(i) {}
-    constexpr Y(std::initializer_list<int> il) : i_(il.begin()[0]), j_(il.begin()[1]) {}
+class Y {
+  int i_;
+  int j_ = 0;
 
-    friend constexpr bool operator==(const Y& x, const Y& y)
-        {return x.i_ == y.i_ && x.j_ == y.j_;}
+public:
+  constexpr Y() : i_(0) {}
+  constexpr Y(int i) : i_(i) {}
+  constexpr Y(std::initializer_list<int> il) : i_(il.begin()[0]), j_(il.begin()[1]) {}
+
+  friend constexpr bool operator==(const Y& x, const Y& y) { return x.i_ == y.i_ && x.j_ == y.j_; }
 };
 
-class Z
-{
-    int i_;
-    int j_ = 0;
-public:
-    Z() : i_(0) {}
-    Z(int i) : i_(i) {}
-    Z(std::initializer_list<int> il) : i_(il.begin()[0]), j_(il.begin()[1])
-        {TEST_THROW(6);}
+class Z {
+  int i_;
+  int j_ = 0;
 
-    friend bool operator==(const Z& x, const Z& y)
-        {return x.i_ == y.i_ && x.j_ == y.j_;}
+public:
+  Z() : i_(0) {}
+  Z(int i) : i_(i) {}
+  Z(std::initializer_list<int> il) : i_(il.begin()[0]), j_(il.begin()[1]) { TEST_THROW(6); }
+
+  friend bool operator==(const Z& x, const Z& y) { return x.i_ == y.i_ && x.j_ == y.j_; }
 };
 
-int main(int, char**)
-{
-    {
-        static_assert(!std::is_constructible<X, std::initializer_list<int>&>::value, "");
-        static_assert(!std::is_constructible<optional<X>, std::initializer_list<int>&>::value, "");
-    }
-    {
-        optional<std::vector<int>> opt(in_place, {3, 1});
-        assert(static_cast<bool>(opt) == true);
-        assert((*opt == std::vector<int>{3, 1}));
-        assert(opt->size() == 2);
-    }
-    {
-        optional<std::vector<int>> opt(in_place, {3, 1}, std::allocator<int>());
-        assert(static_cast<bool>(opt) == true);
-        assert((*opt == std::vector<int>{3, 1}));
-        assert(opt->size() == 2);
-    }
-    {
-        static_assert(std::is_constructible<optional<Y>, std::initializer_list<int>&>::value, "");
-        constexpr optional<Y> opt(in_place, {3, 1});
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(*opt == Y{3, 1}, "");
+int main(int, char**) {
+  {
+    static_assert(!std::is_constructible<X, std::initializer_list<int>&>::value, "");
+    static_assert(!std::is_constructible<optional<X>, std::initializer_list<int>&>::value, "");
+  }
+  {
+    optional<std::vector<int>> opt(in_place, {3, 1});
+    assert(static_cast<bool>(opt) == true);
+    assert((*opt == std::vector<int>{3, 1}));
+    assert(opt->size() == 2);
+  }
+  {
+    optional<std::vector<int>> opt(in_place, {3, 1}, std::allocator<int>());
+    assert(static_cast<bool>(opt) == true);
+    assert((*opt == std::vector<int>{3, 1}));
+    assert(opt->size() == 2);
+  }
+  {
+    static_assert(std::is_constructible<optional<Y>, std::initializer_list<int>&>::value, "");
+    constexpr optional<Y> opt(in_place, {3, 1});
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(*opt == Y{3, 1}, "");
 
-        struct test_constexpr_ctor
-            : public optional<Y>
-        {
-            constexpr test_constexpr_ctor(in_place_t, std::initializer_list<int> i)
-                : optional<Y>(in_place, i) {}
-        };
-
-    }
+    struct test_constexpr_ctor : public optional<Y> {
+      constexpr test_constexpr_ctor(in_place_t, std::initializer_list<int> i) : optional<Y>(in_place, i) {}
+    };
+  }
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    {
-        static_assert(std::is_constructible<optional<Z>, std::initializer_list<int>&>::value, "");
-        try
-        {
-            optional<Z> opt(in_place, {3, 1});
-            assert(false);
-        }
-        catch (int i)
-        {
-            assert(i == 6);
-        }
+  {
+    static_assert(std::is_constructible<optional<Z>, std::initializer_list<int>&>::value, "");
+    try {
+      optional<Z> opt(in_place, {3, 1});
+      assert(false);
+    } catch (int i) {
+      assert(i == 6);
     }
+  }
 #endif
 
   return 0;

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/move.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/move.pass.cpp
@@ -12,70 +12,64 @@
 
 // constexpr optional(optional<T>&& rhs);
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 #include "archetypes.h"
 
 using std::optional;
 
-template <class T, class ...InitArgs>
-void test(InitArgs&&... args)
-{
-    const optional<T> orig(std::forward<InitArgs>(args)...);
-    optional<T> rhs(orig);
-    bool rhs_engaged = static_cast<bool>(rhs);
-    optional<T> lhs = std::move(rhs);
-    assert(static_cast<bool>(lhs) == rhs_engaged);
-    if (rhs_engaged)
-        assert(*lhs == *orig);
+template <class T, class... InitArgs>
+void test(InitArgs&&... args) {
+  const optional<T> orig(std::forward<InitArgs>(args)...);
+  optional<T> rhs(orig);
+  bool rhs_engaged = static_cast<bool>(rhs);
+  optional<T> lhs  = std::move(rhs);
+  assert(static_cast<bool>(lhs) == rhs_engaged);
+  if (rhs_engaged)
+    assert(*lhs == *orig);
 }
 
-template <class T, class ...InitArgs>
-constexpr bool constexpr_test(InitArgs&&... args)
-{
-    static_assert( std::is_trivially_copy_constructible_v<T>, ""); // requirement
-    const optional<T> orig(std::forward<InitArgs>(args)...);
-    optional<T> rhs(orig);
-    optional<T> lhs = std::move(rhs);
-    return (lhs.has_value() == orig.has_value()) &&
-           (lhs.has_value() ? *lhs == *orig : true);
+template <class T, class... InitArgs>
+constexpr bool constexpr_test(InitArgs&&... args) {
+  static_assert(std::is_trivially_copy_constructible_v<T>, ""); // requirement
+  const optional<T> orig(std::forward<InitArgs>(args)...);
+  optional<T> rhs(orig);
+  optional<T> lhs = std::move(rhs);
+  return (lhs.has_value() == orig.has_value()) && (lhs.has_value() ? *lhs == *orig : true);
 }
 
 void test_throwing_ctor() {
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    struct Z {
-        Z() : count(0) {}
-        Z(Z&& o) : count(o.count + 1)
-        { if (count == 2) throw 6; }
-        int count;
-    };
-    Z z;
-    optional<Z> rhs(std::move(z));
-    try
-    {
-        optional<Z> lhs(std::move(rhs));
-        assert(false);
+  struct Z {
+    Z() : count(0) {}
+    Z(Z&& o) : count(o.count + 1) {
+      if (count == 2)
+        throw 6;
     }
-    catch (int i)
-    {
-        assert(i == 6);
-    }
+    int count;
+  };
+  Z z;
+  optional<Z> rhs(std::move(z));
+  try {
+    optional<Z> lhs(std::move(rhs));
+    assert(false);
+  } catch (int i) {
+    assert(i == 6);
+  }
 #endif
 }
 
-
-template <class T, class ...InitArgs>
-void test_ref(InitArgs&&... args)
-{
-    optional<T> rhs(std::forward<InitArgs>(args)...);
-    bool rhs_engaged = static_cast<bool>(rhs);
-    optional<T> lhs = std::move(rhs);
-    assert(static_cast<bool>(lhs) == rhs_engaged);
-    if (rhs_engaged)
-        assert(&(*lhs) == &(*rhs));
+template <class T, class... InitArgs>
+void test_ref(InitArgs&&... args) {
+  optional<T> rhs(std::forward<InitArgs>(args)...);
+  bool rhs_engaged = static_cast<bool>(rhs);
+  optional<T> lhs  = std::move(rhs);
+  assert(static_cast<bool>(lhs) == rhs_engaged);
+  if (rhs_engaged)
+    assert(&(*lhs) == &(*rhs));
 }
 
 void test_reference_extension() {
@@ -143,80 +137,79 @@ void test_reference_extension() {
 #endif
 }
 
-int main(int, char**)
-{
-    test<int>();
-    test<int>(3);
-    static_assert(constexpr_test<int>(), "" );
-    static_assert(constexpr_test<int>(3), "" );
+int main(int, char**) {
+  test<int>();
+  test<int>(3);
+  static_assert(constexpr_test<int>(), "");
+  static_assert(constexpr_test<int>(3), "");
 
-    {
-        optional<const int> o(42);
-        optional<const int> o2(std::move(o));
-        assert(*o2 == 42);
-    }
-    {
-        using T = TestTypes::TestType;
-        T::reset();
-        optional<T> rhs;
-        assert(T::alive == 0);
-        const optional<T> lhs(std::move(rhs));
-        assert(lhs.has_value() == false);
-        assert(rhs.has_value() == false);
-        assert(T::alive == 0);
-    }
-    TestTypes::TestType::reset();
-    {
-        using T = TestTypes::TestType;
-        T::reset();
-        optional<T> rhs(42);
-        assert(T::alive == 1);
-        assert(T::value_constructed == 1);
-        assert(T::move_constructed == 0);
-        const optional<T> lhs(std::move(rhs));
-        assert(lhs.has_value());
-        assert(rhs.has_value());
-        assert(lhs.value().value == 42);
-        assert(rhs.value().value == -1);
-        assert(T::move_constructed == 1);
-        assert(T::alive == 2);
-    }
-    TestTypes::TestType::reset();
-    {
-        using namespace ConstexprTestTypes;
-        test<TestType>();
-        test<TestType>(42);
-    }
-    {
-        using namespace TrivialTestTypes;
-        test<TestType>();
-        test<TestType>(42);
-    }
-    {
-        test_throwing_ctor();
-    }
-    {
-        struct ThrowsMove {
-          ThrowsMove() noexcept(false) {}
-          ThrowsMove(ThrowsMove const&) noexcept(false) {}
-          ThrowsMove(ThrowsMove &&) noexcept(false) {}
-        };
-        static_assert(!std::is_nothrow_move_constructible<optional<ThrowsMove>>::value, "");
-        struct NoThrowMove {
-          NoThrowMove() noexcept(false) {}
-          NoThrowMove(NoThrowMove const&) noexcept(false) {}
-          NoThrowMove(NoThrowMove &&) noexcept(true) {}
-        };
-        static_assert(std::is_nothrow_move_constructible<optional<NoThrowMove>>::value, "");
-    }
-    {
-        test_reference_extension();
-    }
-    {
+  {
+    optional<const int> o(42);
+    optional<const int> o2(std::move(o));
+    assert(*o2 == 42);
+  }
+  {
+    using T = TestTypes::TestType;
+    T::reset();
+    optional<T> rhs;
+    assert(T::alive == 0);
+    const optional<T> lhs(std::move(rhs));
+    assert(lhs.has_value() == false);
+    assert(rhs.has_value() == false);
+    assert(T::alive == 0);
+  }
+  TestTypes::TestType::reset();
+  {
+    using T = TestTypes::TestType;
+    T::reset();
+    optional<T> rhs(42);
+    assert(T::alive == 1);
+    assert(T::value_constructed == 1);
+    assert(T::move_constructed == 0);
+    const optional<T> lhs(std::move(rhs));
+    assert(lhs.has_value());
+    assert(rhs.has_value());
+    assert(lhs.value().value == 42);
+    assert(rhs.value().value == -1);
+    assert(T::move_constructed == 1);
+    assert(T::alive == 2);
+  }
+  TestTypes::TestType::reset();
+  {
+    using namespace ConstexprTestTypes;
+    test<TestType>();
+    test<TestType>(42);
+  }
+  {
+    using namespace TrivialTestTypes;
+    test<TestType>();
+    test<TestType>(42);
+  }
+  {
+    test_throwing_ctor();
+  }
+  {
+    struct ThrowsMove {
+      ThrowsMove() noexcept(false) {}
+      ThrowsMove(ThrowsMove const&) noexcept(false) {}
+      ThrowsMove(ThrowsMove&&) noexcept(false) {}
+    };
+    static_assert(!std::is_nothrow_move_constructible<optional<ThrowsMove>>::value, "");
+    struct NoThrowMove {
+      NoThrowMove() noexcept(false) {}
+      NoThrowMove(NoThrowMove const&) noexcept(false) {}
+      NoThrowMove(NoThrowMove&&) noexcept(true) {}
+    };
+    static_assert(std::is_nothrow_move_constructible<optional<NoThrowMove>>::value, "");
+  }
+  {
+    test_reference_extension();
+  }
+  {
     constexpr std::optional<int> o1{4};
     constexpr std::optional<int> o2 = std::move(o1);
-    static_assert( *o2 == 4, "" );
-    }
+    static_assert(*o2 == 4, "");
+  }
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/nullopt_t.pass.cpp
@@ -11,66 +11,57 @@
 
 // constexpr optional(nullopt_t) noexcept;
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "archetypes.h"
 
 #include "test_macros.h"
 
-using std::optional;
-using std::nullopt_t;
 using std::nullopt;
+using std::nullopt_t;
+using std::optional;
 
 template <class Opt>
-void
-test_constexpr()
-{
-    static_assert(std::is_nothrow_constructible<Opt, nullopt_t&>::value, "");
-    static_assert(std::is_trivially_destructible<Opt>::value, "");
-    static_assert(std::is_trivially_destructible<typename Opt::value_type>::value, "");
+void test_constexpr() {
+  static_assert(std::is_nothrow_constructible<Opt, nullopt_t&>::value, "");
+  static_assert(std::is_trivially_destructible<Opt>::value, "");
+  static_assert(std::is_trivially_destructible<typename Opt::value_type>::value, "");
 
-    constexpr Opt opt(nullopt);
-    static_assert(static_cast<bool>(opt) == false, "");
+  constexpr Opt opt(nullopt);
+  static_assert(static_cast<bool>(opt) == false, "");
 
-    struct test_constexpr_ctor
-        : public Opt
-    {
-        constexpr test_constexpr_ctor() {}
-    };
+  struct test_constexpr_ctor : public Opt {
+    constexpr test_constexpr_ctor() {}
+  };
 }
 
 template <class Opt>
-void
-test()
-{
-    static_assert(std::is_nothrow_constructible<Opt, nullopt_t&>::value, "");
-    static_assert(!std::is_trivially_destructible<Opt>::value, "");
-    static_assert(!std::is_trivially_destructible<typename Opt::value_type>::value, "");
-    {
+void test() {
+  static_assert(std::is_nothrow_constructible<Opt, nullopt_t&>::value, "");
+  static_assert(!std::is_trivially_destructible<Opt>::value, "");
+  static_assert(!std::is_trivially_destructible<typename Opt::value_type>::value, "");
+  {
     Opt opt(nullopt);
     assert(static_cast<bool>(opt) == false);
-    }
-    {
+  }
+  {
     const Opt opt(nullopt);
     assert(static_cast<bool>(opt) == false);
-    }
-    struct test_constexpr_ctor
-        : public Opt
-    {
-        constexpr test_constexpr_ctor() {}
-    };
+  }
+  struct test_constexpr_ctor : public Opt {
+    constexpr test_constexpr_ctor() {}
+  };
 }
 
-int main(int, char**)
-{
-    test_constexpr<optional<int>>();
-    test_constexpr<optional<int*>>();
-    test_constexpr<optional<ImplicitTypes::NoCtors>>();
-    test_constexpr<optional<NonTrivialTypes::NoCtors>>();
-    test_constexpr<optional<NonConstexprTypes::NoCtors>>();
-    test<optional<NonLiteralTypes::NoCtors>>();
+int main(int, char**) {
+  test_constexpr<optional<int>>();
+  test_constexpr<optional<int*>>();
+  test_constexpr<optional<ImplicitTypes::NoCtors>>();
+  test_constexpr<optional<NonTrivialTypes::NoCtors>>();
+  test_constexpr<optional<NonConstexprTypes::NoCtors>>();
+  test<optional<NonLiteralTypes::NoCtors>>();
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/optional_U.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/optional_U.pass.cpp
@@ -23,75 +23,68 @@
 using std::optional;
 
 template <class T, class U>
-TEST_CONSTEXPR_CXX20 void
-test(optional<U>&& rhs, bool is_going_to_throw = false)
-{
-    bool rhs_engaged = static_cast<bool>(rhs);
+TEST_CONSTEXPR_CXX20 void test(optional<U>&& rhs, bool is_going_to_throw = false) {
+  bool rhs_engaged = static_cast<bool>(rhs);
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    try
-    {
-        optional<T> lhs = std::move(rhs);
-        assert(is_going_to_throw == false);
-        assert(static_cast<bool>(lhs) == rhs_engaged);
-    }
-    catch (int i)
-    {
-        assert(i == 6);
-    }
-#else
-    if (is_going_to_throw) return;
+  try {
     optional<T> lhs = std::move(rhs);
+    assert(is_going_to_throw == false);
     assert(static_cast<bool>(lhs) == rhs_engaged);
+  } catch (int i) {
+    assert(i == 6);
+  }
+#else
+  if (is_going_to_throw)
+    return;
+  optional<T> lhs = std::move(rhs);
+  assert(static_cast<bool>(lhs) == rhs_engaged);
 #endif
 }
 
-class X
-{
-    int i_;
+class X {
+  int i_;
+
 public:
-    TEST_CONSTEXPR_CXX20 X(int i) : i_(i) {}
-    TEST_CONSTEXPR_CXX20 X(X&& x) : i_(std::exchange(x.i_, 0)) {}
-    TEST_CONSTEXPR_CXX20 ~X() {i_ = 0;}
-    friend constexpr bool operator==(const X& x, const X& y) {return x.i_ == y.i_;}
+  TEST_CONSTEXPR_CXX20 X(int i) : i_(i) {}
+  TEST_CONSTEXPR_CXX20 X(X&& x) : i_(std::exchange(x.i_, 0)) {}
+  TEST_CONSTEXPR_CXX20 ~X() { i_ = 0; }
+  friend constexpr bool operator==(const X& x, const X& y) { return x.i_ == y.i_; }
 };
 
-struct Z
-{
-    Z(int) { TEST_THROW(6); }
+struct Z {
+  Z(int) { TEST_THROW(6); }
 };
 
-template<class T, class U>
-TEST_CONSTEXPR_CXX20 bool test_all()
-{
-    {
-        optional<T> rhs;
-        test<U>(std::move(rhs));
-    }
-    {
-        optional<T> rhs(short{3});
-        test<U>(std::move(rhs));
-    }
-    return true;
+template <class T, class U>
+TEST_CONSTEXPR_CXX20 bool test_all() {
+  {
+    optional<T> rhs;
+    test<U>(std::move(rhs));
+  }
+  {
+    optional<T> rhs(short{3});
+    test<U>(std::move(rhs));
+  }
+  return true;
 }
 
-int main(int, char**)
-{
-    test_all<short, int>();
-    test_all<int, X>();
+int main(int, char**) {
+  test_all<short, int>();
+  test_all<int, X>();
 #if TEST_STD_VER > 17
-    static_assert(test_all<short, int>());
-    static_assert(test_all<int, X>());
+  static_assert(test_all<short, int>());
+  static_assert(test_all<int, X>());
 #endif
-    {
-        optional<int> rhs;
-        test<Z>(std::move(rhs));
-    }
-    {
-        optional<int> rhs(3);
-        test<Z>(std::move(rhs), true);
-    }
+  {
+    optional<int> rhs;
+    test<Z>(std::move(rhs));
+  }
+  {
+    optional<int> rhs(3);
+    test<Z>(std::move(rhs), true);
+  }
 
-    static_assert(!(std::is_constructible<optional<X>, optional<Z>>::value), "");
+  static_assert(!(std::is_constructible<optional<X>, optional<Z>>::value), "");
 
   return 0;
 }

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/rvalue_T.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/rvalue_T.pass.cpp
@@ -12,137 +12,118 @@
 
 // constexpr optional(T&& v);
 
+#include <cassert>
 #include <optional>
 #include <type_traits>
-#include <cassert>
 
 #include "test_macros.h"
 #include "archetypes.h"
 
-
 using std::optional;
 
-
-class Z
-{
+class Z {
 public:
-    Z(int) {}
-    Z(Z&&) {TEST_THROW(6);}
+  Z(int) {}
+  Z(Z&&) { TEST_THROW(6); }
 };
 
+int main(int, char**) {
+  {
+    typedef int T;
+    constexpr optional<T> opt(T(5));
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(*opt == 5, "");
 
-int main(int, char**)
-{
-    {
-        typedef int T;
-        constexpr optional<T> opt(T(5));
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(*opt == 5, "");
+    struct test_constexpr_ctor : public optional<T> {
+      constexpr test_constexpr_ctor(T&&) {}
+    };
+  }
+  {
+    typedef double T;
+    constexpr optional<T> opt(T(3));
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(*opt == 3, "");
 
-        struct test_constexpr_ctor
-            : public optional<T>
-        {
-            constexpr test_constexpr_ctor(T&&) {}
-        };
-    }
-    {
-        typedef double T;
-        constexpr optional<T> opt(T(3));
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(*opt == 3, "");
+    struct test_constexpr_ctor : public optional<T> {
+      constexpr test_constexpr_ctor(T&&) {}
+    };
+  }
+  {
+    const int x = 42;
+    optional<const int> o(std::move(x));
+    assert(*o == 42);
+  }
+  {
+    typedef TestTypes::TestType T;
+    T::reset();
+    optional<T> opt = T{3};
+    assert(T::alive == 1);
+    assert(T::move_constructed == 1);
+    assert(static_cast<bool>(opt) == true);
+    assert(opt.value().value == 3);
+  }
+  {
+    typedef ExplicitTestTypes::TestType T;
+    static_assert(!std::is_convertible<T&&, optional<T>>::value, "");
+    T::reset();
+    optional<T> opt(T{3});
+    assert(T::alive == 1);
+    assert(T::move_constructed == 1);
+    assert(static_cast<bool>(opt) == true);
+    assert(opt.value().value == 3);
+  }
+  {
+    typedef TestTypes::TestType T;
+    T::reset();
+    optional<T> opt = {3};
+    assert(T::alive == 1);
+    assert(T::value_constructed == 1);
+    assert(T::copy_constructed == 0);
+    assert(T::move_constructed == 0);
+    assert(static_cast<bool>(opt) == true);
+    assert(opt.value().value == 3);
+  }
+  {
+    typedef ConstexprTestTypes::TestType T;
+    constexpr optional<T> opt = {T(3)};
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(opt.value().value == 3, "");
 
-        struct test_constexpr_ctor
-            : public optional<T>
-        {
-            constexpr test_constexpr_ctor(T&&) {}
-        };
-    }
-    {
-        const int x = 42;
-        optional<const int> o(std::move(x));
-        assert(*o == 42);
-    }
-    {
-        typedef TestTypes::TestType T;
-        T::reset();
-        optional<T> opt = T{3};
-        assert(T::alive == 1);
-        assert(T::move_constructed == 1);
-        assert(static_cast<bool>(opt) == true);
-        assert(opt.value().value == 3);
-    }
-    {
-        typedef ExplicitTestTypes::TestType T;
-        static_assert(!std::is_convertible<T&&, optional<T>>::value, "");
-        T::reset();
-        optional<T> opt(T{3});
-        assert(T::alive == 1);
-        assert(T::move_constructed == 1);
-        assert(static_cast<bool>(opt) == true);
-        assert(opt.value().value == 3);
-    }
-    {
-        typedef TestTypes::TestType T;
-        T::reset();
-        optional<T> opt = {3};
-        assert(T::alive == 1);
-        assert(T::value_constructed == 1);
-        assert(T::copy_constructed == 0);
-        assert(T::move_constructed == 0);
-        assert(static_cast<bool>(opt) == true);
-        assert(opt.value().value == 3);
-    }
-    {
-        typedef ConstexprTestTypes::TestType T;
-        constexpr optional<T> opt = {T(3)};
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(opt.value().value == 3, "");
+    struct test_constexpr_ctor : public optional<T> {
+      constexpr test_constexpr_ctor(const T&) {}
+    };
+  }
+  {
+    typedef ConstexprTestTypes::TestType T;
+    constexpr optional<T> opt = {3};
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(opt.value().value == 3, "");
 
-        struct test_constexpr_ctor
-            : public optional<T>
-        {
-            constexpr test_constexpr_ctor(const T&) {}
-        };
-    }
-    {
-        typedef ConstexprTestTypes::TestType T;
-        constexpr optional<T> opt = {3};
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(opt.value().value == 3, "");
+    struct test_constexpr_ctor : public optional<T> {
+      constexpr test_constexpr_ctor(const T&) {}
+    };
+  }
+  {
+    typedef ExplicitConstexprTestTypes::TestType T;
+    static_assert(!std::is_convertible<T&&, optional<T>>::value, "");
+    constexpr optional<T> opt(T{3});
+    static_assert(static_cast<bool>(opt) == true, "");
+    static_assert(opt.value().value == 3, "");
 
-        struct test_constexpr_ctor
-            : public optional<T>
-        {
-            constexpr test_constexpr_ctor(const T&) {}
-        };
-    }
-    {
-        typedef ExplicitConstexprTestTypes::TestType T;
-        static_assert(!std::is_convertible<T&&, optional<T>>::value, "");
-        constexpr optional<T> opt(T{3});
-        static_assert(static_cast<bool>(opt) == true, "");
-        static_assert(opt.value().value == 3, "");
-
-        struct test_constexpr_ctor
-            : public optional<T>
-        {
-            constexpr test_constexpr_ctor(T&&) {}
-        };
-
-    }
+    struct test_constexpr_ctor : public optional<T> {
+      constexpr test_constexpr_ctor(T&&) {}
+    };
+  }
 #ifndef TEST_HAS_NO_EXCEPTIONS
-    {
-        try
-        {
-            Z z(3);
-            optional<Z> opt(std::move(z));
-            assert(false);
-        }
-        catch (int i)
-        {
-            assert(i == 6);
-        }
+  {
+    try {
+      Z z(3);
+      optional<Z> opt(std::move(z));
+      assert(false);
+    } catch (int i) {
+      assert(i == 6);
     }
+  }
 #endif
 
   return 0;


### PR DESCRIPTION
- Mass-reformat tests in `std/utilities/optional/optional.object/optional.object.ctor` and rearrange header `#include`s
- No functional changes
- Prelude for #169203