### PR TITLE
[clang][Parser] Allow private type aliases in out-of-line member function return types

### DIFF
--- a/clang/test/Interpreter/private-member-access.cpp
+++ b/clang/test/Interpreter/private-member-access.cpp
@@ -1,0 +1,35 @@
+// RUN: cat %s | clang-repl | FileCheck %s
+
+extern "C" int printf(const char*, ...);
+
+// Test 1: Pointer to private type alias (the original bug report)
+class io_context { using impl_type = int; public: impl_type* get(); };
+io_context::impl_type* io_context::get() { return nullptr; }
+printf("Pointer to private type: %s\n", io_context().get() == nullptr ? "passed" : "failed");
+// CHECK: Pointer to private type: passed
+
+// Test 2: Reference to private type
+class RefReturn { using ref_t = int; ref_t value = 42; public: ref_t& getRef(); };
+RefReturn::ref_t& RefReturn::getRef() { return value; }
+printf("Reference to private type: %d\n", RefReturn().getRef());
+// CHECK: Reference to private type: 42
+
+// Test 3: Double pointer to private type
+class PtrPtr { using inner_t = int; public: inner_t** get(); };
+PtrPtr::inner_t** PtrPtr::get() { static int* p = nullptr; return &p; }
+printf("Double pointer to private type: %s\n", PtrPtr().get() != nullptr ? "passed" : "failed");
+// CHECK: Double pointer to private type: passed
+
+// Test 4: Const reference to private type
+class ConstRef { using data_t = int; data_t val = 100; public: const data_t& get(); };
+const ConstRef::data_t& ConstRef::get() { return val; }
+printf("Const reference to private type: %d\n", ConstRef().get());
+// CHECK: Const reference to private type: 100
+
+// Test 5: Pointer to private nested struct
+class Container { struct Node { int x; }; public: Node* create(); };
+Container::Node* Container::create() { return new Node{789}; }
+printf("Pointer to private nested struct: %d\n", Container().create()->x);
+// CHECK: Pointer to private nested struct: 789
+
+%quit


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/164885.

Used Copilot. Run all clang tests locally with `ninja check-clang` (everything that was gree in main is also green here.)

From https://github.com/llvm/llvm-project/issues/164885, `clang-repl` fails to handle private member aliases in member function return type, we can see the issue below in clang-repl that works just fine in normal clang. 

Fix: Extend the heuristic in ParseTentative.cpp that skips isCXXSimpleDeclaration to also recognize pointer/reference patterns (A::B *id, A::B &id, A::B &&id, A::B **id) as likely declarations, avoiding the premature access check.

```c
/***** somecode.c *****/
struct scheduler
{ };

class io_context
{
  using impl_type = scheduler;

public:
  impl_type *foo();
};

/* The error doesn't occur if `impl_type` is a parameter type. Only for the return type. */
io_context::impl_type *io_context::foo()
{ return nullptr; }

```


```bash
# ***** in clang-repl ***** #
❯ clang-repl
clang-repl> #include "asio-repro.hpp"
In file included from <<< inputs >>>:1:
In file included from input_line_1:1:
./asio-repro.hpp:13:13: error: 'impl_type' is a private member of 'io_context'
   13 | io_context::impl_type *io_context::add_impl()
      |             ^
./asio-repro.hpp:7:9: note: implicitly declared private here
    7 |   using impl_type = scheduler;
      |         ^
error: Parsing failed.

# LLVM 22 (head)
```