### PR TITLE
[fuzzer][test-only] Bump runs for reduce_inputs.test unseeded run

### DIFF
--- a/compiler-rt/test/fuzzer/reduce_inputs.test
+++ b/compiler-rt/test/fuzzer/reduce_inputs.test
@@ -4,7 +4,7 @@ RUN: rm -rf %t/C
 RUN: mkdir -p %t/C
 RUN: %cpp_compiler %S/ShrinkControlFlowSimpleTest.cpp -o %t-ShrinkControlFlowSimpleTest
 RUN: %cpp_compiler %S/ShrinkControlFlowTest.cpp -o %t-ShrinkControlFlowTest
-RUN: %run %t-ShrinkControlFlowSimpleTest  -exit_on_item=0eb8e4ed029b774d80f2b66408203801cb982a60   -runs=1000000 %t/C 2>&1 | FileCheck %s
+RUN: %run %t-ShrinkControlFlowSimpleTest  -exit_on_item=0eb8e4ed029b774d80f2b66408203801cb982a60   -runs=10000000 %t/C 2>&1 | FileCheck %s
 CHECK: INFO: found item with checksum '0eb8e4ed029b774d80f2b66408203801cb982a60'
 
 # Test that reduce_inputs deletes redundant files in the corpus.


### PR DESCRIPTION
I have seen a failure whereby the fuzzer failed to reach the expected input and thus failed the test.

This patch bumps the max executions to 10,000,000 in order to give the fuzzer a better chance of reaching the expected input. Most runs complete successfully, so I do not see this adding test time in the general case; I believe it's a fair tradeoff for the unlucky seed to run for longer if it reduces the noise from false positives. Note, this updates a different `RUN:` to https://github.com/llvm/llvm-project/pull/165402.

rdar://162122184