### PR TITLE
[libc++][C++03] Fix ODR tests

### DIFF
--- a/libcxx/test/extensions/libcxx/odr_signature.exceptions.sh.cpp
+++ b/libcxx/test/extensions/libcxx/odr_signature.exceptions.sh.cpp
@@ -9,8 +9,6 @@
 // ABI tags have no effect in MSVC mode.
 // XFAIL: msvc
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 // Test that we encode whether exceptions are supported in an ABI tag to avoid
 // ODR violations when linking TUs that have different values for it.
 
@@ -24,14 +22,14 @@
 
 // -fno-exceptions
 #ifdef TU1
-#  include <__config>
+#  include <version>
 _LIBCPP_HIDE_FROM_ABI TEST_NOINLINE inline int f() { return 1; }
 int tu1() { return f(); }
 #endif // TU1
 
 // -fexceptions
 #ifdef TU2
-#  include <__config>
+#  include <version>
 _LIBCPP_HIDE_FROM_ABI TEST_NOINLINE inline int f() { return 2; }
 int tu2() { return f(); }
 #endif // TU2

--- a/libcxx/test/extensions/libcxx/odr_signature.hardening.sh.cpp
+++ b/libcxx/test/extensions/libcxx/odr_signature.hardening.sh.cpp
@@ -9,8 +9,6 @@
 // ABI tags have no effect in MSVC mode.
 // XFAIL: msvc
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 // Test that we encode the hardening mode in an ABI tag to avoid ODR violations
 // when linking TUs that have different values for it.
 
@@ -27,28 +25,28 @@
 
 // fast hardening mode
 #ifdef TU1
-#  include <__config>
+#  include <version>
 _LIBCPP_HIDE_FROM_ABI TEST_NOINLINE inline int f() { return 1; }
 int tu1() { return f(); }
 #endif // TU1
 
 // extensive hardening mode
 #ifdef TU2
-#  include <__config>
+#  include <version>
 _LIBCPP_HIDE_FROM_ABI TEST_NOINLINE inline int f() { return 2; }
 int tu2() { return f(); }
 #endif // TU2
 
 // debug hardening mode
 #ifdef TU3
-#  include <__config>
+#  include <version>
 _LIBCPP_HIDE_FROM_ABI TEST_NOINLINE inline int f() { return 3; }
 int tu3() { return f(); }
 #endif // TU3
 
 // No hardening
 #ifdef TU4
-#  include <__config>
+#  include <version>
 _LIBCPP_HIDE_FROM_ABI TEST_NOINLINE inline int f() { return 4; }
 int tu4() { return f(); }
 #endif // TU4


### PR DESCRIPTION
We don't really need to include `<__config>`. We just need to include a public C++ header.
