### PR TITLE
[Clang] Add Picolibc environment type for triples

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -280,6 +280,7 @@ public:
     MuslX32,
     MuslWALI,
     LLVM,
+    Picolibc,
 
     MSVC,
     Itanium,
@@ -865,6 +866,9 @@ public:
            getEnvironment() == Triple::MuslWALI ||
            getEnvironment() == Triple::OpenHOS || isOSLiteOS();
   }
+
+  // Tests whether the environment is picolibc
+  bool isPicolibc() const { return getEnvironment() == Triple::Picolibc; }
 
   /// Tests whether the target is OHOS
   /// LiteOS default enviroment is also OHOS, but omited on triple.

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -378,6 +378,8 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
   case MuslWALI:
     return "muslwali";
   case Simulator: return "simulator";
+  case Picolibc:
+    return "picolibc";
   case Pixel: return "pixel";
   case Vertex: return "vertex";
   case Geometry: return "geometry";
@@ -747,6 +749,7 @@ static Triple::OSType parseOS(StringRef OSName) {
 
 static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
   return StringSwitch<Triple::EnvironmentType>(EnvironmentName)
+      .StartsWith("picolibc", Triple::Picolibc)
       .StartsWith("eabihf", Triple::EABIHF)
       .StartsWith("eabi", Triple::EABI)
       .StartsWith("gnuabin32", Triple::GNUABIN32)


### PR DESCRIPTION
This patch adds Picolibc as part of triple so toolchains can switch the to Picolibc based on triple.
Hexagon toolchain uses the triple hexagon-none-picolibc.