### PR TITLE
AMDGPU: Use RegClassByHwMode to manage GWS operand special case

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -347,6 +347,11 @@ public:
     return isRegKind() && getReg() == AMDGPU::SGPR_NULL;
   }
 
+  bool isAV_LdSt_32_Align2_RegOp() const {
+    return isRegClass(AMDGPU::VGPR_32RegClassID) ||
+           isRegClass(AMDGPU::AGPR_32RegClassID);
+  }
+
   bool isVRegWithInputMods() const;
   template <bool IsFake16> bool isT16_Lo128VRegWithInputMods() const;
   template <bool IsFake16> bool isT16VRegWithInputMods() const;

--- a/llvm/lib/Target/AMDGPU/DSInstructions.td
+++ b/llvm/lib/Target/AMDGPU/DSInstructions.td
@@ -463,7 +463,7 @@ class DS_GWS_0D <string opName>
 
 class DS_GWS_1D <string opName>
 : DS_GWS<opName,
-  (ins AVLdSt_32:$data0, Offset:$offset),
+  (ins AV_LdSt_32_Align2_RegOp:$data0, Offset:$offset),
   " $data0$offset gds"> {
 
   let has_gws_data0 = 1;

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
@@ -491,6 +491,18 @@ void AMDGPUInstPrinter::printVINTRPDst(const MCInst *MI, unsigned OpNo,
   printRegularOperand(MI, OpNo, STI, O);
 }
 
+void AMDGPUInstPrinter::printAVLdSt32Align2RegOp(const MCInst *MI,
+                                                 unsigned OpNo,
+                                                 const MCSubtargetInfo &STI,
+                                                 raw_ostream &O) {
+  MCRegister Reg = MI->getOperand(OpNo).getReg();
+
+  // On targets with an even alignment requirement
+  if (MCRegister SubReg = MRI.getSubReg(Reg, AMDGPU::sub0))
+    Reg = SubReg;
+  printRegOperand(Reg, O, MRI);
+}
+
 void AMDGPUInstPrinter::printImmediateInt16(uint32_t Imm,
                                             const MCSubtargetInfo &STI,
                                             raw_ostream &O) {

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.h
@@ -77,6 +77,9 @@ private:
                    raw_ostream &O);
   void printVINTRPDst(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
                       raw_ostream &O);
+  void printAVLdSt32Align2RegOp(const MCInst *MI, unsigned OpNo,
+                                const MCSubtargetInfo &STI, raw_ostream &O);
+
   void printImmediateInt16(uint32_t Imm, const MCSubtargetInfo &STI,
                            raw_ostream &O);
   void printImmediateBF16(uint32_t Imm, const MCSubtargetInfo &STI,

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -6429,8 +6429,6 @@ SITargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
   case AMDGPU::DS_GWS_INIT:
   case AMDGPU::DS_GWS_SEMA_BR:
   case AMDGPU::DS_GWS_BARRIER:
-    TII->enforceOperandRCAlignment(MI, AMDGPU::OpName::data0);
-    [[fallthrough]];
   case AMDGPU::DS_GWS_SEMA_V:
   case AMDGPU::DS_GWS_SEMA_P:
   case AMDGPU::DS_GWS_SEMA_RELEASE_ALL:

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1657,6 +1657,7 @@ public:
 
   const TargetSchedModel &getSchedModel() const { return SchedModel; }
 
+  // FIXME: This should be removed
   // Enforce operand's \p OpName even alignment if required by target.
   // This is used if an operand is a 32 bit register but needs to be aligned
   // regardless.

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
@@ -1328,6 +1328,17 @@ def VS_64_AlignTarget : SIRegisterClassLike<64, true, false, true>,
   let DecoderMethod = "decodeSrcRegOrImm9";
 }
 
+
+// Special case for DS_GWS instructions. The register input is really
+// 32-bit, but it needs to be even aligned on targets with a VGPR
+// alignment requirement.
+def AV_LdSt_32_Align2 : SIRegisterClassLike</*Bitwidth=*/32, /*VGPR=*/true, /*AGPR=*/true>,
+                        RegClassByHwMode<
+  [DefaultMode_Wave64, DefaultMode_Wave32, AVAlign2LoadStoreMode, AlignedVGPRNoAGPRMode_Wave64, AlignedVGPRNoAGPRMode_Wave32],
+  [VGPR_32,            VGPR_32,            AV_64_Align2,          VReg_64_Align2,               VReg_64_Align2]> {
+  let DecoderMethod = "decodeAVLdSt<32>";
+}
+
 class RegImmMatcher<string name> : AsmOperandClass {
   let Name = name;
   let RenderMethod = "addRegOrImmOperands";
@@ -1578,6 +1589,17 @@ foreach size = ["64", "96", "128", "160", "256", "1024" ] in {
   def AVLdSt_#size : AVLdStOperand<!cast<RegisterClassLike>("AV_LdSt_"#size#_AlignTarget)>;
   def AVLdSt_#size#_Align1 : AVLdStOperand<!cast<RegisterClassLike>("AV_LdSt_"#size#_Align1)>;
   def AVLdSt_#size#_Align2 : AVLdStOperand<!cast<RegisterClassLike>("AV_LdSt_"#size#_Align2)>;
+}
+
+def AV_LdSt_32_Align2_RegMatcher : AsmOperandClass {
+  let Name = "AV_LdSt_32_Align2_RegOp";
+  let RenderMethod = "addRegOperands";
+}
+
+def AV_LdSt_32_Align2_RegOp : RegisterOperand<AV_LdSt_32_Align2> {
+  let ParserMatchClass = AV_LdSt_32_Align2_RegMatcher;
+  let PrintMethod = "printAVLdSt32Align2RegOp";
+  let EncoderMethod = "getAVOperandEncoding";
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/AMDGPU/gws_agpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/gws_agpr.ll
@@ -3,128 +3,72 @@
 ; RUN: llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck -check-prefixes=CHECK,GISEL %s
 
 define void @gws_init_offset0() #0 {
-; SDAG-LABEL: gws_init_offset0:
-; SDAG:       ; %bb.0:
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a0
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    s_mov_b32 m0, 0
-; SDAG-NEXT:    s_nop 0
-; SDAG-NEXT:    ds_gws_init a0 gds
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-LABEL: gws_init_offset0:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a0
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v0, a0
-; GISEL-NEXT:    s_mov_b32 m0, 0
-; GISEL-NEXT:    s_nop 0
-; GISEL-NEXT:    ds_gws_init v0 gds
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    s_setpc_b64 s[30:31]
+; CHECK-LABEL: gws_init_offset0:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_mov_b32 m0, 0
+; CHECK-NEXT:    s_nop 0
+; CHECK-NEXT:    ds_gws_init a0 gds
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
   %val = call i32 asm "; def $0", "=a"()
   call void @llvm.amdgcn.ds.gws.init(i32 %val, i32 0)
   ret void
 }
 
 define void @gws_init_offset63() #0 {
-; SDAG-LABEL: gws_init_offset63:
-; SDAG:       ; %bb.0:
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a0
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    s_mov_b32 m0, 0
-; SDAG-NEXT:    s_nop 0
-; SDAG-NEXT:    ds_gws_init a0 offset:63 gds
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-LABEL: gws_init_offset63:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a0
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v0, a0
-; GISEL-NEXT:    s_mov_b32 m0, 0
-; GISEL-NEXT:    s_nop 0
-; GISEL-NEXT:    ds_gws_init v0 offset:63 gds
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    s_setpc_b64 s[30:31]
+; CHECK-LABEL: gws_init_offset63:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_mov_b32 m0, 0
+; CHECK-NEXT:    s_nop 0
+; CHECK-NEXT:    ds_gws_init a0 offset:63 gds
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
   %val = call i32 asm "; def $0", "=a"()
   call void @llvm.amdgcn.ds.gws.init(i32 %val, i32 63)
   ret void
 }
 
 define void @gws_init_sgpr_offset(i32 inreg %offset) #0 {
-; SDAG-LABEL: gws_init_sgpr_offset:
-; SDAG:       ; %bb.0:
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a0
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    s_lshl_b32 m0, s16, 16
-; SDAG-NEXT:    s_nop 0
-; SDAG-NEXT:    ds_gws_init a0 gds
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-LABEL: gws_init_sgpr_offset:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a0
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v0, a0
-; GISEL-NEXT:    s_lshl_b32 m0, s16, 16
-; GISEL-NEXT:    s_nop 0
-; GISEL-NEXT:    ds_gws_init v0 gds
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    s_setpc_b64 s[30:31]
+; CHECK-LABEL: gws_init_sgpr_offset:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_lshl_b32 m0, s16, 16
+; CHECK-NEXT:    s_nop 0
+; CHECK-NEXT:    ds_gws_init a0 gds
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
   %val = call i32 asm "; def $0", "=a"()
   call void @llvm.amdgcn.ds.gws.init(i32 %val, i32 %offset)
   ret void
 }
 
 define amdgpu_kernel void @gws_init_agpr_offset() #0 {
-; SDAG-LABEL: gws_init_agpr_offset:
-; SDAG:       ; %bb.0:
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a1
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    v_accvgpr_read_b32 v0, a1
-; SDAG-NEXT:    v_readfirstlane_b32 s0, v0
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a0
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    s_lshl_b32 m0, s0, 16
-; SDAG-NEXT:    s_nop 0
-; SDAG-NEXT:    ds_gws_init a0 gds
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    s_endpgm
-;
-; GISEL-LABEL: gws_init_agpr_offset:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a1
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v0, a1
-; GISEL-NEXT:    v_readfirstlane_b32 s0, v0
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a0
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v2, a0
-; GISEL-NEXT:    s_lshl_b32 m0, s0, 16
-; GISEL-NEXT:    s_nop 0
-; GISEL-NEXT:    ds_gws_init v2 gds
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    s_endpgm
+; CHECK-LABEL: gws_init_agpr_offset:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a1
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v0, a1
+; CHECK-NEXT:    v_readfirstlane_b32 s0, v0
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_lshl_b32 m0, s0, 16
+; CHECK-NEXT:    s_nop 0
+; CHECK-NEXT:    ds_gws_init a0 gds
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    s_endpgm
   %val = call i32 asm "; def $0", "=a"()
   %offset = call i32 asm "; def $0", "=a"()
   call void @llvm.amdgcn.ds.gws.init(i32 %val, i32 %offset)
@@ -132,40 +76,22 @@ define amdgpu_kernel void @gws_init_agpr_offset() #0 {
 }
 
 define void @gws_init_agpr_offset_add1() #0 {
-; SDAG-LABEL: gws_init_agpr_offset_add1:
-; SDAG:       ; %bb.0:
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a1
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    v_accvgpr_read_b32 v0, a1
-; SDAG-NEXT:    v_readfirstlane_b32 s4, v0
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a0
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    s_lshl_b32 m0, s4, 16
-; SDAG-NEXT:    s_nop 0
-; SDAG-NEXT:    ds_gws_init a0 offset:1 gds
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-LABEL: gws_init_agpr_offset_add1:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a1
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v0, a1
-; GISEL-NEXT:    v_readfirstlane_b32 s4, v0
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a0
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v2, a0
-; GISEL-NEXT:    s_lshl_b32 m0, s4, 16
-; GISEL-NEXT:    s_nop 0
-; GISEL-NEXT:    ds_gws_init v2 offset:1 gds
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    s_setpc_b64 s[30:31]
+; CHECK-LABEL: gws_init_agpr_offset_add1:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a1
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    v_accvgpr_read_b32 v0, a1
+; CHECK-NEXT:    v_readfirstlane_b32 s4, v0
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_lshl_b32 m0, s4, 16
+; CHECK-NEXT:    s_nop 0
+; CHECK-NEXT:    ds_gws_init a0 offset:1 gds
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
   %val = call i32 asm "; def $0", "=a"()
   %offset.base = call i32 asm "; def $0", "=a"()
   %offset = add i32 %offset.base, 1
@@ -195,90 +121,51 @@ define amdgpu_kernel void @gws_init_vgpr_offset_add(i32 %val) #0 {
 }
 
 define void @gws_barrier_offset0() #0 {
-; SDAG-LABEL: gws_barrier_offset0:
-; SDAG:       ; %bb.0:
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a0
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    s_mov_b32 m0, 0
-; SDAG-NEXT:    s_nop 0
-; SDAG-NEXT:    ds_gws_barrier a0 gds
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-LABEL: gws_barrier_offset0:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a0
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v0, a0
-; GISEL-NEXT:    s_mov_b32 m0, 0
-; GISEL-NEXT:    s_nop 0
-; GISEL-NEXT:    ds_gws_barrier v0 gds
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    s_setpc_b64 s[30:31]
+; CHECK-LABEL: gws_barrier_offset0:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_mov_b32 m0, 0
+; CHECK-NEXT:    s_nop 0
+; CHECK-NEXT:    ds_gws_barrier a0 gds
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
   %val = call i32 asm "; def $0", "=a"()
   call void @llvm.amdgcn.ds.gws.barrier(i32 %val, i32 0)
   ret void
 }
 
 define void @gws_barrier_offset63() #0 {
-; SDAG-LABEL: gws_barrier_offset63:
-; SDAG:       ; %bb.0:
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a0
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    s_mov_b32 m0, 0
-; SDAG-NEXT:    s_nop 0
-; SDAG-NEXT:    ds_gws_barrier a0 offset:63 gds
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-LABEL: gws_barrier_offset63:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a0
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v0, a0
-; GISEL-NEXT:    s_mov_b32 m0, 0
-; GISEL-NEXT:    s_nop 0
-; GISEL-NEXT:    ds_gws_barrier v0 offset:63 gds
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    s_setpc_b64 s[30:31]
+; CHECK-LABEL: gws_barrier_offset63:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_mov_b32 m0, 0
+; CHECK-NEXT:    s_nop 0
+; CHECK-NEXT:    ds_gws_barrier a0 offset:63 gds
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
   %val = call i32 asm "; def $0", "=a"()
   call void @llvm.amdgcn.ds.gws.barrier(i32 %val, i32 63)
   ret void
 }
 
 define void @gws_barrier_sgpr_offset(i32 inreg %offset) #0 {
-; SDAG-LABEL: gws_barrier_sgpr_offset:
-; SDAG:       ; %bb.0:
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a0
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    s_lshl_b32 m0, s16, 16
-; SDAG-NEXT:    s_nop 0
-; SDAG-NEXT:    ds_gws_barrier a0 gds
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-LABEL: gws_barrier_sgpr_offset:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a0
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v0, a0
-; GISEL-NEXT:    s_lshl_b32 m0, s16, 16
-; GISEL-NEXT:    s_nop 0
-; GISEL-NEXT:    ds_gws_barrier v0 gds
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    s_setpc_b64 s[30:31]
+; CHECK-LABEL: gws_barrier_sgpr_offset:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_lshl_b32 m0, s16, 16
+; CHECK-NEXT:    s_nop 0
+; CHECK-NEXT:    ds_gws_barrier a0 gds
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
   %val = call i32 asm "; def $0", "=a"()
   call void @llvm.amdgcn.ds.gws.barrier(i32 %val, i32 %offset)
   ret void
@@ -311,30 +198,17 @@ define void @gws_sema_v_offset0() #0 {
 }
 
 define void @gws_sema_br_offset0() #0 {
-; SDAG-LABEL: gws_sema_br_offset0:
-; SDAG:       ; %bb.0:
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    ;;#ASMSTART
-; SDAG-NEXT:    ; def a0
-; SDAG-NEXT:    ;;#ASMEND
-; SDAG-NEXT:    s_mov_b32 m0, 0
-; SDAG-NEXT:    s_nop 0
-; SDAG-NEXT:    ds_gws_sema_br a0 gds
-; SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-LABEL: gws_sema_br_offset0:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    ;;#ASMSTART
-; GISEL-NEXT:    ; def a0
-; GISEL-NEXT:    ;;#ASMEND
-; GISEL-NEXT:    v_accvgpr_read_b32 v0, a0
-; GISEL-NEXT:    s_mov_b32 m0, 0
-; GISEL-NEXT:    s_nop 0
-; GISEL-NEXT:    ds_gws_sema_br v0 gds
-; GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-NEXT:    s_setpc_b64 s[30:31]
+; CHECK-LABEL: gws_sema_br_offset0:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; def a0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_mov_b32 m0, 0
+; CHECK-NEXT:    s_nop 0
+; CHECK-NEXT:    ds_gws_sema_br a0 gds
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
   %val = call i32 asm "; def $0", "=a"()
   call void @llvm.amdgcn.ds.gws.sema.br(i32 %val, i32 0)
   ret void

--- a/llvm/test/CodeGen/AMDGPU/verify-ds-gws-align.mir
+++ b/llvm/test/CodeGen/AMDGPU/verify-ds-gws-align.mir
@@ -11,10 +11,23 @@
 # GFX90A-ERR: DS_GWS_BARRIER killed %2.sub0:vreg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
 # GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
 # GFX90A-ERR: DS_GWS_INIT killed %3:vgpr_32, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
-# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
+# GFX90A-ERR: *** Bad machine code: Illegal physical register for instruction ***
 # GFX90A-ERR: DS_GWS_INIT $vgpr1, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
-# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers for DS_GWS instructions ***
+# GFX90A-ERR: *** Bad machine code: Illegal physical register for instruction ***
 # GFX90A-ERR: DS_GWS_INIT $agpr1, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers ***
+# GFX90A-ERR: DS_GWS_INIT %4:vreg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
+# GFX90A-ERR: DS_GWS_INIT %4:vreg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers ***
+# GFX90A-ERR: DS_GWS_INIT %5:areg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
+# GFX90A-ERR: DS_GWS_INIT %5:areg_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Subtarget requires even aligned vector registers ***
+# GFX90A-ERR: DS_GWS_INIT %6:av_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+# GFX90A-ERR: *** Bad machine code: Illegal virtual register for instruction ***
+# GFX90A-ERR: DS_GWS_INIT %6:av_64, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+
 ---
 name:            gws_odd_vgpr
 body:             |
@@ -33,6 +46,22 @@ body:             |
     DS_GWS_INIT $vgpr1, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
     $agpr1 = IMPLICIT_DEF
     DS_GWS_INIT $agpr1, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+
+    $vgpr3_vgpr4 = IMPLICIT_DEF
+    DS_GWS_INIT $vgpr1_vgpr2, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+
+    $agpr3_agpr4 = IMPLICIT_DEF
+    DS_GWS_INIT $agpr3_agpr4, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+
+    %4:vreg_64 = IMPLICIT_DEF
+    DS_GWS_INIT %4, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+
+    %5:areg_64 = IMPLICIT_DEF
+    DS_GWS_INIT %5, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+
+    %6:av_64 = IMPLICIT_DEF
+    DS_GWS_INIT %6, 0, implicit $m0, implicit $exec :: (store (s32) into custom "GWSResource")
+
     S_ENDPGM 0
 
 ...

--- a/llvm/test/MC/AMDGPU/ds_gws_sgpr_err.s
+++ b/llvm/test/MC/AMDGPU/ds_gws_sgpr_err.s
@@ -1,0 +1,32 @@
+// RUN: not llvm-mc -triple=amdgcn -mcpu=tahiti -filetype=null %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=bonaire -filetype=null %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx908 -filetype=null %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx90a -filetype=null %s 2>&1 | FileCheck %s
+
+// CHECK: :[[@LINE+1]]:13: error: invalid operand for instruction
+ds_gws_init s0 offset:65535 gds
+
+// CHECK: :[[@LINE+1]]:13: error: invalid operand for instruction
+ds_gws_init s[0:1] offset:65535 gds
+
+// CHECK: :[[@LINE+1]]:13: error: invalid operand for instruction
+ds_gws_init s1 offset:65535 gds
+
+// CHECK: :[[@LINE+1]]:16: error: invalid operand for instruction
+ds_gws_barrier s1 gds
+
+// CHECK: :[[@LINE+1]]:16: error: invalid operand for instruction
+ds_gws_barrier s2 gds
+
+// CHECK: :[[@LINE+1]]:15: error: invalid operand for instruction
+ds_gws_sema_v s1 gds
+
+// CHECK: :[[@LINE+1]]:15: error: invalid operand for instruction
+ds_gws_sema_v s2 gds
+
+// CHECK: :[[@LINE+1]]:16: error: invalid operand for instruction
+ds_gws_sema_br s1 gds
+
+// CHECK: :[[@LINE+1]]:16: error: invalid operand for instruction
+ds_gws_sema_br s2 gds
+

--- a/llvm/test/MC/AMDGPU/gfx90a_ldst_acc.s
+++ b/llvm/test/MC/AMDGPU/gfx90a_ldst_acc.s
@@ -9782,63 +9782,63 @@ ds_condxchg32_rtn_b64 a[6:7], v1, a[2:3]
 ds_condxchg32_rtn_b64 a[6:7], v1, a[2:3] offset:4
 
 // GFX90A: ds_gws_init a0 offset:65535 gds ; encoding: [0xff,0xff,0x33,0xdb,0x00,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_init a0 offset:65535 gds
 
 // GFX90A: ds_gws_init a254 offset:65535 gds ; encoding: [0xff,0xff,0x33,0xdb,0xfe,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_init a254 offset:65535 gds
 
 // GFX90A: ds_gws_init a2 gds ; encoding: [0x00,0x00,0x33,0xdb,0x02,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_init a2 gds
 
 // GFX90A: ds_gws_init a0 gds ; encoding: [0x00,0x00,0x33,0xdb,0x00,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_init a0 gds
 
 // GFX90A: ds_gws_init a0 offset:4 gds ; encoding: [0x04,0x00,0x33,0xdb,0x00,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_init a0 offset:4 gds
 
 // GFX90A: ds_gws_sema_br a2 offset:65535 gds ; encoding: [0xff,0xff,0x37,0xdb,0x02,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_sema_br a2 offset:65535 gds
 
 // GFX90A: ds_gws_sema_br a254 offset:65535 gds ; encoding: [0xff,0xff,0x37,0xdb,0xfe,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_sema_br a254 offset:65535 gds
 
 // GFX90A: ds_gws_sema_br a0 gds ; encoding: [0x00,0x00,0x37,0xdb,0x00,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_sema_br a0 gds
 
 // GFX90A: ds_gws_sema_br a2 gds ; encoding: [0x00,0x00,0x37,0xdb,0x02,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_sema_br a2 gds
 
 // GFX90A: ds_gws_sema_br a0 offset:4 gds ; encoding: [0x04,0x00,0x37,0xdb,0x00,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_sema_br a0 offset:4 gds
 
 // GFX90A: ds_gws_barrier a2 offset:65535 gds ; encoding: [0xff,0xff,0x3b,0xdb,0x02,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_barrier a2 offset:65535 gds
 
 // GFX90A: ds_gws_barrier a254 offset:65535 gds ; encoding: [0xff,0xff,0x3b,0xdb,0xfe,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_barrier a254 offset:65535 gds
 
 // GFX90A: ds_gws_barrier a0 gds ; encoding: [0x00,0x00,0x3b,0xdb,0x00,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_barrier a0 gds
 
 // GFX90A: ds_gws_barrier a2 gds ; encoding: [0x00,0x00,0x3b,0xdb,0x02,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_barrier a2 gds
 
 // GFX90A: ds_gws_barrier a0 offset:4 gds ; encoding: [0x04,0x00,0x3b,0xdb,0x00,0x00,0x00,0x00]
-// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid operand for instruction
+// NOT-GFX90A: :[[@LINE+1]]:{{[0-9]+}}: error: invalid register class: agpr loads and stores not supported on this GPU
 ds_gws_barrier a0 offset:4 gds
 
 // GFX90A: ds_consume a5 offset:65535      ; encoding: [0xff,0xff,0x7a,0xdb,0x00,0x00,0x00,0x05]


### PR DESCRIPTION
On targets that require even aligned 64-bit VGPRs, GWS operands
require even alignment of a 32-bit operand. Previously we had a hacky
post-processing which added an implicit operand to try to manage
the constraint. This would require special casing in other passes
to avoid breaking the operand constraint. This moves the handling
into the instruction definition, so other passes no longer need
to consider this edge case. MC still does need to special case this,
to print/parse as a 32-bit register. This also still ends up net
less work than introducing even aligned 32-bit register classes.

This also should be applied to the image special case.