### PR TITLE
[MLIR][OpenMP] Add OpenMPToLLVMIRTranslation support for is_device_ptr

### DIFF
--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -1145,8 +1145,11 @@ bool ClauseProcessor::processIsDevicePtr(
       [&](const omp::clause::IsDevicePtr &clause,
           const parser::CharBlock &source) {
         mlir::Location location = converter.genLocation(source);
+        // Force a map so the descriptor is materialized on the device with the
+        // device address inside.
         mlir::omp::ClauseMapFlags mapTypeBits =
-            mlir::omp::ClauseMapFlags::is_device_ptr;
+            mlir::omp::ClauseMapFlags::is_device_ptr |
+            mlir::omp::ClauseMapFlags::to;
         processMapObjects(stmtCtx, location, clause.v, mapTypeBits,
                           parentMemberIndices, result.isDevicePtrVars,
                           isDeviceSyms);

--- a/flang/test/Integration/OpenMP/map-types-and-sizes.f90
+++ b/flang/test/Integration/OpenMP/map-types-and-sizes.f90
@@ -33,6 +33,15 @@ subroutine mapType_array
   !$omp end target
 end subroutine mapType_array
 
+!CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [1 x i64] [i64 8]
+!CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [1 x i64] [i64 288]
+subroutine mapType_is_device_ptr
+  use iso_c_binding, only : c_ptr
+  type(c_ptr) :: p
+  !$omp target is_device_ptr(p)
+  !$omp end target
+end subroutine mapType_is_device_ptr
+
 !CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [4 x i64] [i64 0, i64 24, i64 8, i64 0]
 !CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [4 x i64] [i64 32, i64 281474976711169, i64 281474976711171, i64 281474976711187]
 subroutine mapType_ptr

--- a/flang/test/Integration/OpenMP/map-types-and-sizes.f90
+++ b/flang/test/Integration/OpenMP/map-types-and-sizes.f90
@@ -34,7 +34,7 @@ subroutine mapType_array
 end subroutine mapType_array
 
 !CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [1 x i64] [i64 8]
-!CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [1 x i64] [i64 288]
+!CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [1 x i64] [i64 33]
 subroutine mapType_is_device_ptr
   use iso_c_binding, only : c_ptr
   type(c_ptr) :: p

--- a/mlir/test/Target/LLVMIR/omptarget-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-llvm.mlir
@@ -622,3 +622,20 @@ module attributes {omp.target_triples = ["amdgcn-amd-amdhsa"]} {
 // CHECK:         br label %[[VAL_40]]
 // CHECK:       omp.done:                                         ; preds = %[[VAL_68]], %[[VAL_63]], %[[VAL_32]]
 // CHECK:         ret void
+
+// -----
+
+module attributes {omp.target_triples = ["amdgcn-amd-amdhsa"]} {
+  llvm.func @_QPomp_target_is_device_ptr(%arg0 : !llvm.ptr) {
+    %map = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.ptr)
+        map_clauses(is_device_ptr) capture(ByRef) -> !llvm.ptr {name = ""}
+    omp.target map_entries(%map -> %ptr_arg : !llvm.ptr) {
+      omp.terminator
+    }
+    llvm.return
+  }
+}
+
+// CHECK: @.offload_sizes = private unnamed_addr constant [1 x i64] [i64 8]
+// CHECK: @.offload_maptypes = private unnamed_addr constant [1 x i64] [i64 288]
+// CHECK-LABEL: define void @_QPomp_target_is_device_ptr

--- a/mlir/test/Target/LLVMIR/openmp-todo.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-todo.mlir
@@ -238,17 +238,6 @@ llvm.func @target_in_reduction(%x : !llvm.ptr) {
 
 // -----
 
-llvm.func @target_is_device_ptr(%x : !llvm.ptr) {
-  // expected-error@below {{not yet implemented: Unhandled clause is_device_ptr in omp.target operation}}
-  // expected-error@below {{LLVM Translation failed for operation: omp.target}}
-  omp.target is_device_ptr(%x : !llvm.ptr) {
-    omp.terminator
-  }
-  llvm.return
-}
-
-// -----
-
 llvm.func @target_enter_data_depend(%x: !llvm.ptr) {
   // expected-error@below {{not yet implemented: Unhandled clause depend in omp.target_enter_data operation}}
   // expected-error@below {{LLVM Translation failed for operation: omp.target_enter_data}}

--- a/offload/test/offloading/fortran/target-is-device-ptr.f90
+++ b/offload/test/offloading/fortran/target-is-device-ptr.f90
@@ -1,0 +1,46 @@
+! Validate that a device pointer obtained via omp_get_mapped_ptr can be used
+! inside a TARGET region with the is_device_ptr clause.
+! REQUIRES: flang, amdgcn-amd-amdhsa
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+
+program is_device_ptr_target
+  use iso_c_binding, only : c_ptr, c_loc
+  implicit none
+
+  interface
+    function omp_get_mapped_ptr(host_ptr, device_num)                       &
+        bind(C, name="omp_get_mapped_ptr")
+      use iso_c_binding, only : c_ptr, c_int
+      type(c_ptr) :: omp_get_mapped_ptr
+      type(c_ptr), value :: host_ptr
+      integer(c_int), value :: device_num
+    end function omp_get_mapped_ptr
+  end interface
+
+  integer, parameter :: n = 4
+  integer, parameter :: dev = 0
+  integer, target :: a(n)
+  type(c_ptr) :: dptr
+  integer :: flag
+
+  a = [2, 4, 6, 8]
+  flag = 0
+
+  !$omp target data map(tofrom: a, flag)
+    dptr = omp_get_mapped_ptr(c_loc(a), dev)
+
+    !$omp target is_device_ptr(dptr) map(tofrom: flag)
+      flag = flag + 1
+    !$omp end target
+  !$omp end target data
+
+  if (flag .eq. 1 .and. all(a == [2, 4, 6, 8])) then
+    print *, "PASS"
+  else
+    print *, "FAIL", a
+  end if
+
+end program is_device_ptr_target
+
+!CHECK: PASS

--- a/offload/test/offloading/fortran/target-is-device-ptr.f90
+++ b/offload/test/offloading/fortran/target-is-device-ptr.f90
@@ -4,41 +4,55 @@
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
 
+module mod
+  implicit none
+  integer, parameter :: n = 4
+contains
+  subroutine kernel(dptr)
+    use iso_c_binding, only : c_ptr, c_f_pointer
+    implicit none
+
+    type(c_ptr) :: dptr
+    integer, dimension(:), pointer :: b
+    integer :: i
+
+    b => null()
+
+    !$omp target is_device_ptr(dptr)
+      call c_f_pointer(dptr, b, [n])
+      do i = 1, n
+        b(i) = b(i) + 1
+      end do
+    !$omp end target
+  end subroutine kernel
+end module mod
+
 program is_device_ptr_target
-  use iso_c_binding, only : c_ptr, c_loc
+  use iso_c_binding, only : c_ptr, c_loc, c_f_pointer
+  use omp_lib, only: omp_get_default_device, omp_get_mapped_ptr
+  use mod, only: kernel, n
   implicit none
 
-  interface
-    function omp_get_mapped_ptr(host_ptr, device_num)                       &
-        bind(C, name="omp_get_mapped_ptr")
-      use iso_c_binding, only : c_ptr, c_int
-      type(c_ptr) :: omp_get_mapped_ptr
-      type(c_ptr), value :: host_ptr
-      integer(c_int), value :: device_num
-    end function omp_get_mapped_ptr
-  end interface
-
-  integer, parameter :: n = 4
-  integer, parameter :: dev = 0
-  integer, target :: a(n)
+  integer, dimension(n), target :: a
+  integer :: dev
   type(c_ptr) :: dptr
-  integer :: flag
 
   a = [2, 4, 6, 8]
-  flag = 0
+  print '("BEFORE:", I3)', a
 
-  !$omp target data map(tofrom: a, flag)
+  dev = omp_get_default_device()
+
+  !$omp target data map(tofrom: a)
     dptr = omp_get_mapped_ptr(c_loc(a), dev)
-
-    !$omp target is_device_ptr(dptr) map(tofrom: flag)
-      flag = flag + 1
-    !$omp end target
+    call kernel(dptr)
   !$omp end target data
 
-  if (flag .eq. 1 .and. all(a == [2, 4, 6, 8])) then
-    print *, "PASS"
+  print '("AFTER: ", I3)', a
+
+  if (all(a == [3, 5, 7, 9])) then
+    print '("PASS")'
   else
-    print *, "FAIL", a
+    print '("FAIL   ", I3)', a
   end if
 
 end program is_device_ptr_target


### PR DESCRIPTION
This PR adds support for the OpenMP `is_device_ptr` clause in the MLIR to LLVM IR translation for target regions. The `is_device_ptr` clause allows device pointers (allocated via OpenMP runtime APIs) to be used directly in target regions without implicit mapping.