### PR TITLE
[clangd] Fix dangling references to StringMap's value.

### DIFF
--- a/clang-tools-extra/clangd/GlobalCompilationDatabase.h
+++ b/clang-tools-extra/clangd/GlobalCompilationDatabase.h
@@ -143,7 +143,7 @@ private:
   class DirectoryCache;
   // Keyed by possibly-case-folded directory path.
   // We can hand out pointers as they're stable and entries are never removed.
-  mutable llvm::StringMap<DirectoryCache> DirCaches;
+  mutable llvm::StringMap<std::unique_ptr<DirectoryCache>> DirCaches;
   mutable std::mutex DirCachesMutex;
 
   std::vector<DirectoryCache *>


### PR DESCRIPTION
StringMap insertion may cause elements to be rehased, or the underlying storage to be reallocated, so it is generatelly unsafe to take pointers to StringMap "values". This in turn caused clangd to fail to load its on disk cache as the code depended on pointer equality (and immutability) to work.

After this change, clangd will successfully re-open its index for large projects (e.g., LLVM itself), thus improving the developer experience.