### PR TITLE
[bazel] Use zlib-ng from the BCR

### DIFF
--- a/utils/bazel/MODULE.bazel
+++ b/utils/bazel/MODULE.bazel
@@ -15,6 +15,7 @@ bazel_dep(name = "rules_cc", version = "0.2.11")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
 bazel_dep(name = "rules_python", version = "1.6.3")
 bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "zlib-ng", version = "2.0.7", repo_name = "llvm_zlib")
 bazel_dep(name = "zstd", version = "1.5.7", repo_name = "llvm_zstd")
 
 llvm_repos_extension = use_extension(":extensions.bzl", "llvm_repos_extension")
@@ -22,7 +23,6 @@ use_repo(
     llvm_repos_extension,
     "gmp",
     "llvm-raw",
-    "llvm_zlib",
     "mpc",
     "mpfr",
     "nanobind",

--- a/utils/bazel/MODULE.bazel.lock
+++ b/utils/bazel/MODULE.bazel.lock
@@ -220,6 +220,8 @@
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
+    "https://bcr.bazel.build/modules/zlib-ng/2.0.7/MODULE.bazel": "3ca640b745b55f287e95aa0477e6cd76dfa0a565725d5412b7d8dae4274436c8",
+    "https://bcr.bazel.build/modules/zlib-ng/2.0.7/source.json": "107bf3a70ecf9f87fe90f7002c9e35423564ffed070affec23d41478503bc5cf",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
@@ -232,7 +234,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%llvm_repos_extension": {
       "general": {
-        "bzlTransitiveDigest": "05R8ZuqDbhn1LOyXHQzta+x0dI9dEY6RIu21atUo+Kw=",
+        "bzlTransitiveDigest": "9jGazpNxASw0pQCCKAMsxGYnVBJH8Mkddp3w7yRm6eU=",
         "usagesDigest": "X0yUkkWyxQ2Y5oZVDkRSE/K4YkDWo1IjhHsL+1weKyU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -243,17 +245,6 @@
             "attributes": {
               "build_file_content": "# empty",
               "path": "../../"
-            }
-          },
-          "llvm_zlib": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "build_file": "@@+llvm_repos_extension+llvm-raw//utils/bazel/third_party_build:zlib-ng.BUILD",
-              "sha256": "e36bb346c00472a1f9ff2a0a4643e590a254be6379da7cddd9daeb9a7f296731",
-              "strip_prefix": "zlib-ng-2.0.7",
-              "urls": [
-                "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip"
-              ]
             }
           },
           "vulkan_headers": {

--- a/utils/bazel/extensions.bzl
+++ b/utils/bazel/extensions.bzl
@@ -17,16 +17,6 @@ def _llvm_repos_extension_impl(module_ctx):
         )
 
     http_archive(
-        name = "llvm_zlib",
-        build_file = "@llvm-raw//utils/bazel/third_party_build:zlib-ng.BUILD",
-        sha256 = "e36bb346c00472a1f9ff2a0a4643e590a254be6379da7cddd9daeb9a7f296731",
-        strip_prefix = "zlib-ng-2.0.7",
-        urls = [
-            "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip",
-        ],
-    )
-
-    http_archive(
         name = "vulkan_headers",
         build_file = "@llvm-raw//utils/bazel/third_party_build:vulkan_headers.BUILD",
         sha256 = "19f491784ef0bc73caff877d11c96a48b946b5a1c805079d9006e3fbaa5c1895",

--- a/utils/bazel/llvm-project-overlay/lld/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lld/BUILD.bazel
@@ -105,8 +105,8 @@ cc_library(
         "//llvm:TargetParser",
         "//llvm:TransformUtils",
         "//llvm:config",
+        "//third-party:zlib",
         "//third-party:zstd",
-        "@llvm_zlib//:zlib",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -493,7 +493,7 @@ cc_library(
         "//llvm:Support",
         "//llvm:TargetParser",
         "//llvm:config",
-        "@llvm_zlib//:zlib",
+        "//third-party:zlib",
     ],
 )
 
@@ -1406,7 +1406,7 @@ cc_library(
         "//lldb:Utility",
         "//llvm:Support",
         "//llvm:config",
-        "@llvm_zlib//:zlib",
+        "//third-party:zlib",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -327,7 +327,7 @@ cc_library(
         # We unconditionally depend on the custom LLVM zlib wrapper. This will
         # be an empty library unless zlib is enabled, in which case it will
         # both provide the necessary dependencies and configuration defines.
-        "@llvm_zlib//:zlib",
+        "//third-party:zlib",
         # We unconditionally depend on the custom LLVM zstd wrapper. This will
         # be an empty library unless zstd is enabled, in which case it will
         # both provide the necessary dependencies and configuration defines.

--- a/utils/bazel/llvm-project-overlay/third-party/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/third-party/BUILD.bazel
@@ -32,3 +32,30 @@ cc_library_wrapper(
         "//conditions:default": [],
     }),
 )
+
+bool_flag(
+    name = "llvm_enable_zlib",
+    build_setting_default = True,
+)
+
+config_setting(
+    name = "llvm_zlib_enabled",
+    flag_values = {":llvm_enable_zlib": "true"},
+)
+
+cc_library_wrapper(
+    name = "zlib",
+    defines = select({
+        ":llvm_zlib_enabled": [
+            "LLVM_ENABLE_ZLIB=1",
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = select({
+        ":llvm_zlib_enabled": [
+            "@llvm_zlib//:zlib-ng",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/utils/bazel/third_party_build/zlib-ng.BUILD
+++ b/utils/bazel/third_party_build/zlib-ng.BUILD
@@ -1,23 +1,13 @@
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
     # BSD/MIT-like license (for zlib)
     licenses = ["notice"],
-)
-
-bool_flag(
-    name = "llvm_enable_zlib",
-    build_setting_default = True,
-)
-
-config_setting(
-    name = "llvm_zlib_enabled",
-    flag_values = {":llvm_enable_zlib": "true"},
 )
 
 copy_file(
@@ -31,7 +21,7 @@ copy_file(
 cc_library(
     name = "zlib",
     srcs = select({
-        ":llvm_zlib_enabled": [
+        "@llvm-project//third-party:llvm_zlib_enabled": [
             "adler32.c",
             "adler32_p.h",
             "chunkset.c",
@@ -79,7 +69,7 @@ cc_library(
         "//conditions:default": [],
     }),
     hdrs = select({
-        ":llvm_zlib_enabled": [
+        "@llvm-project//third-party:llvm_zlib_enabled": [
             "zlib.h",
             ":zconf_gen",
         ],
@@ -96,7 +86,7 @@ cc_library(
         # the default config for reproducibility.
     ],
     defines = select({
-        ":llvm_zlib_enabled": [
+        "@llvm-project//third-party:llvm_zlib_enabled": [
             "LLVM_ENABLE_ZLIB=1",
         ],
         "//conditions:default": [],


### PR DESCRIPTION
This way if a downstream project also uses this, it is dedup'd
