### PR TITLE
[PGO] Add REQUIRES to test

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/vectorize-zero-estimated-trip-count.ll
+++ b/llvm/test/Transforms/LoopVectorize/vectorize-zero-estimated-trip-count.ll
@@ -2,6 +2,7 @@
 ; LoopVectorize behavior while it tries to create runtime memory checks inside
 ; an outer loop.
 
+; REQUIRES: x86-registered-target
 ; RUN: opt -passes=loop-vectorize -S %s | FileCheck %s
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"


### PR DESCRIPTION
The test was added by b8ef25aa643761233dc5b74d9fb7c38a2064d9c7. It failed on at least the following bots, but the failure did not reproduce on my test machines or in pre-commit CI:

- https://lab.llvm.org/buildbot/#/builders/190/builds/31643
- https://lab.llvm.org/buildbot/#/builders/65/builds/25949
- https://lab.llvm.org/buildbot/#/builders/154/builds/24417

d69e70149636efa0293310303878fbf9a5f31433 did not fix the failure. Hopefully this will.