### PR TITLE
[OpenCL] Disable __opencl_c_ext_fp64_* features if cl_khr_fp64 is not supported

### DIFF
--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1848,6 +1848,9 @@ public:
     }
   }
 
+  /// Set features that depend on other features.
+  virtual void setDependentOpenCLOpts();
+
   /// Get supported OpenCL extensions and optional core features.
   llvm::StringMap<bool> &getSupportedOpenCLOpts() {
     return getTargetOpts().OpenCLFeaturesMap;

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -640,6 +640,17 @@ bool TargetInfo::areDefaultedSMFStillPOD(const LangOptions &LangOpts) const {
   return LangOpts.getClangABICompat() > LangOptions::ClangABI::Ver15;
 }
 
+void TargetInfo::setDependentOpenCLOpts() {
+  auto &Opts = getSupportedOpenCLOpts();
+  if (!hasFeatureEnabled(Opts, "cl_khr_fp64") ||
+      !hasFeatureEnabled(Opts, "__opencl_c_fp64")) {
+    setFeatureEnabled(Opts, "__opencl_c_ext_fp64_global_atomic_add", false);
+    setFeatureEnabled(Opts, "__opencl_c_ext_fp64_local_atomic_add", false);
+    setFeatureEnabled(Opts, "__opencl_c_ext_fp64_global_atomic_min_max", false);
+    setFeatureEnabled(Opts, "__opencl_c_ext_fp64_local_atomic_min_max", false);
+  }
+}
+
 LangAS TargetInfo::getOpenCLTypeAddrSpace(OpenCLTypeKind TK) const {
   switch (TK) {
   case OCLTK_Image:

--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -862,6 +862,7 @@ TargetInfo *TargetInfo::CreateTargetInfo(DiagnosticsEngine &Diags,
 
   Target->setSupportedOpenCLOpts();
   Target->setCommandLineOpenCLOpts();
+  Target->setDependentOpenCLOpts();
   Target->setMaxAtomicWidth();
 
   if (!Opts->DarwinTargetVariantTriple.empty())

--- a/clang/lib/Headers/opencl-c.h
+++ b/clang/lib/Headers/opencl-c.h
@@ -13781,6 +13781,7 @@ float __ovld atomic_fetch_max_explicit(volatile atomic_float *,
     defined(__opencl_c_ext_fp32_local_atomic_min_max)
 
 #if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
+#ifdef cl_khr_fp64
 #if defined(__opencl_c_ext_fp64_global_atomic_min_max)
 double __ovld atomic_fetch_min(volatile __global atomic_double *, double);
 double __ovld atomic_fetch_max(volatile __global atomic_double *, double);
@@ -13821,6 +13822,7 @@ double __ovld atomic_fetch_max_explicit(volatile atomic_double *,
                                         double, memory_order, memory_scope);
 #endif // defined(__opencl_c_ext_fp64_global_atomic_min_max) &&                \
     defined(__opencl_c_ext_fp64_local_atomic_min_max)
+#endif // cl_khr_fp64
 #endif // defined(cl_khr_int64_base_atomics) &&                                \
     defined(cl_khr_int64_extended_atomics)
 
@@ -13907,6 +13909,7 @@ float __ovld atomic_fetch_sub_explicit(volatile atomic_float *,
     defined(__opencl_c_ext_fp32_local_atomic_add)
 
 #if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
+#ifdef cl_khr_fp64
 #if defined(__opencl_c_ext_fp64_global_atomic_add)
 double __ovld atomic_fetch_add(volatile __global atomic_double *, double);
 double __ovld atomic_fetch_sub(volatile __global atomic_double *, double);
@@ -13947,6 +13950,7 @@ double __ovld atomic_fetch_sub_explicit(volatile atomic_double *,
                                         double, memory_order, memory_scope);
 #endif // defined(__opencl_c_ext_fp64_global_atomic_add) &&                    \
     defined(__opencl_c_ext_fp64_local_atomic_add)
+#endif // cl_khr_fp64
 #endif // defined(cl_khr_int64_base_atomics) &&                                \
     defined(cl_khr_int64_extended_atomics)
 

--- a/clang/lib/Headers/opencl-c.h
+++ b/clang/lib/Headers/opencl-c.h
@@ -13781,7 +13781,6 @@ float __ovld atomic_fetch_max_explicit(volatile atomic_float *,
     defined(__opencl_c_ext_fp32_local_atomic_min_max)
 
 #if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
-#ifdef cl_khr_fp64
 #if defined(__opencl_c_ext_fp64_global_atomic_min_max)
 double __ovld atomic_fetch_min(volatile __global atomic_double *, double);
 double __ovld atomic_fetch_max(volatile __global atomic_double *, double);
@@ -13822,7 +13821,6 @@ double __ovld atomic_fetch_max_explicit(volatile atomic_double *,
                                         double, memory_order, memory_scope);
 #endif // defined(__opencl_c_ext_fp64_global_atomic_min_max) &&                \
     defined(__opencl_c_ext_fp64_local_atomic_min_max)
-#endif // cl_khr_fp64
 #endif // defined(cl_khr_int64_base_atomics) &&                                \
     defined(cl_khr_int64_extended_atomics)
 
@@ -13909,7 +13907,6 @@ float __ovld atomic_fetch_sub_explicit(volatile atomic_float *,
     defined(__opencl_c_ext_fp32_local_atomic_add)
 
 #if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
-#ifdef cl_khr_fp64
 #if defined(__opencl_c_ext_fp64_global_atomic_add)
 double __ovld atomic_fetch_add(volatile __global atomic_double *, double);
 double __ovld atomic_fetch_sub(volatile __global atomic_double *, double);
@@ -13950,7 +13947,6 @@ double __ovld atomic_fetch_sub_explicit(volatile atomic_double *,
                                         double, memory_order, memory_scope);
 #endif // defined(__opencl_c_ext_fp64_global_atomic_add) &&                    \
     defined(__opencl_c_ext_fp64_local_atomic_add)
-#endif // cl_khr_fp64
 #endif // defined(cl_khr_int64_base_atomics) &&                                \
     defined(cl_khr_int64_extended_atomics)
 

--- a/clang/test/Misc/opencl-c-3.0.incorrect_define.cl
+++ b/clang/test/Misc/opencl-c-3.0.incorrect_define.cl
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -verify -triple spir-unknown-unknown -cl-std=CL3.0 -cl-ext=-__opencl_c_fp64,-cl_khr_fp64 %s
+// RUN: %clang_cc1 -verify -triple spir-unknown-unknown -cl-std=clc++2021 -cl-ext=-__opencl_c_fp64,-cl_khr_fp64 %s
+
+#if __opencl_c_ext_fp64_global_atomic_add != 0
+#error "Incorrectly defined __opencl_c_ext_fp64_global_atomic_add"
+#endif
+#if __opencl_c_ext_fp64_local_atomic_add != 0
+#error "Incorrectly defined __opencl_c_ext_fp64_local_atomic_add"
+#endif
+#if __opencl_c_ext_fp64_global_atomic_min_max != 0
+#error "Incorrectly defined __opencl_c_ext_fp64_global_atomic_min_max"
+#endif
+#if __opencl_c_ext_fp64_local_atomic_min_max != 0
+#error "Incorrectly defined __opencl_c_ext_fp64_local_atomic_min_max"
+#endif
+
+// expected-no-diagnostics


### PR DESCRIPTION
Fix kernel build when cl_khr_fp64 is not enabled:
opencl-c.h:13785:50: error: unknown type name 'atomic_double'
 13785 | double __ovld atomic_fetch_min(volatile __global atomic_double *, double);
opencl-c.h:13785:67: error: use of type 'double' requires cl_khr_fp64 and __opencl_c_fp64 support
 13785 | double __ovld atomic_fetch_min(volatile __global atomic_double *, double);

This is a regression introduced by 423bdb2b. Before that commit, __opencl_c_ext_fp64_global_atomic_add was guarded by cl_khr_fp64 in opencl-c-base.h.