### PR TITLE
[libc++][stack] Applied `[[nodiscard]]`

### DIFF
--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -235,9 +235,9 @@ public:
 #  endif
 
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const { return c.empty(); }
-  _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
-  _LIBCPP_HIDE_FROM_ABI reference top() { return c.back(); }
-  _LIBCPP_HIDE_FROM_ABI const_reference top() const { return c.back(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reference top() { return c.back(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reference top() const { return c.back(); }
 
   _LIBCPP_HIDE_FROM_ABI void push(const value_type& __v) { c.push_back(__v); }
 #  ifndef _LIBCPP_CXX03_LANG

--- a/libcxx/test/libcxx/diagnostics/stack.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/stack.nodiscard.verify.cpp
@@ -13,6 +13,11 @@
 #include <stack>
 
 void test() {
-  std::stack<int> stack;
-  stack.empty(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::stack<int> st;
+  const std::stack<int> cst;
+
+  st.empty(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  st.size();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  st.top();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cst.top();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
 }


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

-  https://libcxx.llvm.org/CodingGuidelines.html#apply-nodiscard-where-relevant