### PR TITLE
[AArch64] Assert `expandMOVImm` prioritizes optimal single MOVZ/N

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ExpandImm.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandImm.cpp
@@ -549,6 +549,8 @@ void AArch64_IMM::expandMOVImm(uint64_t Imm, unsigned BitSize,
   // Prefer MOVZ/MOVN over ORR because of the rules for the "mov" alias.
   if ((BitSize / 16) - OneChunks <= 1 || (BitSize / 16) - ZeroChunks <= 1) {
     expandMOVImmSimple(Imm, BitSize, OneChunks, ZeroChunks, Insn);
+    assert(Insn.size() == 1 &&
+           "Move of immediate should have expanded to a single MOVZ/MOVN");
     return;
   }
 


### PR DESCRIPTION
The expansion of move immediate in `expandMOVImm` follows the priority of the `MOV` alias. In addition, the selection there properly prefers expansion based on perf optimality order. This change adds a simple assert that `expandMOVImmSimple` expands a single optimal MOVZ/MOVK.