### PR TITLE
[LLD] Extend support for RISCV vendor-specific relocations to include dynamic relocations as well.

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1644,8 +1644,11 @@ void elf::postScanRelocations(Ctx &ctx) {
   }
 
   assert(ctx.symAux.size() == 1);
-  for (Symbol *sym : ctx.symtab->getSymbols())
-    fn(*sym);
+  // When RISCV vendor-specific relocations are used in the GOT, a new marker
+  // symbol may be introduced during this iteration, so we have to use an
+  // invalidation-safe loop.
+  for (size_t i = 0; i < ctx.symtab->getSymbols().size(); ++i)
+    fn(*ctx.symtab->getSymbols()[i]);
 
   // Local symbols may need the aforementioned non-preemptible ifunc and GOT
   // handling. They don't need regular PLT.


### PR DESCRIPTION
This potentially requires materializing the vendor namespace symbol at link-time, which introduces
some complexity. Additionally we have to ensure that R_RISCV_VENDOR relocations do not interfere
with the normal dynamic relocation sorting.
