### PR TITLE
[lldb] Unify DW_OP_deref and DW_OP_deref_size implementations

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -884,15 +884,14 @@ static llvm::Error Evaluate_DW_OP_deref_size(DWARFExpression::Stack &stack,
                                              lldb::ModuleSP module_sp,
                                              Process *process, Target *target,
                                              uint8_t size) {
-  if (stack.empty()) {
+  if (stack.empty())
     return llvm::createStringError(
         "expression stack empty for DW_OP_deref_size");
-  }
 
-  if (size > 8) {
+  if (size > 8)
     return llvm::createStringError(
         "Invalid address size for DW_OP_deref_size: %d\n", size);
-  }
+
   Value::ValueType value_type = stack.back().GetValueType();
   switch (value_type) {
   case Value::ValueType::HostAddress: {
@@ -900,9 +899,8 @@ static llvm::Error Evaluate_DW_OP_deref_size(DWARFExpression::Stack &stack,
     intptr_t ptr;
     ::memcpy(&ptr, src, sizeof(void *));
     // I can't decide whether the size operand should apply to the bytes in
-    // their
-    // lldb-host endianness or the target endianness.. I doubt this'll ever
-    // come up but I'll opt for assuming big endian regardless.
+    // their lldb-host endianness or the target endianness.. I doubt this'll
+    // ever come up but I'll opt for assuming big endian regardless.
     switch (size) {
     case 1:
       ptr = ptr & 0xff;
@@ -916,10 +914,9 @@ static llvm::Error Evaluate_DW_OP_deref_size(DWARFExpression::Stack &stack,
     case 4:
       ptr = ptr & 0xffffffff;
       break;
-    // the casts are added to work around the case where intptr_t is a 32
-    // bit quantity;
-    // presumably we won't hit the 5..7 cases if (void*) is 32-bits in this
-    // program.
+    // The casts are added to work around the case where intptr_t is a 32-bit
+    // quantity. Presumably we won't hit the 5..7 cases if (void*) is 32-bits in
+    // this program.
     case 5:
       ptr = (intptr_t)ptr & 0xffffffffffULL;
       break;
@@ -951,20 +948,19 @@ static llvm::Error Evaluate_DW_OP_deref_size(DWARFExpression::Stack &stack,
       uint8_t addr_bytes[8];
       Status error;
 
-      if (target && target->ReadMemory(so_addr, &addr_bytes, size, error,
-                                       /*force_live_memory=*/false) == size) {
-        ObjectFile *objfile = module_sp->GetObjectFile();
-
-        stack.back().GetScalar() = DerefSizeExtractDataHelper(
-            addr_bytes, size, objfile->GetByteOrder(), size);
-        stack.back().ClearContext();
-        break;
-      } else {
+      if (!target || target->ReadMemory(so_addr, &addr_bytes, size, error,
+                                        /*force_live_memory=*/false) != size)
         return llvm::createStringError(
-            "Failed to dereference pointer for DW_OP_deref_size: "
+            "failed to dereference pointer for DW_OP_deref_size: "
             "%s\n",
             error.AsCString());
-      }
+
+      ObjectFile *objfile = module_sp->GetObjectFile();
+
+      stack.back().GetScalar() = DerefSizeExtractDataHelper(
+          addr_bytes, size, objfile->GetByteOrder(), size);
+      stack.back().ClearContext();
+      break;
     }
     stack.back().GetScalar() = load_addr;
     // Fall through to load address promotion code below.
@@ -975,37 +971,30 @@ static llvm::Error Evaluate_DW_OP_deref_size(DWARFExpression::Stack &stack,
     // Promote Scalar to LoadAddress and fall through.
     stack.back().SetValueType(Value::ValueType::LoadAddress);
     [[fallthrough]];
-  case Value::ValueType::LoadAddress:
-    if (exe_ctx) {
-      if (process) {
-        lldb::addr_t pointer_addr =
-            stack.back().GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
-        uint8_t addr_bytes[sizeof(lldb::addr_t)];
-        Status error;
-        if (process->ReadMemory(pointer_addr, &addr_bytes, size, error) ==
-            size) {
-
-          stack.back().GetScalar() = DerefSizeExtractDataHelper(
-              addr_bytes, sizeof(addr_bytes), process->GetByteOrder(), size);
-          stack.back().ClearContext();
-        } else {
-          return llvm::createStringError(
-              "Failed to dereference pointer from 0x%" PRIx64
-              " for DW_OP_deref: %s\n",
-              pointer_addr, error.AsCString());
-        }
-      } else {
-
-        return llvm::createStringError("NULL process for DW_OP_deref_size");
-      }
-    } else {
+  case Value::ValueType::LoadAddress: {
+    if (!exe_ctx)
       return llvm::createStringError(
-          "NULL execution context for DW_OP_deref_size");
-    }
-    break;
+          "no execution context for DW_OP_deref_size");
+    if (!process)
+      return llvm::createStringError("no process for DW_OP_deref_size");
+
+    lldb::addr_t pointer_addr =
+        stack.back().GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
+    uint8_t addr_bytes[sizeof(lldb::addr_t)];
+    Status error;
+
+    if (process->ReadMemory(pointer_addr, &addr_bytes, size, error) != size)
+      return llvm::createStringError(
+          "failed to dereference pointer from 0x%" PRIx64
+          " for DW_OP_deref_size: %s\n",
+          pointer_addr, error.AsCString());
+
+    stack.back().GetScalar() = DerefSizeExtractDataHelper(
+        addr_bytes, sizeof(addr_bytes), process->GetByteOrder(), size);
+    stack.back().ClearContext();
+  } break;
 
   case Value::ValueType::Invalid:
-
     return llvm::createStringError("invalid value for DW_OP_deref_size");
   }
 

--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -861,14 +861,13 @@ ResolveLoadAddress(ExecutionContext *exe_ctx, lldb::ModuleSP &module_sp,
   return load_addr;
 }
 
-/// Helper function to move common code used to load sized data from a uint8_t
-/// buffer.
+/// @brief Helper function to load sized data from a uint8_t buffer.
 ///
-/// \param addr_bytes uint8_t buffer containg raw data
-/// \param size_addr_bytes how large is the underlying raw data
-/// \param byte_order what is the byter order of the underlyig data
-/// \param size How much of the underlying data we want to use
-/// \return The underlying data converted into a Scalar
+/// @param addr_bytes The buffer containing raw data.
+/// @param size_addr_bytes How large is the underlying raw data.
+/// @param byte_order What is the byte order of the underlying data.
+/// @param size How much of the underlying data we want to use.
+/// @return The underlying data converted into a Scalar.
 static Scalar DerefSizeExtractDataHelper(uint8_t *addr_bytes,
                                          size_t size_addr_bytes,
                                          ByteOrder byte_order, size_t size) {
@@ -877,8 +876,7 @@ static Scalar DerefSizeExtractDataHelper(uint8_t *addr_bytes,
   lldb::offset_t addr_data_offset = 0;
   if (size <= 8)
     return addr_data.GetMaxU64(&addr_data_offset, size);
-  else
-    return addr_data.GetAddress(&addr_data_offset);
+  return addr_data.GetAddress(&addr_data_offset);
 }
 
 static llvm::Error Evaluate_DW_OP_deref_size(DWARFExpression::Stack &stack,

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -237,8 +237,9 @@ static llvm::Expected<Value> Evaluate(llvm::ArrayRef<uint8_t> expr,
                                       DWARFExpression::Delegate *unit = nullptr,
                                       ExecutionContext *exe_ctx = nullptr,
                                       RegisterContext *reg_ctx = nullptr) {
-  DataExtractor extractor(expr.data(), expr.size(), lldb::eByteOrderLittle,
-                          /*addr_size*/ 4);
+  DataExtractor extractor(
+      expr.data(), expr.size(), lldb::eByteOrderLittle,
+      /*addr_size*/ exe_ctx ? exe_ctx->GetAddressByteSize() : 4);
 
   return DWARFExpression::Evaluate(exe_ctx, reg_ctx, module_sp, extractor, unit,
                                    lldb::eRegisterKindLLDB,


### PR DESCRIPTION
This commit unifies the code in the dwarf expression evaluator that handles these two deref operations. Previously we had similar, but not identical code for handling them.

The implementation was taken from the DW_OP_deref_size code path since that handles the general case. We put that code into an Evaluate_DW_OP_deref_size function and call it with the address size when evaluating DW_OP_deref.

There were initially two test failures when I made the change. The `DW_op_deref_no_ptr_fixing` unittest failed because we were not correctly setting the address size when we created the DataExtractor. The `DW_OP_deref test` failed because previously the expression `DW_OP_lit4, DW_OP_deref` would evaluate to a LoadAddress, but the code for deref_size was evaluating it to a scalar.

The difference was in how it handled a deref of a scalar value type. In the deref code path we convert a scalar to a load address, but this was not done in the deref_size code path.

```
  case Value::ValueType::Scalar:
      stack.back().SetValueType(Value::ValueType::LoadAddress);
```

I decided to modify the deref_size code to also convert the value to a load address to keep the test passing.

There is no functional change intended here. The motivation is to reduce the number of code paths that implement the deref operation.