### PR TITLE
[BOLT] Fix assertion test

### DIFF
--- a/bolt/unittests/Core/MCPlusBuilder.cpp
+++ b/bolt/unittests/Core/MCPlusBuilder.cpp
@@ -171,9 +171,11 @@ TEST_P(MCPlusBuilderTester, AArch64_BTI) {
   ASSERT_EQ(II->getOperand(0).getImm(), 34);
   ASSERT_TRUE(BC->MIB->isBTILandingPad(*II, true, false));
 
+#ifndef NDEBUG
   MCInst BTIinvalid;
   ASSERT_DEATH(BC->MIB->createBTI(BTIinvalid, false, false),
                "No target kinds!");
+#endif
 
   MCInst Paciasp = MCInstBuilder(AArch64::PACIASP);
   II = BB->addInstruction(Paciasp);


### PR DESCRIPTION
The AArch64_BTI MCPlusBuilder unittest was failing in no assertion
builds. Add `#ifndef NDEBUG` to exclude the assertion test from
no assertion builds.