### PR TITLE
[libc++][C++03] Remove code in the C++03-specific tests that is guarded on the language version

### DIFF
--- a/libcxx/test/libcxx-03/algorithms/half_positive.pass.cpp
+++ b/libcxx/test/libcxx-03/algorithms/half_positive.pass.cpp
@@ -41,17 +41,5 @@ int main(int, char**)
 #endif // !defined(TEST_HAS_NO_INT128)
     }
 
-#if TEST_STD_VER >= 11
-    {
-        static_assert(test<char>(), "");
-        static_assert(test<int>(), "");
-        static_assert(test<long>(), "");
-        static_assert(test<std::size_t>(), "");
-#if !defined(TEST_HAS_NO_INT128)
-        static_assert(test<__int128_t>(), "");
-#endif // !defined(TEST_HAS_NO_INT128)
-    }
-#endif // TEST_STD_VER >= 11
-
   return 0;
 }

--- a/libcxx/test/libcxx-03/algorithms/robust_against_copying_comparators.pass.cpp
+++ b/libcxx/test/libcxx-03/algorithms/robust_against_copying_comparators.pass.cpp
@@ -82,17 +82,6 @@ struct BinaryTransform {
   TEST_CONSTEXPR T operator()(T, T) const { return 0; }
 };
 
-#if TEST_STD_VER > 17
-template <class T>
-struct ThreeWay {
-  int* copies_;
-  constexpr explicit ThreeWay(int* copies) : copies_(copies) {}
-  constexpr ThreeWay(const ThreeWay& rhs) : copies_(rhs.copies_) { *copies_ += 1; }
-  constexpr ThreeWay& operator=(const ThreeWay&) = default;
-  constexpr std::strong_ordering operator()(T, T) const { return std::strong_ordering::equal; }
-};
-#endif
-
 template <class T>
 TEST_CONSTEXPR_CXX20 bool all_the_algorithms() {
   T a[10]   = {};
@@ -109,28 +98,14 @@ TEST_CONSTEXPR_CXX20 bool all_the_algorithms() {
   int copies = 0;
   (void)std::adjacent_find(first, last, Equal<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER >= 11
-  (void)std::all_of(first, last, UnaryTrue<T>(&copies));
-  assert(copies == 0);
-  (void)std::any_of(first, last, UnaryTrue<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::binary_search(first, last, value, Less<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER > 17
-  (void)std::clamp(value, value, value, Less<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::count_if(first, last, UnaryTrue<T>(&copies));
   assert(copies == 0);
   (void)std::copy_if(first, last, first2, UnaryTrue<T>(&copies));
   assert(copies == 0);
   (void)std::equal(first, last, first2, Equal<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER > 11
-  (void)std::equal(first, last, first2, last2, Equal<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::equal_range(first, last, value, Less<T>(&copies));
   assert(copies == 0);
   (void)std::find_end(first, last, first2, mid2, Equal<T>(&copies));
@@ -144,10 +119,6 @@ TEST_CONSTEXPR_CXX20 bool all_the_algorithms() {
   (void)std::for_each(first, last, UnaryVoid<T>(&copies));
   assert(copies == 1);
   copies = 0;
-#if TEST_STD_VER > 14
-  (void)std::for_each_n(first, count, UnaryVoid<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::generate(first, last, NullaryValue<T>(&copies));
   assert(copies == 0);
   (void)std::generate_n(first, count, NullaryValue<T>(&copies));
@@ -162,10 +133,6 @@ TEST_CONSTEXPR_CXX20 bool all_the_algorithms() {
   assert(copies == 0);
   (void)std::is_permutation(first, last, first2, Equal<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER > 11
-  (void)std::is_permutation(first, last, first2, last2, Equal<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::is_sorted(first, last, Less<T>(&copies));
   assert(copies == 0);
   (void)std::is_sorted_until(first, last, Less<T>(&copies));
@@ -176,52 +143,28 @@ TEST_CONSTEXPR_CXX20 bool all_the_algorithms() {
   }
   (void)std::lexicographical_compare(first, last, first2, last2, Less<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER > 17
-  (void)std::lexicographical_compare_three_way(first, last, first2, last2, ThreeWay<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::lower_bound(first, last, value, Less<T>(&copies));
   assert(copies == 0);
   (void)std::make_heap(first, last, Less<T>(&copies));
   assert(copies == 0);
   (void)std::max(value, value, Less<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER >= 11
-  (void)std::max({value, value}, Less<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::max_element(first, last, Less<T>(&copies));
   assert(copies == 0);
   (void)std::merge(first, mid, mid, last, first2, Less<T>(&copies));
   assert(copies == 0);
   (void)std::min(value, value, Less<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER >= 11
-  (void)std::min({value, value}, Less<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::min_element(first, last, Less<T>(&copies));
   assert(copies == 0);
   (void)std::minmax(value, value, Less<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER >= 11
-  (void)std::minmax({value, value}, Less<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::minmax_element(first, last, Less<T>(&copies));
   assert(copies == 0);
   (void)std::mismatch(first, last, first2, Equal<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER > 11
-  (void)std::mismatch(first, last, first2, last2, Equal<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::next_permutation(first, last, Less<T>(&copies));
   assert(copies == 0);
-#if TEST_STD_VER >= 11
-  (void)std::none_of(first, last, UnaryTrue<T>(&copies));
-  assert(copies == 0);
-#endif
   (void)std::nth_element(first, mid, last, Less<T>(&copies));
   assert(copies == 0);
   (void)std::partial_sort(first, mid, last, Less<T>(&copies));
@@ -299,14 +242,6 @@ bool test_segmented_iterator() {
   assert(copies == 1);
   copies = 0;
 
-#if TEST_STD_VER >= 20
-  std::vector<std::vector<int>> vecs(3, std::vector<int>(10));
-  auto v = std::views::join(vecs);
-  (void)std::for_each(v.begin(), v.end(), UnaryVoid<int>(&copies));
-  assert(copies == 1);
-  copies = 0;
-#endif
-
   return true;
 }
 
@@ -314,10 +249,6 @@ int main(int, char**) {
   all_the_algorithms<void*>();
   all_the_algorithms<int>();
   assert(test_segmented_iterator());
-#if TEST_STD_VER > 17
-  static_assert(all_the_algorithms<void*>());
-  static_assert(all_the_algorithms<int>());
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/algorithms/robust_against_cpp20_hostile_iterators.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/algorithms/robust_against_cpp20_hostile_iterators.compile.pass.cpp
@@ -99,10 +99,6 @@ void test() {
   (void) std::equal_range(it, it, 0, pred);
   (void) std::equal(it, it, it);
   (void) std::equal(it, it, it, pred);
-#if TEST_STD_VER > 11
-  (void) std::equal(it, it, it, it);
-  (void) std::equal(it, it, it, it, pred);
-#endif
   (void) std::fill_n(it, 0, 0);
   (void) std::fill(it, it, 0);
   (void) std::find_end(it, it, it, it);
@@ -112,9 +108,6 @@ void test() {
   (void) std::find_if_not(it, it, pred);
   (void) std::find_if(it, it, pred);
   (void) std::find(it, it, 0);
-#if TEST_STD_VER > 14
-  (void) std::for_each_n(it, 0, pred);
-#endif
   (void) std::for_each(it, it, pred);
   (void) std::generate_n(it, 0, pred);
   (void) std::generate(it, it, pred);
@@ -129,20 +122,12 @@ void test() {
   (void) std::is_partitioned(it, it, pred);
   (void) std::is_permutation(it, it, it);
   (void) std::is_permutation(it, it, it, pred);
-#if TEST_STD_VER > 11
-  (void) std::is_permutation(it, it, it, it);
-  (void) std::is_permutation(it, it, it, it, pred);
-#endif
   (void) std::is_sorted_until(it, it);
   (void) std::is_sorted_until(it, it, pred);
   (void) std::is_sorted(it, it);
   (void) std::is_sorted(it, it, pred);
   (void) std::lexicographical_compare(it, it, it, it);
   (void) std::lexicographical_compare(it, it, it, it, pred);
-#if TEST_STD_VER > 17
-  (void)std::lexicographical_compare_three_way(it, it, it, it);
-  (void)std::lexicographical_compare_three_way(it, it, it, it, std::compare_three_way());
-#endif
   (void) std::lower_bound(it, it, 0);
   (void) std::lower_bound(it, it, 0, pred);
   (void) std::make_heap(it, it);
@@ -189,14 +174,8 @@ void test() {
   (void) std::reverse(it, it);
   (void) std::rotate_copy(it, it, it, it);
   (void) std::rotate(it, it, it);
-#if TEST_STD_VER > 14
-  (void) std::sample(it, it, it, 0, rng);
-#endif
   (void) std::search(it, it, it, it);
   (void) std::search(it, it, it, it, pred);
-#if TEST_STD_VER > 14
-  (void) std::search(it, it, std::default_searcher<Cpp20HostileIterator<int*>>(it, it));
-#endif
   (void) std::set_difference(it, it, it, it, it);
   (void) std::set_difference(it, it, it, it, it, pred);
   (void) std::set_intersection(it, it, it, it, it);
@@ -205,10 +184,6 @@ void test() {
   (void) std::set_symmetric_difference(it, it, it, it, it, pred);
   (void) std::set_union(it, it, it, it, it);
   (void) std::set_union(it, it, it, it, it, pred);
-#if TEST_STD_VER > 17
-  (void) std::shift_left(it, it, 0);
-  (void) std::shift_right(it, it, 0);
-#endif
   (void) std::shuffle(it, it, rng);
   (void) std::sort_heap(it, it);
   (void) std::sort_heap(it, it, pred);

--- a/libcxx/test/libcxx-03/containers/sequences/vector/asan.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/sequences/vector/asan.pass.cpp
@@ -26,29 +26,6 @@ extern "C" void __sanitizer_set_death_callback(void (*callback)(void));
 void do_exit() { exit(0); }
 
 int main(int, char**) {
-#if TEST_STD_VER >= 11
-  {
-    typedef int T;
-    typedef cpp17_input_iterator<T*> MyInputIter;
-    std::vector<T, min_allocator<T>> v;
-    v.reserve(1);
-    int i[] = {42};
-    v.insert(v.begin(), MyInputIter(i), MyInputIter(i + 1));
-    assert(v[0] == 42);
-    assert(is_contiguous_container_asan_correct(v));
-  }
-  {
-    typedef char T;
-    typedef cpp17_input_iterator<T*> MyInputIter;
-    std::vector<T, unaligned_allocator<T>> v;
-    v.reserve(1);
-    char i[] = {'a', 'b'};
-    v.insert(v.begin(), MyInputIter(i), MyInputIter(i + 2));
-    assert(v[0] == 'a');
-    assert(v[1] == 'b');
-    assert(is_contiguous_container_asan_correct(v));
-  }
-#endif // TEST_STD_VER >= 11
   {
     typedef cpp17_input_iterator<int*> MyInputIter;
     // Sould not trigger ASan.

--- a/libcxx/test/libcxx-03/containers/sequences/vector/asan_throw.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/sequences/vector/asan_throw.pass.cpp
@@ -68,23 +68,6 @@ void test_push_back() {
   assert(is_contiguous_container_asan_correct(v));
 }
 
-void test_emplace_back() {
-#if TEST_STD_VER >= 11
-  std::vector<X> v;
-  v.reserve(2);
-  v.push_back(X(2));
-  assert(v.size() == 1);
-  try {
-    v.emplace_back(42);
-    assert(0);
-  } catch (int e) {
-    assert(v.size() == 1);
-  }
-  assert(v.size() == 1);
-  assert(is_contiguous_container_asan_correct(v));
-#endif
-}
-
 void test_insert_range() {
   std::vector<X> v;
   v.reserve(4);
@@ -117,24 +100,6 @@ void test_insert() {
   }
   assert(v.size() == 2);
   assert(is_contiguous_container_asan_correct(v));
-}
-
-void test_emplace() {
-#if TEST_STD_VER >= 11
-  std::vector<X> v;
-  v.reserve(3);
-  v.insert(v.end(), X(1));
-  v.insert(v.begin(), X(2));
-  assert(v.size() == 2);
-  try {
-    v.emplace(v.end(), 42);
-    assert(0);
-  } catch (int e) {
-    assert(v.size() == 2);
-  }
-  assert(v.size() == 2);
-  assert(is_contiguous_container_asan_correct(v));
-#endif
 }
 
 void test_insert_range2() {
@@ -219,10 +184,8 @@ void test_resize_param() {
 
 int main(int, char**) {
   test_push_back();
-  test_emplace_back();
   test_insert_range();
   test_insert();
-  test_emplace();
   test_insert_range2();
   test_insert_n();
   test_insert_n2();

--- a/libcxx/test/libcxx-03/input.output/string.streams/stringbuf/const_sso_buffer.pass.cpp
+++ b/libcxx/test/libcxx-03/input.output/string.streams/stringbuf/const_sso_buffer.pass.cpp
@@ -20,7 +20,6 @@
 #include <cassert>
 
 #include "test_macros.h"
-#include "min_allocator.h"
 
 template <class CharT>
 struct test_buf : public std::basic_stringbuf<CharT> {
@@ -40,29 +39,6 @@ struct test_buf : public std::basic_stringbuf<CharT> {
   explicit test_buf(std::ios_base::openmode which) : std::basic_stringbuf<CharT>(which) {}
 
   explicit test_buf(const std::basic_string<CharT>& s) : std::basic_stringbuf<CharT>(s) {}
-#if TEST_STD_VER >= 20
-  explicit test_buf(const std::allocator<CharT>& a) : std::basic_stringbuf<CharT>(a) {}
-  test_buf(std::ios_base::openmode which, const std::allocator<CharT>& a) : std::basic_stringbuf<CharT>(which, a) {}
-  explicit test_buf(std::basic_string<CharT>&& s)
-      : std::basic_stringbuf<CharT>(std::forward<std::basic_string<CharT>>(s)) {}
-
-  test_buf(const std::basic_string<CharT, std::char_traits<CharT>, min_allocator<CharT>>& s,
-           const std::allocator<CharT>& a)
-      : std::basic_stringbuf<CharT>(s, a) {}
-  test_buf(const std::basic_string<CharT, std::char_traits<CharT>, min_allocator<CharT>>& s,
-           std::ios_base::openmode which,
-           const std::allocator<CharT>& a)
-      : std::basic_stringbuf<CharT>(s, which, a) {}
-  test_buf(const std::basic_string<CharT, std::char_traits<CharT>, min_allocator<CharT>>& s)
-      : std::basic_stringbuf<CharT>(s) {}
-#endif //  TEST_STD_VER >= 20
-
-#if TEST_STD_VER >= 26
-  test_buf(std::basic_string_view<CharT> s) : std::basic_stringbuf<CharT>(s) {}
-  test_buf(std::basic_string_view<CharT> s, const std::allocator<CharT>& a) : std::basic_stringbuf<CharT>(s, a) {}
-  test_buf(std::basic_string_view<CharT> s, std::ios_base::openmode which, const std::allocator<CharT>& a)
-      : std::basic_stringbuf<CharT>(s, which, a) {}
-#endif //  TEST_STD_VER >= 26
 };
 
 template <class CharT>
@@ -88,76 +64,6 @@ static void test() {
     assert(b.pptr() == b.pbase());
     assert(b.epptr() == b.pbase() + size); // copy so uses size
   }
-#if TEST_STD_VER >= 20
-  {
-    test_buf<CharT> b = test_buf<CharT>(std::allocator<CharT>());
-    assert(b.pbase() != nullptr);
-    assert(b.pptr() == b.pbase());
-    assert(b.epptr() == b.pbase() + size);
-  }
-  {
-    test_buf<CharT> b = test_buf<CharT>(std::ios_base::out, std::allocator<CharT>());
-    assert(b.pbase() != nullptr);
-    assert(b.pptr() == b.pbase());
-    assert(b.epptr() == b.pbase() + size);
-  }
-  {
-    std::basic_string<CharT> s;
-    s.reserve(1024);
-    std::size_t capacity = s.capacity();
-    test_buf<CharT> b    = test_buf<CharT>(std::move(s));
-    assert(b.pbase() != nullptr);
-    assert(b.pptr() == b.pbase());
-    assert(b.epptr() >= b.pbase() + capacity); // move so uses s.capacity()
-  }
-  {
-    std::basic_string<CharT, std::char_traits<CharT>, min_allocator<CharT>> s;
-    s.reserve(1024);
-    test_buf<CharT> b = test_buf<CharT>(s, std::allocator<CharT>());
-    assert(b.pbase() != nullptr);
-    assert(b.pptr() == b.pbase());
-    assert(b.epptr() == b.pbase() + size); // copy so uses size
-  }
-  {
-    std::basic_string<CharT, std::char_traits<CharT>, min_allocator<CharT>> s;
-    s.reserve(1024);
-    test_buf<CharT> b = test_buf<CharT>(s, std::ios_base::out, std::allocator<CharT>());
-    assert(b.pbase() != nullptr);
-    assert(b.pptr() == b.pbase());
-    assert(b.epptr() == b.pbase() + size); // copy so uses size
-  }
-  {
-    std::basic_string<CharT, std::char_traits<CharT>, min_allocator<CharT>> s;
-    s.reserve(1024);
-    test_buf<CharT> b = test_buf<CharT>(s);
-    assert(b.pbase() != nullptr);
-    assert(b.pptr() == b.pbase());
-    assert(b.epptr() == b.pbase() + size); // copy so uses size
-  }
-#endif // TEST_STD_VER >= 20
-#if TEST_STD_VER >= 26
-  {
-    std::basic_string_view<CharT> s;
-    test_buf<CharT> b = test_buf<CharT>(s);
-    assert(b.pbase() != nullptr);
-    assert(b.pptr() == b.pbase());
-    assert(b.epptr() == b.pbase() + size);
-  }
-  {
-    std::basic_string_view<CharT> s;
-    test_buf<CharT> b = test_buf<CharT>(s, std::allocator<CharT>());
-    assert(b.pbase() != nullptr);
-    assert(b.pptr() == b.pbase());
-    assert(b.epptr() == b.pbase() + size);
-  }
-  {
-    std::basic_string_view<CharT> s;
-    test_buf<CharT> b = test_buf<CharT>(s, std::ios_base::out, std::allocator<CharT>());
-    assert(b.pbase() != nullptr);
-    assert(b.pptr() == b.pbase());
-    assert(b.epptr() == b.pbase() + size);
-  }
-#endif // TEST_STD_VER >= 26
 }
 
 int main(int, char**) {

--- a/libcxx/test/libcxx-03/iterators/bounded_iter/arithmetic.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/bounded_iter/arithmetic.pass.cpp
@@ -99,14 +99,6 @@ TEST_CONSTEXPR_CXX14 bool tests() {
 
 int main(int, char**) {
   tests<int*>();
-#if TEST_STD_VER > 11
-  static_assert(tests<int*>(), "");
-#endif
-
-#if TEST_STD_VER > 17
-  tests<contiguous_iterator<int*> >();
-  static_assert(tests<contiguous_iterator<int*> >(), "");
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/iterators/bounded_iter/comparison.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/bounded_iter/comparison.pass.cpp
@@ -60,28 +60,11 @@ TEST_CONSTEXPR_CXX14 bool tests() {
     assert(iter1 >= iter1);
   }
 
-#if TEST_STD_VER >= 20
-  // P1614
-  std::same_as<std::strong_ordering> decltype(auto) r1 = iter1 <=> iter2;
-  assert(r1 == std::strong_ordering::less);
-#endif
-
   return true;
 }
 
 int main(int, char**) {
   tests<int*>();
-#if TEST_STD_VER > 11
-  static_assert(tests<int*>(), "");
-#endif
-
-#if TEST_STD_VER > 17
-  tests<contiguous_iterator<int*>>();
-  static_assert(tests<contiguous_iterator<int*>>());
-
-  tests<three_way_contiguous_iterator<int*>>();
-  static_assert(tests<three_way_contiguous_iterator<int*>>());
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/iterators/bounded_iter/pointer_traits.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/bounded_iter/pointer_traits.pass.cpp
@@ -37,10 +37,6 @@ TEST_CONSTEXPR_CXX14 bool tests() {
     std::__bounded_iter<Iter> const iter2 = std::__make_bounded_iter(Iter(e), Iter(b), Iter(e));
     assert(std::__to_address(iter1) == b); // in-bounds iterator
     assert(std::__to_address(iter2) == e); // out-of-bounds iterator
-#if TEST_STD_VER > 17
-    assert(std::to_address(iter1) == b); // in-bounds iterator
-    assert(std::to_address(iter2) == e); // out-of-bounds iterator
-#endif
   }
 
   return true;
@@ -48,14 +44,6 @@ TEST_CONSTEXPR_CXX14 bool tests() {
 
 int main(int, char**) {
   tests<int*>();
-#if TEST_STD_VER > 11
-  static_assert(tests<int*>(), "");
-#endif
-
-#if TEST_STD_VER > 17
-  tests<contiguous_iterator<int*> >();
-  static_assert(tests<contiguous_iterator<int*> >(), "");
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/iterators/bounded_iter/types.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/bounded_iter/types.compile.pass.cpp
@@ -18,32 +18,9 @@
 
 #include "test_macros.h"
 
-#if TEST_STD_VER > 17
-struct Iterator {
-  struct value_type {};
-  using difference_type = int;
-  struct pointer {};
-  using reference = value_type&;
-  struct iterator_category : std::random_access_iterator_tag {};
-  using iterator_concept = std::contiguous_iterator_tag;
-};
-
-using BoundedIter1 = std::__bounded_iter<Iterator>;
-static_assert(std::is_same<BoundedIter1::value_type, Iterator::value_type>::value, "");
-static_assert(std::is_same<BoundedIter1::difference_type, Iterator::difference_type>::value, "");
-static_assert(std::is_same<BoundedIter1::pointer, Iterator::pointer>::value, "");
-static_assert(std::is_same<BoundedIter1::reference, Iterator::reference>::value, "");
-static_assert(std::is_same<BoundedIter1::iterator_category, Iterator::iterator_category>::value, "");
-static_assert(std::is_same<BoundedIter1::iterator_concept, Iterator::iterator_concept>::value, "");
-#endif
-
-
 using BoundedIter2 = std::__bounded_iter<int*>;
 static_assert(std::is_same<BoundedIter2::value_type, int>::value, "");
 static_assert(std::is_same<BoundedIter2::difference_type, std::ptrdiff_t>::value, "");
 static_assert(std::is_same<BoundedIter2::pointer, int*>::value, "");
 static_assert(std::is_same<BoundedIter2::reference, int&>::value, "");
 static_assert(std::is_same<BoundedIter2::iterator_category, std::random_access_iterator_tag>::value, "");
-#if TEST_STD_VER > 17
-static_assert(std::is_same<BoundedIter2::iterator_concept, std::contiguous_iterator_tag>::value, "");
-#endif

--- a/libcxx/test/libcxx-03/iterators/contiguous_iterators.conv.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/contiguous_iterators.conv.compile.pass.cpp
@@ -54,12 +54,3 @@ static_assert(!std::is_constructible<std::vector<Base>::iterator, std::vector<De
 static_assert(!std::is_constructible<std::vector<Base>::const_iterator, std::vector<Derived>::iterator>::value, "");
 static_assert(!std::is_constructible<std::vector<Base>::const_iterator, std::vector<Derived>::const_iterator>::value,
               "");
-
-#if TEST_STD_VER >= 20
-static_assert(!std::is_convertible_v<std::span<Derived>::iterator, std::span<Base>::iterator>);
-static_assert(!std::is_convertible_v<std::span<Derived>::iterator, std::span<const Base>::iterator>);
-static_assert(!std::is_convertible_v<std::span<const Derived>::iterator, std::span<Base>::iterator>);
-static_assert(!std::is_constructible_v<std::span<Base>::iterator, std::span<Derived>::iterator>);
-static_assert(!std::is_constructible_v<std::span<Base>::iterator, std::span<const Derived>::iterator>);
-static_assert(!std::is_constructible_v<std::span<const Base>::iterator, std::span<const Derived>::iterator>);
-#endif

--- a/libcxx/test/libcxx-03/iterators/contiguous_iterators.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/contiguous_iterators.pass.cpp
@@ -27,14 +27,6 @@
 #include "test_macros.h"
 #include "test_iterators.h"
 
-#if TEST_STD_VER >= 17
-#include <string_view>
-#endif
-
-#if TEST_STD_VER >= 20
-#include <span>
-#endif
-
 class T;  // incomplete
 
 class my_input_iterator
@@ -94,58 +86,11 @@ public:
     friend bool operator>=(const Self&, const Self&);
 };
 
-#if TEST_STD_VER >= 20
-class my_contiguous_iterator
-{
-    struct tag : std::contiguous_iterator_tag {};
-    typedef my_contiguous_iterator Self;
-    int *state_;
-public:
-    typedef tag iterator_category;
-    typedef int value_type;
-    typedef int difference_type;
-    typedef int* pointer;
-    typedef int& reference;
-    typedef int element_type;  // enable to_address via pointer_traits
-
-    my_contiguous_iterator();
-    reference operator*() const;
-    pointer operator->() const;
-    reference operator[](difference_type) const;
-
-    Self& operator++();
-    Self operator++(int);
-    Self& operator--();
-    Self operator--(int);
-    friend Self& operator+=(Self&, difference_type);
-    friend Self& operator-=(Self&, difference_type);
-    friend Self operator+(Self, difference_type);
-    friend Self operator+(difference_type, Self);
-    friend Self operator-(Self, difference_type);
-    friend difference_type operator-(Self, Self);
-    friend bool operator==(const Self&, const Self&);
-    friend bool operator!=(const Self&, const Self&);
-    friend bool operator<(const Self&, const Self&);
-    friend bool operator>(const Self&, const Self&);
-    friend bool operator<=(const Self&, const Self&);
-    friend bool operator>=(const Self&, const Self&);
-};
-#endif
-
 struct fake_deque_iterator : std::deque<int>::iterator {
     using element_type = int;
 };
 static_assert(std::__has_random_access_iterator_category<fake_deque_iterator>::value, "");
 static_assert(!std::__libcpp_is_contiguous_iterator<fake_deque_iterator>::value, "");
-
-#if TEST_STD_VER >= 20
-struct fake2_deque_iterator : std::deque<int>::iterator {
-    using iterator_concept = std::contiguous_iterator_tag;
-    using element_type = int;
-};
-static_assert(std::__has_random_access_iterator_category<fake2_deque_iterator>::value, "");
-static_assert(std::__libcpp_is_contiguous_iterator<fake2_deque_iterator>::value, "");
-#endif
 
 int main(int, char**)
 {
@@ -158,9 +103,6 @@ int main(int, char**)
 
     static_assert((!std::__libcpp_is_contiguous_iterator<my_input_iterator>::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<my_random_access_iterator>::value), "");
-#if TEST_STD_VER >= 20
-    static_assert(( std::__libcpp_is_contiguous_iterator<my_contiguous_iterator>::value), "");
-#endif
 
     // move_iterator changes value category, which makes it pretty sketchy to use in optimized codepaths
     static_assert((!std::__libcpp_is_contiguous_iterator<std::move_iterator<char *> >::value), "");
@@ -168,18 +110,12 @@ int main(int, char**)
     static_assert((!std::__libcpp_is_contiguous_iterator<std::move_iterator<int *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<std::move_iterator<T *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<std::move_iterator<my_random_access_iterator> >::value), "");
-#if TEST_STD_VER >= 20
-    static_assert((!std::__libcpp_is_contiguous_iterator<std::move_iterator<my_contiguous_iterator> >::value), "");
-#endif
 
     static_assert((!std::__libcpp_is_contiguous_iterator<std::reverse_iterator<char *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<std::reverse_iterator<const char *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<std::reverse_iterator<int *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<std::reverse_iterator<T *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<std::reverse_iterator<my_random_access_iterator> >::value), "");
-#if TEST_STD_VER >= 20
-    static_assert((!std::__libcpp_is_contiguous_iterator<std::reverse_iterator<my_contiguous_iterator> >::value), "");
-#endif
 
     static_assert(( std::__libcpp_is_contiguous_iterator<std::__wrap_iter<char *> >::value), "");
     static_assert(( std::__libcpp_is_contiguous_iterator<std::__wrap_iter<const char *> >::value), "");
@@ -192,20 +128,12 @@ int main(int, char**)
     static_assert(( std::__libcpp_is_contiguous_iterator<std::__wrap_iter<my_random_access_iterator> >::value), "");
     static_assert(( std::__libcpp_is_contiguous_iterator<std::__wrap_iter<std::__wrap_iter<my_random_access_iterator> > >::value), "");
 
-#if TEST_STD_VER >= 20
-    static_assert(( std::__libcpp_is_contiguous_iterator<std::__wrap_iter<my_contiguous_iterator> >::value), "");
-    static_assert(( std::__libcpp_is_contiguous_iterator<std::__wrap_iter<std::__wrap_iter<my_contiguous_iterator> > >::value), "");
-#endif
-
 //  iterators in the libc++ test suite
     static_assert((!std::__libcpp_is_contiguous_iterator<cpp17_output_iterator <char *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<cpp17_input_iterator  <char *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<forward_iterator      <char *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<bidirectional_iterator<char *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<random_access_iterator<char *> >::value), "");
-#if TEST_STD_VER >= 20
-    static_assert(( std::__libcpp_is_contiguous_iterator<contiguous_iterator   <char *> >::value), "");
-#endif
     static_assert((!std::__libcpp_is_contiguous_iterator<ThrowingIterator      <char *> >::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<NonThrowingIterator   <char *> >::value), "");
 
@@ -243,23 +171,6 @@ int main(int, char**)
     static_assert((!std::__libcpp_is_contiguous_iterator<std::vector<bool>::const_iterator>             ::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<std::vector<bool>::reverse_iterator>           ::value), "");
     static_assert((!std::__libcpp_is_contiguous_iterator<std::vector<bool>::const_reverse_iterator>     ::value), "");
-
-#if TEST_STD_VER >= 11
-    static_assert(( std::__libcpp_is_contiguous_iterator<std::initializer_list<int>::iterator>      ::value), "");
-    static_assert(( std::__libcpp_is_contiguous_iterator<std::initializer_list<int>::const_iterator>::value), "");
-#endif
-
-#if TEST_STD_VER >= 17
-    static_assert(( std::__libcpp_is_contiguous_iterator<std::string_view::iterator>      ::value), "");
-    static_assert(( std::__libcpp_is_contiguous_iterator<std::string_view::const_iterator>::value), "");
-#endif
-
-#if TEST_STD_VER >= 20
-    static_assert(( std::__libcpp_is_contiguous_iterator<std::span<      int>::iterator>        ::value), "");
-    static_assert((!std::__libcpp_is_contiguous_iterator<std::span<      int>::reverse_iterator>::value), "");
-    static_assert(( std::__libcpp_is_contiguous_iterator<std::span<const int>::iterator>        ::value), "");
-    static_assert((!std::__libcpp_is_contiguous_iterator<std::span<const int>::reverse_iterator>::value), "");
-#endif
 
     return 0;
 }

--- a/libcxx/test/libcxx-03/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/get_container.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/predef.iterators/insert.iterators/back.insert.iter.ops/get_container.pass.cpp
@@ -17,7 +17,6 @@
 
 #include "test_macros.h"
 #include "nasty_containers.h"
-#include "test_constexpr_container.h"
 
 template <class C>
 TEST_CONSTEXPR_CXX20 bool test(C c) {
@@ -29,9 +28,6 @@ TEST_CONSTEXPR_CXX20 bool test(C c) {
 int main(int, char**) {
   test(std::vector<int>());
   test(nasty_vector<int>());
-#if TEST_STD_VER >= 20
-  test(ConstexprFixedCapacityDeque<int, 10>());
-  static_assert(test(ConstexprFixedCapacityDeque<int, 10>()));
-#endif
+
   return 0;
 }

--- a/libcxx/test/libcxx-03/iterators/unwrap_iter.pass.cpp
+++ b/libcxx/test/libcxx-03/iterators/unwrap_iter.pass.cpp
@@ -51,9 +51,6 @@ TEST_CONSTEXPR_CXX20 bool test() {
 
 int main(int, char**) {
   test();
-#if TEST_STD_VER > 17
-  static_assert(test());
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/language.support/support.dynamic/libcpp_deallocate.sh.cpp
+++ b/libcxx/test/libcxx-03/language.support/support.dynamic/libcpp_deallocate.sh.cpp
@@ -200,13 +200,6 @@ void test_allocator_and_new_match() {
   stats.reset();
 #elif defined(NO_SIZE)
   stats.reset();
-#  if TEST_STD_VER >= 11
-  {
-    int* x = DoNotOptimize(new int(42));
-    delete x;
-    assert(stats.expect_plain());
-  }
-#  endif
   stats.reset();
   {
     AlignedType* a = DoNotOptimize(new AlignedType());

--- a/libcxx/test/libcxx-03/libcpp_alignof.pass.cpp
+++ b/libcxx/test/libcxx-03/libcpp_alignof.pass.cpp
@@ -19,9 +19,6 @@ template <class T>
 void test() {
   static_assert(_LIBCPP_ALIGNOF(T) == std::alignment_of<T>::value, "");
   static_assert(_LIBCPP_ALIGNOF(T) == TEST_ALIGNOF(T), "");
-#if TEST_STD_VER >= 11
-  static_assert(_LIBCPP_ALIGNOF(T) == alignof(T), "");
-#endif
 #ifdef TEST_COMPILER_CLANG
   static_assert(_LIBCPP_ALIGNOF(T) == _Alignof(T), "");
 #endif

--- a/libcxx/test/libcxx-03/memory/allocation_guard.pass.cpp
+++ b/libcxx/test/libcxx-03/memory/allocation_guard.pass.cpp
@@ -85,11 +85,7 @@ struct AssignableAllocator {
   TEST_CONSTEXPR_CXX20 void construct(pointer p, U&& val) {
     if (stats_ != nullptr)
       ++stats_->construct_count;
-#if TEST_STD_VER > 17
-    std::construct_at(std::to_address(p), std::forward<U>(val));
-#else
     ::new (static_cast<void*>(p)) T(std::forward<U>(val));
-#endif
   }
 
   TEST_CONSTEXPR_CXX14 void destroy(pointer p) {

--- a/libcxx/test/libcxx-03/memory/swap_allocator.pass.cpp
+++ b/libcxx/test/libcxx-03/memory/swap_allocator.pass.cpp
@@ -58,24 +58,5 @@ int main(int, char**) {
     assert(a2.i == 42);
   }
 
-#if TEST_STD_VER >= 11
-  {
-    NoexceptSwapAlloc noexcept_alloc;
-    static_assert(noexcept(std::__swap_allocator(noexcept_alloc, noexcept_alloc)), "");
-  }
-
-#if TEST_STD_VER > 11
-  { // From C++14, `__swap_allocator` is unconditionally noexcept.
-    ThrowingSwapAlloc throwing_alloc;
-    static_assert(noexcept(std::__swap_allocator(throwing_alloc, throwing_alloc)), "");
-  }
-#else
-  { // Until C++14, `__swap_allocator` is only noexcept if the underlying `swap` function is `noexcept`.
-    ThrowingSwapAlloc throwing_alloc;
-    static_assert(!noexcept(std::__swap_allocator(throwing_alloc, throwing_alloc)), "");
-  }
-#endif // TEST_STD_VER > 11
-#endif // TEST_STD_VER >= 11
-
   return 0;
 }

--- a/libcxx/test/libcxx-03/numerics/bit.ops.pass.cpp
+++ b/libcxx/test/libcxx-03/numerics/bit.ops.pass.cpp
@@ -29,9 +29,6 @@ TEST_CONSTEXPR_CXX14 bool test() {
 
 int main(int, char**) {
   test();
-#if TEST_STD_VER > 11
-  static_assert(test(), "");
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/strings/basic.string/string.capacity/max_size.pass.cpp
+++ b/libcxx/test/libcxx-03/strings/basic.string/string.capacity/max_size.pass.cpp
@@ -112,9 +112,6 @@ TEST_CONSTEXPR_CXX20 bool test() {
 
 int main(int, char**) {
   test();
-#if TEST_STD_VER > 17
-  static_assert(test());
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/strings/basic.string/string.cons/copy_shrunk_long.pass.cpp
+++ b/libcxx/test/libcxx-03/strings/basic.string/string.cons/copy_shrunk_long.pass.cpp
@@ -15,7 +15,6 @@
 
 #include "test_macros.h"
 #include "test_allocator.h"
-#include "min_allocator.h"
 
 template <class S>
 TEST_CONSTEXPR_CXX20 bool test() {
@@ -33,13 +32,6 @@ TEST_CONSTEXPR_CXX20 bool test() {
 
 int main(int, char**) {
   test<std::basic_string<char, std::char_traits<char>, test_allocator<char> > >();
-#if TEST_STD_VER >= 11
-  test<std::basic_string<char, std::char_traits<char>, min_allocator<char>>>();
-#endif
-#if TEST_STD_VER > 17
-  static_assert(test<std::basic_string<char, std::char_traits<char>, test_allocator<char>>>());
-  static_assert(test<std::basic_string<char, std::char_traits<char>, min_allocator<char>>>());
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/strings/c.strings/constexpr_memmove.pass.cpp
+++ b/libcxx/test/libcxx-03/strings/c.strings/constexpr_memmove.pass.cpp
@@ -148,8 +148,6 @@ TEST_CONSTEXPR_CXX14 bool test() {
 
 int main(int, char**) {
   test();
-#if TEST_STD_VER >= 14
-  static_assert(test(), "");
-#endif
+
   return 0;
 }

--- a/libcxx/test/libcxx-03/type_traits/is_trivially_relocatable.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/type_traits/is_trivially_relocatable.compile.pass.cpp
@@ -128,30 +128,10 @@ static_assert(!std::__libcpp_is_trivially_relocatable<std::deque<int, test_alloc
 static_assert(std::__libcpp_is_trivially_relocatable<std::exception_ptr>::value, "");
 #endif
 
-// expected
-#if TEST_STD_VER >= 23
-static_assert(std::__libcpp_is_trivially_relocatable<std::expected<int, int> >::value);
-static_assert(std::__libcpp_is_trivially_relocatable<std::expected<std::unique_ptr<int>, int>>::value);
-static_assert(std::__libcpp_is_trivially_relocatable<std::expected<int, std::unique_ptr<int>>>::value);
-static_assert(std::__libcpp_is_trivially_relocatable<std::expected<std::unique_ptr<int>, std::unique_ptr<int>>>::value);
-
-static_assert(!std::__libcpp_is_trivially_relocatable<std::expected<int, NotTriviallyCopyable>>::value);
-static_assert(!std::__libcpp_is_trivially_relocatable<std::expected<NotTriviallyCopyable, int>>::value);
-static_assert(
-    !std::__libcpp_is_trivially_relocatable<std::expected<NotTriviallyCopyable, NotTriviallyCopyable>>::value);
-#endif
-
 // locale
 #ifndef TEST_HAS_NO_LOCALIZATION
 static_assert(std::__libcpp_is_trivially_relocatable<std::locale>::value, "");
 #endif
-
-// optional
-#if TEST_STD_VER >= 17
-static_assert(std::__libcpp_is_trivially_relocatable<std::optional<int>>::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::optional<NotTriviallyCopyable>>::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::optional<std::unique_ptr<int>>>::value, "");
-#endif // TEST_STD_VER >= 17
 
 // pair
 static_assert(std::__libcpp_is_trivially_relocatable<std::pair<int, int> >::value, "");
@@ -164,23 +144,6 @@ static_assert(std::__libcpp_is_trivially_relocatable<std::pair<std::unique_ptr<i
 
 // shared_ptr
 static_assert(std::__libcpp_is_trivially_relocatable<std::shared_ptr<NotTriviallyCopyable> >::value, "");
-
-// tuple
-#if TEST_STD_VER >= 11
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<> >::value, "");
-
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::tuple<NotTriviallyCopyable> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<std::unique_ptr<int> > >::value, "");
-
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<int, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::tuple<NotTriviallyCopyable, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::tuple<int, NotTriviallyCopyable> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::tuple<NotTriviallyCopyable, NotTriviallyCopyable> >::value,
-              "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::tuple<std::unique_ptr<int>, std::unique_ptr<int> > >::value,
-              "");
-#endif // TEST_STD_VER >= 11
 
 // unique_ptr
 struct NotTriviallyRelocatableDeleter {
@@ -214,21 +177,6 @@ static_assert(!std::__libcpp_is_trivially_relocatable<std::unique_ptr<int, NotTr
               "");
 static_assert(!std::__libcpp_is_trivially_relocatable<std::unique_ptr<int[], NotTriviallyRelocatablePointer> >::value,
               "");
-
-// variant
-#if TEST_STD_VER >= 17
-static_assert(std::__libcpp_is_trivially_relocatable<std::variant<int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::variant<NotTriviallyCopyable> >::value, "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::variant<std::unique_ptr<int> > >::value, "");
-
-static_assert(std::__libcpp_is_trivially_relocatable<std::variant<int, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::variant<NotTriviallyCopyable, int> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::variant<int, NotTriviallyCopyable> >::value, "");
-static_assert(!std::__libcpp_is_trivially_relocatable<std::variant<NotTriviallyCopyable, NotTriviallyCopyable> >::value,
-              "");
-static_assert(std::__libcpp_is_trivially_relocatable<std::variant<std::unique_ptr<int>, std::unique_ptr<int> > >::value,
-              "");
-#endif // TEST_STD_VER >= 17
 
 // vector
 static_assert(std::__libcpp_is_trivially_relocatable<std::vector<int> >::value, "");

--- a/libcxx/test/libcxx-03/utilities/function.objects/func.require/bullet_4_5_6.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/function.objects/func.require/bullet_4_5_6.pass.cpp
@@ -85,10 +85,6 @@ private:
             runTestDispatch<E>(M, dref2, &dref2.object.object);
             runTestPropCVDispatch<E>(M, obj_ptr, &obj_ptr->object);
             runTestPropCVDispatch<E>(M, der_ptr, &der_ptr->object);
-#if TEST_STD_VER >= 11
-            runTestPropCVDispatch<E>(M, rref, &(rref.get().object));
-            runTestPropCVDispatch<E>(M, drref, &(drref.get().object));
-#endif
             runTestNoPropDispatch<E>(M, dref, &dref.object.object);
         }
         {
@@ -100,10 +96,6 @@ private:
             runTestDispatch<E>(M, dref2, &dref2.object.object);
             runTestPropCVDispatch<E>(M, obj_ptr, &obj_ptr->object);
             runTestPropCVDispatch<E>(M, der_ptr, &der_ptr->object);
-#if TEST_STD_VER >= 11
-            runTestPropCVDispatch<E>(M, rref, &(rref.get().object));
-            runTestPropCVDispatch<E>(M, drref, &(drref.get().object));
-#endif
             runTestNoPropDispatch<E>(M, dref,    &dref.object.object);
         }
         {
@@ -115,10 +107,6 @@ private:
             runTestDispatch<E>(M, dref2, &dref2.object.object);
             runTestPropCVDispatch<E>(M, obj_ptr, &obj_ptr->object);
             runTestPropCVDispatch<E>(M, der_ptr, &der_ptr->object);
-#if TEST_STD_VER >= 11
-            runTestPropCVDispatch<E>(M, rref, &(rref.get().object));
-            runTestPropCVDispatch<E>(M, drref, &(drref.get().object));
-#endif
             runTestNoPropDispatch<E>(M, dref,    &dref.object.object);
         }
         {
@@ -130,10 +118,6 @@ private:
             runTestDispatch<E>(M, dref2, &dref2.object.object);
             runTestPropCVDispatch<E>(M, obj_ptr, &obj_ptr->object);
             runTestPropCVDispatch<E>(M, der_ptr, &der_ptr->object);
-#if TEST_STD_VER >= 11
-            runTestPropCVDispatch<E>(M, rref, &(rref.get().object));
-            runTestPropCVDispatch<E>(M, drref, &(drref.get().object));
-#endif
             runTestNoPropDispatch<E>(M, dref,    &dref.object.object);
         }
     }
@@ -144,12 +128,6 @@ private:
         runTest<Expect const&>         (M, C_<T const&>(obj),          expect);
         runTest<Expect volatile&>      (M, C_<T volatile&>(obj),       expect);
         runTest<Expect const volatile&>(M, C_<T const volatile&>(obj), expect);
-#if TEST_STD_VER >= 11
-        runTest<Expect&&>               (M, C_<T&&>(obj),                expect);
-        runTest<Expect const&&>         (M, C_<T const&&>(obj),          expect);
-        runTest<Expect volatile&&>      (M, C_<T volatile&&>(obj),       expect);
-        runTest<Expect const volatile&&>(M, C_<T const volatile&&>(obj), expect);
-#endif
     }
 
     template <class Expect, class Fn, class T>
@@ -166,12 +144,6 @@ private:
         runTest<Expect&>(M, C_<T const&>(obj),          expect);
         runTest<Expect&>(M, C_<T volatile&>(obj),       expect);
         runTest<Expect&>(M, C_<T const volatile&>(obj), expect);
-#if TEST_STD_VER >= 11
-        runTest<Expect&>(M, C_<T&&>(obj),                expect);
-        runTest<Expect&>(M, C_<T const&&>(obj),          expect);
-        runTest<Expect&>(M, C_<T volatile&&>(obj),       expect);
-        runTest<Expect&>(M, C_<T const volatile&&>(obj), expect);
-#endif
     }
 
     template <class Expect, class Fn, class T>
@@ -184,11 +156,7 @@ private:
     }
 
     template <class Expect, class Fn, class T>
-#if TEST_STD_VER >= 11
-    void runTest(Fn M, T&& obj, ObjectType* expect) {
-#else
     void runTest(Fn M, T& obj, ObjectType* expect ) {
-#endif
         {
             static_assert((std::is_same<
                 decltype(std::__invoke(M, std::forward<T>(obj))), Expect

--- a/libcxx/test/libcxx-03/utilities/function.objects/func.require/bullet_7.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/function.objects/func.require/bullet_7.pass.cpp
@@ -115,49 +115,6 @@ private:
 };
 
 
-#if TEST_STD_VER >= 11
-
-//==============================================================================
-// freeFunction11 - A C++11 free function.
-template <class ...Args>
-void*& freeFunction11(Args&&...) {
-    return FunctionPtrID<void*&(Args&&...), freeFunction11>::setUncheckedCall();
-}
-
-template <class ...Args>
-void*& freeFunction11(Args&&...,...) {
-    return FunctionPtrID<void*&(Args&&...,...), freeFunction11>::setUncheckedCall();
-}
-
-//==============================================================================
-// Functor11 - C++11 reference qualified test member functions.
-struct Functor11 {
-    typedef void*& R;
-    typedef Functor11 C;
-
-#define F(CV) \
-    template <class ...Args> \
-    R operator()(Args&&...) CV { return MethodID<R(C::*)(Args&&...) CV>::setUncheckedCall(); }
-#
-    F(&)
-    F(const &)
-    F(volatile &)
-    F(const volatile &)
-    F(&&)
-    F(const &&)
-    F(volatile &&)
-    F(const volatile &&)
-#undef F
-public:
-    Functor11() {}
-private:
-    Functor11(Functor11 const&);
-    Functor11& operator=(Functor11 const&);
-};
-
-#endif // TEST_STD_VER >= 11
-
-
 //==============================================================================
 // TestCaseFunctorImp - A test case for an operator() class method.
 //   ClassType - The type of the call object.
@@ -207,19 +164,9 @@ public:
 //==============================================================================
 //                          runTest Helpers
 //==============================================================================
-#if TEST_STD_VER >= 11
-template <class Sig, int Arity, class ArgCaster>
-void runFunctionTestCase11() {
-    TestCaseFreeFunction<Sig, freeFunction11, Arity, ArgCaster>();
-}
-#endif
-
 template <class Sig, int Arity, class ArgCaster>
 void runFunctionTestCase() {
     TestCaseFreeFunction<Sig, freeFunction03, Arity, ArgCaster>();
-#if TEST_STD_VER >= 11
-    runFunctionTestCase11<Sig, Arity, ArgCaster>();
-#endif
 }
 
 template <class Sig, int Arity, class ObjCaster, class ArgCaster>
@@ -231,14 +178,6 @@ template <class Sig, int Arity, class ObjCaster>
 void runFunctorTestCase() {
     TestCaseFunctorImp<Functor03, Sig, Arity, ObjCaster>::run();
 }
-
-#if TEST_STD_VER >= 11
-// runTestCase - Run a test case for C++11 class functor types
-template <class Sig, int Arity, class ObjCaster, class ArgCaster = LValueCaster>
-void runFunctorTestCase11() {
-    TestCaseFunctorImp<Functor11, Sig, Arity, ObjCaster, ArgCaster>::run();
-}
-#endif
 
 // runTestCase - Run a test case for both function and functor types.
 template <class Sig, int Arity, class ArgCaster>
@@ -264,11 +203,6 @@ int main(int, char**) {
     runFunctionTestCase<R(A&, ...),                     1, LValueCaster      >();
     runFunctionTestCase<R(A&, A&, ...),                 2, LValueCaster      >();
     runFunctionTestCase<R(A&, A&, A&, ...),             3, LValueCaster      >();
-
-#if TEST_STD_VER >= 11
-    runFunctionTestCase11<R(A&&),                       1, MoveCaster        >();
-    runFunctionTestCase11<R(A&&, ...),                  1, MoveCaster        >();
-#endif
 
     runFunctorTestCase<R(),                             0, LValueCaster      >();
     runFunctorTestCase<R() const,                       0, ConstCaster       >();
@@ -301,28 +235,6 @@ int main(int, char**) {
     runFunctorTestCase<R(CA&, CA&, CA&) volatile,       3, VolatileCaster, CC>();
     runFunctorTestCase<R(CA&, CA&, CA&) const volatile, 3, CVCaster,       CC>();
     }
-
-#if TEST_STD_VER >= 11
-    runFunctorTestCase11<R() &,                    0, LValueCaster          >();
-    runFunctorTestCase11<R() const &,              0, ConstCaster           >();
-    runFunctorTestCase11<R() volatile &,           0, VolatileCaster        >();
-    runFunctorTestCase11<R() const volatile &,     0, CVCaster              >();
-    runFunctorTestCase11<R() &&,                   0, MoveCaster            >();
-    runFunctorTestCase11<R() const &&,             0, MoveConstCaster       >();
-    runFunctorTestCase11<R() volatile &&,          0, MoveVolatileCaster    >();
-    runFunctorTestCase11<R() const volatile &&,    0, MoveCVCaster          >();
-    {
-    typedef MoveCaster MC;
-    runFunctorTestCase11<R(A&&) &,                 1, LValueCaster,       MC>();
-    runFunctorTestCase11<R(A&&) const &,           1, ConstCaster,        MC>();
-    runFunctorTestCase11<R(A&&) volatile &,        1, VolatileCaster,     MC>();
-    runFunctorTestCase11<R(A&&) const volatile &,  1, CVCaster,           MC>();
-    runFunctorTestCase11<R(A&&) &&,                1, MoveCaster,         MC>();
-    runFunctorTestCase11<R(A&&) const &&,          1, MoveConstCaster,    MC>();
-    runFunctorTestCase11<R(A&&) volatile &&,       1, MoveVolatileCaster, MC>();
-    runFunctorTestCase11<R(A&&) const volatile &&, 1, MoveCVCaster,       MC>();
-    }
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/utilities/function.objects/func.require/invoke.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/function.objects/func.require/invoke.pass.cpp
@@ -23,24 +23,12 @@ struct Type
 {
     Array<char, 1>::type& f1();
     Array<char, 2>::type& f2() const;
-#if TEST_STD_VER >= 11
-    Array<char, 1>::type& g1()        &;
-    Array<char, 2>::type& g2() const  &;
-    Array<char, 3>::type& g3()       &&;
-    Array<char, 4>::type& g4() const &&;
-#endif
 };
 
 int main(int, char**)
 {
     static_assert(sizeof(std::__invoke(&Type::f1, std::declval<Type        >())) == 1, "");
     static_assert(sizeof(std::__invoke(&Type::f2, std::declval<Type const  >())) == 2, "");
-#if TEST_STD_VER >= 11
-    static_assert(sizeof(std::__invoke(&Type::g1, std::declval<Type       &>())) == 1, "");
-    static_assert(sizeof(std::__invoke(&Type::g2, std::declval<Type const &>())) == 2, "");
-    static_assert(sizeof(std::__invoke(&Type::g3, std::declval<Type      &&>())) == 3, "");
-    static_assert(sizeof(std::__invoke(&Type::g4, std::declval<Type const&&>())) == 4, "");
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/utilities/function.objects/func.require/invoke_helpers.h
+++ b/libcxx/test/libcxx-03/utilities/function.objects/func.require/invoke_helpers.h
@@ -52,13 +52,7 @@ struct Caster {
     struct apply {
         typedef typename std::remove_reference<T>::type RawType;
         typedef typename QualTag::template apply<RawType>::type CVType;
-#if TEST_STD_VER >= 11
-        typedef typename std::conditional<RValue,
-            CVType&&, CVType&
-        >::type type;
-#else
         typedef CVType& type;
-#endif
     };
 
     template <class T>
@@ -165,21 +159,10 @@ struct DerefPropType {
     template <class Up>
     explicit DerefPropType(Up const& val) : object(val) {}
 
-#if TEST_STD_VER < 11
     To& operator*() { return object; }
     To const& operator*() const { return object; }
     To volatile& operator*() volatile  { return object; }
     To const volatile& operator*() const volatile { return object; }
-#else
-    To& operator*() & { return object; }
-    To const& operator*() const & { return object; }
-    To volatile& operator*() volatile  & { return object; }
-    To const volatile& operator*() const volatile & { return object; }
-    To&& operator*() && { return static_cast<To &&>(object); }
-    To const&& operator*() const && { return static_cast<To const&&>(object); }
-    To volatile&& operator*() volatile  && { return static_cast<To volatile&&>(object); }
-    To const volatile&& operator*() const volatile && { return static_cast<To const volatile&&>(object); }
-#endif
 };
 
 //==============================================================================

--- a/libcxx/test/libcxx-03/utilities/is_pointer_in_range.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/is_pointer_in_range.pass.cpp
@@ -18,20 +18,6 @@ TEST_CONSTEXPR_CXX14 void test_cv_quals() {
   assert(!std::__is_pointer_in_range(&i, &i, &i));
   assert(std::__is_pointer_in_range(&i, &i + 1, &i));
   assert(!std::__is_pointer_in_range(&i, &i + 1, &j));
-
-#if TEST_STD_VER >= 20
-  {
-    T* arr1 = new int[4]{1, 2, 3, 4};
-    U* arr2 = new int[4]{5, 6, 7, 8};
-
-    assert(!std::__is_pointer_in_range(arr1, arr1 + 4, arr2));
-    assert(std::__is_pointer_in_range(arr1, arr1 + 4, arr1 + 3));
-    assert(!std::__is_pointer_in_range(arr1, arr1, arr1 + 3));
-
-    delete[] arr1;
-    delete[] arr2;
-  }
-#endif
 }
 
 TEST_CONSTEXPR_CXX14 bool test() {
@@ -48,9 +34,6 @@ TEST_CONSTEXPR_CXX14 bool test() {
 
 int main(int, char**) {
   test();
-#if TEST_STD_VER >= 14
-  static_assert(test(), "");
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/utilities/is_valid_range.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/is_valid_range.pass.cpp
@@ -39,14 +39,6 @@ TEST_CONSTEXPR_CXX14 void check_type() {
     assert(!std::__is_valid_range(static_cast<TQualified*>(&arr[1]), static_cast<TQualified*>(&arr[0])));
     assert(!std::__is_valid_range(static_cast<TQualified*>(&arr[2]), static_cast<TQualified*>(&arr[0])));
   }
-
-#if TEST_STD_VER >= 20
-  {
-    T* arr = new int[4]{1, 2, 3, 4};
-    assert(std::__is_valid_range(static_cast<TQualified*>(arr), static_cast<TQualified*>(arr + 4)));
-    delete[] arr;
-  }
-#endif
 }
 
 TEST_CONSTEXPR_CXX14 bool test() {
@@ -60,9 +52,6 @@ TEST_CONSTEXPR_CXX14 bool test() {
 
 int main(int, char**) {
   test();
-#if TEST_STD_VER >= 14
-  static_assert(test(), "");
-#endif
 
   return 0;
 }

--- a/libcxx/test/libcxx-03/utilities/memory/pointer.conversion/to_address.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/memory/pointer.conversion/to_address.pass.cpp
@@ -152,8 +152,6 @@ TEST_CONSTEXPR_CXX14 bool test() {
 
 int main(int, char**) {
     test();
-#if TEST_STD_VER >= 14
-    static_assert(test(), "");
-#endif
+
     return 0;
 }

--- a/libcxx/test/libcxx-03/utilities/memory/pointer.conversion/to_address_std_iterators.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/memory/pointer.conversion/to_address_std_iterators.pass.cpp
@@ -44,12 +44,6 @@ int main(int, char**) {
     test_container_iterators(std::array<int, 3>());
     test_container_iterators(std::vector<int>(3));
     test_container_iterators(std::string("abc"));
-#if TEST_STD_VER >= 17
-    test_container_iterators(std::string_view("abc"));
-#endif
-#if TEST_STD_VER >= 20
-    test_container_iterators(std::span<const char>("abc"));
-#endif
     test_valarray_iterators();
 
     return 0;

--- a/libcxx/test/libcxx-03/utilities/meta/is_referenceable.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/meta/is_referenceable.compile.pass.cpp
@@ -33,10 +33,6 @@ static_assert((std::__libcpp_is_referenceable<Foo>::value), "");
 static_assert((std::__libcpp_is_referenceable<const Foo>::value), "");
 static_assert((std::__libcpp_is_referenceable<Foo&>::value), "");
 static_assert((std::__libcpp_is_referenceable<const Foo&>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((std::__libcpp_is_referenceable<Foo&&>::value), "");
-static_assert((std::__libcpp_is_referenceable<const Foo&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<int __attribute__((__vector_size__(8)))>::value), "");
 static_assert((std::__libcpp_is_referenceable<const int __attribute__((__vector_size__(8)))>::value), "");
@@ -45,146 +41,42 @@ static_assert((std::__libcpp_is_referenceable<const float __attribute__((__vecto
 
 // Functions without cv-qualifiers are referenceable
 static_assert((std::__libcpp_is_referenceable<void()>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((!std::__libcpp_is_referenceable<void() const>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void() &>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void() const&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void() &&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void() const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void(int)>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((!std::__libcpp_is_referenceable<void(int) const>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int) &>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int) const&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int) &&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void(int, float)>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((!std::__libcpp_is_referenceable<void(int, float) const>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float) &>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float) const&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float) &&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void(int, float, Foo&)>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&) const>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&) &>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&) const&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&) &&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void(...)>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((!std::__libcpp_is_referenceable<void(...) const>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(...) &>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(...) const&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(...) &&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(...) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void(int, ...)>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((!std::__libcpp_is_referenceable<void(int, ...) const>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, ...) &>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, ...) const&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, ...) &&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, ...) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void(int, float, ...)>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((!std::__libcpp_is_referenceable<void(int, float, ...) const>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, ...) &>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, ...) const&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, ...) &&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, ...) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void(int, float, Foo&, ...)>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&, ...) const>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&, ...) &>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&, ...) const&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&, ...) &&>::value), "");
-static_assert((!std::__libcpp_is_referenceable<void(int, float, Foo&, ...) const&&>::value), "");
-#endif
 
 // member functions with or without cv-qualifiers are referenceable
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)()>::value), "");
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)() const>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)() &>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)() const&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)() &&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)() const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int)>::value), "");
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int) const>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int) &>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int) const&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int) &&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float)>::value), "");
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float) const>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float) &>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float) const&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float) &&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&)>::value), "");
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&) const>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&) &>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&) const&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&) &&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(...)>::value), "");
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(...) const>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(...) &>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(...) const&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(...) &&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(...) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, ...)>::value), "");
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, ...) const>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, ...) &>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, ...) const&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, ...) &&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, ...) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, ...)>::value), "");
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, ...) const>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, ...) &>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, ...) const&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, ...) &&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, ...) const&&>::value), "");
-#endif
 
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&, ...)>::value), "");
 static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&, ...) const>::value), "");
-#if TEST_STD_VER >= 11
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&, ...) &>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&, ...) const&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&, ...) &&>::value), "");
-static_assert((std::__libcpp_is_referenceable<void (Foo::*)(int, float, Foo&, ...) const&&>::value), "");
-#endif

--- a/libcxx/test/libcxx-03/utilities/no_destroy.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/no_destroy.pass.cpp
@@ -11,11 +11,6 @@
 
 #include "test_macros.h"
 
-#if TEST_STD_VER > 17
-// Test constexpr-constructibility.
-constinit std::__no_destroy<int> nd_int_const(std::__uninitialized_tag{});
-#endif
-
 struct DestroyLast {
   ~DestroyLast() { assert(*ptr == 5); }
 

--- a/libcxx/test/libcxx-03/utilities/utility/pairs/pairs.pair/abi.non_trivial_copy_move.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/utility/pairs/pairs.pair/abi.non_trivial_copy_move.pass.cpp
@@ -31,48 +31,7 @@ template <class T>
 struct HasNonTrivialABI : std::integral_constant<bool,
     !std::is_trivially_destructible<T>::value
     || (std::is_copy_constructible<T>::value && !std::is_trivially_copy_constructible<T>::value)
-#if TEST_STD_VER >= 11
-   || (std::is_move_constructible<T>::value && !std::is_trivially_move_constructible<T>::value)
-#endif
 > {};
-
-#if TEST_STD_VER >= 11
-struct NonTrivialDtor {
-    NonTrivialDtor(NonTrivialDtor const&) = default;
-    ~NonTrivialDtor();
-};
-NonTrivialDtor::~NonTrivialDtor() {}
-static_assert(HasNonTrivialABI<NonTrivialDtor>::value, "");
-
-struct NonTrivialCopy {
-    NonTrivialCopy(NonTrivialCopy const&);
-};
-NonTrivialCopy::NonTrivialCopy(NonTrivialCopy const&) {}
-static_assert(HasNonTrivialABI<NonTrivialCopy>::value, "");
-
-struct NonTrivialMove {
-    NonTrivialMove(NonTrivialMove const&) = default;
-    NonTrivialMove(NonTrivialMove&&);
-};
-NonTrivialMove::NonTrivialMove(NonTrivialMove&&) {}
-static_assert(HasNonTrivialABI<NonTrivialMove>::value, "");
-
-struct DeletedCopy {
-    DeletedCopy(DeletedCopy const&) = delete;
-    DeletedCopy(DeletedCopy&&) = default;
-};
-static_assert(!HasNonTrivialABI<DeletedCopy>::value, "");
-
-struct TrivialMove {
-  TrivialMove(TrivialMove &&) = default;
-};
-static_assert(!HasNonTrivialABI<TrivialMove>::value, "");
-
-struct Trivial {
-    Trivial(Trivial const&) = default;
-};
-static_assert(!HasNonTrivialABI<Trivial>::value, "");
-#endif
 
 
 void test_trivial()
@@ -82,62 +41,6 @@ void test_trivial()
         static_assert(std::is_copy_constructible<P>::value, "");
         static_assert(HasNonTrivialABI<P>::value, "");
     }
-#if TEST_STD_VER >= 11
-    {
-        typedef std::pair<int, short> P;
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(HasNonTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<NonTrivialDtor, int>;
-        static_assert(!std::is_trivially_destructible<P>::value, "");
-        static_assert(std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-        static_assert(HasNonTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<NonTrivialCopy, int>;
-        static_assert(std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-        static_assert(HasNonTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<NonTrivialMove, int>;
-        static_assert(std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-        static_assert(HasNonTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<DeletedCopy, int>;
-        static_assert(!std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-        static_assert(HasNonTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<Trivial, int>;
-        static_assert(std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-        static_assert(HasNonTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<TrivialMove, int>;
-        static_assert(!std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-        static_assert(HasNonTrivialABI<P>::value, "");
-    }
-#endif
 }
 
 void test_layout() {

--- a/libcxx/test/libcxx-03/utilities/utility/pairs/pairs.pair/abi.trivial_copy_move.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/utility/pairs/pairs.pair/abi.trivial_copy_move.pass.cpp
@@ -28,48 +28,7 @@ template <class T>
 struct HasTrivialABI : std::integral_constant<bool,
     std::is_trivially_destructible<T>::value
     && (!std::is_copy_constructible<T>::value || std::is_trivially_copy_constructible<T>::value)
-#if TEST_STD_VER >= 11
-   && (!std::is_move_constructible<T>::value || std::is_trivially_move_constructible<T>::value)
-#endif
 > {};
-
-#if TEST_STD_VER >= 11
-struct NonTrivialDtor {
-    NonTrivialDtor(NonTrivialDtor const&) = default;
-    ~NonTrivialDtor();
-};
-NonTrivialDtor::~NonTrivialDtor() {}
-static_assert(!HasTrivialABI<NonTrivialDtor>::value, "");
-
-struct NonTrivialCopy {
-    NonTrivialCopy(NonTrivialCopy const&);
-};
-NonTrivialCopy::NonTrivialCopy(NonTrivialCopy const&) {}
-static_assert(!HasTrivialABI<NonTrivialCopy>::value, "");
-
-struct NonTrivialMove {
-    NonTrivialMove(NonTrivialMove const&) = default;
-    NonTrivialMove(NonTrivialMove&&);
-};
-NonTrivialMove::NonTrivialMove(NonTrivialMove&&) {}
-static_assert(!HasTrivialABI<NonTrivialMove>::value, "");
-
-struct DeletedCopy {
-    DeletedCopy(DeletedCopy const&) = delete;
-    DeletedCopy(DeletedCopy&&) = default;
-};
-static_assert(HasTrivialABI<DeletedCopy>::value, "");
-
-struct TrivialMove {
-  TrivialMove(TrivialMove &&) = default;
-};
-static_assert(HasTrivialABI<TrivialMove>::value, "");
-
-struct Trivial {
-    Trivial(Trivial const&) = default;
-};
-static_assert(HasTrivialABI<Trivial>::value, "");
-#endif
 
 struct TrivialNoAssignment {
   int arr[4];
@@ -90,78 +49,14 @@ void test_trivial()
         static_assert(std::is_copy_constructible<P>::value, "");
         static_assert(HasTrivialABI<P>::value, "");
     }
-#if TEST_STD_VER >= 11
-    {
-        typedef std::pair<int, short> P;
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(HasTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<NonTrivialDtor, int>;
-        static_assert(!std::is_trivially_destructible<P>::value, "");
-        static_assert(std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-        static_assert(!HasTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<NonTrivialCopy, int>;
-        static_assert(std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-        static_assert(!HasTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<NonTrivialMove, int>;
-        static_assert(std::is_copy_constructible<P>::value, "");
-        static_assert(std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-        static_assert(!HasTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<DeletedCopy, int>;
-        static_assert(!std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(std::is_trivially_move_constructible<P>::value, "");
-        static_assert(HasTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<Trivial, int>;
-        static_assert(std::is_copy_constructible<P>::value, "");
-        static_assert(std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(std::is_trivially_move_constructible<P>::value, "");
-        static_assert(HasTrivialABI<P>::value, "");
-    }
-    {
-        using P = std::pair<TrivialMove, int>;
-        static_assert(!std::is_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(std::is_move_constructible<P>::value, "");
-        static_assert(std::is_trivially_move_constructible<P>::value, "");
-        static_assert(HasTrivialABI<P>::value, "");
-    }
-#endif
     {
         using P = std::pair<TrivialNoAssignment, int>;
         static_assert(std::is_trivially_copy_constructible<P>::value, "");
         static_assert(std::is_trivially_move_constructible<P>::value, "");
-#if TEST_STD_VER >= 11 // This is https://llvm.org/PR90605
-        static_assert(!std::is_trivially_copy_assignable<P>::value, "");
-        static_assert(!std::is_trivially_move_assignable<P>::value, "");
-#endif // TEST_STD_VER >= 11
         static_assert(std::is_trivially_destructible<P>::value, "");
     }
     {
         using P = std::pair<TrivialNoConstruction, int>;
-#if TEST_STD_VER >= 11
-        static_assert(!std::is_trivially_copy_constructible<P>::value, "");
-        static_assert(!std::is_trivially_move_constructible<P>::value, "");
-#endif // TEST_STD_VER >= 11
         static_assert(!std::is_trivially_copy_assignable<P>::value, "");
         static_assert(!std::is_trivially_move_assignable<P>::value, "");
         static_assert(std::is_trivially_destructible<P>::value, "");

--- a/libcxx/test/libcxx-03/utilities/utility/pairs/pairs.pair/abi.trivially_copyable.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/utilities/utility/pairs/pairs.pair/abi.trivially_copyable.compile.pass.cpp
@@ -52,13 +52,8 @@ static_assert(!std::is_trivially_copyable<std::pair<int, char> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<char, int> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<std::pair<char, char>, int> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<trivially_copyable, int> >::value, "");
-#if TEST_STD_VER == 03 // Known ABI difference
 static_assert(!std::is_trivially_copyable<std::pair<trivially_copyable_no_copy_assignment, int> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<trivially_copyable_no_move_assignment, int> >::value, "");
-#else
-static_assert(std::is_trivially_copyable<std::pair<trivially_copyable_no_copy_assignment, int> >::value, "");
-static_assert(std::is_trivially_copyable<std::pair<trivially_copyable_no_move_assignment, int> >::value, "");
-#endif
 static_assert(!std::is_trivially_copyable<std::pair<trivially_copyable_no_construction, int> >::value, "");
 
 static_assert(std::is_trivially_copy_constructible<std::pair<int, int> >::value, "");


### PR DESCRIPTION
This is dead code, since `test/libcxx-03` is only ever executed with `-std=c++03`.
