### PR TITLE
[bazel][libc] Remove target compatibility restrictions for float128

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -171,11 +171,6 @@ libc_support_library(
 libc_support_library(
     name = "llvm_libc_types_float128",
     hdrs = ["include/llvm-libc-types/float128.h"],
-    target_compatible_with = select({
-        "@platforms//os:linux": [],
-        "@platforms//os:windows": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
     deps = [":llvm_libc_macros_float_macros"],
 )
 


### PR DESCRIPTION
The restrictions here aren't nearly as much about the OS as the compiler and architecture, but the Bazel restriction was OS-based. Everything seems to work well on even Arm64 macOS, and I would expect most BSDs and other OSes to work well with Clang's support on x86-64.

The source code here already handles detecting when there is compiler support for the type. And the users of this don't `select` or do anything else to conditionally include the header, so it seems better to not restrict access to the header from the build system, and instead continue making the source code compatible or a no-op on relevant configurations.