### PR TITLE
Revert "[libcxx][ci] Temporarily disable ARM jobs"

### DIFF
--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -33,64 +33,63 @@ definitions:
       - "**/CMakeOutput.log"
 
 steps:
-# Linaro's ARM builders are temporarily offline.
-#- group: ARM
-#  steps:
-#  - label: AArch64
-#    command: libcxx/utils/ci/run-buildbot aarch64
-#    agents:
-#      queue: libcxx-builders-linaro-arm
-#      arch: aarch64
-#    <<: *common
-#
-#  - label: AArch64 -fno-exceptions
-#    command: libcxx/utils/ci/run-buildbot aarch64-no-exceptions
-#    agents:
-#      queue: libcxx-builders-linaro-arm
-#      arch: aarch64
-#    <<: *common
-#
-#  - label: Armv8
-#    command: libcxx/utils/ci/run-buildbot armv8
-#    agents:
-#      queue: libcxx-builders-linaro-arm
-#      arch: armv8l
-#    <<: *common
-#
-#  - label: Armv8 -fno-exceptions
-#    command: libcxx/utils/ci/run-buildbot armv8-no-exceptions
-#    agents:
-#      queue: libcxx-builders-linaro-arm
-#      arch: armv8l
-#    <<: *common
-#
-#  - label: Armv7
-#    command: libcxx/utils/ci/run-buildbot armv7
-#    agents:
-#      queue: libcxx-builders-linaro-arm
-#      arch: armv8l
-#    <<: *common
-#
-#  - label: Armv7 -fno-exceptions
-#    command: libcxx/utils/ci/run-buildbot armv7-no-exceptions
-#    agents:
-#      queue: libcxx-builders-linaro-arm
-#      arch: armv8l
-#    <<: *common
-#
-#  - label: Armv7-M picolibc
-#    command: libcxx/utils/ci/run-buildbot armv7m-picolibc
-#    agents:
-#      queue: libcxx-builders-linaro-arm
-#      arch: aarch64
-#    <<: *common
-#
-#  - label: Armv7-M picolibc -fno-exceptions
-#    command: libcxx/utils/ci/run-buildbot armv7m-picolibc-no-exceptions
-#    agents:
-#      queue: libcxx-builders-linaro-arm
-#      arch: aarch64
-#    <<: *common
+- group: ARM
+  steps:
+  - label: AArch64
+    command: libcxx/utils/ci/run-buildbot aarch64
+    agents:
+      queue: libcxx-builders-linaro-arm
+      arch: aarch64
+    <<: *common
+
+  - label: AArch64 -fno-exceptions
+    command: libcxx/utils/ci/run-buildbot aarch64-no-exceptions
+    agents:
+      queue: libcxx-builders-linaro-arm
+      arch: aarch64
+    <<: *common
+
+  - label: Armv8
+    command: libcxx/utils/ci/run-buildbot armv8
+    agents:
+      queue: libcxx-builders-linaro-arm
+      arch: armv8l
+    <<: *common
+
+  - label: Armv8 -fno-exceptions
+    command: libcxx/utils/ci/run-buildbot armv8-no-exceptions
+    agents:
+      queue: libcxx-builders-linaro-arm
+      arch: armv8l
+    <<: *common
+
+  - label: Armv7
+    command: libcxx/utils/ci/run-buildbot armv7
+    agents:
+      queue: libcxx-builders-linaro-arm
+      arch: armv8l
+    <<: *common
+
+  - label: Armv7 -fno-exceptions
+    command: libcxx/utils/ci/run-buildbot armv7-no-exceptions
+    agents:
+      queue: libcxx-builders-linaro-arm
+      arch: armv8l
+    <<: *common
+
+  - label: Armv7-M picolibc
+    command: libcxx/utils/ci/run-buildbot armv7m-picolibc
+    agents:
+      queue: libcxx-builders-linaro-arm
+      arch: aarch64
+    <<: *common
+
+  - label: Armv7-M picolibc -fno-exceptions
+    command: libcxx/utils/ci/run-buildbot armv7m-picolibc-no-exceptions
+    agents:
+      queue: libcxx-builders-linaro-arm
+      arch: aarch64
+    <<: *common
 
 - group: AIX
   steps:


### PR DESCRIPTION
Reverts llvm/llvm-project#169318

Our builders are back online. I see them picking up existing jobs.