### PR TITLE
[RISCV] Add a InstRW to COPY in RISCVSchedSpacemitX60.td.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSpacemitX60.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSpacemitX60.td
@@ -860,6 +860,10 @@ def : WriteRes<WriteCSR, [SMX60_IEU]>;
 def : WriteRes<WriteNop, [SMX60_IEU]>;
 def : WriteRes<WriteRdVLENB, [SMX60_IEUA]>;
 
+// Give COPY instructions an execution resource.
+// FIXME: This could be better modeled by looking at the regclasses of the operands.
+def : InstRW<[WriteIALU], (instrs COPY)>;
+
 //===----------------------------------------------------------------------===//
 // Bypass and advance
 def : ReadAdvance<ReadJmp, 0>;

--- a/llvm/test/CodeGen/RISCV/rvv/vxrm-insert-out-of-loop.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vxrm-insert-out-of-loop.ll
@@ -308,30 +308,30 @@ define void @test1(ptr nocapture noundef writeonly %dst, i32 noundef signext %i_
 ; RV64X60-NEXT:    addi s1, a7, -1
 ; RV64X60-NEXT:    zext.w s1, s1
 ; RV64X60-NEXT:    mul t3, a1, s1
-; RV64X60-NEXT:    mul t4, a3, s1
-; RV64X60-NEXT:    mul t5, a5, s1
-; RV64X60-NEXT:    add s0, a0, a6
+; RV64X60-NEXT:    mul t5, a3, s1
+; RV64X60-NEXT:    mul t4, a5, s1
+; RV64X60-NEXT:    add s1, a0, a6
 ; RV64X60-NEXT:    csrr t2, vlenb
-; RV64X60-NEXT:    add s1, a2, a6
-; RV64X60-NEXT:    add t3, t3, s0
-; RV64X60-NEXT:    add s0, a4, a6
-; RV64X60-NEXT:    add t4, t4, s1
-; RV64X60-NEXT:    li t6, 32
+; RV64X60-NEXT:    add s0, a2, a6
+; RV64X60-NEXT:    add s2, s1, t3
+; RV64X60-NEXT:    add t3, a4, a6
 ; RV64X60-NEXT:    add t5, t5, s0
-; RV64X60-NEXT:    sltu s0, a0, t4
-; RV64X60-NEXT:    sltu s1, a2, t3
-; RV64X60-NEXT:    and t4, s0, s1
-; RV64X60-NEXT:    or s2, a1, a3
+; RV64X60-NEXT:    or t6, a1, a3
+; RV64X60-NEXT:    add t4, t4, t3
 ; RV64X60-NEXT:    sltu s0, a0, t5
-; RV64X60-NEXT:    sltu s1, a4, t3
-; RV64X60-NEXT:    srli t3, s2, 63
-; RV64X60-NEXT:    and s0, s0, s1
-; RV64X60-NEXT:    or s1, a1, a5
-; RV64X60-NEXT:    or t4, t4, t3
+; RV64X60-NEXT:    sltu s1, a2, s2
+; RV64X60-NEXT:    and t5, s0, s1
 ; RV64X60-NEXT:    slli t3, t2, 1
+; RV64X60-NEXT:    sltu t4, a0, t4
+; RV64X60-NEXT:    sltu s0, a4, s2
+; RV64X60-NEXT:    srli s1, t6, 63
+; RV64X60-NEXT:    and s0, t4, s0
+; RV64X60-NEXT:    or t4, t5, s1
+; RV64X60-NEXT:    or s1, a1, a5
+; RV64X60-NEXT:    li t5, 32
 ; RV64X60-NEXT:    srli s1, s1, 63
 ; RV64X60-NEXT:    or s0, s0, s1
-; RV64X60-NEXT:    maxu s1, t3, t6
+; RV64X60-NEXT:    maxu s1, t3, t5
 ; RV64X60-NEXT:    or s0, t4, s0
 ; RV64X60-NEXT:    sltu s1, a6, s1
 ; RV64X60-NEXT:    or s0, s0, s1


### PR DESCRIPTION
This prevents the scheduler from thinking copy instructions are free. In #167008, we saw cases where the scheduler moved ABI copies past other instructions creating high register pressure that caused the register allocator to run out of registers. They can't be spilled because the physical register lifetime was increased, not the virtual register.

Ideally, we would detect what registers the COPY is for, but for now I've just treated it as a scalar integer copy.