### PR TITLE
[libc++] Always define _LIBCPP_GLIBC_PREREQ

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -678,18 +678,10 @@ typedef __char32_t char32_t;
 #    endif // _LIBCPP_HAS_THREAD_API
 #  endif   // _LIBCPP_HAS_THREADS
 
-#  if _LIBCPP_HAS_THREAD_API_PTHREAD
-#    if defined(__ANDROID__) && __ANDROID_API__ >= 30
-#      define _LIBCPP_HAS_COND_CLOCKWAIT 1
-#    elif defined(_LIBCPP_GLIBC_PREREQ)
-#      if _LIBCPP_GLIBC_PREREQ(2, 30)
-#        define _LIBCPP_HAS_COND_CLOCKWAIT 1
-#      else
-#        define _LIBCPP_HAS_COND_CLOCKWAIT 0
-#      endif
-#    else
-#      define _LIBCPP_HAS_COND_CLOCKWAIT 0
-#    endif
+#  if !_LIBCPP_HAS_THREAD_API_PTHREAD
+#    define _LIBCPP_HAS_COND_CLOCKWAIT 0
+#  elif (defined(__ANDROID__) && __ANDROID_API__ >= 30) || _LIBCPP_GLIBC_PREREQ(2, 30)
+#    define _LIBCPP_HAS_COND_CLOCKWAIT 1
 #  else
 #    define _LIBCPP_HAS_COND_CLOCKWAIT 0
 #  endif
@@ -855,12 +847,8 @@ typedef __char32_t char32_t;
 // the latter depends on internal GNU libc details that are not appropriate
 // to depend on here, so any declarations present when __cpp_char8_t is not
 // defined are ignored.
-#  if defined(_LIBCPP_GLIBC_PREREQ)
-#    if _LIBCPP_GLIBC_PREREQ(2, 36) && defined(__cpp_char8_t)
-#      define _LIBCPP_HAS_C8RTOMB_MBRTOC8 1
-#    else
-#      define _LIBCPP_HAS_C8RTOMB_MBRTOC8 0
-#    endif
+#  if _LIBCPP_GLIBC_PREREQ(2, 36) && defined(__cpp_char8_t)
+#    define _LIBCPP_HAS_C8RTOMB_MBRTOC8 1
 #  else
 #    define _LIBCPP_HAS_C8RTOMB_MBRTOC8 0
 #  endif

--- a/libcxx/include/__configuration/platform.h
+++ b/libcxx/include/__configuration/platform.h
@@ -31,15 +31,15 @@
 #endif
 
 // Need to detect which libc we're using if we're on Linux.
-#if defined(__linux__) || defined(__AMDGPU__) || defined(__NVPTX__)
-#  if __has_include(<features.h>)
-#    include <features.h>
-#    if defined(__GLIBC_PREREQ)
-#      define _LIBCPP_GLIBC_PREREQ(a, b) __GLIBC_PREREQ(a, b)
-#    else
-#      define _LIBCPP_GLIBC_PREREQ(a, b) 0
-#    endif // defined(__GLIBC_PREREQ)
-#  endif
+#if (defined(__linux__) || defined(__AMDGPU__) || defined(__NVPTX__)) && __has_include(<features.h>)
+#  include <features.h>
+#  if defined(__GLIBC_PREREQ)
+#    define _LIBCPP_GLIBC_PREREQ(a, b) __GLIBC_PREREQ(a, b)
+#  else
+#    define _LIBCPP_GLIBC_PREREQ(a, b) 0
+#  endif // defined(__GLIBC_PREREQ)
+#else
+#  define _LIBCPP_GLIBC_PREREQ(a, b) 0
 #endif
 
 // This is required in order for _NEWLIB_VERSION to be defined in places where we use it.

--- a/libcxx/include/__random/binomial_distribution.h
+++ b/libcxx/include/__random/binomial_distribution.h
@@ -98,13 +98,7 @@ public:
 };
 
 // Some libc declares the math functions to be `noexcept`.
-#if defined(_LIBCPP_GLIBC_PREREQ)
-#  if _LIBCPP_GLIBC_PREREQ(2, 8)
-#    define _LIBCPP_LGAMMA_R_NOEXCEPT _NOEXCEPT
-#  else
-#    define _LIBCPP_LGAMMA_R_NOEXCEPT
-#  endif
-#elif defined(__LLVM_LIBC__)
+#if _LIBCPP_GLIBC_PREREQ(2, 8) || defined(__LLVM_LIBC__)
 #  define _LIBCPP_LGAMMA_R_NOEXCEPT _NOEXCEPT
 #else
 #  define _LIBCPP_LGAMMA_R_NOEXCEPT

--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -41,17 +41,10 @@
 #include <time.h>
 
 // since Linux 4.5 and FreeBSD 13, but the Linux libc wrapper is only provided by glibc >= 2.27 and musl
-#if defined(__linux__)
-#  if defined(_LIBCPP_GLIBC_PREREQ)
-#    if _LIBCPP_GLIBC_PREREQ(2, 27)
-#      define _LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE
-#    endif
-#  elif _LIBCPP_HAS_MUSL_LIBC
-#    define _LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE
-#  endif
-#elif defined(__FreeBSD__)
+#if _LIBCPP_GLIBC_PREREQ(2, 27) || _LIBCPP_HAS_MUSL_LIBC || defined(__FreeBSD__)
 #  define _LIBCPP_FILESYSTEM_USE_COPY_FILE_RANGE
 #endif
+
 #if __has_include(<sys/sendfile.h>)
 #  include <sys/sendfile.h>
 #  define _LIBCPP_FILESYSTEM_USE_SENDFILE


### PR DESCRIPTION
Always defining the macro allows us to simplify the few places where it's used.
