### PR TITLE
[offload][lit] Fix compilation of two offload tests

### DIFF
--- a/offload/test/offloading/shared_lib_fp_mapping.c
+++ b/offload/test/offloading/shared_lib_fp_mapping.c
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 
-extern int func(); // Provided in liba.so, returns 42
+extern int func(void); // Provided in liba.so, returns 42
 typedef int (*fp_t)();
 
 int main() {

--- a/offload/test/offloading/shared_lib_fp_mapping.c
+++ b/offload/test/offloading/shared_lib_fp_mapping.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 extern int func(void); // Provided in liba.so, returns 42
-typedef int (*fp_t)();
+typedef int (*fp_t)(void);
 
 int main() {
   int x = 0;

--- a/offload/test/offloading/static_linking.c
+++ b/offload/test/offloading/static_linking.c
@@ -14,7 +14,7 @@ int foo() {
 }
 #else
 #include <stdio.h>
-int foo();
+int foo(void);
 
 int main() {
   int x = foo();


### PR DESCRIPTION
These are C tests, not C++, so no function parameters means unspecified number of parameters, not `void`. 

These compile fine on the current tested offload targets because an error is only [thrown](https://github.com/llvm/llvm-project/blob/main/clang/lib/Sema/SemaDecl.cpp#L10695) if the calling convention doesn't support variadic arguments, which they happen to.

When compiling this test for other targets that do not support variadic arguments, we get an error, which does not seem intentional.

Just add `void` to the parameter list.