### PR TITLE
[BOLT][AArch64] Tweak heuristics for epilogue recognition

### DIFF
--- a/bolt/test/AArch64/epilogue-determination.s
+++ b/bolt/test/AArch64/epilogue-determination.s
@@ -1,5 +1,6 @@
 # Test that we will not incorrectly take the first basic block in function
-# `_foo` as epilogue due to the first load from stack instruction.
+# `_foo` or the second basic block in function `_goo` as epilogue, and will
+# recognize epilogues in the other cases.
 
 # RUN: %clang %cflags %s -o %t.so -Wl,-q
 # RUN: llvm-bolt %t.so -o %t.bolt --print-cfg | FileCheck %s
@@ -13,8 +14,9 @@ _foo:
   ldrsw x9, [x10, x9, lsl #2]
   add x10, x10, x9
   br x10
-# CHECK-NOT: x10 # TAILCALL
-# CHECK: x10 # UNKNOWN CONTROL FLOW
+# CHECK-LABEL: _foo
+# CHECK: br x10
+# CHECK-SAME: # UNKNOWN CONTROL FLOW
   mov x0, 0
   ret
   mov x0, 1
@@ -31,13 +33,51 @@ _bar:
   stp x29, x30, [sp, #-0x10]!
   mov x29, sp
   sub sp, sp, #0x10
+  tbnz x0, #0x3, _L2
   ldr x8, [x29, #0x30]
   blr x8
+_L2:
   add sp, sp, #0x10
   ldp x29, x30, [sp], #0x10
   br x2
-# CHECK-NOT: x2 # UNKNOWN CONTROL FLOW
-# CHECK: x2 # TAILCALL
+# CHECK-LABEL: _bar
+# CHECK: br x2
+# CHECK-SAME: # TAILCALL
+
+  .global _goo
+  .type _goo, %function
+_goo:
+  ldr w8, [sp]
+  adr x10, _jmptbl2
+  ldrsw x9, [x10, x9, lsl #2]
+  add x10, x10, x9
+  str x30, [sp, #-0x10]!
+  bl _bar
+  ldr x30, [sp], #0x10
+  mov x1, x0
+  mov x0, xzr
+  br x10
+# CHECK-LABEL: _goo
+# CHECK: br x10
+# CHECK-SAME: # UNKNOWN CONTROL FLOW
+  mov x0, 0
+  ret
+  mov x0, 1
+  ret
+
+  .global _faz
+  .type _faz, %function
+_faz:
+  str x30, [sp, #-0x10]!
+  tbnz x0, #0x1, _L3
+  bl _bar
+_L3:
+  ldr x30, [sp], #0x10
+  mov x0, x1
+  br x3
+# CHECK-LABEL: _faz
+# CHECK: br x3
+# CHECK-SAME: # TAILCALL
 
   .global _start
   .type _start, %function


### PR DESCRIPTION
If a basic block contains a load into LR from stack and has no instruction saving LR onto stack, we just assume the basic block is an epilogue.

This is not meant to accurately recognize epilogue in all possible cases, but to have BOLT be conservative on treating basic block as epilogue and then turning indirect branch with unknown control flow to tail call.