### PR TITLE
[GOFF] Implement lowerConstant/emitGlobalVariables/emitGlobalAlias for z/OS

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2792,6 +2792,10 @@ void TargetLoweringObjectFileGOFF::getModuleMetadata(Module &M) {
   TextLD->setWeak(false);
   TextLD->setADA(ADAPR);
   TextSection->setBeginSymbol(TextLD);
+  // Initialize the label for the ADA section.
+  MCSymbolGOFF *ADASym = static_cast<MCSymbolGOFF *>(
+      getContext().getOrCreateSymbol(ADAPR->getName()));
+  ADAPR->setBeginSymbol(ADASym);
 }
 
 MCSection *TargetLoweringObjectFileGOFF::getExplicitSectionGlobal(

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
@@ -130,6 +130,9 @@ public:
   void emitFunctionEntryLabel() override;
   void emitFunctionBodyEnd() override;
   void emitStartOfAsmFile(Module &M) override;
+  void emitGlobalVariable(const GlobalVariable *GV) override;
+  void emitGlobalAlias(const Module &M, const GlobalAlias &GA) override;
+  const MCExpr *lowerConstant(const Constant *CV, const Constant *BaseCV = nullptr, uint64_t Offset = 0) override;
 
 private:
   void emitCallInformation(CallType CT);


### PR DESCRIPTION
Add additional functionality required on z/OS for `lowerConstant`, `emitGlobalVariable`, and `emitGlobalAlias`. The main addition is to properly apply the attribute to the various `MCSymbols` and also emit the correct `MCExpr`. 