### PR TITLE
[CIR] Add missing switch cases for AO__scoped_atomic_uinc/udec_wrap in emitAtomicOp

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -644,6 +644,9 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   case AtomicExpr::AO__scoped_atomic_nand_fetch:
 
   case AtomicExpr::AO__scoped_atomic_fetch_nand:
+
+  case AtomicExpr::AO__scoped_atomic_uinc_wrap:
+  case AtomicExpr::AO__scoped_atomic_udec_wrap:
     cgf.cgm.errorNYI(expr->getSourceRange(), "emitAtomicOp: expr op NYI");
     return;
   }


### PR DESCRIPTION
Fix build error: enumeration values 'AO__scoped_atomic_udec_wrap' and
'AO__scoped_atomic_uinc_wrap' not handled in switch [-Werror,-Wswitch]
The two builtins were added in 5d38cddc3b00.