### PR TITLE
[CIR][NFC] Cleanup builtin helper function interfaces

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -21,13 +21,12 @@ using namespace clang;
 using namespace clang::CIRGen;
 
 template <typename... Operands>
-static mlir::Value emitIntrinsicCallOp(CIRGenFunction &cgf, const CallExpr *e,
+static mlir::Value emitIntrinsicCallOp(CIRGenFunction &cgf, mlir::Location loc,
                                        const std::string &str,
                                        const mlir::Type &resTy,
                                        Operands &&...op) {
   CIRGenBuilderTy &builder = cgf.getBuilder();
-  mlir::Location location = cgf.getLoc(e->getExprLoc());
-  return cir::LLVMIntrinsicCallOp::create(builder, location,
+  return cir::LLVMIntrinsicCallOp::create(builder, loc,
                                           builder.getStringAttr(str), resTy,
                                           std::forward<Operands>(op)...)
       .getResult();
@@ -68,7 +67,7 @@ static mlir::Value emitVectorFCmp(CIRGenBuilderTy &builder,
   return bitCast;
 }
 
-static mlir::Value getMaskVecValue(CIRGenFunction &cgf, const CallExpr *expr,
+static mlir::Value getMaskVecValue(CIRGenFunction &cgf, mlir::Location loc,
                                    mlir::Value mask, unsigned numElems) {
 
   CIRGenBuilderTy &builder = cgf.getBuilder();
@@ -84,8 +83,7 @@ static mlir::Value getMaskVecValue(CIRGenFunction &cgf, const CallExpr *expr,
     for (auto i : llvm::seq<unsigned>(0, numElems))
       indices.push_back(cir::IntAttr::get(i32Ty, i));
 
-    maskVec = builder.createVecShuffle(cgf.getLoc(expr->getExprLoc()), maskVec,
-                                       maskVec, indices);
+    maskVec = builder.createVecShuffle(loc, maskVec, maskVec, indices);
   }
   return maskVec;
 }
@@ -132,15 +130,20 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   default:
     return {};
   case X86::BI_mm_clflush:
-    return emitIntrinsicCallOp(*this, expr, "x86.sse2.clflush", voidTy, ops[0]);
+    return emitIntrinsicCallOp(*this, getLoc(expr->getExprLoc()),
+                               "x86.sse2.clflush", voidTy, ops[0]);
   case X86::BI_mm_lfence:
-    return emitIntrinsicCallOp(*this, expr, "x86.sse2.lfence", voidTy);
+    return emitIntrinsicCallOp(*this, getLoc(expr->getExprLoc()),
+                               "x86.sse2.lfence", voidTy);
   case X86::BI_mm_pause:
-    return emitIntrinsicCallOp(*this, expr, "x86.sse2.pause", voidTy);
+    return emitIntrinsicCallOp(*this, getLoc(expr->getExprLoc()),
+                               "x86.sse2.pause", voidTy);
   case X86::BI_mm_mfence:
-    return emitIntrinsicCallOp(*this, expr, "x86.sse2.mfence", voidTy);
+    return emitIntrinsicCallOp(*this, getLoc(expr->getExprLoc()),
+                               "x86.sse2.mfence", voidTy);
   case X86::BI_mm_sfence:
-    return emitIntrinsicCallOp(*this, expr, "x86.sse.sfence", voidTy);
+    return emitIntrinsicCallOp(*this, getLoc(expr->getExprLoc()),
+                               "x86.sse.sfence", voidTy);
   case X86::BI_mm_prefetch:
   case X86::BI__rdtsc:
   case X86::BI__builtin_ia32_rdtscp: {
@@ -152,15 +155,17 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   case X86::BI__builtin_ia32_lzcnt_u16:
   case X86::BI__builtin_ia32_lzcnt_u32:
   case X86::BI__builtin_ia32_lzcnt_u64: {
-    mlir::Value isZeroPoison = builder.getFalse(getLoc(expr->getExprLoc()));
-    return emitIntrinsicCallOp(*this, expr, "ctlz", ops[0].getType(),
+    mlir::Location loc = getLoc(expr->getExprLoc());
+    mlir::Value isZeroPoison = builder.getFalse(loc);
+    return emitIntrinsicCallOp(*this, loc, "ctlz", ops[0].getType(),
                                mlir::ValueRange{ops[0], isZeroPoison});
   }
   case X86::BI__builtin_ia32_tzcnt_u16:
   case X86::BI__builtin_ia32_tzcnt_u32:
   case X86::BI__builtin_ia32_tzcnt_u64: {
-    mlir::Value isZeroPoison = builder.getFalse(getLoc(expr->getExprLoc()));
-    return emitIntrinsicCallOp(*this, expr, "cttz", ops[0].getType(),
+    mlir::Location loc = getLoc(expr->getExprLoc());
+    mlir::Value isZeroPoison = builder.getFalse(loc);
+    return emitIntrinsicCallOp(*this, loc, "cttz", ops[0].getType(),
                                mlir::ValueRange{ops[0], isZeroPoison});
   }
   case X86::BI__builtin_ia32_undef128:
@@ -216,14 +221,14 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
     mlir::Location loc = getLoc(expr->getExprLoc());
     Address tmp = createMemTemp(expr->getArg(0)->getType(), loc);
     builder.createStore(loc, ops[0], tmp);
-    return emitIntrinsicCallOp(*this, expr, "x86.sse.ldmxcsr",
+    return emitIntrinsicCallOp(*this, loc, "x86.sse.ldmxcsr",
                                builder.getVoidTy(), tmp.getPointer());
   }
   case X86::BI_mm_getcsr:
   case X86::BI__builtin_ia32_stmxcsr: {
     mlir::Location loc = getLoc(expr->getExprLoc());
     Address tmp = createMemTemp(expr->getType(), loc);
-    emitIntrinsicCallOp(*this, expr, "x86.sse.stmxcsr", builder.getVoidTy(),
+    emitIntrinsicCallOp(*this, loc, "x86.sse.stmxcsr", builder.getVoidTy(),
                         tmp.getPointer());
     return builder.createLoad(loc, tmp);
   }
@@ -605,50 +610,48 @@ mlir::Value CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID,
   case X86::BI__builtin_ia32_kshiftlihi:
   case X86::BI__builtin_ia32_kshiftlisi:
   case X86::BI__builtin_ia32_kshiftlidi: {
+    mlir::Location loc = getLoc(expr->getExprLoc());
     unsigned shiftVal =
         ops[1].getDefiningOp<cir::ConstantOp>().getIntValue().getZExtValue() &
         0xff;
     unsigned numElems = cast<cir::IntType>(ops[0].getType()).getWidth();
 
     if (shiftVal >= numElems)
-      return builder.getNullValue(ops[0].getType(), getLoc(expr->getExprLoc()));
+      return builder.getNullValue(ops[0].getType(), loc);
 
-    mlir::Value in = getMaskVecValue(*this, expr, ops[0], numElems);
+    mlir::Value in = getMaskVecValue(*this, loc, ops[0], numElems);
 
     SmallVector<mlir::Attribute, 64> indices;
     mlir::Type i32Ty = builder.getSInt32Ty();
     for (auto i : llvm::seq<unsigned>(0, numElems))
       indices.push_back(cir::IntAttr::get(i32Ty, numElems + i - shiftVal));
 
-    mlir::Value zero =
-        builder.getNullValue(in.getType(), getLoc(expr->getExprLoc()));
-    mlir::Value sv =
-        builder.createVecShuffle(getLoc(expr->getExprLoc()), zero, in, indices);
+    mlir::Value zero = builder.getNullValue(in.getType(), loc);
+    mlir::Value sv = builder.createVecShuffle(loc, zero, in, indices);
     return builder.createBitcast(sv, ops[0].getType());
   }
   case X86::BI__builtin_ia32_kshiftriqi:
   case X86::BI__builtin_ia32_kshiftrihi:
   case X86::BI__builtin_ia32_kshiftrisi:
   case X86::BI__builtin_ia32_kshiftridi: {
+    mlir::Location loc = getLoc(expr->getExprLoc());
     unsigned shiftVal =
         ops[1].getDefiningOp<cir::ConstantOp>().getIntValue().getZExtValue() &
         0xff;
     unsigned numElems = cast<cir::IntType>(ops[0].getType()).getWidth();
 
     if (shiftVal >= numElems)
-      return builder.getNullValue(ops[0].getType(), getLoc(expr->getExprLoc()));
+      return builder.getNullValue(ops[0].getType(), loc);
 
-    mlir::Value in = getMaskVecValue(*this, expr, ops[0], numElems);
+    mlir::Value in = getMaskVecValue(*this, loc, ops[0], numElems);
 
     SmallVector<mlir::Attribute, 64> indices;
     mlir::Type i32Ty = builder.getSInt32Ty();
     for (auto i : llvm::seq<unsigned>(0, numElems))
       indices.push_back(cir::IntAttr::get(i32Ty, i + shiftVal));
 
-    mlir::Value zero =
-        builder.getNullValue(in.getType(), getLoc(expr->getExprLoc()));
-    mlir::Value sv =
-        builder.createVecShuffle(getLoc(expr->getExprLoc()), in, zero, indices);
+    mlir::Value zero = builder.getNullValue(in.getType(), loc);
+    mlir::Value sv = builder.createVecShuffle(loc, in, zero, indices);
     return builder.createBitcast(sv, ops[0].getType());
   }
   case X86::BI__builtin_ia32_vprotbi:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -22,8 +22,7 @@ using namespace clang::CIRGen;
 
 template <typename... Operands>
 static mlir::Value emitIntrinsicCallOp(CIRGenBuilderTy &builder,
-                                       mlir::Location loc,
-                                       const StringRef str,
+                                       mlir::Location loc, const StringRef str,
                                        const mlir::Type &resTy,
                                        Operands &&...op) {
   return cir::LLVMIntrinsicCallOp::create(builder, loc,


### PR DESCRIPTION
A couple of builtin helper functions were taking a clang::Expr argument but only using it to build an MLIR location. This change updates these functions to take a location directly.