### PR TITLE
[PowerPC] Fix unused variable after 0c9c62adf165eb

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -15673,8 +15673,8 @@ static SDValue ConvertSETCCToXori(SDNode *N, SelectionDAG &DAG) {
   SDValue RHS = N->getOperand(1);
   SDLoc DL(N);
 
-  ISD::CondCode CC = cast<CondCodeSDNode>(N->getOperand(2))->get();
-  assert((CC == ISD::SETEQ) && "CC must be ISD::SETEQ.");
+  assert((cast<CondCodeSDNode>(N->getOperand(2))->get() == ISD::SETEQ) &&
+         "CC must be ISD::SETEQ.");
   // Rewrite it as XORI (and X, 1), 1.
   auto MakeXor1 = [&](SDValue V) {
     EVT VT = V.getValueType();


### PR DESCRIPTION
This variable is only used in an assertion, so inline it per the LLVM coding standards.