### PR TITLE
[MLIR][Timing] Fix timing report of nested pass pipeline and negative Rest field when using -mlir-timing (Try to close #169443)

### DIFF
--- a/mlir/lib/Pass/PassTiming.cpp
+++ b/mlir/lib/Pass/PassTiming.cpp
@@ -90,8 +90,8 @@ struct PassTiming : public PassInstrumentation {
     auto &activeTimers = activeThreadTimers[tid];
     auto &parentScope = activeTimers.empty() ? rootScope : activeTimers.back();
 
+    parentTimerIndices[{tid, pass}] = activeTimers.size();
     if (auto *adaptor = dyn_cast<OpToOpPassAdaptor>(pass)) {
-      parentTimerIndices[{tid, pass}] = activeTimers.size();
       auto scope =
           parentScope.nest(pass->getThreadingSiblingOrThis(),
                            [adaptor]() { return adaptor->getAdaptorName(); });
@@ -107,8 +107,7 @@ struct PassTiming : public PassInstrumentation {
 
   void runAfterPass(Pass *pass, Operation *) override {
     auto tid = llvm::get_threadid();
-    if (isa<OpToOpPassAdaptor>(pass))
-      parentTimerIndices.erase({tid, pass});
+    parentTimerIndices.erase({tid, pass});
     auto &activeTimers = activeThreadTimers[tid];
     assert(!activeTimers.empty() && "expected active timer");
     activeTimers.pop_back();

--- a/mlir/test/Pass/pass-timing.mlir
+++ b/mlir/test/Pass/pass-timing.mlir
@@ -5,6 +5,8 @@
 // RUN: mlir-opt %s -mlir-disable-threading=false -verify-each=true -pass-pipeline='builtin.module(func.func(cse,canonicalize,cse))' -mlir-timing -mlir-timing-display=list 2>&1 | FileCheck -check-prefix=MT_LIST %s
 // RUN: mlir-opt %s -mlir-disable-threading=false -verify-each=true -pass-pipeline='builtin.module(func.func(cse,canonicalize,cse))' -mlir-timing -mlir-timing-display=tree 2>&1 | FileCheck -check-prefix=MT_PIPELINE %s
 // RUN: mlir-opt %s -mlir-disable-threading=true -verify-each=false -test-pm-nested-pipeline -mlir-timing -mlir-timing-display=tree 2>&1 | FileCheck -check-prefix=NESTED_PIPELINE %s
+// RUN: mlir-opt %s -mlir-disable-threading=true -verify-each=true -pass-pipeline='builtin.module(func.func(cse,canonicalize,cse),inline)' -mlir-timing -mlir-timing-display=tree 2>&1 | FileCheck -check-prefix=DYNAMIC-PIPELINE %s
+// RUN: mlir-opt %s -mlir-disable-threading=false -verify-each=true -pass-pipeline='builtin.module(func.func(cse,canonicalize,cse),inline)' -mlir-timing -mlir-timing-display=tree 2>&1 | FileCheck -check-prefix=DYNAMIC-PIPELINE %s
 
 // LIST: Execution time report
 // LIST: Total Execution Time:
@@ -94,6 +96,24 @@
 // NESTED_PIPELINE-NEXT: Output
 // NESTED_PIPELINE-NEXT: Rest
 // NESTED_PIPELINE-NEXT: Total
+
+// DYNAMIC-PIPELINE: Execution time report
+// DYNAMIC-PIPELINE: Total Execution Time:
+// DYNAMIC-PIPELINE: Name
+// DYNAMIC-PIPELINE-NEXT: Parser
+// DYNAMIC-PIPELINE-NEXT: 'func.func' Pipeline
+// DYNAMIC-PIPELINE-NEXT:   CSE
+// DYNAMIC-PIPELINE-NEXT:     (A) DominanceInfo
+// DYNAMIC-PIPELINE-NEXT:   Canonicalizer
+// DYNAMIC-PIPELINE-NEXT:   CSE
+// DYNAMIC-PIPELINE-NEXT:     (A) DominanceInfo
+// DYNAMIC-PIPELINE-NEXT: Inliner
+// DYNAMIC-PIPELINE-NEXT:   (A) CallGraph
+// DYNAMIC-PIPELINE-NEXT:   'func.func' Pipeline
+// DYNAMIC-PIPELINE-NEXT:     Canonicalizer
+// DYNAMIC-PIPELINE-NEXT: Output
+// DYNAMIC-PIPELINE-NEXT: Rest
+// DYNAMIC-PIPELINE-NEXT: Total
 
 func.func @foo() {
   return


### PR DESCRIPTION
This PR tries to close [[MLIR][Timing] Nested pipeline is displayed at top level and show negative Rest field when using -mlir-timing](https://github.com/llvm/llvm-project/issues/169443)

Here is the timing report of the `inliner` pass w/o and w/ this change:
```
# w/o this change
build/bin/mlir-opt -inline mlir/test/Transforms/inlining-repeated-use.mlir -mlir-timing -o 1.txt
===-------------------------------------------------------------------------===
                         ... Execution time report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0009 seconds

  ----Wall Time----  ----Name----
    0.0003 ( 40.1%)  Parser
    0.0003 ( 37.5%)  Inliner
    0.0000 (  1.3%)    (A) CallGraph
    0.0001 (  7.9%)  'func.func' Pipeline
    0.0001 (  7.7%)    Canonicalizer
    0.0002 ( 19.9%)  Output
   -0.0000 ( -5.5%)  Rest
    0.0009 (100.0%)  Total

# w/ this change
build/bin/mlir-opt -inline mlir/test/Transforms/inlining-repeated-use.mlir -mlir-timing -o 1.txt
===-------------------------------------------------------------------------===
                         ... Execution time report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0007 seconds

  ----Wall Time----  ----Name----
    0.0003 ( 46.5%)  Parser
    0.0003 ( 37.1%)  Inliner
    0.0000 (  1.1%)    (A) CallGraph
    0.0001 (  7.7%)    'func.func' Pipeline
    0.0001 (  7.4%)      Canonicalizer
    0.0001 ( 12.2%)  Output
    0.0000 (  4.2%)  Rest
    0.0007 (100.0%)  Total
```

Also take `mlir/test/Pass/dynamic-pipeline-nested.mlir` as an example:

```
# w/o this change
build/install/bin/mlir-opt mlir/test/Pass/dynamic-pipeline-nested.mlir -pass-pipeline='builtin.module(builtin.module(test-dynamic-pipeline{op-name=inner_mod1 dynamic-pipeline=cse}),inline)'  --mlir-disable-threading -mlir-timing > /dev/null
Dynamic execute 'cse' on builtin.module
===-------------------------------------------------------------------------===
                         ... Execution time report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0005 seconds

  ----Wall Time----  ----Name----
    0.0003 ( 58.3%)  Parser
    0.0000 (  4.7%)  'builtin.module' Pipeline
    0.0000 (  4.6%)    TestDynamicPipelinePass
    0.0000 (  1.6%)  'builtin.module' Pipeline
    0.0000 (  1.5%)    CSE
    0.0000 (  0.1%)      (A) DominanceInfo
    0.0001 ( 22.7%)  Inliner
    0.0000 (  1.3%)    (A) CallGraph
    0.0000 (  3.5%)  'func.func' Pipeline
    0.0000 (  3.3%)    Canonicalizer
    0.0000 (  6.6%)  Output
    0.0000 (  1.9%)  Rest
    0.0005 (100.0%)  Total

# w/ this change
Dynamic execute 'cse' on builtin.module
===-------------------------------------------------------------------------===
                         ... Execution time report ...
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0023 seconds

  ----Wall Time----  ----Name----
    0.0017 ( 71.5%)  Parser
    0.0001 (  2.6%)  'builtin.module' Pipeline
    0.0001 (  2.6%)    (anonymous namespace)::TestDynamicPipelinePass
    0.0000 (  1.5%)      'builtin.module' Pipeline
    0.0000 (  1.5%)        CSE
    0.0000 (  0.0%)          (A) DominanceInfo
    0.0003 ( 14.9%)  Inliner
    0.0000 (  1.0%)    (A) CallGraph
    0.0001 (  3.2%)    'func.func' Pipeline
    0.0001 (  3.2%)      Canonicalizer
    0.0001 (  4.8%)  Output
    0.0001 (  5.6%)  Rest
    0.0023 (100.0%)  Total
```