### PR TITLE
[libcxx] [test] Fix the gets-removed.verify.cpp test with Clang 21

### DIFF
--- a/libcxx/test/std/input.output/file.streams/c.files/gets-removed.verify.cpp
+++ b/libcxx/test/std/input.output/file.streams/c.files/gets-removed.verify.cpp
@@ -12,6 +12,6 @@
 
 #include <cstdio>
 
-void f(char const* str) {
+void f(char* str) {
   (void)std::gets(str); // expected-error {{no member named 'gets' in namespace 'std'}}
 }


### PR DESCRIPTION
This fixes test errors like this, at least for a mingw target, if building with Clang 21 instead of Clang 20, as in the CI environment:

    # .---command stderr------------
    # | error: 'expected-error' diagnostics seen but not expected:
    # |   File C:\a\llvm-mingw\llvm-mingw\llvm-project\libcxx\test\std\input.output\file.streams\c.files\gets-removed.verify.cpp Line 16: cannot initialize a parameter of type 'char *' with an lvalue of type 'const char *'
    # | 1 error generated.
    # `-----------------------------
    # error: command failed with exit status: 1

This extra, unexpected diagnostic appears in Clang 21, since commit 9eef4d1c5fa6b1bcbbe675c14ca8301d5d346f7b ("Remove delayed typo expressions"). Before this, we got the expected diagnostic `error: no member named 'gets' in namespace 'std'`, with the typo correction hint `did you mean 'puts'?`. After this change, we get the typo correction hint `did you mean simply 'gets'?` instead. And with the typo correction finding `::gets`, it goes on to produce a second diagnostic about mismatched parameter for that function.

Avoid these unexpected diagnostics by passing the right type of parameter to the gets function.