### PR TITLE
[Clang][TypePrinter] Make printNestedNameSpecifier look at typedefs

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1790,8 +1790,8 @@ void NamedDecl::printNestedNameSpecifier(raw_ostream &OS,
       else
         OS << *ND;
     } else if (const auto *RD = dyn_cast<RecordDecl>(DC)) {
-      if (TypedefNameDecl *Typedef = RD->getTypedefNameForAnonDecl())
-        OS << Typedef->getIdentifier()->getName();
+      if (TypedefNameDecl *TD = RD->getTypedefNameForAnonDecl())
+        OS << *TD;
       else if (!RD->getIdentifier())
         OS << "(anonymous " << RD->getKindName() << ')';
       else

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -1790,7 +1790,9 @@ void NamedDecl::printNestedNameSpecifier(raw_ostream &OS,
       else
         OS << *ND;
     } else if (const auto *RD = dyn_cast<RecordDecl>(DC)) {
-      if (!RD->getIdentifier())
+      if (TypedefNameDecl *Typedef = RD->getTypedefNameForAnonDecl())
+        OS << Typedef->getIdentifier()->getName();
+      else if (!RD->getIdentifier())
         OS << "(anonymous " << RD->getKindName() << ')';
       else
         OS << *RD;

--- a/clang/unittests/AST/TypePrinterTest.cpp
+++ b/clang/unittests/AST/TypePrinterTest.cpp
@@ -341,3 +341,23 @@ TEST(TypePrinter, NestedNameSpecifiers) {
         Policy.AnonymousTagLocations = false;
       }));
 }
+
+TEST(TypePrinter, NestedNameSpecifiersTypedef) {
+  constexpr char Code[] = R"cpp(
+    typedef union {
+      struct {
+        struct {
+          unsigned int baz;
+        } bar;
+      };
+    } foo;
+  )cpp";
+
+  ASSERT_TRUE(PrintedTypeMatches(
+      Code, {}, fieldDecl(hasName("bar"), hasType(qualType().bind("id"))),
+      "struct foo::(anonymous struct)::(unnamed)",
+      [](PrintingPolicy &Policy) {
+        Policy.FullyQualifiedName = true;
+        Policy.AnonymousTagLocations = false;
+      }));
+}

--- a/clang/unittests/AST/TypePrinterTest.cpp
+++ b/clang/unittests/AST/TypePrinterTest.cpp
@@ -355,8 +355,7 @@ TEST(TypePrinter, NestedNameSpecifiersTypedef) {
 
   ASSERT_TRUE(PrintedTypeMatches(
       Code, {}, fieldDecl(hasName("bar"), hasType(qualType().bind("id"))),
-      "struct foo::(anonymous struct)::(unnamed)",
-      [](PrintingPolicy &Policy) {
+      "struct foo::(anonymous struct)::(unnamed)", [](PrintingPolicy &Policy) {
         Policy.FullyQualifiedName = true;
         Policy.AnonymousTagLocations = false;
       }));


### PR DESCRIPTION
This is to resolve a regression caused by #168534.

Now when we have an anonymous object like a struct or union that has a typedef attached, we print the typedef name instead of listing it as anonymous.