### PR TITLE
[BOLT] Skip writing BAT entries with zero hash

### DIFF
--- a/bolt/include/bolt/Profile/BoltAddressTranslation.h
+++ b/bolt/include/bolt/Profile/BoltAddressTranslation.h
@@ -182,6 +182,8 @@ private:
   /// translation map entry
   const static uint32_t BRANCHENTRY = 0x1;
 
+  uint64_t NumInvalidEntries = 0;
+
 public:
   /// Map basic block input offset to a basic block index and hash pair.
   class BBHashMapTy {
@@ -283,6 +285,10 @@ public:
 
 private:
   FuncHashesTy FuncHashes;
+
+  /// Filters out invalid entries from the BAT map.
+  void dropInvalidEntries(MapTy &Map, uint64_t Address,
+                          const BBHashMapTy &BBHashMap);
 };
 } // namespace bolt
 

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -2417,8 +2417,6 @@ std::error_code DataAggregator::writeBATYAML(BinaryContext &BC,
       // Skip printing if there's no profile data
       llvm::erase_if(
           YamlBF.Blocks, [](const yaml::bolt::BinaryBasicBlockProfile &YamlBB) {
-            if ((size_t)YamlBB.Hash == 0)
-              return true;
             auto HasCount = [](const auto &SI) { return SI.Count; };
             bool HasAnyCount = YamlBB.ExecCount ||
                                llvm::any_of(YamlBB.Successors, HasCount) ||

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -2417,6 +2417,8 @@ std::error_code DataAggregator::writeBATYAML(BinaryContext &BC,
       // Skip printing if there's no profile data
       llvm::erase_if(
           YamlBF.Blocks, [](const yaml::bolt::BinaryBasicBlockProfile &YamlBB) {
+            if ((size_t)YamlBB.Hash == 0)
+              return true;
             auto HasCount = [](const auto &SI) { return SI.Count; };
             bool HasAnyCount = YamlBB.ExecCount ||
                                llvm::any_of(YamlBB.Successors, HasCount) ||


### PR DESCRIPTION
When generating the YAML profile from a Post-BAT binary, the [writer](https://github.com/llvm/llvm-project/blob/llvmorg-22-init/bolt/lib/Profile/DataAggregator.cpp#L2327) seems to unconditionally trust and use the BBHashMap from the BAT table. However, it appears that in some scenarios, a recorded basic block (BB) hash within this map is 0. 

 When infer-stale-profile is enabled, profile.yaml generated by this way may trigger an assertion failure [here](https://github.com/llvm/llvm-project/blob/llvmorg-22-init/bolt/lib/Profile/StaleProfileMatching.cpp#L645) and crash. So this patch tries to drop the BB profiles  with a hash of 0 in writeBATYAML().
