### PR TITLE
[Flang-rt] Remove COMPILE_ONLY from flang-rt CMake file.

### DIFF
--- a/flang-rt/cmake/modules/HandleLibs.cmake
+++ b/flang-rt/cmake/modules/HandleLibs.cmake
@@ -45,8 +45,6 @@ elseif (FLANG_RT_LIBCXX_PROVIDER STREQUAL "llvm")
   endif ()
 
   if (FLANG_RT_HAS_STDLIB_FLAG)
-    target_compile_options(flang-rt-libc-headers INTERFACE
-      $<$<COMPILE_LANGUAGE:CXX,C>:$<COMPILE_ONLY:-stdlib=libc++>>
-    )
+    target_compile_options(flang-rt-libc-headers INTERFACE $<$<COMPILE_LANGUAGE:CXX,C>:-stdlib=libc++>)
   endif ()
 endif ()


### PR DESCRIPTION
COMPILE_ONLY was introduced in cmake 3.27.0. We cannot use this feature, because LLVM supports cmake 3.20.0.