### PR TITLE
[orc-rt] Add ErrorAsOutParameter convenience constructor.

### DIFF
--- a/orc-rt/include/orc-rt/Error.h
+++ b/orc-rt/include/orc-rt/Error.h
@@ -278,6 +278,8 @@ public:
       (void)!!*Err;
   }
 
+  ErrorAsOutParameter(Error &Err) : Err(&Err) { (void)!!Err; }
+
   ~ErrorAsOutParameter() {
     // Clear the checked bit.
     if (Err && !*Err)

--- a/orc-rt/unittests/ErrorTest.cpp
+++ b/orc-rt/unittests/ErrorTest.cpp
@@ -257,6 +257,15 @@ TEST(ErrorTest, ErrorAsOutParameterUnchecked) {
       << "ErrorAsOutParameter did not clear the checked flag on destruction.";
 }
 
+// Test that we can construct an ErrorAsOutParameter from an Error&.
+TEST(ErrorTest, ErrorAsOutParameterRefConstructor) {
+  Error E = Error::success();
+  {
+    ErrorAsOutParameter _(E); // construct with Error&.
+  }
+  (void)!!E;
+}
+
 // Check 'Error::isA<T>' method handling.
 TEST(ErrorTest, IsAHandling) {
   // Check 'isA' handling.


### PR DESCRIPTION
Allows construction of ErrorAsOutParameters from Error references.