### PR TITLE
[QualGroup][docs] Update meeting schedule and link for slides

### DIFF
--- a/llvm/docs/GettingInvolved.rst
+++ b/llvm/docs/GettingInvolved.rst
@@ -209,7 +209,7 @@ what to add to your calendar invite.
      - `ics <https://drive.google.com/file/d/1ten-u-4yjOcCoONUtR4_AxsFxRDTUp1b/view?usp=sharing>`__
      - `Meeting details/agenda: <https://docs.google.com/document/d/1Glzy2JiWuysbD-HBWGUOkZqT09GJ4_Ljodr0lXD5XfQ/edit>`__
    * - `LLVM Qualification Working Group <https://llvm.org/docs/QualGroup.html>`__
-     - 1st Tuesday/Wednesday of the month
+     - 1st Tuesday of the month
      - `ics <https://calendar.google.com/calendar/ical/c_fe5774fa2769c5085d6b87e8fac272e8940e7d0089bc0e0a58dc3ead7978504b%40group.calendar.google.com/public/basic.ics>`__
        `gcal <https://calendar.google.com/calendar/embed?src=c_fe5774fa2769c5085d6b87e8fac272e8940e7d0089bc0e0a58dc3ead7978504b%40group.calendar.google.com&ctz=Asia%2FTokyo>`__
      - `Minutes/docs <https://discourse.llvm.org/t/llvm-qualification-wg-sync-ups-meeting-minutes/87148>`__

--- a/llvm/docs/QualGroup.rst
+++ b/llvm/docs/QualGroup.rst
@@ -241,15 +241,8 @@ Agendas, meeting notes, and presentation slides for the sync-ups are shared to e
 Upcoming and past meeting agendas, and meeting minutes are published in a dedicated thread
 on the LLVM Discourse forum: `Meeting Agendas and Minutes <https://discourse.llvm.org/t/llvm-qualification-wg-sync-ups-meeting-minutes/87148>`_ 
 
-Slides used to support discussions during sync-up meetings are stored in LLVM's GitHub repository.
-
-Available slides:
-
-* (add future entries here)
-* `October 2025 <https://docs.google.com/presentation/d/1ND2SkjgcHvcEbQmMd8ExL-PpRXouP49T-wfy3xf2yRQ/edit?usp=sharing>`_
-* `September 2025 <https://docs.google.com/presentation/d/1SZAE-QHfJED6CxJCCtBkPDxcw7XU9ORX54TJyXe1ppc/edit?usp=sharing>`_
-* `August 2025 <https://docs.google.com/presentation/d/1K8GWoRm8ZAeyyGvTeV5f-sMOhMr7WHiEk6_Nm5Fk10o/edit?usp=sharing>`_
-* `July 2025 <https://docs.google.com/presentation/d/1ktURe9qz5ggbdOQYK-2ISpiC18B-Y_35WvGyAnnxEpw/edit?usp=sharing>`_
+Slides used to support discussions during sync-up meetings are stored in a dedicated Google Drive folder: `Link <https://drive.google.com/drive/u/1/folders/1nu3JAanE0gqQDll0S9ofVy4FOFezc6Mm>`_.
+Note: that the naming convention for these slides is YYYYMM_llvm_qual_wg.
 
 AI Transcription Policy
 =======================

--- a/llvm/docs/QualGroup.rst
+++ b/llvm/docs/QualGroup.rst
@@ -242,7 +242,7 @@ Upcoming and past meeting agendas, and meeting minutes are published in a dedica
 on the LLVM Discourse forum: `Meeting Agendas and Minutes <https://discourse.llvm.org/t/llvm-qualification-wg-sync-ups-meeting-minutes/87148>`_ 
 
 Slides used to support discussions during sync-up meetings are stored in a dedicated Google Drive folder: `Link <https://drive.google.com/drive/u/1/folders/1nu3JAanE0gqQDll0S9ofVy4FOFezc6Mm>`_.
-Note: that the naming convention for these slides is YYYYMM_llvm_qual_wg.
+Note that the naming convention for these slides is *YYYYMM*_llvm_qual_wg.
 
 AI Transcription Policy
 =======================

--- a/llvm/docs/QualGroup.rst
+++ b/llvm/docs/QualGroup.rst
@@ -242,7 +242,7 @@ Upcoming and past meeting agendas, and meeting minutes are published in a dedica
 on the LLVM Discourse forum: `Meeting Agendas and Minutes <https://discourse.llvm.org/t/llvm-qualification-wg-sync-ups-meeting-minutes/87148>`_ 
 
 Slides used to support discussions during sync-up meetings are stored in a dedicated Google Drive folder: `Link <https://drive.google.com/drive/u/1/folders/1nu3JAanE0gqQDll0S9ofVy4FOFezc6Mm>`_.
-Note that the naming convention for these slides is *YYYYMM*_llvm_qual_wg.
+Note that the naming convention for these slides is *YYYYMM*\_llvm_qual_wg.
 
 AI Transcription Policy
 =======================


### PR DESCRIPTION
Summary
======
This PR update the schedule for online sync-up and update link for past meeting slides.

Changes
======
* Remove the wednesday schedule, since we did not have the meeting for Americas-friendly timezones.
* Use a single folder for past meeting slides instead of individual links.

Related Links
=========
* [Meeting materials for Qualification Working Group](https://llvm.org/docs/QualGroup.html#meeting-materials)
* [Online Sync-Ups](https://llvm.org/docs/GettingInvolved.html#online-sync-ups)
