### PR TITLE
[mlir][LLVMIR] Handle missing functions in CGProfile module flags

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -243,16 +243,17 @@ convertModuleFlagValue(StringRef key, ArrayAttr arrayAttr,
 
   if (key == LLVMDialect::getModuleFlagKeyCGProfileName()) {
     for (auto entry : arrayAttr.getAsRange<ModuleFlagCGProfileEntryAttr>()) {
-      llvm::Metadata *fromMetadata =
-          entry.getFrom()
-              ? llvm::ValueAsMetadata::get(moduleTranslation.lookupFunction(
-                    entry.getFrom().getValue()))
-              : nullptr;
-      llvm::Metadata *toMetadata =
-          entry.getTo()
-              ? llvm::ValueAsMetadata::get(
-                    moduleTranslation.lookupFunction(entry.getTo().getValue()))
-              : nullptr;
+      const auto getFuncMetadata =
+          [&](FlatSymbolRefAttr sym) -> llvm::Metadata * {
+        if (!sym)
+          return nullptr;
+        if (llvm::Function *fn =
+                moduleTranslation.lookupFunction(sym.getValue()))
+          return llvm::ValueAsMetadata::get(fn);
+        return nullptr;
+      };
+      llvm::Metadata *const fromMetadata = getFuncMetadata(entry.getFrom());
+      llvm::Metadata *const toMetadata = getFuncMetadata(entry.getTo());
 
       llvm::Metadata *vals[] = {
           fromMetadata, toMetadata,

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -243,8 +243,7 @@ convertModuleFlagValue(StringRef key, ArrayAttr arrayAttr,
 
   if (key == LLVMDialect::getModuleFlagKeyCGProfileName()) {
     for (auto entry : arrayAttr.getAsRange<ModuleFlagCGProfileEntryAttr>()) {
-      const auto getFuncMetadata =
-          [&](FlatSymbolRefAttr sym) -> llvm::Metadata * {
+      auto getFuncMetadata = [&](FlatSymbolRefAttr sym) -> llvm::Metadata * {
         if (!sym)
           return nullptr;
         if (llvm::Function *fn =
@@ -252,8 +251,8 @@ convertModuleFlagValue(StringRef key, ArrayAttr arrayAttr,
           return llvm::ValueAsMetadata::get(fn);
         return nullptr;
       };
-      llvm::Metadata *const fromMetadata = getFuncMetadata(entry.getFrom());
-      llvm::Metadata *const toMetadata = getFuncMetadata(entry.getTo());
+      llvm::Metadata *fromMetadata = getFuncMetadata(entry.getFrom());
+      llvm::Metadata *toMetadata = getFuncMetadata(entry.getTo());
 
       llvm::Metadata *vals[] = {
           fromMetadata, toMetadata,

--- a/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
@@ -1,5 +1,9 @@
 // RUN: mlir-translate %s -mlir-to-llvmir | FileCheck %s
-// CHECK: !llvm.module.flags
+// CHECK: !llvm.module.flags = !{!0, !3}
+// CHECK: !0 = !{i32 5, !"CG Profile", !1}
+// CHECK: !1 = distinct !{!2, !2, !2}
+// CHECK: !2 = !{null, null, i64 222}
+// CHECK: !3 = !{i32 2, !"Debug Info Version", i32 3}
 
 module {
   llvm.module_flags [#llvm.mlir.module_flag<append, "CG Profile", [

--- a/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
@@ -2,25 +2,9 @@
 // CHECK: !llvm.module.flags
 
 module {
-  llvm.module_flags [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>,
-                     #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>,
-                     #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>,
-                     #llvm.mlir.module_flag<max, "uwtable", 2 : i32>,
-                     #llvm.mlir.module_flag<max, "frame-pointer", 1 : i32>,
-                     #llvm.mlir.module_flag<override, "probe-stack", "inline-asm">,
-                     #llvm.mlir.module_flag<append, "CG Profile", [
+  llvm.module_flags [#llvm.mlir.module_flag<append, "CG Profile", [
                        #llvm.cgprofile_entry<from = @from, to = @to, count = 222>,
                        #llvm.cgprofile_entry<from = @from, count = 222>,
                        #llvm.cgprofile_entry<from = @to, to = @from, count = 222>
-                    ]>,
-                    #llvm.mlir.module_flag<error, "ProfileSummary",
-                       #llvm.profile_summary<format = InstrProf, total_count = 263646, max_count = 86427,
-                         max_internal_count = 86427, max_function_count = 4691,
-                         num_counts = 3712, num_functions = 796,
-                         is_partial_profile = 0,
-                         partial_profile_ratio = 0.000000e+00 : f64,
-                         detailed_summary =
-                           <cut_off = 10000, min_count = 86427, num_counts = 1>,
-                           <cut_off = 100000, min_count = 86427, num_counts = 1>
-                    >>]
+                    ]>]
 }

--- a/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
@@ -1,9 +1,9 @@
 // RUN: mlir-translate %s -mlir-to-llvmir | FileCheck %s
-// CHECK: !llvm.module.flags = !{!0, !3}
-// CHECK: !0 = !{i32 5, !"CG Profile", !1}
-// CHECK: !1 = distinct !{!2, !2, !2}
-// CHECK: !2 = !{null, null, i64 222}
-// CHECK: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK: !llvm.module.flags = !{![[CG_FLAG:[0-9]+]], ![[DBG_FLAG:[0-9]+]]}
+// CHECK: [[CG_FLAG]] = !{i32 5, !"CG Profile", [[CG_LIST:![0-9]+]]}
+// CHECK: [[CG_LIST]] = distinct !{[[CG_ENTRY:![0-9]+]], [[CG_ENTRY]], [[CG_ENTRY]]}
+// CHECK: [[CG_ENTRY]] = !{null, null, i64 222}
+// CHECK: [[DBG_FLAG]] = !{i32 2, !"Debug Info Version", i32 3}
 
 module {
   llvm.module_flags [#llvm.mlir.module_flag<append, "CG Profile", [

--- a/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
@@ -1,9 +1,9 @@
 // RUN: mlir-translate %s -mlir-to-llvmir | FileCheck %s
 // CHECK: !llvm.module.flags = !{![[CG_FLAG:[0-9]+]], ![[DBG_FLAG:[0-9]+]]}
-// CHECK: [[CG_FLAG]] = !{i32 5, !"CG Profile", [[CG_LIST:![0-9]+]]}
-// CHECK: [[CG_LIST]] = distinct !{[[CG_ENTRY:![0-9]+]], [[CG_ENTRY]], [[CG_ENTRY]]}
-// CHECK: [[CG_ENTRY]] = !{null, null, i64 222}
-// CHECK: [[DBG_FLAG]] = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK: ![[CG_FLAG]] = !{i32 5, !"CG Profile", ![[CG_LIST:[0-9]+]]}
+// CHECK: ![[CG_LIST]] = distinct !{![[CG_ENTRY:[0-9]+]], ![[CG_ENTRY]], ![[CG_ENTRY]]}
+// CHECK: ![[CG_ENTRY]] = !{null, null, i64 222}
+// CHECK: ![[DBG_FLAG]] = !{i32 2, !"Debug Info Version", i32 3}
 
 module {
   llvm.module_flags [#llvm.mlir.module_flag<append, "CG Profile", [

--- a/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid-cg-profile.mlir
@@ -1,0 +1,26 @@
+// RUN: mlir-translate %s -mlir-to-llvmir | FileCheck %s
+// CHECK: !llvm.module.flags
+
+module {
+  llvm.module_flags [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>,
+                     #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>,
+                     #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>,
+                     #llvm.mlir.module_flag<max, "uwtable", 2 : i32>,
+                     #llvm.mlir.module_flag<max, "frame-pointer", 1 : i32>,
+                     #llvm.mlir.module_flag<override, "probe-stack", "inline-asm">,
+                     #llvm.mlir.module_flag<append, "CG Profile", [
+                       #llvm.cgprofile_entry<from = @from, to = @to, count = 222>,
+                       #llvm.cgprofile_entry<from = @from, count = 222>,
+                       #llvm.cgprofile_entry<from = @to, to = @from, count = 222>
+                    ]>,
+                    #llvm.mlir.module_flag<error, "ProfileSummary",
+                       #llvm.profile_summary<format = InstrProf, total_count = 263646, max_count = 86427,
+                         max_internal_count = 86427, max_function_count = 4691,
+                         num_counts = 3712, num_functions = 796,
+                         is_partial_profile = 0,
+                         partial_profile_ratio = 0.000000e+00 : f64,
+                         detailed_summary =
+                           <cut_off = 10000, min_count = 86427, num_counts = 1>,
+                           <cut_off = 100000, min_count = 86427, num_counts = 1>
+                    >>]
+}


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/160717

Now `build/bin/mlir-translate -mlir-to-llvmir mlir/test/Dialect/LLVMIR/module-roundtrip.mlir` passes.