### PR TITLE
[Support] Permit "default" string in AllocToken mode parsing

### DIFF
--- a/llvm/lib/Support/AllocToken.cpp
+++ b/llvm/lib/Support/AllocToken.cpp
@@ -24,6 +24,7 @@ llvm::getAllocTokenModeFromString(StringRef Name) {
       .Case("random", AllocTokenMode::Random)
       .Case("typehash", AllocTokenMode::TypeHash)
       .Case("typehashpointersplit", AllocTokenMode::TypeHashPointerSplit)
+      .Case("default", DefaultAllocTokenMode)
       .Default(std::nullopt);
 }
 


### PR DESCRIPTION
Update getAllocTokenModeFromString() to recognize "default" as a valid mode string, mapping it to `DefaultAllocTokenMode`.