### PR TITLE
[MLIR][OpenMP] Bail early in sortMapIndices if indices are the same

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4095,6 +4095,12 @@ static void sortMapIndices(llvm::SmallVectorImpl<size_t> &indices,
   llvm::SmallVector<size_t> occludedChildren;
   llvm::sort(
       indices.begin(), indices.end(), [&](const size_t a, const size_t b) {
+        // Bail early if we are asked to look at the same index. If we do not
+        // bail early, we can end up mistakenly adding indices to
+        // occludedChildren. This can occur with some types of libc++ hardening.
+        if (a == b)
+          return false;
+
         auto memberIndicesA = cast<ArrayAttr>(indexAttr[a]);
         auto memberIndicesB = cast<ArrayAttr>(indexAttr[b]);
 


### PR DESCRIPTION
If we are given the same index in the comparator callback, simply return false. Otherwise we will end up adding invalid items to occludedChildren, causing extra items to get removed that should not be, resulting in failures that manifest in different forms (assertions, asan failures, ubsan failures, etc.).