### PR TITLE
[lldb] [disassembler] chore: enhance VariableAnnotator to return structured data: introduce VariableAnnotator::AnnotateStructured method

### DIFF
--- a/lldb/include/lldb/Core/Disassembler.h
+++ b/lldb/include/lldb/Core/Disassembler.h
@@ -570,24 +570,40 @@ private:
   const Disassembler &operator=(const Disassembler &) = delete;
 };
 
+/// Structured data for a single variable annotation.
+struct VariableAnnotation {
+  std::string variable_name;
+  /// Location description (e.g., "r15", "undef", "const_0").
+  std::string location_description;
+  /// Whether variable is live at this instruction.
+  bool is_live;
+  /// Register numbering scheme for location interpretation.
+  lldb::RegisterKind register_kind;
+  /// Where this annotation is valid.
+  std::optional<lldb_private::AddressRange> address_range;
+  /// Source file where variable was declared.
+  std::optional<std::string> decl_file;
+  /// Line number where variable was declared.
+  std::optional<uint32_t> decl_line;
+  /// Variable's type name.
+  std::optional<std::string> type_name;
+};
+
 /// Tracks live variable annotations across instructions and produces
 /// per-instruction "events" like `name = RDI` or `name = <undef>`.
 class VariableAnnotator {
-  struct VarState {
-    /// Display name.
-    std::string name;
-    /// Last printed location (empty means <undef>).
-    std::string last_loc;
-  };
 
   // Live state from the previous instruction, keyed by Variable::GetID().
-  llvm::DenseMap<lldb::user_id_t, VarState> m_live_vars;
+  llvm::DenseMap<lldb::user_id_t, VariableAnnotation> m_live_vars;
 
 public:
   /// Compute annotation strings for a single instruction and update
   /// `m_live_vars`. Returns only the events that should be printed *at this
   /// instruction*.
   std::vector<std::string> Annotate(Instruction &inst);
+
+  /// Returns structured data for all variables relevant at this instruction.
+  std::vector<VariableAnnotation> AnnotateStructured(Instruction &inst);
 };
 
 } // namespace lldb_private

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -293,9 +293,8 @@ AddVariableAnnotationToVector(std::vector<VariableAnnotation> &annotations,
                               VariableAnnotation annotation_entity,
                               const bool is_live) {
   annotation_entity.is_live = is_live;
-  if (!is_live) {
+  if (!is_live) 
     annotation_entity.location_description = kUndefLocation;
-  }
   annotations.push_back(std::move(annotation_entity));
 }
 

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -315,10 +315,7 @@ std::vector<std::string> VariableAnnotator::Annotate(Instruction &inst) {
              ? llvm::StringRef(kUndefLocationFormatted)
              : llvm::StringRef(annotation.location_description));
 
-    const auto display_string =
-        llvm::formatv("{0} = {1}", annotation.variable_name, location).str();
-
-    events.push_back(std::move(display_string));
+    events.push_back(llvm::formatv("{0} = {1}", annotation.variable_name, location).str());
   }
 
   return events;

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -293,7 +293,7 @@ AddVariableAnnotationToVector(std::vector<VariableAnnotation> &annotations,
                               VariableAnnotation annotation_entity,
                               const bool is_live) {
   annotation_entity.is_live = is_live;
-  if (!is_live) 
+  if (!is_live)
     annotation_entity.location_description = kUndefLocation;
   annotations.push_back(std::move(annotation_entity));
 }

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -315,7 +315,8 @@ std::vector<std::string> VariableAnnotator::Annotate(Instruction &inst) {
              ? llvm::StringRef(kUndefLocationFormatted)
              : llvm::StringRef(annotation.location_description));
 
-    events.push_back(llvm::formatv("{0} = {1}", annotation.variable_name, location).str());
+    events.push_back(
+        llvm::formatv("{0} = {1}", annotation.variable_name, location).str());
   }
 
   return events;

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -436,14 +436,12 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
   // 1) Starts/changes: iterate current_vars and compare with m_live_vars.
   for (const auto &KV : current_vars) {
     auto it = m_live_vars.find(KV.first);
-    if (it == m_live_vars.end()) {
+    if (it == m_live_vars.end())
       // Newly live.
       AddVariableAnnotationToVector(annotations, KV.second, true);
-    } else if (it->second.location_description !=
-               KV.second.location_description) {
+    else if (it->second.location_description != KV.second.location_description)
       // Location changed.
       AddVariableAnnotationToVector(annotations, KV.second, true);
-    }
   }
 
   // 2) Ends: anything that was live but is not in current_vars becomes

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -309,7 +309,7 @@ std::vector<std::string> VariableAnnotator::Annotate(Instruction &inst) {
   std::vector<std::string> events;
   events.reserve(structured_annotations.size());
 
-  for (const auto &annotation : structured_annotations) {
+  for (const VariableAnnotation &annotation : structured_annotations) {
     const llvm::StringRef location =
         (annotation.location_description == kUndefLocation
              ? llvm::StringRef(kUndefLocationFormatted)

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -450,9 +450,8 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
   // 2) Ends: anything that was live but is not in current_vars becomes
   // UndefLocation.
   for (const auto &KV : m_live_vars)
-    if (!current_vars.count(KV.first)) {
+    if (!current_vars.count(KV.first))
       AddVariableAnnotationToVector(annotations, KV.second, false);
-    }
 
   // Commit new state.
   m_live_vars = std::move(current_vars);

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -425,7 +425,7 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
         type_name = type_str;
 
     current_vars.try_emplace(
-        f v->GetID(),
+        v->GetID(),
         VariableAnnotation{std::string(name), std::string(loc), true,
                            entry.expr->GetRegisterKind(), entry.file_range,
                            decl_file, decl_line, type_name});

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -286,9 +286,8 @@ bool Disassembler::ElideMixedSourceAndDisassemblyLine(
   return false;
 }
 
-static constexpr const char *UndefLocation = "undef";
-static const std::string UndefLocationFormatted =
-    llvm::formatv("<{0}>", UndefLocation).str();
+static constexpr const llvm::StringLiteral kUndefLocation = "undef";
+static contexpr const llvm::StringLiteral kUndefLocationFormatted = "<undef>";
 
 // For each instruction, this block attempts to resolve in-scope variables
 // and determine if the current PC falls within their

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -336,7 +336,7 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
       VariableAnnotation annotation_entity = KV.second;
       annotation_entity.is_live = false;
       annotation_entity.location_description = kUndefLocation;
-      annotations.push_back(annotation_entity);
+      annotations.push_back(std::move(annotation_entity));
     }
     m_live_vars.clear();
     return annotations;
@@ -353,7 +353,7 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
       VariableAnnotation annotation_entity = KV.second;
       annotation_entity.is_live = false;
       annotation_entity.location_description = kUndefLocation;
-      annotations.push_back(annotation_entity);
+      annotations.push_back(std::move(annotation_entity));
     }
     m_live_vars.clear();
     return annotations;
@@ -441,13 +441,13 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
       // Newly live.
       VariableAnnotation annotation_entity = KV.second;
       annotation_entity.is_live = true;
-      annotations.push_back(annotation_entity);
+      annotations.push_back(std::move(annotation_entity));
     } else if (it->second.location_description !=
                KV.second.location_description) {
       // Location changed.
       VariableAnnotation annotation_entity = KV.second;
       annotation_entity.is_live = true;
-      annotations.push_back(annotation_entity);
+      annotations.push_back(std::move(annotation_entity));
     }
   }
 
@@ -458,7 +458,7 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
       auto annotation_entity = KV.second;
       annotation_entity.is_live = false;
       annotation_entity.location_description = kUndefLocation;
-      annotations.push_back(annotation_entity);
+      annotations.push_back(std::move(annotation_entity));
     }
 
   // Commit new state.


### PR DESCRIPTION
## Description
Contribution to this topic [Rich Disassembler for LLDB](https://discourse.llvm.org/t/rich-disassembler-for-lldb/76952), this part.
```
The rich disassembler output should be exposed as structured data and made available through LLDB’s scripting API so more tooling could be built on top of this
```

----

This pr introduces new method `AnnotateStructured` in `VariableAnnotator` class, which returns the result as a vector of `VariableAnnotation` structured data, compared to original `Annotate`.

Additionally structured data is enhanced with information inferred from `DWARFExpressionEntry` and variable declaration data.

I have moved this part of functionality form a bigger pr https://github.com/llvm/llvm-project/pull/165163 to make it easier to review, deliver smaller chunk faster in an incremental way. 

## Testing
Run test with
```sh
./build/bin/lldb-dotest -v -p TestVariableAnnotationsDisassembler.py lldb/test/API/functionalities/disassembler-variables
```

all tests (9 existing) are passing.

<details>
<summary>screenshot 2025-11-24</summary>
<img width="1344" height="875" alt="screenshot" src="https://github.com/user-attachments/assets/863e0fca-1e3e-43dc-bfa3-4b78ce287ae6" />
</details>


<details>
<summary>screenshot 2025-11-26</summary>
<img width="1851" height="865" alt="image" src="https://github.com/user-attachments/assets/d47dacee-a679-4a49-ab22-efb5a16fe29c" />
</details>

<details>
<summary>screenshot 2025-12-03</summary>
<img width="1592" height="922" alt="Screenshot From 2025-12-03 22-11-30" src="https://github.com/user-attachments/assets/957ded3d-bea1-43d0-8241-d342dfc2c7b0" />
</details>
  