### PR TITLE
opt: Try to respect target-abi command line option

### DIFF
--- a/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
+++ b/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
@@ -22,6 +22,7 @@ namespace llvm {
 
 class MCTargetOptions;
 enum class EmitDwarfUnwindType;
+class StringRef;
 
 namespace mc {
 
@@ -62,9 +63,9 @@ LLVM_ABI bool getX86RelaxRelocations();
 
 LLVM_ABI bool getX86Sse2Avx();
 
-LLVM_ABI std::string getABIName();
+LLVM_ABI StringRef getABIName();
 
-LLVM_ABI std::string getAsSecureLogFile();
+LLVM_ABI StringRef getAsSecureLogFile();
 
 /// Create this object with static storage to register mc-related command
 /// line options.

--- a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+++ b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
@@ -24,6 +24,13 @@ using namespace llvm;
     return *NAME##View;                                                        \
   }
 
+#define MCSTROPT(TY, NAME)                                                     \
+  static cl::opt<std::string> *NAME##View;                                     \
+  StringRef llvm::mc::get##NAME() {                                            \
+    assert(NAME##View && "RegisterMCTargetOptionsFlags not created.");         \
+    return *NAME##View;                                                        \
+  }
+
 #define MCOPT_EXP(TY, NAME)                                                    \
   MCOPT(TY, NAME)                                                              \
   std::optional<TY> llvm::mc::getExplicit##NAME() {                            \
@@ -52,8 +59,8 @@ MCOPT(bool, Crel)
 MCOPT(bool, ImplicitMapSyms)
 MCOPT(bool, X86RelaxRelocations)
 MCOPT(bool, X86Sse2Avx)
-MCOPT(std::string, ABIName)
-MCOPT(std::string, AsSecureLogFile)
+MCSTROPT(std::string, ABIName)
+MCSTROPT(std::string, AsSecureLogFile)
 
 llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
 #define MCBINDOPT(NAME)                                                        \

--- a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+++ b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
@@ -24,7 +24,7 @@ using namespace llvm;
     return *NAME##View;                                                        \
   }
 
-#define MCSTROPT(TY, NAME)                                                     \
+#define MCSTROPT(NAME)                                                         \
   static cl::opt<std::string> *NAME##View;                                     \
   StringRef llvm::mc::get##NAME() {                                            \
     assert(NAME##View && "RegisterMCTargetOptionsFlags not created.");         \
@@ -59,8 +59,8 @@ MCOPT(bool, Crel)
 MCOPT(bool, ImplicitMapSyms)
 MCOPT(bool, X86RelaxRelocations)
 MCOPT(bool, X86Sse2Avx)
-MCSTROPT(std::string, ABIName)
-MCSTROPT(std::string, AsSecureLogFile)
+MCSTROPT(ABIName)
+MCSTROPT(AsSecureLogFile)
 
 llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
 #define MCBINDOPT(NAME)                                                        \

--- a/llvm/test/tools/opt/infer-data-layout-target-abi.ll
+++ b/llvm/test/tools/opt/infer-data-layout-target-abi.ll
@@ -1,0 +1,8 @@
+;; Check that we infer the correct datalayout from a target triple
+; RUN: opt -mtriple=mips64-- -S -passes=no-op-module -target-abi=n32 < %s | FileCheck -check-prefix=N32 %s
+; RUN: opt -mtriple=mips64-- -S -passes=no-op-module -target-abi=n64 < %s | FileCheck -check-prefix=N64 %s
+
+target datalayout = ""
+
+; N32: target datalayout = "E-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+; N64: target datalayout = "E-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"

--- a/llvm/test/tools/opt/infer-data-layout-target-abi.ll
+++ b/llvm/test/tools/opt/infer-data-layout-target-abi.ll
@@ -1,3 +1,4 @@
+; REQUIRES: mips-registered-target
 ;; Check that we infer the correct datalayout from a target triple
 ; RUN: opt -mtriple=mips64-- -S -passes=no-op-module -target-abi=n32 < %s | FileCheck -check-prefix=N32 %s
 ; RUN: opt -mtriple=mips64-- -S -passes=no-op-module -target-abi=n64 < %s | FileCheck -check-prefix=N64 %s


### PR DESCRIPTION
Mips seems kind of broken with these options. n32 seems to
override the 64-bit arch with 32-bit pointers, and trying
to use any 32-bit mips triple also just errors with any
options.