### PR TITLE
[scudo] Lock/unlock MutexTSDs in disable/enable.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tsd_shared.h
+++ b/compiler-rt/lib/scudo/standalone/tsd_shared.h
@@ -93,6 +93,7 @@ struct TSDRegistrySharedT {
 
   void disable() NO_THREAD_SAFETY_ANALYSIS {
     Mutex.lock();
+    MutexTSDs.lock();
     for (u32 I = 0; I < TSDsArraySize; I++)
       TSDs[I].lock();
   }
@@ -100,6 +101,7 @@ struct TSDRegistrySharedT {
   void enable() NO_THREAD_SAFETY_ANALYSIS {
     for (s32 I = static_cast<s32>(TSDsArraySize - 1); I >= 0; I--)
       TSDs[I].unlock();
+    MutexTSDs.unlock();
     Mutex.unlock();
   }
 


### PR DESCRIPTION
It is possible that a fork could occur while MutexTSDs is being held and then cause a deadlock in a forked process when something attempts to lock it again. Instead add it to the enable/disable list of mutexes.