### PR TITLE
[BOLT][Tests] Use AT&T assembler syntax only for X86 tests

### DIFF
--- a/bolt/test/X86/lit.local.cfg
+++ b/bolt/test/X86/lit.local.cfg
@@ -1,7 +1,7 @@
 if not "X86" in config.root.targets:
     config.unsupported = True
 
-flags = "--target=x86_64-unknown-linux-gnu -nostdlib"
+flags = "--target=x86_64-unknown-linux-gnu -nostdlib -mllvm -x86-asm-syntax=att"
 
 config.substitutions.insert(0, ("%cflags", f"%cflags {flags}"))
 config.substitutions.insert(0, ("%cxxflags", f"%cxxflags {flags}"))

--- a/bolt/test/lit.local.cfg
+++ b/bolt/test/lit.local.cfg
@@ -5,7 +5,7 @@ if not "linux" in host_triple:
   host_triple = host_triple.split("-")[0] + "-unknown-linux-gnu"
 
 common_linker_flags = "-fuse-ld=lld -Wl,--unresolved-symbols=ignore-all -Wl,--build-id=none -pie"
-flags = f"--target={host_triple} -fPIE {common_linker_flags} -mllvm -x86-asm-syntax=att"
+flags = f"--target={host_triple} -fPIE {common_linker_flags}"
 
 config.substitutions.insert(0, ("%cflags", f"%cflags {flags}"))
 config.substitutions.insert(0, ("%cxxflags", f"%cxxflags {flags}"))


### PR DESCRIPTION
Enabling AT&T syntax for all tests is broken when X86 target is not enabled as reported in #167225.