### PR TITLE
[SystemZ] Serialize ada entry flags

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -2360,3 +2360,19 @@ SystemZInstrInfo::isCopyInstrImpl(const MachineInstr &MI) const {
 
   return std::nullopt;
 }
+
+std::pair<unsigned, unsigned>
+SystemZInstrInfo::decomposeMachineOperandsTargetFlags(unsigned TF) const {
+  return std::make_pair(TF, 0u);
+}
+
+ArrayRef<std::pair<unsigned, const char *>>
+SystemZInstrInfo::getSerializableDirectMachineOperandTargetFlags() const {
+  using namespace SystemZII;
+
+  static const std::pair<unsigned, const char *> TargetFlags[] = {
+      {MO_ADA_DATA_SYMBOL_ADDR, "systemz-ada-datasymboladdr"},
+      {MO_ADA_INDIRECT_FUNC_DESC, "systemz-ada-indirectfuncdesc"},
+      {MO_ADA_DIRECT_FUNC_DESC, "systemz-ada-directfuncdesc"}};
+  return ArrayRef(TargetFlags);
+}

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
@@ -391,6 +391,12 @@ public:
 
   std::optional<DestSourcePair>
   isCopyInstrImpl(const MachineInstr &MI) const override;
+
+  std::pair<unsigned, unsigned>
+  decomposeMachineOperandsTargetFlags(unsigned TF) const override;
+
+  ArrayRef<std::pair<unsigned, const char *>>
+  getSerializableDirectMachineOperandTargetFlags() const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
@@ -76,13 +76,11 @@ enum {
 
 // z/OS XPLink specific: classifies the types of
 // accesses to the ADA (Associated Data Area).
-// These enums contains values that overlap with the above MO_ enums,
-// but that's fine since the above enums are used with ELF,
-// while these values are used with z/OS.
+// These enum values should not overlap with the above MO_ enums.
 enum {
-  MO_ADA_DATA_SYMBOL_ADDR = 1,
-  MO_ADA_INDIRECT_FUNC_DESC,
-  MO_ADA_DIRECT_FUNC_DESC,
+  MO_ADA_DATA_SYMBOL_ADDR = (1 << 2),
+  MO_ADA_INDIRECT_FUNC_DESC = (2 << 2),
+  MO_ADA_DIRECT_FUNC_DESC = (3 << 2),
 };
 
 // Classifies a branch.

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
@@ -71,13 +71,10 @@ enum {
   MO_GOT = (1 << 0),
 
   // @INDNTPOFF
-  MO_INDNTPOFF = (2 << 0)
-};
+  MO_INDNTPOFF = (2 << 0),
 
-// z/OS XPLink specific: classifies the types of
-// accesses to the ADA (Associated Data Area).
-// These enum values should not overlap with the above MO_ enums.
-enum {
+  // z/OS XPLink specific: classifies the types of
+  // accesses to the ADA (Associated Data Area).
   MO_ADA_DATA_SYMBOL_ADDR = (1 << 2),
   MO_ADA_INDIRECT_FUNC_DESC = (2 << 2),
   MO_ADA_DIRECT_FUNC_DESC = (3 << 2),

--- a/llvm/test/CodeGen/SystemZ/zos-target-flags.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-target-flags.ll
@@ -1,0 +1,17 @@
+; RUN: llc -mtriple=s390x-ibm-zos -stop-after=systemz-isel --simplify-mir < %s | FileCheck %s
+
+
+declare i64 @calc(i64 noundef, ptr noundef)
+declare i64 @morework(i64 noundef)
+
+@i = external local_unnamed_addr global i64, align 8
+
+define i64 @work() {
+entry:
+; CHECK:    %{{.*}}:addr64bit = ADA_ENTRY_VALUE target-flags(systemz-ada-datasymboladdr) @i,
+; CHECK:    %{{.*}}:addr64bit = ADA_ENTRY_VALUE target-flags(systemz-ada-directfuncdesc) @calc,
+; CHECK:    %{{.*}}:addr64bit = ADA_ENTRY_VALUE target-flags(systemz-ada-indirectfuncdesc) @morework,
+  %0 = load i64, ptr @i, align 8
+  %call = tail call i64 @calc(i64 noundef %0, ptr noundef nonnull @morework) #2
+  ret i64 %call
+}


### PR DESCRIPTION
Adding support for serializing the ada entry flags helps with mir based test cases. Without this change, the flags are simple displayed as being "unkmown".