### PR TITLE
[lldb] [test-suite] fix typo in variable in darwin builder

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/darwin.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/darwin.py
@@ -60,7 +60,7 @@ def get_triple_str(arch, vendor, os, version, env):
 
     component = [arch, vendor, os + version]
     if env:
-        components.append(env)
+        component.append(env)
     return "-".join(component)
 
 


### PR DESCRIPTION
While taking a look at the code of lldb test-suite packages, I have noticed that in `get_triple_str` in `darwin.py` env is added inside a `components` list, which is probably supposed to be `component` (defined on the line 61). 