### PR TITLE
[TableGen] Change a reachable assert to a fatal error

### DIFF
--- a/llvm/test/TableGen/ValueTypeByHwModeMissingRegInfo.td
+++ b/llvm/test/TableGen/ValueTypeByHwModeMissingRegInfo.td
@@ -1,0 +1,30 @@
+// RUN: not llvm-tblgen -gen-asm-matcher -I %p/../../include %s -o - 2>&1 | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+def Is32Bit : Predicate<"!Subtarget->is64Bit()">;
+def Is64Bit : Predicate<"Subtarget->is64Bit()">;
+defvar Ptr32 = DefaultMode;
+def Ptr64 : HwMode<[Is64Bit]>;
+
+class MyReg<string n> : Register<n> {
+  let Namespace = "MyTarget";
+}
+
+def X0 : MyReg<"x0">;
+def X1 : MyReg<"x1">;
+def X2 : MyReg<"x2">;
+def X3 : MyReg<"x3">;
+
+def XLenVT : ValueTypeByHwMode<[Ptr32, Ptr64], [i32, i64]>;
+def XLenRI : RegInfoByHwMode<[Ptr32,             Ptr64],
+                             [RegInfo<32,32,32>, RegInfo<64,64,64>]>;
+
+def XRegs : RegisterClass<"MyTarget", [XLenVT], 32, (add X0, X1, X2, X3)> {
+  // Note: Would need this to determine size, otherwise we get an error.
+  // let RegInfos = XLenRI;
+}
+// CHECK: [[#@LINE-4]]:5: error: Impossible to determine register size
+
+def MyTargetISA : InstrInfo;
+def MyTarget : Target { let InstructionSet = MyTargetISA; }

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -734,8 +734,8 @@ CodeGenRegisterClass::CodeGenRegisterClass(CodeGenRegBank &RegBank,
   if (const Record *RV = R->getValueAsOptionalDef("RegInfos"))
     RSI = RegSizeInfoByHwMode(RV, RegBank.getHwModes());
   unsigned Size = R->getValueAsInt("Size");
-  assert((RSI.hasDefault() || Size != 0 || VTs[0].isSimple()) &&
-         "Impossible to determine register size");
+  if (!(RSI.hasDefault() || Size != 0 || VTs[0].isSimple()))
+    PrintFatalError(R->getLoc(), "Impossible to determine register size");
   if (!RSI.hasDefault()) {
     RegSizeInfo RI;
     RI.RegSize = RI.SpillSize =

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -734,7 +734,7 @@ CodeGenRegisterClass::CodeGenRegisterClass(CodeGenRegBank &RegBank,
   if (const Record *RV = R->getValueAsOptionalDef("RegInfos"))
     RSI = RegSizeInfoByHwMode(RV, RegBank.getHwModes());
   unsigned Size = R->getValueAsInt("Size");
-  if (!(RSI.hasDefault() || Size != 0 || VTs[0].isSimple()))
+  if (!RSI.hasDefault() && Size == 0 && !VTs[0].isSimple())
     PrintFatalError(R->getLoc(), "Impossible to determine register size");
   if (!RSI.hasDefault()) {
     RegSizeInfo RI;


### PR DESCRIPTION
I hit this when using a RegisterClass with a ValueTypeByHwMode that
was missing the RegInfos field. Add a test for this error.
