### PR TITLE
[PGO] Add missing target datalayout in test

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/vectorize-zero-estimated-trip-count.ll
+++ b/llvm/test/Transforms/LoopVectorize/vectorize-zero-estimated-trip-count.ll
@@ -4,6 +4,7 @@
 
 ; RUN: opt -passes=loop-vectorize -S %s | FileCheck %s
 
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Look for basic signs that vectorization ran and produced memory checks.


### PR DESCRIPTION
The test was added by b8ef25aa643761233dc5b74d9fb7c38a2064d9c7.  It failed on at least the following bots, but the failure did not reproduce on my test machines or in pre-commit CI:

- https://lab.llvm.org/buildbot/#/builders/190/builds/31638
- https://lab.llvm.org/buildbot/#/builders/190/builds/31638

This fix hopefully addresses at least the warnings there.