### PR TITLE
Reland: [GPUToXeVMPipeline][Pipeline] Modify pipeline to add `convert-vector-to-llvm`.

### DIFF
--- a/mlir/lib/Dialect/GPU/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/Pipelines/CMakeLists.txt
@@ -21,6 +21,7 @@ add_mlir_dialect_library(MLIRGPUPipelines
   MLIRNVVMToLLVM
   MLIRReconcileUnrealizedCasts
   MLIRSCFToControlFlow
+  MLIRVectorToLLVMPass
   MLIRVectorToSCF
   MLIRXeGPUTransforms
   MLIRXeGPUToXeVM

--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToXeVMPipeline.cpp
@@ -111,8 +111,11 @@ void buildPostGPUCommonPassPipeline(
     pm.addPass(createGpuToLLVMConversionPass(gpuToLLVMOptions));
   }
   pm.addPass(createLowerAffinePass());
+  pm.addPass(createConvertVectorToLLVMPass());
   pm.addPass(createConvertToLLVMPass());
   pm.addPass(createReconcileUnrealizedCastsPass());
+  pm.addNestedPass<gpu::GPUModuleOp>(createCanonicalizerPass());
+  pm.addNestedPass<gpu::GPUModuleOp>(createCSEPass());
   // gpu-module-to-binary
   {
     GpuModuleToBinaryPassOptions gpuToModuleBinOptions;


### PR DESCRIPTION
`convert-vector-to-llvm` pass applies a set of vector transformation patterns that are not included in the standard `convert-to-llvm` pass interface. These additional transformations are required to properly lower MLIR vector operations. Since not all vector ops have direct `llvm` dialect lowering, many of them must first be progressively rewritten into simpler or more canonical vector ops, which are then lowered to `llvm`. Therefore, running `convert-vector-to-llvm` is necessary to ensure a complete and correct lowering of vector operations to the `llvm` dialect.

Original PR: https://github.com/llvm/llvm-project/pull/166204 + post-commit failure fixes.