### PR TITLE
[AMDGPU] Insert inliner anchor earlier

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetPassConfig.h
+++ b/llvm/include/llvm/CodeGen/TargetPassConfig.h
@@ -364,6 +364,15 @@ protected:
     return true;
   }
 
+  /// Add passes at the start of the function pass manager created after
+  /// enforcing CGSCC ordering. This hook is only called when
+  /// requiresCodeGenSCCOrder() returns true.
+  ///
+  /// Targets can use this to insert passes that need to run at the beginning
+  /// of the codegen function pass manager, after the CGSCC boundary has been
+  /// established.
+  virtual void addInitialCGSCCCodeGenPasses() {}
+
   /// addMachineSSAOptimization - Add standard passes that optimize machine
   /// instructions in SSA form.
   virtual void addMachineSSAOptimization();

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -966,8 +966,10 @@ void TargetPassConfig::addISelPrepare() {
   addPreISel();
 
   // Force codegen to run according to the callgraph.
-  if (requiresCodeGenSCCOrder())
+  if (requiresCodeGenSCCOrder()) {
     addPass(new DummyCGSCCPass);
+    addInitialCGSCCCodeGenPasses();
+  }
 
   if (getOptLevel() != CodeGenOptLevel::None)
     addPass(createObjCARCContractPass());

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1245,6 +1245,7 @@ public:
   }
 
   bool addPreISel() override;
+  void addInitialCGSCCCodeGenPasses() override;
   void addMachineSSAOptimization() override;
   bool addILPOpts() override;
   bool addInstSelector() override;
@@ -1502,6 +1503,11 @@ bool GCNPassConfig::addPreISel() {
     addPass(&AMDGPUPerfHintAnalysisLegacyID);
 
   return false;
+}
+
+void GCNPassConfig::addInitialCGSCCCodeGenPasses() {
+  if (EnableAMDGPUMachineLevelInliner)
+    addPass(createAMDGPUInliningAnchorPass());
 }
 
 void GCNPassConfig::addMachineSSAOptimization() {

--- a/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
+++ b/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
@@ -1614,7 +1614,8 @@
 ; INLINER-NEXT:        Loop-Closed SSA Form Pass
 ; INLINER-NEXT:      Analysis if a function is memory bound
 ; INLINER-NEXT:      DummyCGSCCPass
-; INLINER-NEXT:      FunctionPass Manager
+; INLINER-NEXT:      AMDGPU Inlining Pass Manager
+; INLINER-NEXT:        AMDGPU Inlining Anchor
 ; INLINER-NEXT:        Dominator Tree Construction
 ; INLINER-NEXT:        Basic Alias Analysis (stateless AA impl)
 ; INLINER-NEXT:        Function Alias Analysis Results
@@ -1745,15 +1746,11 @@
 ; INLINER-NEXT:        Machine Copy Propagation Pass
 ; INLINER-NEXT:        Post-RA pseudo instruction expansion pass
 ; INLINER-NEXT:        SI Shrink Instructions
-; INLINER-NEXT:      AMDGPU Inlining Pass Manager
 ; INLINER-NEXT:        AMDGPU Inlining Anchor
 ; INLINER-NEXT:        AMDGPU Machine Level Inliner
 ; INLINER-NEXT:        SI post-RA bundler
 ; INLINER-NEXT:        MachineDominator Tree Construction
 ; INLINER-NEXT:        Machine Natural Loop Construction
-; INLINER-NEXT:        Dominator Tree Construction
-; INLINER-NEXT:        Basic Alias Analysis (stateless AA impl)
-; INLINER-NEXT:        Function Alias Analysis Results
 ; INLINER-NEXT:        PostRA Machine Instruction Scheduler
 ; INLINER-NEXT:        Machine Block Frequency Analysis
 ; INLINER-NEXT:        MachinePostDominator Tree Construction


### PR DESCRIPTION
Add a new hook for inserting passes right after the last DummyCGSCC pass
and use it to insert the anchor. This changes the last FunctionPass
manager to be an inlining pass manager, thus preserving some of the
analyses that might be computed before the inliner and used after it (to
be fair that's never going to be a lot of analyses, since inlining is
pretty plastic, but at least some of the IR-level analyses that have
absolutely no reason to change can be computed only once).

This is how I originally designed the code, but I don't feel like I have
a good name/abstraction for this exact point in the pipeline, hence the
separate patch.