### PR TITLE
[cmake] Fix semicolon expansion when passing LLVM_TABLEGEN_FLAGS

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -69,6 +69,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
          "${LLVM_EXTERNAL_PROJECTS}")
   string(REPLACE ";" "$<SEMICOLON>" llvm_enable_runtimes_arg
          "${LLVM_ENABLE_RUNTIMES}")
+  string(REPLACE ";" "$<SEMICOLON>" llvm_tablegen_flags
+         "${LLVM_TABLEGEN_FLAGS}")
 
   set(external_project_source_dirs)
   foreach(project ${LLVM_EXTERNAL_PROJECTS})
@@ -100,7 +102,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
         -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN="${LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN}"
         -DLLVM_INCLUDE_BENCHMARKS=OFF
         -DLLVM_INCLUDE_TESTS=OFF
-        -DLLVM_TABLEGEN_FLAGS="${LLVM_TABLEGEN_FLAGS}"
+        -DLLVM_TABLEGEN_FLAGS="${llvm_tablegen_flags}"
         -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}"
         ${build_type_flags} ${linker_flag} ${external_clang_dir} ${libc_flags}
         ${ARGN}


### PR DESCRIPTION
This patch uses common workaround for cmake semicolon expansion to spaces