### PR TITLE
[Clang][OpenMP] Make test use clang_cc1

### DIFF
--- a/clang/test/OpenMP/parallel_default_variableCategory_codegen.cpp
+++ b/clang/test/OpenMP/parallel_default_variableCategory_codegen.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -Xclang -verify -Wno-vla -fopenmp -fopenmp-version=60 -x c++ -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -x c++ -emit-llvm %s -o - | FileCheck %s
 // expected-no-diagnostics
 #ifndef HEADER
 #define HEADER


### PR DESCRIPTION
This test does not actually need to use the clang driver. Using the driver means that the environment plays much more into the tests results. We ran into a situation where the driver decided not to pass -fopenmp to the cc1 invocation, causing the test to fail.

This also makes the test more consistent with the other OpenMP tests and should make it slightly faster (no subprocess invocation).