### PR TITLE
[mlir][x86vector] Add missing Linalg dependency

### DIFF
--- a/mlir/lib/Dialect/X86Vector/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/X86Vector/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_dialect_library(MLIRX86VectorTransforms
   MLIRArithDialect
   MLIRX86VectorDialect
   MLIRIR
+  MLIRLinalgDialect
   MLIRLLVMCommonConversion
   MLIRLLVMDialect
   MLIRVectorDialect


### PR DESCRIPTION
Adds required dependency for `inferContractionDims`.

Fixes #168074