### PR TITLE
[ADT] Fix implicit reliance on cassert in StringTable.h

### DIFF
--- a/llvm/include/llvm/ADT/StringTable.h
+++ b/llvm/include/llvm/ADT/StringTable.h
@@ -11,6 +11,7 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
+#include <cassert>
 #include <iterator>
 #include <limits>
 


### PR DESCRIPTION
Adds an explicit include of `<cassert>` in StringTable.h rather than relying on the one in StringRef.h. Fixes potential compile errors if assert() was undef'ed between StringRef.h and StringTable.h inclusion.

Noticed the issue after c9f573463ebd7b4e46da4877802f2364f700e54a.