### PR TITLE
[lldb][AIX] Added Kill() implementation

### DIFF
--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -222,10 +222,13 @@ Status NativeProcessAIX::Kill() {
     break;
   }
 
-  llvm::Error result =
-      (PtraceWrapper(PT_KILL, GetID(), nullptr, nullptr, 0)).takeError();
-  if (!result)
-    error.FromErrorString("Kill failed");
+  llvm::Expected<int> result =
+      PtraceWrapper(PT_KILL, GetID(), nullptr, nullptr, 0);
+  if (!result) {
+    std::string error_string = std::string("Kill failed for process. error: ") +
+                               llvm::toString(result.takeError());
+    error.FromErrorString(error_string.c_str());
+  }
   return error;
 }
 

--- a/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
+++ b/lldb/source/Plugins/Process/AIX/NativeProcessAIX.cpp
@@ -137,12 +137,6 @@ void NativeProcessAIX::Manager::SigchldHandler() {
     auto wait_result = WaitPid();
     if (!wait_result)
       return;
-    lldb::pid_t pid = wait_result->first;
-    WaitStatus status = wait_result->second;
-
-    llvm::any_of(m_processes, [&](NativeProcessAIX *process) {
-      return process->TryHandleWaitStatus(pid, status);
-    });
   }
 }
 


### PR DESCRIPTION
This PR is in reference to porting LLDB on AIX.

Link to discussions on llvm [discourse](https://discourse.llvm.org/t/port-lldb-to-ibm-aix/80640) and [github](https://github.com/llvm/llvm-project/issues/101657).
Complete changes together in this draft:
- https://github.com/llvm/llvm-project/pull/102601

**Description:**
Extending Kill and SigchldHandler for NativeProcessAIX.

Ref: [AIX ptrace](https://www.ibm.com/docs/en/aix/7.3.0?topic=p-ptrace-ptracex-ptrace64-subroutine)