### PR TITLE
[NFC][M68k] Refactor away MOV8dc and MOV8cd

### DIFF
--- a/llvm/lib/Target/M68k/M68kExpandPseudo.cpp
+++ b/llvm/lib/Target/M68k/M68kExpandPseudo.cpp
@@ -187,11 +187,6 @@ bool M68kExpandPseudo::ExpandMI(MachineBasicBlock &MBB,
     return TII->ExpandMOVSZX_RM(MIB, false, TII->get(M68k::MOV16dq), MVT::i32,
                                 MVT::i16);
 
-  case M68k::MOV8cd:
-    return TII->ExpandCCR(MIB, /*IsToCCR=*/true);
-  case M68k::MOV8dc:
-    return TII->ExpandCCR(MIB, /*IsToCCR=*/false);
-
   case M68k::MOVM16jm_P:
     return TII->ExpandMOVEM(MIB, TII->get(M68k::MOVM16jm), /*IsRM=*/false);
   case M68k::MOVM32jm_P:

--- a/llvm/lib/Target/M68k/M68kInstrData.td
+++ b/llvm/lib/Target/M68k/M68kInstrData.td
@@ -357,12 +357,6 @@ def MOVM32mp_P : MxMOVEM_RM_Pseudo<MxType32r, MxType32.POp>;
 
 //===----------------------------------------------------------------------===//
 // MOVE to/from SR/CCR
-//
-// A special care must be taken working with to/from CCR since it is basically
-// word-size SR register truncated for user mode thus it only supports word-size
-// instructions. Plus the original M68000 does not support moves from CCR. So in
-// order to use CCR effectively one MUST use proper byte-size pseudo instructi-
-// ons that will be resolved sometime after RA pass.
 //===----------------------------------------------------------------------===//
 
 /// Move to CCR
@@ -394,7 +388,6 @@ foreach AM = MxMoveSupportedAMs in {
 
 // Only data register is allowed.
 def MOV16cd : MxMoveToCCR<MxOp16AddrMode_d.Op, MxMoveSrcOpEnc_d>;
-def MOV8cd  : MxMoveToCCRPseudo<MxOp8AddrMode_d.Op>;
 
 /// Move from CCR
 /// --------------------------------------------------
@@ -436,7 +429,6 @@ foreach AM = MxMoveSupportedAMs in {
 
 // Only data register is allowed.
 def MOV16dc : MxMoveFromCCR_R;
-def MOV8dc  : MxMoveFromCCR_RPseudo<MxOp8AddrMode_d.Op>;
 
 /// Move to SR
 /// --------------------------------------------------

--- a/llvm/lib/Target/M68k/M68kInstrInfo.cpp
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.cpp
@@ -572,24 +572,6 @@ bool M68kInstrInfo::ExpandPUSH_POP(MachineInstrBuilder &MIB,
   return true;
 }
 
-bool M68kInstrInfo::ExpandCCR(MachineInstrBuilder &MIB, bool IsToCCR) const {
-  if (MIB->getOpcode() == M68k::MOV8cd) {
-    // Promote used register to the next class
-    MachineOperand &Opd = MIB->getOperand(1);
-    Opd.setReg(getRegisterInfo().getMatchingSuperReg(
-        Opd.getReg(), M68k::MxSubRegIndex8Lo, &M68k::DR16RegClass));
-  }
-
-  // Replace the pseudo instruction with the real one
-  if (IsToCCR)
-    MIB->setDesc(get(M68k::MOV16cd));
-  else
-    // FIXME M68010 or later is required
-    MIB->setDesc(get(M68k::MOV16dc));
-
-  return true;
-}
-
 bool M68kInstrInfo::ExpandMOVEM(MachineInstrBuilder &MIB,
                                 const MCInstrDesc &Desc, bool IsRM) const {
   int Reg = 0, Offset = 0, Base = 0;
@@ -752,29 +734,27 @@ void M68kInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
   bool ToSR = DstReg == M68k::SR;
 
   if (FromCCR) {
-    if (M68k::DR8RegClass.contains(DstReg)) {
-      Opc = M68k::MOV8dc;
-    } else if (M68k::DR16RegClass.contains(DstReg)) {
-      Opc = M68k::MOV16dc;
-    } else if (M68k::DR32RegClass.contains(DstReg)) {
-      Opc = M68k::MOV16dc;
-    } else {
+    Opc = M68k::MOV16dc;
+    if (!M68k::DR8RegClass.contains(DstReg) &&
+        !M68k::DR16RegClass.contains(DstReg) &&
+        !M68k::DR32RegClass.contains(DstReg)) {
       LLVM_DEBUG(dbgs() << "Cannot copy CCR to " << RI.getName(DstReg) << '\n');
       llvm_unreachable("Invalid register for MOVE from CCR");
     }
   } else if (ToCCR) {
+    Opc = M68k::MOV16cd;
     if (M68k::DR8RegClass.contains(SrcReg)) {
-      Opc = M68k::MOV8cd;
-    } else if (M68k::DR16RegClass.contains(SrcReg)) {
-      Opc = M68k::MOV16cd;
-    } else if (M68k::DR32RegClass.contains(SrcReg)) {
-      Opc = M68k::MOV16cd;
-    } else {
+      // Promote used register to the next class
+      SrcReg = getRegisterInfo().getMatchingSuperReg(
+          SrcReg, M68k::MxSubRegIndex8Lo, &M68k::DR16RegClass);
+    } else if (!M68k::DR16RegClass.contains(SrcReg) &&
+               !M68k::DR32RegClass.contains(SrcReg)) {
       LLVM_DEBUG(dbgs() << "Cannot copy " << RI.getName(SrcReg) << " to CCR\n");
       llvm_unreachable("Invalid register for MOVE to CCR");
     }
-  } else if (FromSR || ToSR)
+  } else if (FromSR || ToSR) {
     llvm_unreachable("Cannot emit SR copy instruction");
+  }
 
   if (Opc) {
     BuildMI(MBB, MI, DL, get(Opc), DstReg)

--- a/llvm/lib/Target/M68k/M68kInstrInfo.h
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.h
@@ -318,9 +318,6 @@ public:
   bool ExpandPUSH_POP(MachineInstrBuilder &MIB, const MCInstrDesc &Desc,
                       bool IsPush) const;
 
-  /// Moves to/from CCR
-  bool ExpandCCR(MachineInstrBuilder &MIB, bool IsToCCR) const;
-
   /// Expand all MOVEM pseudos into real MOVEMs
   bool ExpandMOVEM(MachineInstrBuilder &MIB, const MCInstrDesc &Desc,
                    bool IsRM) const;


### PR DESCRIPTION
This obsoletes the FIXME in #85686, but it doesn't address the issue where moves from CCR will still be emitted on 68000. However, all such moves will now be emitted as physreg copies, and the issue can thus be handled there in a followup change.