### PR TITLE
opt: Stop creating TargetMachine to infer the datalayout

### DIFF
--- a/llvm/test/tools/opt/invalid-target.ll
+++ b/llvm/test/tools/opt/invalid-target.ll
@@ -7,10 +7,10 @@
 
 ;; Using "unknown" as the architecture is explicitly allowed (but warns)
 ; RUN: opt -mtriple=unknown -S -passes=no-op-module -o /dev/null < %s 2>&1 | FileCheck %s --check-prefix=UNKNOWN
-; UNKNOWN: warning: failed to infer data layout{{$}}
+; UNKNOWN: warning: failed to infer data layout from target triple{{$}}
 
 ;; However, any other invalid target triple should cause the tool to fail:
 ; RUN: not opt -mtriple=invalid -S -passes=no-op-module -o /dev/null < %s 2>&1 | FileCheck %s --check-prefix=INVALID
-; INVALID: warning: failed to infer data layout{{$}}
+; INVALID: warning: failed to infer data layout from target triple{{$}}
 ; INVALID-NEXT: unrecognized architecture 'invalid' provided.
 ; INVALID-EMPTY:

--- a/llvm/test/tools/opt/invalid-target.ll
+++ b/llvm/test/tools/opt/invalid-target.ll
@@ -7,10 +7,10 @@
 
 ;; Using "unknown" as the architecture is explicitly allowed (but warns)
 ; RUN: opt -mtriple=unknown -S -passes=no-op-module -o /dev/null < %s 2>&1 | FileCheck %s --check-prefix=UNKNOWN
-; UNKNOWN: warning: failed to infer data layout: unable to get target for 'unknown', see --version and --triple.
+; UNKNOWN: warning: failed to infer data layout{{$}}
 
 ;; However, any other invalid target triple should cause the tool to fail:
 ; RUN: not opt -mtriple=invalid -S -passes=no-op-module -o /dev/null < %s 2>&1 | FileCheck %s --check-prefix=INVALID
-; INVALID: warning: failed to infer data layout: unable to get target for 'invalid', see --version and --triple.
+; INVALID: warning: failed to infer data layout{{$}}
 ; INVALID-NEXT: unrecognized architecture 'invalid' provided.
 ; INVALID-EMPTY:

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -543,7 +543,8 @@ optMain(int argc, char **argv,
 
     std::string Str = TT.computeDataLayout();
     if (Str.empty()) {
-      errs() << argv[0] << ": warning: failed to infer data layout\n";
+      errs() << argv[0]
+             << ": warning: failed to infer data layout from target triple\n";
       return std::nullopt;
     }
     return Str;

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -538,15 +538,15 @@ optMain(int argc, char **argv,
     // the IR, we should default to an empty (default) DataLayout.
     if (TripleStr.empty())
       return std::nullopt;
-    // Otherwise we infer the DataLayout from the target machine.
-    Expected<std::unique_ptr<TargetMachine>> ExpectedTM =
-        codegen::createTargetMachineForTriple(TripleStr, GetCodeGenOptLevel());
-    if (!ExpectedTM) {
-      errs() << argv[0] << ": warning: failed to infer data layout: "
-             << toString(ExpectedTM.takeError()) << "\n";
+
+    Triple TT(TripleStr);
+
+    std::string Str = TT.computeDataLayout();
+    if (Str.empty()) {
+      errs() << argv[0] << ": warning: failed to infer data layout\n";
       return std::nullopt;
     }
-    return (*ExpectedTM)->createDataLayout().getStringRepresentation();
+    return Str;
   };
   std::unique_ptr<Module> M;
   if (NoUpgradeDebugInfo)


### PR DESCRIPTION
The Triple directly has the datalayout string in it, so just
use that.

The logical flow here is kind of a mess. We were constructing
a temporary target machine in the asm parser to infer the datalayout,
throwing it away, and then creating another target machine for the
actual compilation. The flow of the Triple construction is still
convoluted, but we can at least drop the TargetMachine.