### PR TITLE
[libc++][queue] Applied `[[nodiscard]]`

### DIFF
--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -401,11 +401,13 @@ public:
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI
 #    if _LIBCPP_STD_VER >= 17
-  decltype(auto) emplace(_Args&&... __args) {
+  decltype(auto)
+  emplace(_Args&&... __args) {
     return c.emplace_back(std::forward<_Args>(__args)...);
   }
 #    else
-  void emplace(_Args&&... __args) {
+  void
+  emplace(_Args&&... __args) {
     c.emplace_back(std::forward<_Args>(__args)...);
   }
 #    endif

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -376,12 +376,12 @@ public:
 #  endif // _LIBCPP_CXX03_LANG
 
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const { return c.empty(); }
-  _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
 
-  _LIBCPP_HIDE_FROM_ABI reference front() { return c.front(); }
-  _LIBCPP_HIDE_FROM_ABI const_reference front() const { return c.front(); }
-  _LIBCPP_HIDE_FROM_ABI reference back() { return c.back(); }
-  _LIBCPP_HIDE_FROM_ABI const_reference back() const { return c.back(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reference front() { return c.front(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reference front() const { return c.front(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reference back() { return c.back(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reference back() const { return c.back(); }
 
   _LIBCPP_HIDE_FROM_ABI void push(const value_type& __v) { c.push_back(__v); }
 #  ifndef _LIBCPP_CXX03_LANG
@@ -401,13 +401,11 @@ public:
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI
 #    if _LIBCPP_STD_VER >= 17
-  decltype(auto)
-  emplace(_Args&&... __args) {
+  decltype(auto) emplace(_Args&&... __args) {
     return c.emplace_back(std::forward<_Args>(__args)...);
   }
 #    else
-  void
-  emplace(_Args&&... __args) {
+  void emplace(_Args&&... __args) {
     c.emplace_back(std::forward<_Args>(__args)...);
   }
 #    endif
@@ -664,8 +662,10 @@ public:
 #  endif
 
   [[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI bool empty() const { return c.empty(); }
-  _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
-  _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI const_reference top() const { return c.front(); }
+  [[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
+  [[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI const_reference top() const {
+    return c.front();
+  }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI void push(const value_type& __v);
 #  ifndef _LIBCPP_CXX03_LANG

--- a/libcxx/test/libcxx/diagnostics/queue.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/queue.nodiscard.verify.cpp
@@ -12,12 +12,24 @@
 
 #include <queue>
 
-void test_queue() {
-  std::queue<int> queue;
-  queue.empty(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-}
+void test() {
+  {
+    std::queue<int> q;
+    const std::queue<int> cq{};
 
-void test_priority_queue() {
-  std::priority_queue<int> priority_queue;
-  priority_queue.empty(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    q.empty();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    q.size();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    q.front();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    cq.front(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    q.back();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    cq.back();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
+
+  {
+    std::priority_queue<int> pq;
+
+    pq.empty(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    pq.size();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    pq.top();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
 }


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

- https://libcxx.llvm.org/CodingGuidelines.html#apply-nodiscard-where-relevant