### PR TITLE
[Analysis] Make ThreadSafety correctly handle base class destructors

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -2820,7 +2820,7 @@ void ThreadSafetyAnalyzer::runAnalysis(AnalysisDeclContext &AC) {
         case CFGElement::AutomaticObjectDtor: {
           CFGAutomaticObjDtor AD = BI.castAs<CFGAutomaticObjDtor>();
           const auto *DD = AD.getDestructorDecl(AC.getASTContext());
-          if (!DD->hasAttrs())
+          if (!DD || !DD->hasAttrs())
             break;
 
           LocksetBuilder.handleCall(

--- a/clang/test/SemaCXX/no-warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/no-warn-thread-safety-analysis.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -Wthread-safety -Wthread-safety-pointer -Wthread-safety-beta -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=0 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -Wthread-safety -Wthread-safety-pointer -Wthread-safety-beta -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=1 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++17 -Wthread-safety -Wthread-safety-pointer -Wthread-safety-beta -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=0 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++17 -Wthread-safety -Wthread-safety-pointer -Wthread-safety-beta -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=1 %s
+// expected-no-diagnostics
+
+struct foo {
+  ~foo();
+};
+struct bar : foo {};
+struct baz : bar {};
+baz foobar(baz a) { return a; }


### PR DESCRIPTION
After the landing of https://github.com/llvm/llvm-project/pull/169320, the clang CFG analyses are able to do slightly more analysis around destructors. This results in thread safety also seeing slightly more destructors. This exposed a bug in ThreadSafety, where we would call getDestructorDecl, which can return nullptr for base class destructors, but not do a null pointer check, resulting in a segmentation fault.

This patch fixes the issue by adding a null pointer check and adds a regression test so this gets caught before downstream integration testing in the future.