### PR TITLE
[bazel] Add alias for zlib-ng for WORKSPACE compat

### DIFF
--- a/utils/bazel/third_party_build/zlib-ng.BUILD
+++ b/utils/bazel/third_party_build/zlib-ng.BUILD
@@ -96,3 +96,8 @@ cc_library(
     strip_include_prefix = ".",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "zlib-ng",
+    actual = ":zlib",
+)


### PR DESCRIPTION
The consumer of zlib in third-party/BUILD.bazel expects zlib-ng from the
BCR, if you still load this version from your WORKSPACE / MODULE.bazel
you need to use this name instead.
