### PR TITLE
[rtsan] Handle attributed IR function declarations

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/RealtimeSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/RealtimeSanitizer.cpp
@@ -90,6 +90,9 @@ PreservedAnalyses RealtimeSanitizerPass::run(Module &M,
       [&](Function *Ctor, FunctionCallee) { appendToGlobalCtors(M, Ctor, 0); });
 
   for (Function &F : M) {
+    if (F.empty())
+      continue;
+
     if (F.hasFnAttribute(Attribute::SanitizeRealtime))
       runSanitizeRealtime(F);
 

--- a/llvm/test/Instrumentation/RealtimeSanitizer/rtsan_attrib_declare.ll
+++ b/llvm/test/Instrumentation/RealtimeSanitizer/rtsan_attrib_declare.ll
@@ -1,0 +1,11 @@
+; RUN: opt < %s -passes='rtsan' -S | FileCheck %s
+
+declare void @declared_realtime_function() sanitize_realtime #0
+
+declare void @declared_blocking_function() sanitize_realtime_blocking #0
+
+; RealtimeSanitizer pass should ignore attributed functions that are just declarations
+; CHECK: declared_realtime_function
+; CHECK-EMPTY:
+; CHECK: declared_blocking_function
+; CHECK-EMPTY:


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/169377.

Previously, the RealtimeSanitizer pass only handled attributed function _definitions_ in IR, and we have recently found that attributed function _declarations_ caused it to crash. To fix the issue, we must check whether the IR function is empty before attempting to do any manipulation of its instructions.

This PR:

- Adds checks for whether IR `Function`s are `empty()` ~~in each relevant~~ at the top-level RTSan pass routine
- ~~Removes the utility function `rtsanPreservedCFGAnalyses` from the pass, whose result was unused and which would otherwise have complicated the fix~~ 