### PR TITLE
WIP [ADT][NFC] SmallVector performance improvements

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -238,7 +238,7 @@ protected:
 
     bool ReferencesStorage = false;
     int64_t Index = -1;
-    if (!U::TakesParamByValue) {
+    if constexpr (!U::TakesParamByValue) {
       if (LLVM_UNLIKELY(This->isReferenceToStorage(&Elt))) {
         ReferencesStorage = true;
         Index = &Elt - This->begin();
@@ -627,11 +627,22 @@ private:
     }
 
     this->reserve(N);
-    for (auto I = this->end(), E = this->begin() + N; I != E; ++I)
-      if (ForOverwrite)
-        new (&*I) T;
-      else
-        new (&*I) T();
+
+    // Use batch init for trivial types
+    if constexpr (std::is_trivially_copyable_v<T> &&
+                  std::is_trivially_default_constructible_v<T> &&
+                  std::is_trivially_destructible_v<T>) {
+      if constexpr (!ForOverwrite)
+        std::memset(this->end(), 0, (N - this->size()) * sizeof(T));
+      // ForOverwrite: skip initialization entirely
+    } else {
+      // Non-trivial types: construct individually
+      for (auto I = this->end(), E = this->begin() + N; I != E; ++I)
+        if constexpr (ForOverwrite)
+          new (&*I) T;
+        else
+          new (&*I) T();
+    }
     this->set_size(N);
   }
 
@@ -801,9 +812,10 @@ private:
     // the reference (never happens if TakesParamByValue).
     static_assert(!TakesParamByValue || std::is_same<ArgType, T>::value,
                   "ArgType must be 'T' when taking by value!");
-    if (!TakesParamByValue && this->isReferenceToRange(EltPtr, I, this->end()))
-      ++EltPtr;
-
+    if constexpr (!TakesParamByValue) {
+      if (this->isReferenceToRange(EltPtr, I, this->end()))
+        ++EltPtr;
+    }
     *I = ::std::forward<ArgType>(*EltPtr);
     return I;
   }
@@ -849,9 +861,10 @@ public:
 
       // If we just moved the element we're inserting, be sure to update
       // the reference (never happens if TakesParamByValue).
-      if (!TakesParamByValue && I <= EltPtr && EltPtr < this->end())
-        EltPtr += NumToInsert;
-
+      if constexpr (!TakesParamByValue) {
+        if (I <= EltPtr && EltPtr < this->end())
+          EltPtr += NumToInsert;
+      }
       std::fill_n(I, NumToInsert, *EltPtr);
       return I;
     }
@@ -867,9 +880,10 @@ public:
 
     // If we just moved the element we're inserting, be sure to update
     // the reference (never happens if TakesParamByValue).
-    if (!TakesParamByValue && I <= EltPtr && EltPtr < this->end())
-      EltPtr += NumToInsert;
-
+    if constexpr (!TakesParamByValue) {
+      if (I <= EltPtr && EltPtr < this->end())
+        EltPtr += NumToInsert;
+    }
     // Replace the overwritten part.
     std::fill_n(I, NumOverwritten, *EltPtr);
 


### PR DESCRIPTION
SmallVector performance optimizations. SmallVector is used prolifically throughout the code base making it a good optimization target.

- Use "_if constexpr_"(c++17)
- Batch initialize the POD types in _resize_() that is in hot path.

Performance benchmark:
Release build with asserts enabled.
`check-llvm` Testing Time delta shows ~6% improvement

Testing:
`check-llvm`
`check-llvm-unit`