### PR TITLE
[OpenMP] Add docs for fb_nullify/fb_preserve

### DIFF
--- a/clang/docs/OpenMPSupport.rst
+++ b/clang/docs/OpenMPSupport.rst
@@ -633,8 +633,8 @@ implementation.
 |                                                             |                           |                           | RT: @abhinavgaba (https://github.com/llvm/llvm-project/pull/149036,      |
 |                                                             |                           |                           | https://github.com/llvm/llvm-project/pull/158370)                        |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
-| need_device_ptr modifier for adjust_args clause             | :part:`partial`           | :none:`unclaimed`         | Clang Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905
-|                                                             |                           |                           | https://github.com/llvm/llvm-project/pull/169558
+| need_device_ptr modifier for adjust_args clause             | :part:`partial`           | :none:`unclaimed`         | Clang Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905     |
+|                                                             |                           |                           | https://github.com/llvm/llvm-project/pull/169558                         |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
 
 OpenMP Extensions

--- a/clang/docs/OpenMPSupport.rst
+++ b/clang/docs/OpenMPSupport.rst
@@ -580,7 +580,7 @@ implementation.
 | need_device_addr modifier for adjust_args clause            | :part:`partial`           | :none:`unclaimed`         | Parsing/Sema: https://github.com/llvm/llvm-project/pull/143442           |
 |                                                             |                           |                           |               https://github.com/llvm/llvm-project/pull/149586           |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
-| need_device_ptr modifier for adjust_args clause             | :part:`partial`           | :none:`unclaimed`         | Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905           |
+| need_device_ptr modifier for adjust_args clause             | :part:`partial`           | :none:`unclaimed`         | Clang Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905     |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
 | Prescriptive num_threads                                    | :good:`done`              | :none:`unclaimed`         |  https://github.com/llvm/llvm-project/pull/160659                        |
 |                                                             |                           |                           |  https://github.com/llvm/llvm-project/pull/146403                        |

--- a/clang/docs/OpenMPSupport.rst
+++ b/clang/docs/OpenMPSupport.rst
@@ -580,6 +580,8 @@ implementation.
 | need_device_addr modifier for adjust_args clause            | :part:`partial`           | :none:`unclaimed`         | Parsing/Sema: https://github.com/llvm/llvm-project/pull/143442           |
 |                                                             |                           |                           |               https://github.com/llvm/llvm-project/pull/149586           |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
+| need_device_ptr modifier for adjust_args clause             | :part:`partial`           | :none:`unclaimed`         | Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905           |
++-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
 | Prescriptive num_threads                                    | :good:`done`              | :none:`unclaimed`         |  https://github.com/llvm/llvm-project/pull/160659                        |
 |                                                             |                           |                           |  https://github.com/llvm/llvm-project/pull/146403                        |
 |                                                             |                           |                           |  https://github.com/llvm/llvm-project/pull/146404                        |

--- a/clang/docs/OpenMPSupport.rst
+++ b/clang/docs/OpenMPSupport.rst
@@ -633,7 +633,7 @@ implementation.
 |                                                             |                           |                           | RT: @abhinavgaba (https://github.com/llvm/llvm-project/pull/149036,      |
 |                                                             |                           |                           | https://github.com/llvm/llvm-project/pull/158370)                        |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
-| need_device_ptr modifier for adjust_args clause             | :part:`unclaimed`         | :none:`unclaimed`         | Clang Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905     |
+| need_device_ptr modifier for adjust_args clause             | :part:`partial`           | :none:`unclaimed`         | Clang Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905     |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
 
 OpenMP Extensions

--- a/clang/docs/OpenMPSupport.rst
+++ b/clang/docs/OpenMPSupport.rst
@@ -580,7 +580,7 @@ implementation.
 | need_device_addr modifier for adjust_args clause            | :part:`partial`           | :none:`unclaimed`         | Parsing/Sema: https://github.com/llvm/llvm-project/pull/143442           |
 |                                                             |                           |                           |               https://github.com/llvm/llvm-project/pull/149586           |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
-| need_device_ptr modifier for adjust_args clause             | :part:`partial`           | :none:`unclaimed`         | Clang Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905     |
+| need_device_ptr modifier for adjust_args clause             | :part:`unclaimed`         | :none:`unclaimed`         |                                                                          |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
 | Prescriptive num_threads                                    | :good:`done`              | :none:`unclaimed`         |  https://github.com/llvm/llvm-project/pull/160659                        |
 |                                                             |                           |                           |  https://github.com/llvm/llvm-project/pull/146403                        |
@@ -633,7 +633,8 @@ implementation.
 |                                                             |                           |                           | RT: @abhinavgaba (https://github.com/llvm/llvm-project/pull/149036,      |
 |                                                             |                           |                           | https://github.com/llvm/llvm-project/pull/158370)                        |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
-
+| need_device_ptr modifier for adjust_args clause             | :part:`unclaimed`         | :none:`unclaimed`         | Clang Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905     |
++-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
 
 OpenMP Extensions
 =================

--- a/clang/docs/OpenMPSupport.rst
+++ b/clang/docs/OpenMPSupport.rst
@@ -633,7 +633,8 @@ implementation.
 |                                                             |                           |                           | RT: @abhinavgaba (https://github.com/llvm/llvm-project/pull/149036,      |
 |                                                             |                           |                           | https://github.com/llvm/llvm-project/pull/158370)                        |
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
-| need_device_ptr modifier for adjust_args clause             | :part:`partial`           | :none:`unclaimed`         | Clang Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905     |
+| need_device_ptr modifier for adjust_args clause             | :part:`partial`           | :none:`unclaimed`         | Clang Parsing/Sema: https://github.com/llvm/llvm-project/pull/168905
+|                                                             |                           |                           | https://github.com/llvm/llvm-project/pull/169558
 +-------------------------------------------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------+
 
 OpenMP Extensions

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -756,6 +756,8 @@ OpenMP Support
 - Updated parsing and semantic analysis support for ``nowait`` clause to accept
   optional argument in OpenMP >= 60.
 - Added support for ``default`` clause on ``target`` directive.
+- Added support for OpenMP 6.0 ``fb_nullify`` and ``fb_preserve`` fallback
+  modifiers used with the ``need_device_ptr`` map modifier.
 
 Improvements
 ^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -756,8 +756,9 @@ OpenMP Support
 - Updated parsing and semantic analysis support for ``nowait`` clause to accept
   optional argument in OpenMP >= 60.
 - Added support for ``default`` clause on ``target`` directive.
-- Added support for OpenMP 6.0 ``fb_nullify`` and ``fb_preserve`` fallback
-  modifiers used with the ``need_device_ptr`` map modifier.
+- Added parsing and semantic analysis support for ``need_device_ptr`` modifier
+  to accept an optional fallback argument (``fb_nullify`` or ``fb_preserve``)
+  with OpenMP >= 61.
 
 Improvements
 ^^^^^^^^^^^^


### PR DESCRIPTION
Adding documentation following the merge of https://github.com/llvm/llvm-project/pull/168905. 