### PR TITLE
[llvm-dwarfdump][LineCov 1/3] Add variable coverage metrics

### DIFF
--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -198,7 +198,7 @@ OPTIONS
             Show per-variable coverage metrics. The output format is described
             in the section below (:ref:`variable-coverage-format`).
 
-.. option:: --combine-instances
+.. option:: --combine-inline-variable-instances
 
             Use with :option:`--show-variable-coverage` to average variable
             coverage across inlined subroutine instances instead of printing
@@ -267,12 +267,14 @@ across compilations and better reflects the debugging experience. The output is
 a tab-separated table containing the following columns:
 
       - `Function` ==> Name of the function the variable was found in
-      - `InstanceCount` (when :option:`--combine-instances` is specified) ==>
-        Number of instances of the function; this is 1 for functions that have
-        not been inlined, and n+1 for functions that have been inlined n times
-      - `InlChain` (when :option:`--combine-instances` is not specified) ==>
-        Chain of call sites (file and line number) that the function has been
-        inlined into; this will be empty if the function has not been inlined
+      - `InstanceCount` (when :option:`--combine-inline-variable-instances` is
+        specified) ==> Number of instances of the function; this is 1 for
+        functions that have not been inlined, and n+1 for functions that have
+        been inlined n times
+      - `InlChain` (when :option:`--combine-inline-variable-instances` is not
+        specified) ==> Chain of call sites (file and line number) that the
+        function has been inlined into; this will be empty if the function has
+        not been inlined
       - `Variable` ==> Name of the variable
       - `Decl` ==> Source location (file and line number) of the variable's
         declaration

--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -193,6 +193,17 @@ OPTIONS
 
             The :option:`--debug-frame` and :option:`--eh-frame` options are aliases, in cases where both sections are present one command outputs both.
 
+.. option:: --show-variable-coverage
+
+            Show per-variable coverage metrics. The output format is described
+            in the section below (:ref:`variable-coverage-format`).
+
+.. option:: --combine-instances
+
+            Use with :option:`--show-variable-coverage` to average variable
+            coverage across inlined subroutine instances instead of printing
+            them separately.
+
 .. option:: @<FILE>
 
             Read command-line options from `<FILE>`.
@@ -242,6 +253,32 @@ The following is generated if there are no errors reported::
     "error-categories": {},
     "error-count": 0
   }
+
+.. _variable-coverage-format:
+
+FORMAT OF VARIABLE COVERAGE OUTPUT
+---------------------------
+
+The :option:`--show-variable-coverage` option differs from
+:option:`--statistics` by printing per-variable debug info coverage metrics
+based on the number of source lines covered instead of the number of
+instruction bytes. Compared to counting instruction bytes, this is more stable
+across compilations and better reflects the debugging experience. The output is
+a tab-separated table containing the following columns:
+
+      - `Function` ==> Name of the function the variable was found in
+      - `InstanceCount` (when :option:`--combine-instances` is specified) ==>
+      Number of instances of the function; this is 1 for functions that have
+      not been inlined, and n+1 for functions that have been inlined n times
+      - `InlChain` (when :option:`--combine-instances` is not specified) ==>
+      Chain of call sites (file and line number) that the function has been
+      inlined into; this will be empty if the function has not been inlined
+      - `Variable` ==> Name of the variable
+      - `Decl` ==> Source location (file and line number) of the variable's
+      declaration
+      - `LinesCovered` ==> Number of source lines covered by the variable's
+      debug information in the input file
+
 
 EXIT STATUS
 -----------

--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -257,7 +257,7 @@ The following is generated if there are no errors reported::
 .. _variable-coverage-format:
 
 FORMAT OF VARIABLE COVERAGE OUTPUT
----------------------------
+----------------------------------
 
 The :option:`--show-variable-coverage` option differs from
 :option:`--statistics` by printing per-variable debug info coverage metrics

--- a/llvm/docs/CommandGuide/llvm-dwarfdump.rst
+++ b/llvm/docs/CommandGuide/llvm-dwarfdump.rst
@@ -268,16 +268,16 @@ a tab-separated table containing the following columns:
 
       - `Function` ==> Name of the function the variable was found in
       - `InstanceCount` (when :option:`--combine-instances` is specified) ==>
-      Number of instances of the function; this is 1 for functions that have
-      not been inlined, and n+1 for functions that have been inlined n times
+        Number of instances of the function; this is 1 for functions that have
+        not been inlined, and n+1 for functions that have been inlined n times
       - `InlChain` (when :option:`--combine-instances` is not specified) ==>
-      Chain of call sites (file and line number) that the function has been
-      inlined into; this will be empty if the function has not been inlined
+        Chain of call sites (file and line number) that the function has been
+        inlined into; this will be empty if the function has not been inlined
       - `Variable` ==> Name of the variable
       - `Decl` ==> Source location (file and line number) of the variable's
-      declaration
+        declaration
       - `LinesCovered` ==> Number of source lines covered by the variable's
-      debug information in the input file
+        debug information in the input file
 
 
 EXIT STATUS

--- a/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage-opt.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage-opt.ll
@@ -29,106 +29,93 @@
 
 ; ModuleID = 'test.c'
 source_filename = "test.c"
-target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local void @fn1(i32 noundef %0, i32 noundef %1) local_unnamed_addr !dbg !9 {
-  call void @llvm.dbg.value(metadata i32 %0, metadata !14, metadata !DIExpression()), !dbg !18
-  call void @llvm.dbg.value(metadata i32 %1, metadata !15, metadata !DIExpression()), !dbg !18
-  call void @llvm.dbg.value(metadata !DIArgList(i32 %0, i32 %1), metadata !16, metadata !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_stack_value)), !dbg !18
-  call void @llvm.dbg.value(metadata i32 undef, metadata !16, metadata !DIExpression()), !dbg !18
-  call void @llvm.dbg.value(metadata i32 undef, metadata !16, metadata !DIExpression()), !dbg !18
-  call void @llvm.dbg.value(metadata i32 7, metadata !17, metadata !DIExpression()), !dbg !18
-  tail call void @fn2(i32 noundef 7), !dbg !19
-  call void @llvm.dbg.value(metadata i32 undef, metadata !16, metadata !DIExpression(DW_OP_constu, 1, DW_OP_minus, DW_OP_stack_value)), !dbg !18
-  ret void, !dbg !20
+define dso_local void @fn1(i32 %0, i32 %1) local_unnamed_addr !dbg !10 {
+    #dbg_value(i32 poison, !15, !DIExpression(), !19)
+    #dbg_value(i32 poison, !16, !DIExpression(), !19)
+    #dbg_value(!DIArgList(i32 poison, i32 poison), !17, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_stack_value), !19)
+    #dbg_value(i32 poison, !17, !DIExpression(), !19)
+    #dbg_value(i32 poison, !17, !DIExpression(), !19)
+    #dbg_value(i32 7, !18, !DIExpression(), !19)
+  tail call void @fn2(i32 noundef 7) #3, !dbg !20
+    #dbg_value(i32 poison, !17, !DIExpression(DW_OP_constu, 1, DW_OP_minus, DW_OP_stack_value), !19)
+  ret void, !dbg !21
 }
 
-; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture)
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture)
 
-declare !dbg !21 void @fn2(i32 noundef) local_unnamed_addr
+declare !dbg !22 void @fn2(i32 noundef) local_unnamed_addr
 
-; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture)
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local i32 @f() local_unnamed_addr !dbg !25 {
-  %1 = alloca i32, align 4
-  %2 = alloca i32, align 4
-  %3 = bitcast i32* %1 to i8*, !dbg !31
-  call void @llvm.lifetime.start.p0i8(i64 4, i8* nonnull %3), !dbg !31
-  %4 = bitcast i32* %2 to i8*, !dbg !31
-  call void @llvm.lifetime.start.p0i8(i64 4, i8* nonnull %4), !dbg !31
-  call void @llvm.dbg.value(metadata i32* %1, metadata !29, metadata !DIExpression(DW_OP_deref)), !dbg !32
-  call void @fn3(i32* noundef nonnull %1), !dbg !33
-  call void @llvm.dbg.value(metadata i32* %2, metadata !30, metadata !DIExpression(DW_OP_deref)), !dbg !32
-  call void @fn3(i32* noundef nonnull %2), !dbg !34
-  %5 = load i32, i32* %1, align 4, !dbg !35, !tbaa !36
-  call void @llvm.dbg.value(metadata i32 %5, metadata !29, metadata !DIExpression()), !dbg !32
-  %6 = load i32, i32* %2, align 4, !dbg !40, !tbaa !36
-  call void @llvm.dbg.value(metadata i32 %6, metadata !30, metadata !DIExpression()), !dbg !32
-  call void @fn1(i32 noundef %5, i32 noundef %6), !dbg !41
-  call void @llvm.lifetime.end.p0i8(i64 4, i8* nonnull %4), !dbg !42
-  call void @llvm.lifetime.end.p0i8(i64 4, i8* nonnull %3), !dbg !42
-  ret i32 0, !dbg !43
+define dso_local noundef i32 @f() local_unnamed_addr !dbg !25 {
+  %1 = alloca i32, align 4, !DIAssignID !31
+    #dbg_assign(i1 poison, !29, !DIExpression(), !31, ptr %1, !DIExpression(), !32)
+  %2 = alloca i32, align 4, !DIAssignID !33
+    #dbg_assign(i1 poison, !30, !DIExpression(), !33, ptr %2, !DIExpression(), !32)
+  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %1) #3, !dbg !34
+  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %2) #3, !dbg !34
+  call void @fn3(ptr noundef nonnull %1) #3, !dbg !35
+  call void @fn3(ptr noundef nonnull %2) #3, !dbg !36
+  call void @fn1(i32 poison, i32 poison), !dbg !37
+  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %2) #3, !dbg !38
+  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %1) #3, !dbg !38
+  ret i32 0, !dbg !39
 }
 
-declare !dbg !44 void @fn3(i32* noundef) local_unnamed_addr
-
-; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare void @llvm.dbg.value(metadata, metadata, metadata)
+declare !dbg !40 void @fn3(ptr noundef) local_unnamed_addr
 
 !llvm.dbg.cu = !{!0}
-!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
-!llvm.ident = !{!8}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!llvm.ident = !{!9}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.6", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 19.1.7", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
 !1 = !DIFile(filename: "test.c", directory: "/")
 !2 = !{i32 7, !"Dwarf Version", i32 5}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = !{i32 1, !"wchar_size", i32 4}
-!5 = !{i32 7, !"PIC Level", i32 2}
+!5 = !{i32 8, !"PIC Level", i32 2}
 !6 = !{i32 7, !"PIE Level", i32 2}
-!7 = !{i32 7, !"uwtable", i32 1}
-!8 = !{!"clang version 14.0.6"}
-!9 = distinct !DISubprogram(name: "fn1", scope: !1, file: !1, line: 5, type: !10, scopeLine: 6, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !13)
-!10 = !DISubroutineType(types: !11)
-!11 = !{null, !12, !12}
-!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!13 = !{!14, !15, !16, !17}
-!14 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !1, line: 5, type: !12)
-!15 = !DILocalVariable(name: "y", arg: 2, scope: !9, file: !1, line: 5, type: !12)
-!16 = !DILocalVariable(name: "u", scope: !9, file: !1, line: 7, type: !12)
-!17 = !DILocalVariable(name: "a", scope: !9, file: !1, line: 14, type: !12)
-!18 = !DILocation(line: 0, scope: !9)
-!19 = !DILocation(line: 15, column: 3, scope: !9)
-!20 = !DILocation(line: 17, column: 1, scope: !9)
-!21 = !DISubprogram(name: "fn2", scope: !1, file: !1, line: 2, type: !22, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized, retainedNodes: !24)
-!22 = !DISubroutineType(types: !23)
-!23 = !{null, !12}
-!24 = !{}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"debug-info-assignment-tracking", i1 true}
+!9 = !{!"clang version 19.1.7"}
+!10 = distinct !DISubprogram(name: "fn1", scope: !1, file: !1, line: 5, type: !11, scopeLine: 6, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !14)
+!11 = !DISubroutineType(types: !12)
+!12 = !{null, !13, !13}
+!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !{!15, !16, !17, !18}
+!15 = !DILocalVariable(name: "x", arg: 1, scope: !10, file: !1, line: 5, type: !13)
+!16 = !DILocalVariable(name: "y", arg: 2, scope: !10, file: !1, line: 5, type: !13)
+!17 = !DILocalVariable(name: "u", scope: !10, file: !1, line: 7, type: !13)
+!18 = !DILocalVariable(name: "a", scope: !10, file: !1, line: 14, type: !13)
+!19 = !DILocation(line: 0, scope: !10)
+!20 = !DILocation(line: 15, column: 3, scope: !10)
+!21 = !DILocation(line: 17, column: 1, scope: !10)
+!22 = !DISubprogram(name: "fn2", scope: !1, file: !1, line: 2, type: !23, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+!23 = !DISubroutineType(types: !24)
+!24 = !{null, !13}
 !25 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 20, type: !26, scopeLine: 21, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !28)
 !26 = !DISubroutineType(types: !27)
-!27 = !{!12}
+!27 = !{!13}
 !28 = !{!29, !30}
-!29 = !DILocalVariable(name: "l", scope: !25, file: !1, line: 22, type: !12)
-!30 = !DILocalVariable(name: "k", scope: !25, file: !1, line: 22, type: !12)
-!31 = !DILocation(line: 22, column: 3, scope: !25)
+!29 = !DILocalVariable(name: "l", scope: !25, file: !1, line: 22, type: !13)
+!30 = !DILocalVariable(name: "k", scope: !25, file: !1, line: 22, type: !13)
+!31 = distinct !DIAssignID()
 !32 = !DILocation(line: 0, scope: !25)
-!33 = !DILocation(line: 23, column: 3, scope: !25)
-!34 = !DILocation(line: 24, column: 3, scope: !25)
-!35 = !DILocation(line: 25, column: 8, scope: !25)
-!36 = !{!37, !37, i64 0}
-!37 = !{!"int", !38, i64 0}
-!38 = !{!"omnipotent char", !39, i64 0}
-!39 = !{!"Simple C/C++ TBAA"}
-!40 = !DILocation(line: 25, column: 11, scope: !25)
-!41 = !DILocation(line: 25, column: 3, scope: !25)
-!42 = !DILocation(line: 27, column: 1, scope: !25)
-!43 = !DILocation(line: 26, column: 3, scope: !25)
-!44 = !DISubprogram(name: "fn3", scope: !1, file: !1, line: 1, type: !45, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized, retainedNodes: !24)
-!45 = !DISubroutineType(types: !46)
-!46 = !{null, !47}
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !12, size: 64)
+!33 = distinct !DIAssignID()
+!34 = !DILocation(line: 22, column: 3, scope: !25)
+!35 = !DILocation(line: 23, column: 3, scope: !25)
+!36 = !DILocation(line: 24, column: 3, scope: !25)
+!37 = !DILocation(line: 25, column: 3, scope: !25)
+!38 = !DILocation(line: 27, column: 1, scope: !25)
+!39 = !DILocation(line: 26, column: 3, scope: !25)
+!40 = !DISubprogram(name: "fn3", scope: !1, file: !1, line: 1, type: !41, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+!41 = !DISubroutineType(types: !42)
+!42 = !{null, !43}
+!43 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)

--- a/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage-opt.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage-opt.ll
@@ -1,10 +1,7 @@
 ; The source code of the test case:
 ; extern void fn3(int *);
-; extern void fn2 (int);
-; __attribute__((noinline))
-; void
-; fn1 (int x, int y)
-; {
+; extern void fn2(int);
+; __attribute__((noinline)) void fn1(int x, int y) {
 ;   int u = x + y;
 ;   if (x > 1)
 ;     u += 1;
@@ -13,17 +10,18 @@
 ;   if (y > 4)
 ;     u += x;
 ;   int a = 7;
-;   fn2 (a);
-;   u --;
+;   fn2(a);
+;   int v = u;
+;   v++;
+;   u--;
+;   fn2(u);
 ; }
-
-; __attribute__((noinline))
-; int f()
-; {
+; 
+; __attribute__((noinline)) int f() {
 ;   int l, k;
 ;   fn3(&l);
 ;   fn3(&k);
-;   fn1 (l, k);
+;   fn1(l, k);
 ;   return 0;
 ; }
 
@@ -33,43 +31,56 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local void @fn1(i32 %0, i32 %1) local_unnamed_addr !dbg !10 {
-    #dbg_value(i32 poison, !15, !DIExpression(), !19)
-    #dbg_value(i32 poison, !16, !DIExpression(), !19)
-    #dbg_value(!DIArgList(i32 poison, i32 poison), !17, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_stack_value), !19)
-    #dbg_value(i32 poison, !17, !DIExpression(), !19)
-    #dbg_value(i32 poison, !17, !DIExpression(), !19)
-    #dbg_value(i32 7, !18, !DIExpression(), !19)
-  tail call void @fn2(i32 noundef 7) #3, !dbg !20
-    #dbg_value(i32 poison, !17, !DIExpression(DW_OP_constu, 1, DW_OP_minus, DW_OP_stack_value), !19)
-  ret void, !dbg !21
+define dso_local void @fn1(i32 noundef %0, i32 noundef %1) local_unnamed_addr !dbg !10 {
+    #dbg_value(i32 %0, !15, !DIExpression(), !20)
+    #dbg_value(i32 %1, !16, !DIExpression(), !20)
+    #dbg_value(i32 poison, !17, !DIExpression(), !20)
+  %3 = icmp sgt i32 %0, 1, !dbg !21
+  %4 = select i1 %3, i32 1, i32 2, !dbg !23
+    #dbg_value(i32 poison, !17, !DIExpression(), !20)
+  %5 = icmp sgt i32 %1, 4, !dbg !24
+  %6 = select i1 %5, i32 %0, i32 0, !dbg !26
+    #dbg_value(i32 poison, !17, !DIExpression(), !20)
+    #dbg_value(i32 7, !18, !DIExpression(), !20)
+  tail call void @fn2(i32 noundef 7), !dbg !27
+    #dbg_value(i32 poison, !19, !DIExpression(), !20)
+    #dbg_value(i32 poison, !19, !DIExpression(DW_OP_plus_uconst, 1, DW_OP_stack_value), !20)
+  %7 = add i32 %0, -1, !dbg !28
+  %8 = add i32 %7, %1, !dbg !23
+  %9 = add i32 %8, %4, !dbg !26
+  %10 = add i32 %9, %6, !dbg !29
+    #dbg_value(i32 %10, !17, !DIExpression(), !20)
+  tail call void @fn2(i32 noundef %10), !dbg !30
+  ret void, !dbg !31
 }
 
 ; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture)
 
-declare !dbg !22 void @fn2(i32 noundef) local_unnamed_addr
+declare !dbg !32 void @fn2(i32 noundef) local_unnamed_addr
 
 ; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local noundef i32 @f() local_unnamed_addr !dbg !25 {
-  %1 = alloca i32, align 4, !DIAssignID !31
-    #dbg_assign(i1 poison, !29, !DIExpression(), !31, ptr %1, !DIExpression(), !32)
-  %2 = alloca i32, align 4, !DIAssignID !33
-    #dbg_assign(i1 poison, !30, !DIExpression(), !33, ptr %2, !DIExpression(), !32)
-  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %1) #3, !dbg !34
-  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %2) #3, !dbg !34
-  call void @fn3(ptr noundef nonnull %1) #3, !dbg !35
-  call void @fn3(ptr noundef nonnull %2) #3, !dbg !36
-  call void @fn1(i32 poison, i32 poison), !dbg !37
-  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %2) #3, !dbg !38
-  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %1) #3, !dbg !38
-  ret i32 0, !dbg !39
+define dso_local noundef i32 @f() local_unnamed_addr !dbg !35 {
+  %1 = alloca i32, align 4, !DIAssignID !41
+    #dbg_assign(i1 poison, !39, !DIExpression(), !41, ptr %1, !DIExpression(), !42)
+  %2 = alloca i32, align 4, !DIAssignID !43
+    #dbg_assign(i1 poison, !40, !DIExpression(), !43, ptr %2, !DIExpression(), !42)
+  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %1), !dbg !44
+  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %2), !dbg !44
+  call void @fn3(ptr noundef nonnull %1), !dbg !45
+  call void @fn3(ptr noundef nonnull %2), !dbg !46
+  %3 = load i32, ptr %1, align 4, !dbg !47, !tbaa !48
+  %4 = load i32, ptr %2, align 4, !dbg !52, !tbaa !48
+  call void @fn1(i32 noundef %3, i32 noundef %4), !dbg !53
+  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %2), !dbg !54
+  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %1), !dbg !54
+  ret i32 0, !dbg !55
 }
 
-declare !dbg !40 void @fn3(ptr noundef) local_unnamed_addr
+declare !dbg !56 void @fn3(ptr noundef) local_unnamed_addr
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
@@ -85,37 +96,53 @@ declare !dbg !40 void @fn3(ptr noundef) local_unnamed_addr
 !7 = !{i32 7, !"uwtable", i32 2}
 !8 = !{i32 7, !"debug-info-assignment-tracking", i1 true}
 !9 = !{!"clang version 19.1.7"}
-!10 = distinct !DISubprogram(name: "fn1", scope: !1, file: !1, line: 5, type: !11, scopeLine: 6, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !14)
+!10 = distinct !DISubprogram(name: "fn1", scope: !1, file: !1, line: 3, type: !11, scopeLine: 3, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !14)
 !11 = !DISubroutineType(types: !12)
 !12 = !{null, !13, !13}
 !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!14 = !{!15, !16, !17, !18}
-!15 = !DILocalVariable(name: "x", arg: 1, scope: !10, file: !1, line: 5, type: !13)
-!16 = !DILocalVariable(name: "y", arg: 2, scope: !10, file: !1, line: 5, type: !13)
-!17 = !DILocalVariable(name: "u", scope: !10, file: !1, line: 7, type: !13)
-!18 = !DILocalVariable(name: "a", scope: !10, file: !1, line: 14, type: !13)
-!19 = !DILocation(line: 0, scope: !10)
-!20 = !DILocation(line: 15, column: 3, scope: !10)
-!21 = !DILocation(line: 17, column: 1, scope: !10)
-!22 = !DISubprogram(name: "fn2", scope: !1, file: !1, line: 2, type: !23, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
-!23 = !DISubroutineType(types: !24)
-!24 = !{null, !13}
-!25 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 20, type: !26, scopeLine: 21, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !28)
-!26 = !DISubroutineType(types: !27)
-!27 = !{!13}
-!28 = !{!29, !30}
-!29 = !DILocalVariable(name: "l", scope: !25, file: !1, line: 22, type: !13)
-!30 = !DILocalVariable(name: "k", scope: !25, file: !1, line: 22, type: !13)
-!31 = distinct !DIAssignID()
-!32 = !DILocation(line: 0, scope: !25)
-!33 = distinct !DIAssignID()
-!34 = !DILocation(line: 22, column: 3, scope: !25)
-!35 = !DILocation(line: 23, column: 3, scope: !25)
-!36 = !DILocation(line: 24, column: 3, scope: !25)
-!37 = !DILocation(line: 25, column: 3, scope: !25)
-!38 = !DILocation(line: 27, column: 1, scope: !25)
-!39 = !DILocation(line: 26, column: 3, scope: !25)
-!40 = !DISubprogram(name: "fn3", scope: !1, file: !1, line: 1, type: !41, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
-!41 = !DISubroutineType(types: !42)
-!42 = !{null, !43}
-!43 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!14 = !{!15, !16, !17, !18, !19}
+!15 = !DILocalVariable(name: "x", arg: 1, scope: !10, file: !1, line: 3, type: !13)
+!16 = !DILocalVariable(name: "y", arg: 2, scope: !10, file: !1, line: 3, type: !13)
+!17 = !DILocalVariable(name: "u", scope: !10, file: !1, line: 4, type: !13)
+!18 = !DILocalVariable(name: "a", scope: !10, file: !1, line: 11, type: !13)
+!19 = !DILocalVariable(name: "v", scope: !10, file: !1, line: 13, type: !13)
+!20 = !DILocation(line: 0, scope: !10)
+!21 = !DILocation(line: 5, column: 9, scope: !22)
+!22 = distinct !DILexicalBlock(scope: !10, file: !1, line: 5, column: 7)
+!23 = !DILocation(line: 5, column: 7, scope: !10)
+!24 = !DILocation(line: 9, column: 9, scope: !25)
+!25 = distinct !DILexicalBlock(scope: !10, file: !1, line: 9, column: 7)
+!26 = !DILocation(line: 9, column: 7, scope: !10)
+!27 = !DILocation(line: 12, column: 3, scope: !10)
+!28 = !DILocation(line: 4, column: 13, scope: !10)
+!29 = !DILocation(line: 15, column: 4, scope: !10)
+!30 = !DILocation(line: 16, column: 3, scope: !10)
+!31 = !DILocation(line: 17, column: 1, scope: !10)
+!32 = !DISubprogram(name: "fn2", scope: !1, file: !1, line: 2, type: !33, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+!33 = !DISubroutineType(types: !34)
+!34 = !{null, !13}
+!35 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 19, type: !36, scopeLine: 19, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !38)
+!36 = !DISubroutineType(types: !37)
+!37 = !{!13}
+!38 = !{!39, !40}
+!39 = !DILocalVariable(name: "l", scope: !35, file: !1, line: 20, type: !13)
+!40 = !DILocalVariable(name: "k", scope: !35, file: !1, line: 20, type: !13)
+!41 = distinct !DIAssignID()
+!42 = !DILocation(line: 0, scope: !35)
+!43 = distinct !DIAssignID()
+!44 = !DILocation(line: 20, column: 3, scope: !35)
+!45 = !DILocation(line: 21, column: 3, scope: !35)
+!46 = !DILocation(line: 22, column: 3, scope: !35)
+!47 = !DILocation(line: 23, column: 7, scope: !35)
+!48 = !{!49, !49, i64 0}
+!49 = !{!"int", !50, i64 0}
+!50 = !{!"omnipotent char", !51, i64 0}
+!51 = !{!"Simple C/C++ TBAA"}
+!52 = !DILocation(line: 23, column: 10, scope: !35)
+!53 = !DILocation(line: 23, column: 3, scope: !35)
+!54 = !DILocation(line: 25, column: 1, scope: !35)
+!55 = !DILocation(line: 24, column: 3, scope: !35)
+!56 = !DISubprogram(name: "fn3", scope: !1, file: !1, line: 1, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+!57 = !DISubroutineType(types: !58)
+!58 = !{null, !59}
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)

--- a/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage-opt.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage-opt.ll
@@ -1,0 +1,134 @@
+; The source code of the test case:
+; extern void fn3(int *);
+; extern void fn2 (int);
+; __attribute__((noinline))
+; void
+; fn1 (int x, int y)
+; {
+;   int u = x + y;
+;   if (x > 1)
+;     u += 1;
+;   else
+;     u += 2;
+;   if (y > 4)
+;     u += x;
+;   int a = 7;
+;   fn2 (a);
+;   u --;
+; }
+
+; __attribute__((noinline))
+; int f()
+; {
+;   int l, k;
+;   fn3(&l);
+;   fn3(&k);
+;   fn1 (l, k);
+;   return 0;
+; }
+
+; ModuleID = 'test.c'
+source_filename = "test.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @fn1(i32 noundef %0, i32 noundef %1) local_unnamed_addr !dbg !9 {
+  call void @llvm.dbg.value(metadata i32 %0, metadata !14, metadata !DIExpression()), !dbg !18
+  call void @llvm.dbg.value(metadata i32 %1, metadata !15, metadata !DIExpression()), !dbg !18
+  call void @llvm.dbg.value(metadata !DIArgList(i32 %0, i32 %1), metadata !16, metadata !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_stack_value)), !dbg !18
+  call void @llvm.dbg.value(metadata i32 undef, metadata !16, metadata !DIExpression()), !dbg !18
+  call void @llvm.dbg.value(metadata i32 undef, metadata !16, metadata !DIExpression()), !dbg !18
+  call void @llvm.dbg.value(metadata i32 7, metadata !17, metadata !DIExpression()), !dbg !18
+  tail call void @fn2(i32 noundef 7), !dbg !19
+  call void @llvm.dbg.value(metadata i32 undef, metadata !16, metadata !DIExpression(DW_OP_constu, 1, DW_OP_minus, DW_OP_stack_value)), !dbg !18
+  ret void, !dbg !20
+}
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture)
+
+declare !dbg !21 void @fn2(i32 noundef) local_unnamed_addr
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture)
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local i32 @f() local_unnamed_addr !dbg !25 {
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  %3 = bitcast i32* %1 to i8*, !dbg !31
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* nonnull %3), !dbg !31
+  %4 = bitcast i32* %2 to i8*, !dbg !31
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* nonnull %4), !dbg !31
+  call void @llvm.dbg.value(metadata i32* %1, metadata !29, metadata !DIExpression(DW_OP_deref)), !dbg !32
+  call void @fn3(i32* noundef nonnull %1), !dbg !33
+  call void @llvm.dbg.value(metadata i32* %2, metadata !30, metadata !DIExpression(DW_OP_deref)), !dbg !32
+  call void @fn3(i32* noundef nonnull %2), !dbg !34
+  %5 = load i32, i32* %1, align 4, !dbg !35, !tbaa !36
+  call void @llvm.dbg.value(metadata i32 %5, metadata !29, metadata !DIExpression()), !dbg !32
+  %6 = load i32, i32* %2, align 4, !dbg !40, !tbaa !36
+  call void @llvm.dbg.value(metadata i32 %6, metadata !30, metadata !DIExpression()), !dbg !32
+  call void @fn1(i32 noundef %5, i32 noundef %6), !dbg !41
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* nonnull %4), !dbg !42
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* nonnull %3), !dbg !42
+  ret i32 0, !dbg !43
+}
+
+declare !dbg !44 void @fn3(i32* noundef) local_unnamed_addr
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.6", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "test.c", directory: "/")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 1}
+!8 = !{!"clang version 14.0.6"}
+!9 = distinct !DISubprogram(name: "fn1", scope: !1, file: !1, line: 5, type: !10, scopeLine: 6, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !13)
+!10 = !DISubroutineType(types: !11)
+!11 = !{null, !12, !12}
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!13 = !{!14, !15, !16, !17}
+!14 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !1, line: 5, type: !12)
+!15 = !DILocalVariable(name: "y", arg: 2, scope: !9, file: !1, line: 5, type: !12)
+!16 = !DILocalVariable(name: "u", scope: !9, file: !1, line: 7, type: !12)
+!17 = !DILocalVariable(name: "a", scope: !9, file: !1, line: 14, type: !12)
+!18 = !DILocation(line: 0, scope: !9)
+!19 = !DILocation(line: 15, column: 3, scope: !9)
+!20 = !DILocation(line: 17, column: 1, scope: !9)
+!21 = !DISubprogram(name: "fn2", scope: !1, file: !1, line: 2, type: !22, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized, retainedNodes: !24)
+!22 = !DISubroutineType(types: !23)
+!23 = !{null, !12}
+!24 = !{}
+!25 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 20, type: !26, scopeLine: 21, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !28)
+!26 = !DISubroutineType(types: !27)
+!27 = !{!12}
+!28 = !{!29, !30}
+!29 = !DILocalVariable(name: "l", scope: !25, file: !1, line: 22, type: !12)
+!30 = !DILocalVariable(name: "k", scope: !25, file: !1, line: 22, type: !12)
+!31 = !DILocation(line: 22, column: 3, scope: !25)
+!32 = !DILocation(line: 0, scope: !25)
+!33 = !DILocation(line: 23, column: 3, scope: !25)
+!34 = !DILocation(line: 24, column: 3, scope: !25)
+!35 = !DILocation(line: 25, column: 8, scope: !25)
+!36 = !{!37, !37, i64 0}
+!37 = !{!"int", !38, i64 0}
+!38 = !{!"omnipotent char", !39, i64 0}
+!39 = !{!"Simple C/C++ TBAA"}
+!40 = !DILocation(line: 25, column: 11, scope: !25)
+!41 = !DILocation(line: 25, column: 3, scope: !25)
+!42 = !DILocation(line: 27, column: 1, scope: !25)
+!43 = !DILocation(line: 26, column: 3, scope: !25)
+!44 = !DISubprogram(name: "fn3", scope: !1, file: !1, line: 1, type: !45, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized, retainedNodes: !24)
+!45 = !DISubroutineType(types: !46)
+!46 = !{null, !47}
+!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !12, size: 64)

--- a/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage.ll
@@ -29,7 +29,7 @@
 
 ; ModuleID = 'test.c'
 source_filename = "test.c"
-target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
@@ -38,56 +38,53 @@ define dso_local void @fn1(i32 noundef %0, i32 noundef %1) !dbg !10 {
   %4 = alloca i32, align 4
   %5 = alloca i32, align 4
   %6 = alloca i32, align 4
-  store i32 %0, i32* %3, align 4
-  call void @llvm.dbg.declare(metadata i32* %3, metadata !15, metadata !DIExpression()), !dbg !16
-  store i32 %1, i32* %4, align 4
-  call void @llvm.dbg.declare(metadata i32* %4, metadata !17, metadata !DIExpression()), !dbg !18
-  call void @llvm.dbg.declare(metadata i32* %5, metadata !19, metadata !DIExpression()), !dbg !20
-  %7 = load i32, i32* %3, align 4, !dbg !21
-  %8 = load i32, i32* %4, align 4, !dbg !22
+  store i32 %0, ptr %3, align 4
+    #dbg_declare(ptr %3, !15, !DIExpression(), !16)
+  store i32 %1, ptr %4, align 4
+    #dbg_declare(ptr %4, !17, !DIExpression(), !18)
+    #dbg_declare(ptr %5, !19, !DIExpression(), !20)
+  %7 = load i32, ptr %3, align 4, !dbg !21
+  %8 = load i32, ptr %4, align 4, !dbg !22
   %9 = add nsw i32 %7, %8, !dbg !23
-  store i32 %9, i32* %5, align 4, !dbg !20
-  %10 = load i32, i32* %3, align 4, !dbg !24
+  store i32 %9, ptr %5, align 4, !dbg !20
+  %10 = load i32, ptr %3, align 4, !dbg !24
   %11 = icmp sgt i32 %10, 1, !dbg !26
   br i1 %11, label %12, label %15, !dbg !27
 
 12:                                               ; preds = %2
-  %13 = load i32, i32* %5, align 4, !dbg !28
+  %13 = load i32, ptr %5, align 4, !dbg !28
   %14 = add nsw i32 %13, 1, !dbg !28
-  store i32 %14, i32* %5, align 4, !dbg !28
+  store i32 %14, ptr %5, align 4, !dbg !28
   br label %18, !dbg !29
 
 15:                                               ; preds = %2
-  %16 = load i32, i32* %5, align 4, !dbg !30
+  %16 = load i32, ptr %5, align 4, !dbg !30
   %17 = add nsw i32 %16, 2, !dbg !30
-  store i32 %17, i32* %5, align 4, !dbg !30
+  store i32 %17, ptr %5, align 4, !dbg !30
   br label %18
 
 18:                                               ; preds = %15, %12
-  %19 = load i32, i32* %4, align 4, !dbg !31
+  %19 = load i32, ptr %4, align 4, !dbg !31
   %20 = icmp sgt i32 %19, 4, !dbg !33
   br i1 %20, label %21, label %25, !dbg !34
 
 21:                                               ; preds = %18
-  %22 = load i32, i32* %3, align 4, !dbg !35
-  %23 = load i32, i32* %5, align 4, !dbg !36
+  %22 = load i32, ptr %3, align 4, !dbg !35
+  %23 = load i32, ptr %5, align 4, !dbg !36
   %24 = add nsw i32 %23, %22, !dbg !36
-  store i32 %24, i32* %5, align 4, !dbg !36
+  store i32 %24, ptr %5, align 4, !dbg !36
   br label %25, !dbg !37
 
 25:                                               ; preds = %21, %18
-  call void @llvm.dbg.declare(metadata i32* %6, metadata !38, metadata !DIExpression()), !dbg !39
-  store i32 7, i32* %6, align 4, !dbg !39
-  %26 = load i32, i32* %6, align 4, !dbg !40
+    #dbg_declare(ptr %6, !38, !DIExpression(), !39)
+  store i32 7, ptr %6, align 4, !dbg !39
+  %26 = load i32, ptr %6, align 4, !dbg !40
   call void @fn2(i32 noundef %26), !dbg !41
-  %27 = load i32, i32* %5, align 4, !dbg !42
+  %27 = load i32, ptr %5, align 4, !dbg !42
   %28 = add nsw i32 %27, -1, !dbg !42
-  store i32 %28, i32* %5, align 4, !dbg !42
+  store i32 %28, ptr %5, align 4, !dbg !42
   ret void, !dbg !43
 }
-
-; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare void @llvm.dbg.declare(metadata, metadata, metadata)
 
 declare void @fn2(i32 noundef)
 
@@ -95,32 +92,32 @@ declare void @fn2(i32 noundef)
 define dso_local i32 @f() !dbg !44 {
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
-  call void @llvm.dbg.declare(metadata i32* %1, metadata !47, metadata !DIExpression()), !dbg !48
-  call void @llvm.dbg.declare(metadata i32* %2, metadata !49, metadata !DIExpression()), !dbg !50
-  call void @fn3(i32* noundef %1), !dbg !51
-  call void @fn3(i32* noundef %2), !dbg !52
-  %3 = load i32, i32* %1, align 4, !dbg !53
-  %4 = load i32, i32* %2, align 4, !dbg !54
+    #dbg_declare(ptr %1, !47, !DIExpression(), !48)
+    #dbg_declare(ptr %2, !49, !DIExpression(), !50)
+  call void @fn3(ptr noundef %1), !dbg !51
+  call void @fn3(ptr noundef %2), !dbg !52
+  %3 = load i32, ptr %1, align 4, !dbg !53
+  %4 = load i32, ptr %2, align 4, !dbg !54
   call void @fn1(i32 noundef %3, i32 noundef %4), !dbg !55
   ret i32 0, !dbg !56
 }
 
-declare void @fn3(i32* noundef)
+declare void @fn3(ptr noundef)
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
 !llvm.ident = !{!9}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.6", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 19.1.7", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
 !1 = !DIFile(filename: "test.c", directory: "/")
 !2 = !{i32 7, !"Dwarf Version", i32 5}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = !{i32 1, !"wchar_size", i32 4}
-!5 = !{i32 7, !"PIC Level", i32 2}
+!5 = !{i32 8, !"PIC Level", i32 2}
 !6 = !{i32 7, !"PIE Level", i32 2}
-!7 = !{i32 7, !"uwtable", i32 1}
+!7 = !{i32 7, !"uwtable", i32 2}
 !8 = !{i32 7, !"frame-pointer", i32 2}
-!9 = !{!"clang version 14.0.6"}
+!9 = !{!"clang version 19.1.7"}
 !10 = distinct !DISubprogram(name: "fn1", scope: !1, file: !1, line: 5, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
 !11 = !DISubroutineType(types: !12)
 !12 = !{null, !13, !13}

--- a/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage.ll
@@ -1,10 +1,7 @@
 ; The source code of the test case:
 ; extern void fn3(int *);
-; extern void fn2 (int);
-; __attribute__((noinline))
-; void
-; fn1 (int x, int y)
-; {
+; extern void fn2(int);
+; __attribute__((noinline)) void fn1(int x, int y) {
 ;   int u = x + y;
 ;   if (x > 1)
 ;     u += 1;
@@ -13,17 +10,18 @@
 ;   if (y > 4)
 ;     u += x;
 ;   int a = 7;
-;   fn2 (a);
-;   u --;
+;   fn2(a);
+;   int v = u;
+;   v++;
+;   u--;
+;   fn2(u);
 ; }
-
-; __attribute__((noinline))
-; int f()
-; {
+; 
+; __attribute__((noinline)) int f() {
 ;   int l, k;
 ;   fn3(&l);
 ;   fn3(&k);
-;   fn1 (l, k);
+;   fn1(l, k);
 ;   return 0;
 ; }
 
@@ -38,68 +36,77 @@ define dso_local void @fn1(i32 noundef %0, i32 noundef %1) !dbg !10 {
   %4 = alloca i32, align 4
   %5 = alloca i32, align 4
   %6 = alloca i32, align 4
+  %7 = alloca i32, align 4
   store i32 %0, ptr %3, align 4
     #dbg_declare(ptr %3, !15, !DIExpression(), !16)
   store i32 %1, ptr %4, align 4
     #dbg_declare(ptr %4, !17, !DIExpression(), !18)
     #dbg_declare(ptr %5, !19, !DIExpression(), !20)
-  %7 = load i32, ptr %3, align 4, !dbg !21
-  %8 = load i32, ptr %4, align 4, !dbg !22
-  %9 = add nsw i32 %7, %8, !dbg !23
-  store i32 %9, ptr %5, align 4, !dbg !20
-  %10 = load i32, ptr %3, align 4, !dbg !24
-  %11 = icmp sgt i32 %10, 1, !dbg !26
-  br i1 %11, label %12, label %15, !dbg !27
+  %8 = load i32, ptr %3, align 4, !dbg !21
+  %9 = load i32, ptr %4, align 4, !dbg !22
+  %10 = add nsw i32 %8, %9, !dbg !23
+  store i32 %10, ptr %5, align 4, !dbg !20
+  %11 = load i32, ptr %3, align 4, !dbg !24
+  %12 = icmp sgt i32 %11, 1, !dbg !26
+  br i1 %12, label %13, label %16, !dbg !27
 
-12:                                               ; preds = %2
-  %13 = load i32, ptr %5, align 4, !dbg !28
-  %14 = add nsw i32 %13, 1, !dbg !28
-  store i32 %14, ptr %5, align 4, !dbg !28
-  br label %18, !dbg !29
+13:                                               ; preds = %2
+  %14 = load i32, ptr %5, align 4, !dbg !28
+  %15 = add nsw i32 %14, 1, !dbg !28
+  store i32 %15, ptr %5, align 4, !dbg !28
+  br label %19, !dbg !29
 
-15:                                               ; preds = %2
-  %16 = load i32, ptr %5, align 4, !dbg !30
-  %17 = add nsw i32 %16, 2, !dbg !30
-  store i32 %17, ptr %5, align 4, !dbg !30
-  br label %18
+16:                                               ; preds = %2
+  %17 = load i32, ptr %5, align 4, !dbg !30
+  %18 = add nsw i32 %17, 2, !dbg !30
+  store i32 %18, ptr %5, align 4, !dbg !30
+  br label %19
 
-18:                                               ; preds = %15, %12
-  %19 = load i32, ptr %4, align 4, !dbg !31
-  %20 = icmp sgt i32 %19, 4, !dbg !33
-  br i1 %20, label %21, label %25, !dbg !34
+19:                                               ; preds = %16, %13
+  %20 = load i32, ptr %4, align 4, !dbg !31
+  %21 = icmp sgt i32 %20, 4, !dbg !33
+  br i1 %21, label %22, label %26, !dbg !34
 
-21:                                               ; preds = %18
-  %22 = load i32, ptr %3, align 4, !dbg !35
-  %23 = load i32, ptr %5, align 4, !dbg !36
-  %24 = add nsw i32 %23, %22, !dbg !36
-  store i32 %24, ptr %5, align 4, !dbg !36
-  br label %25, !dbg !37
+22:                                               ; preds = %19
+  %23 = load i32, ptr %3, align 4, !dbg !35
+  %24 = load i32, ptr %5, align 4, !dbg !36
+  %25 = add nsw i32 %24, %23, !dbg !36
+  store i32 %25, ptr %5, align 4, !dbg !36
+  br label %26, !dbg !37
 
-25:                                               ; preds = %21, %18
+26:                                               ; preds = %22, %19
     #dbg_declare(ptr %6, !38, !DIExpression(), !39)
   store i32 7, ptr %6, align 4, !dbg !39
-  %26 = load i32, ptr %6, align 4, !dbg !40
-  call void @fn2(i32 noundef %26), !dbg !41
-  %27 = load i32, ptr %5, align 4, !dbg !42
-  %28 = add nsw i32 %27, -1, !dbg !42
-  store i32 %28, ptr %5, align 4, !dbg !42
-  ret void, !dbg !43
+  %27 = load i32, ptr %6, align 4, !dbg !40
+  call void @fn2(i32 noundef %27), !dbg !41
+    #dbg_declare(ptr %7, !42, !DIExpression(), !43)
+  %28 = load i32, ptr %5, align 4, !dbg !44
+  store i32 %28, ptr %7, align 4, !dbg !43
+  %29 = load i32, ptr %7, align 4, !dbg !45
+  %30 = add nsw i32 %29, 1, !dbg !45
+  store i32 %30, ptr %7, align 4, !dbg !45
+  %31 = load i32, ptr %5, align 4, !dbg !46
+  %32 = add nsw i32 %31, -1, !dbg !46
+  store i32 %32, ptr %5, align 4, !dbg !46
+  %33 = load i32, ptr %5, align 4, !dbg !47
+  call void @fn2(i32 noundef %33), !dbg !48
+  ret void, !dbg !49
 }
 
 declare void @fn2(i32 noundef)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define dso_local i32 @f() !dbg !44 {
+define dso_local i32 @f() !dbg !50 {
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
-    #dbg_declare(ptr %1, !47, !DIExpression(), !48)
-    #dbg_declare(ptr %2, !49, !DIExpression(), !50)
-  call void @fn3(ptr noundef %1), !dbg !51
-  call void @fn3(ptr noundef %2), !dbg !52
-  %3 = load i32, ptr %1, align 4, !dbg !53
-  %4 = load i32, ptr %2, align 4, !dbg !54
-  call void @fn1(i32 noundef %3, i32 noundef %4), !dbg !55
-  ret i32 0, !dbg !56
+    #dbg_declare(ptr %1, !53, !DIExpression(), !54)
+    #dbg_declare(ptr %2, !55, !DIExpression(), !56)
+  call void @fn3(ptr noundef %1), !dbg !57
+  call void @fn3(ptr noundef %2), !dbg !58
+  %3 = load i32, ptr %1, align 4, !dbg !59
+  %4 = load i32, ptr %2, align 4, !dbg !60
+  call void @fn1(i32 noundef %3, i32 noundef %4), !dbg !61
+  ret i32 0, !dbg !62
 }
 
 declare void @fn3(ptr noundef)
@@ -118,50 +125,56 @@ declare void @fn3(ptr noundef)
 !7 = !{i32 7, !"uwtable", i32 2}
 !8 = !{i32 7, !"frame-pointer", i32 2}
 !9 = !{!"clang version 19.1.7"}
-!10 = distinct !DISubprogram(name: "fn1", scope: !1, file: !1, line: 5, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!10 = distinct !DISubprogram(name: "fn1", scope: !1, file: !1, line: 3, type: !11, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
 !11 = !DISubroutineType(types: !12)
 !12 = !{null, !13, !13}
 !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 !14 = !{}
-!15 = !DILocalVariable(name: "x", arg: 1, scope: !10, file: !1, line: 5, type: !13)
-!16 = !DILocation(line: 5, column: 10, scope: !10)
-!17 = !DILocalVariable(name: "y", arg: 2, scope: !10, file: !1, line: 5, type: !13)
-!18 = !DILocation(line: 5, column: 17, scope: !10)
-!19 = !DILocalVariable(name: "u", scope: !10, file: !1, line: 7, type: !13)
-!20 = !DILocation(line: 7, column: 7, scope: !10)
-!21 = !DILocation(line: 7, column: 11, scope: !10)
-!22 = !DILocation(line: 7, column: 15, scope: !10)
-!23 = !DILocation(line: 7, column: 13, scope: !10)
-!24 = !DILocation(line: 8, column: 7, scope: !25)
-!25 = distinct !DILexicalBlock(scope: !10, file: !1, line: 8, column: 7)
-!26 = !DILocation(line: 8, column: 9, scope: !25)
-!27 = !DILocation(line: 8, column: 7, scope: !10)
-!28 = !DILocation(line: 9, column: 7, scope: !25)
-!29 = !DILocation(line: 9, column: 5, scope: !25)
-!30 = !DILocation(line: 11, column: 7, scope: !25)
-!31 = !DILocation(line: 12, column: 7, scope: !32)
-!32 = distinct !DILexicalBlock(scope: !10, file: !1, line: 12, column: 7)
-!33 = !DILocation(line: 12, column: 9, scope: !32)
-!34 = !DILocation(line: 12, column: 7, scope: !10)
-!35 = !DILocation(line: 13, column: 10, scope: !32)
-!36 = !DILocation(line: 13, column: 7, scope: !32)
-!37 = !DILocation(line: 13, column: 5, scope: !32)
-!38 = !DILocalVariable(name: "a", scope: !10, file: !1, line: 14, type: !13)
-!39 = !DILocation(line: 14, column: 7, scope: !10)
-!40 = !DILocation(line: 15, column: 8, scope: !10)
-!41 = !DILocation(line: 15, column: 3, scope: !10)
-!42 = !DILocation(line: 16, column: 5, scope: !10)
-!43 = !DILocation(line: 17, column: 1, scope: !10)
-!44 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 20, type: !45, scopeLine: 21, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
-!45 = !DISubroutineType(types: !46)
-!46 = !{!13}
-!47 = !DILocalVariable(name: "l", scope: !44, file: !1, line: 22, type: !13)
-!48 = !DILocation(line: 22, column: 7, scope: !44)
-!49 = !DILocalVariable(name: "k", scope: !44, file: !1, line: 22, type: !13)
-!50 = !DILocation(line: 22, column: 10, scope: !44)
-!51 = !DILocation(line: 23, column: 3, scope: !44)
-!52 = !DILocation(line: 24, column: 3, scope: !44)
-!53 = !DILocation(line: 25, column: 8, scope: !44)
-!54 = !DILocation(line: 25, column: 11, scope: !44)
-!55 = !DILocation(line: 25, column: 3, scope: !44)
-!56 = !DILocation(line: 26, column: 3, scope: !44)
+!15 = !DILocalVariable(name: "x", arg: 1, scope: !10, file: !1, line: 3, type: !13)
+!16 = !DILocation(line: 3, column: 40, scope: !10)
+!17 = !DILocalVariable(name: "y", arg: 2, scope: !10, file: !1, line: 3, type: !13)
+!18 = !DILocation(line: 3, column: 47, scope: !10)
+!19 = !DILocalVariable(name: "u", scope: !10, file: !1, line: 4, type: !13)
+!20 = !DILocation(line: 4, column: 7, scope: !10)
+!21 = !DILocation(line: 4, column: 11, scope: !10)
+!22 = !DILocation(line: 4, column: 15, scope: !10)
+!23 = !DILocation(line: 4, column: 13, scope: !10)
+!24 = !DILocation(line: 5, column: 7, scope: !25)
+!25 = distinct !DILexicalBlock(scope: !10, file: !1, line: 5, column: 7)
+!26 = !DILocation(line: 5, column: 9, scope: !25)
+!27 = !DILocation(line: 5, column: 7, scope: !10)
+!28 = !DILocation(line: 6, column: 7, scope: !25)
+!29 = !DILocation(line: 6, column: 5, scope: !25)
+!30 = !DILocation(line: 8, column: 7, scope: !25)
+!31 = !DILocation(line: 9, column: 7, scope: !32)
+!32 = distinct !DILexicalBlock(scope: !10, file: !1, line: 9, column: 7)
+!33 = !DILocation(line: 9, column: 9, scope: !32)
+!34 = !DILocation(line: 9, column: 7, scope: !10)
+!35 = !DILocation(line: 10, column: 10, scope: !32)
+!36 = !DILocation(line: 10, column: 7, scope: !32)
+!37 = !DILocation(line: 10, column: 5, scope: !32)
+!38 = !DILocalVariable(name: "a", scope: !10, file: !1, line: 11, type: !13)
+!39 = !DILocation(line: 11, column: 7, scope: !10)
+!40 = !DILocation(line: 12, column: 7, scope: !10)
+!41 = !DILocation(line: 12, column: 3, scope: !10)
+!42 = !DILocalVariable(name: "v", scope: !10, file: !1, line: 13, type: !13)
+!43 = !DILocation(line: 13, column: 7, scope: !10)
+!44 = !DILocation(line: 13, column: 11, scope: !10)
+!45 = !DILocation(line: 14, column: 4, scope: !10)
+!46 = !DILocation(line: 15, column: 4, scope: !10)
+!47 = !DILocation(line: 16, column: 7, scope: !10)
+!48 = !DILocation(line: 16, column: 3, scope: !10)
+!49 = !DILocation(line: 17, column: 1, scope: !10)
+!50 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 19, type: !51, scopeLine: 19, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!13}
+!53 = !DILocalVariable(name: "l", scope: !50, file: !1, line: 20, type: !13)
+!54 = !DILocation(line: 20, column: 7, scope: !50)
+!55 = !DILocalVariable(name: "k", scope: !50, file: !1, line: 20, type: !13)
+!56 = !DILocation(line: 20, column: 10, scope: !50)
+!57 = !DILocation(line: 21, column: 3, scope: !50)
+!58 = !DILocation(line: 22, column: 3, scope: !50)
+!59 = !DILocation(line: 23, column: 7, scope: !50)
+!60 = !DILocation(line: 23, column: 10, scope: !50)
+!61 = !DILocation(line: 23, column: 3, scope: !50)
+!62 = !DILocation(line: 24, column: 3, scope: !50)

--- a/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/Inputs/coverage.ll
@@ -1,0 +1,170 @@
+; The source code of the test case:
+; extern void fn3(int *);
+; extern void fn2 (int);
+; __attribute__((noinline))
+; void
+; fn1 (int x, int y)
+; {
+;   int u = x + y;
+;   if (x > 1)
+;     u += 1;
+;   else
+;     u += 2;
+;   if (y > 4)
+;     u += x;
+;   int a = 7;
+;   fn2 (a);
+;   u --;
+; }
+
+; __attribute__((noinline))
+; int f()
+; {
+;   int l, k;
+;   fn3(&l);
+;   fn3(&k);
+;   fn1 (l, k);
+;   return 0;
+; }
+
+; ModuleID = 'test.c'
+source_filename = "test.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local void @fn1(i32 noundef %0, i32 noundef %1) !dbg !10 {
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca i32, align 4
+  %6 = alloca i32, align 4
+  store i32 %0, i32* %3, align 4
+  call void @llvm.dbg.declare(metadata i32* %3, metadata !15, metadata !DIExpression()), !dbg !16
+  store i32 %1, i32* %4, align 4
+  call void @llvm.dbg.declare(metadata i32* %4, metadata !17, metadata !DIExpression()), !dbg !18
+  call void @llvm.dbg.declare(metadata i32* %5, metadata !19, metadata !DIExpression()), !dbg !20
+  %7 = load i32, i32* %3, align 4, !dbg !21
+  %8 = load i32, i32* %4, align 4, !dbg !22
+  %9 = add nsw i32 %7, %8, !dbg !23
+  store i32 %9, i32* %5, align 4, !dbg !20
+  %10 = load i32, i32* %3, align 4, !dbg !24
+  %11 = icmp sgt i32 %10, 1, !dbg !26
+  br i1 %11, label %12, label %15, !dbg !27
+
+12:                                               ; preds = %2
+  %13 = load i32, i32* %5, align 4, !dbg !28
+  %14 = add nsw i32 %13, 1, !dbg !28
+  store i32 %14, i32* %5, align 4, !dbg !28
+  br label %18, !dbg !29
+
+15:                                               ; preds = %2
+  %16 = load i32, i32* %5, align 4, !dbg !30
+  %17 = add nsw i32 %16, 2, !dbg !30
+  store i32 %17, i32* %5, align 4, !dbg !30
+  br label %18
+
+18:                                               ; preds = %15, %12
+  %19 = load i32, i32* %4, align 4, !dbg !31
+  %20 = icmp sgt i32 %19, 4, !dbg !33
+  br i1 %20, label %21, label %25, !dbg !34
+
+21:                                               ; preds = %18
+  %22 = load i32, i32* %3, align 4, !dbg !35
+  %23 = load i32, i32* %5, align 4, !dbg !36
+  %24 = add nsw i32 %23, %22, !dbg !36
+  store i32 %24, i32* %5, align 4, !dbg !36
+  br label %25, !dbg !37
+
+25:                                               ; preds = %21, %18
+  call void @llvm.dbg.declare(metadata i32* %6, metadata !38, metadata !DIExpression()), !dbg !39
+  store i32 7, i32* %6, align 4, !dbg !39
+  %26 = load i32, i32* %6, align 4, !dbg !40
+  call void @fn2(i32 noundef %26), !dbg !41
+  %27 = load i32, i32* %5, align 4, !dbg !42
+  %28 = add nsw i32 %27, -1, !dbg !42
+  store i32 %28, i32* %5, align 4, !dbg !42
+  ret void, !dbg !43
+}
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata)
+
+declare void @fn2(i32 noundef)
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @f() !dbg !44 {
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  call void @llvm.dbg.declare(metadata i32* %1, metadata !47, metadata !DIExpression()), !dbg !48
+  call void @llvm.dbg.declare(metadata i32* %2, metadata !49, metadata !DIExpression()), !dbg !50
+  call void @fn3(i32* noundef %1), !dbg !51
+  call void @fn3(i32* noundef %2), !dbg !52
+  %3 = load i32, i32* %1, align 4, !dbg !53
+  %4 = load i32, i32* %2, align 4, !dbg !54
+  call void @fn1(i32 noundef %3, i32 noundef %4), !dbg !55
+  ret i32 0, !dbg !56
+}
+
+declare void @fn3(i32* noundef)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!llvm.ident = !{!9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 14.0.6", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "test.c", directory: "/")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 1}
+!8 = !{i32 7, !"frame-pointer", i32 2}
+!9 = !{!"clang version 14.0.6"}
+!10 = distinct !DISubprogram(name: "fn1", scope: !1, file: !1, line: 5, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!11 = !DISubroutineType(types: !12)
+!12 = !{null, !13, !13}
+!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !{}
+!15 = !DILocalVariable(name: "x", arg: 1, scope: !10, file: !1, line: 5, type: !13)
+!16 = !DILocation(line: 5, column: 10, scope: !10)
+!17 = !DILocalVariable(name: "y", arg: 2, scope: !10, file: !1, line: 5, type: !13)
+!18 = !DILocation(line: 5, column: 17, scope: !10)
+!19 = !DILocalVariable(name: "u", scope: !10, file: !1, line: 7, type: !13)
+!20 = !DILocation(line: 7, column: 7, scope: !10)
+!21 = !DILocation(line: 7, column: 11, scope: !10)
+!22 = !DILocation(line: 7, column: 15, scope: !10)
+!23 = !DILocation(line: 7, column: 13, scope: !10)
+!24 = !DILocation(line: 8, column: 7, scope: !25)
+!25 = distinct !DILexicalBlock(scope: !10, file: !1, line: 8, column: 7)
+!26 = !DILocation(line: 8, column: 9, scope: !25)
+!27 = !DILocation(line: 8, column: 7, scope: !10)
+!28 = !DILocation(line: 9, column: 7, scope: !25)
+!29 = !DILocation(line: 9, column: 5, scope: !25)
+!30 = !DILocation(line: 11, column: 7, scope: !25)
+!31 = !DILocation(line: 12, column: 7, scope: !32)
+!32 = distinct !DILexicalBlock(scope: !10, file: !1, line: 12, column: 7)
+!33 = !DILocation(line: 12, column: 9, scope: !32)
+!34 = !DILocation(line: 12, column: 7, scope: !10)
+!35 = !DILocation(line: 13, column: 10, scope: !32)
+!36 = !DILocation(line: 13, column: 7, scope: !32)
+!37 = !DILocation(line: 13, column: 5, scope: !32)
+!38 = !DILocalVariable(name: "a", scope: !10, file: !1, line: 14, type: !13)
+!39 = !DILocation(line: 14, column: 7, scope: !10)
+!40 = !DILocation(line: 15, column: 8, scope: !10)
+!41 = !DILocation(line: 15, column: 3, scope: !10)
+!42 = !DILocation(line: 16, column: 5, scope: !10)
+!43 = !DILocation(line: 17, column: 1, scope: !10)
+!44 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 20, type: !45, scopeLine: 21, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!45 = !DISubroutineType(types: !46)
+!46 = !{!13}
+!47 = !DILocalVariable(name: "l", scope: !44, file: !1, line: 22, type: !13)
+!48 = !DILocation(line: 22, column: 7, scope: !44)
+!49 = !DILocalVariable(name: "k", scope: !44, file: !1, line: 22, type: !13)
+!50 = !DILocation(line: 22, column: 10, scope: !44)
+!51 = !DILocation(line: 23, column: 3, scope: !44)
+!52 = !DILocation(line: 24, column: 3, scope: !44)
+!53 = !DILocation(line: 25, column: 8, scope: !44)
+!54 = !DILocation(line: 25, column: 11, scope: !44)
+!55 = !DILocation(line: 25, column: 3, scope: !44)
+!56 = !DILocation(line: 26, column: 3, scope: !44)

--- a/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
+++ b/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
@@ -16,9 +16,9 @@ RUN: llvm-dwarfdump --show-variable-coverage --combine-inline-variable-instances
 
 COMBINE:      Variable coverage statistics:
 COMBINE-NEXT: Function InstanceCount Variable Decl LinesCovered
-COMBINE-NEXT: f 1 k test.c:22 2
-COMBINE-NEXT: f 1 l test.c:22 3
-COMBINE-NEXT: fn1 1 a test.c:14 1
-COMBINE-NEXT: fn1 1 u test.c:7 1
-COMBINE-NEXT: fn1 1 x test.c:5 1
-COMBINE-NEXT: fn1 1 y test.c:5 1
+COMBINE-NEXT: f 1 k test.c:22 5
+COMBINE-NEXT: f 1 l test.c:22 5
+COMBINE-NEXT: fn1 1 a test.c:14 0
+COMBINE-NEXT: fn1 1 u test.c:7 0
+COMBINE-NEXT: fn1 1 x test.c:5 0
+COMBINE-NEXT: fn1 1 y test.c:5 0

--- a/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
+++ b/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
@@ -12,7 +12,7 @@ CHECK-NEXT: fn1 u test.c:7 11
 CHECK-NEXT: fn1 x test.c:5 11
 CHECK-NEXT: fn1 y test.c:5 11
 
-RUN: llvm-dwarfdump --show-variable-coverage --combine-instances %t-opt.o | FileCheck %s --check-prefix=COMBINE
+RUN: llvm-dwarfdump --show-variable-coverage --combine-inline-variable-instances %t-opt.o | FileCheck %s --check-prefix=COMBINE
 
 COMBINE:      Variable coverage statistics:
 COMBINE-NEXT: Function InstanceCount Variable Decl LinesCovered

--- a/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
+++ b/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
@@ -5,20 +5,22 @@ RUN: llvm-dwarfdump --show-variable-coverage %t.o | FileCheck %s
 
 CHECK:      Variable coverage statistics:
 CHECK-NEXT: Function InlChain Variable Decl LinesCovered
-CHECK-NEXT: f k test.c:22 5
-CHECK-NEXT: f l test.c:22 5
-CHECK-NEXT: fn1 a test.c:14 11
-CHECK-NEXT: fn1 u test.c:7 11
-CHECK-NEXT: fn1 x test.c:5 11
-CHECK-NEXT: fn1 y test.c:5 11
+CHECK-NEXT: f k test.c:20 5
+CHECK-NEXT: f l test.c:20 5
+CHECK-NEXT: fn1 a test.c:11 14
+CHECK-NEXT: fn1 u test.c:4 14
+CHECK-NEXT: fn1 v test.c:13 14
+CHECK-NEXT: fn1 x test.c:3 14
+CHECK-NEXT: fn1 y test.c:3 14
 
 RUN: llvm-dwarfdump --show-variable-coverage --combine-inline-variable-instances %t-opt.o | FileCheck %s --check-prefix=COMBINE
 
 COMBINE:      Variable coverage statistics:
 COMBINE-NEXT: Function InstanceCount Variable Decl LinesCovered
-COMBINE-NEXT: f 1 k test.c:22 5
-COMBINE-NEXT: f 1 l test.c:22 5
-COMBINE-NEXT: fn1 1 a test.c:14 0
-COMBINE-NEXT: fn1 1 u test.c:7 0
-COMBINE-NEXT: fn1 1 x test.c:5 0
-COMBINE-NEXT: fn1 1 y test.c:5 0
+COMBINE-NEXT: f 1 k test.c:20 5
+COMBINE-NEXT: f 1 l test.c:20 5
+COMBINE-NEXT: fn1 1 a test.c:11 5
+COMBINE-NEXT: fn1 1 u test.c:4 1
+COMBINE-NEXT: fn1 1 v test.c:13 0
+COMBINE-NEXT: fn1 1 x test.c:3 7
+COMBINE-NEXT: fn1 1 y test.c:3 7

--- a/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
+++ b/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
@@ -1,0 +1,24 @@
+; RUN: llc %S/Inputs/coverage.ll -o %t.o -filetype=obj
+; RUN: llc %S/Inputs/coverage-opt.ll -o %t-opt.o -filetype=obj
+
+; RUN: llvm-dwarfdump --show-variable-coverage %t.o | FileCheck %s
+
+; CHECK:      Variable coverage statistics:
+; CHECK-NEXT: Function InlChain Variable Decl LinesCovered
+; CHECK-NEXT: f k test.c:22 5
+; CHECK-NEXT: f l test.c:22 5
+; CHECK-NEXT: fn1 a test.c:14 11
+; CHECK-NEXT: fn1 u test.c:7 11
+; CHECK-NEXT: fn1 x test.c:5 11
+; CHECK-NEXT: fn1 y test.c:5 11
+
+; RUN: llvm-dwarfdump --show-variable-coverage --combine-instances %t-opt.o | FileCheck %s --check-prefix=COMBINE
+
+; COMBINE:      Variable coverage statistics:
+; COMBINE-NEXT: Function InstanceCount Variable Decl LinesCovered
+; COMBINE-NEXT: f 1 k test.c:22 2
+; COMBINE-NEXT: f 1 l test.c:22 3
+; COMBINE-NEXT: fn1 1 a test.c:14 1
+; COMBINE-NEXT: fn1 1 u test.c:7 1
+; COMBINE-NEXT: fn1 1 x test.c:5 1
+; COMBINE-NEXT: fn1 1 y test.c:5 1

--- a/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
+++ b/llvm/test/tools/llvm-dwarfdump/X86/coverage.test
@@ -1,24 +1,24 @@
-; RUN: llc %S/Inputs/coverage.ll -o %t.o -filetype=obj
-; RUN: llc %S/Inputs/coverage-opt.ll -o %t-opt.o -filetype=obj
+RUN: llc %S/Inputs/coverage.ll -o %t.o -filetype=obj
+RUN: llc %S/Inputs/coverage-opt.ll -o %t-opt.o -filetype=obj
 
-; RUN: llvm-dwarfdump --show-variable-coverage %t.o | FileCheck %s
+RUN: llvm-dwarfdump --show-variable-coverage %t.o | FileCheck %s
 
-; CHECK:      Variable coverage statistics:
-; CHECK-NEXT: Function InlChain Variable Decl LinesCovered
-; CHECK-NEXT: f k test.c:22 5
-; CHECK-NEXT: f l test.c:22 5
-; CHECK-NEXT: fn1 a test.c:14 11
-; CHECK-NEXT: fn1 u test.c:7 11
-; CHECK-NEXT: fn1 x test.c:5 11
-; CHECK-NEXT: fn1 y test.c:5 11
+CHECK:      Variable coverage statistics:
+CHECK-NEXT: Function InlChain Variable Decl LinesCovered
+CHECK-NEXT: f k test.c:22 5
+CHECK-NEXT: f l test.c:22 5
+CHECK-NEXT: fn1 a test.c:14 11
+CHECK-NEXT: fn1 u test.c:7 11
+CHECK-NEXT: fn1 x test.c:5 11
+CHECK-NEXT: fn1 y test.c:5 11
 
-; RUN: llvm-dwarfdump --show-variable-coverage --combine-instances %t-opt.o | FileCheck %s --check-prefix=COMBINE
+RUN: llvm-dwarfdump --show-variable-coverage --combine-instances %t-opt.o | FileCheck %s --check-prefix=COMBINE
 
-; COMBINE:      Variable coverage statistics:
-; COMBINE-NEXT: Function InstanceCount Variable Decl LinesCovered
-; COMBINE-NEXT: f 1 k test.c:22 2
-; COMBINE-NEXT: f 1 l test.c:22 3
-; COMBINE-NEXT: fn1 1 a test.c:14 1
-; COMBINE-NEXT: fn1 1 u test.c:7 1
-; COMBINE-NEXT: fn1 1 x test.c:5 1
-; COMBINE-NEXT: fn1 1 y test.c:5 1
+COMBINE:      Variable coverage statistics:
+COMBINE-NEXT: Function InstanceCount Variable Decl LinesCovered
+COMBINE-NEXT: f 1 k test.c:22 2
+COMBINE-NEXT: f 1 l test.c:22 3
+COMBINE-NEXT: fn1 1 a test.c:14 1
+COMBINE-NEXT: fn1 1 u test.c:7 1
+COMBINE-NEXT: fn1 1 x test.c:5 1
+COMBINE-NEXT: fn1 1 y test.c:5 1

--- a/llvm/tools/llvm-dwarfdump/CMakeLists.txt
+++ b/llvm/tools/llvm-dwarfdump/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_tool(llvm-dwarfdump
+  Coverage.cpp
   SectionSizes.cpp
   Statistics.cpp
   llvm-dwarfdump.cpp

--- a/llvm/tools/llvm-dwarfdump/Coverage.cpp
+++ b/llvm/tools/llvm-dwarfdump/Coverage.cpp
@@ -1,0 +1,244 @@
+//===-- Coverage.cpp - Debug info coverage metrics ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm-dwarfdump.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/DebugInfo/DIContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
+#include "llvm/DebugInfo/DWARF/DWARFCompileUnit.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/DebugProgramInstruction.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+#include <set>
+
+using namespace llvm;
+using namespace llvm::dwarf;
+using namespace llvm::object;
+
+typedef std::pair<std::string, std::string> StringPair;
+
+static std::optional<std::set<std::pair<uint16_t, uint32_t>>>
+computeVariableCoverage(DWARFContext &DICtx, DWARFDie DIE,
+                        const DWARFDebugLine::LineTable *const LineTable) {
+  auto addLines = [](const DWARFDebugLine::LineTable *LineTable,
+                     std::set<std::pair<uint16_t, uint32_t>> &Lines,
+                     DWARFAddressRange Range,
+                     std::map<std::string, uint16_t, std::less<>> &FileNames) {
+    std::vector<uint32_t> Rows;
+    if (LineTable->lookupAddressRange({Range.LowPC, Range.SectionIndex},
+                                      Range.HighPC - Range.LowPC, Rows)) {
+      for (const auto &RowI : Rows) {
+        const auto Row = LineTable->Rows[RowI];
+        if (Row.Address.Address < Range.LowPC)
+          continue;
+        const auto FileIndex = Row.File;
+
+        if (!any_of(FileNames,
+                    [FileIndex](auto &FN) { return FN.second == FileIndex; })) {
+          std::string Name;
+          LineTable->getFileNameByIndex(
+              FileIndex, "",
+              DILineInfoSpecifier::FileLineInfoKind::RelativeFilePath, Name);
+          FileNames.emplace(Name, FileIndex);
+        }
+
+        const auto Line = Row.Line;
+        if (Line) // ignore zero lines
+          Lines.insert({FileIndex, Line});
+      }
+    }
+  };
+
+  std::map<std::string, uint16_t, std::less<>> FileNames;
+
+  auto Locations = DIE.getLocations(DW_AT_location);
+  std::optional<std::set<std::pair<uint16_t, uint32_t>>> Lines;
+  if (Locations) {
+    for (const auto &L : Locations.get()) {
+      if (L.Range) {
+        if (!Lines)
+          Lines = {{}};
+        addLines(LineTable, *Lines, L.Range.value(), FileNames);
+      }
+    }
+  } else {
+    consumeError(Locations.takeError());
+  }
+
+  auto Ranges = DIE.getParent().getAddressRanges();
+  std::optional<std::set<std::pair<uint16_t, uint32_t>>> ParentLines;
+  if (Ranges) {
+    ParentLines = {{}};
+    for (const auto &R : Ranges.get())
+      addLines(LineTable, *ParentLines, R, FileNames);
+  } else {
+    consumeError(Ranges.takeError());
+  }
+
+  if (!Lines && ParentLines) {
+    Lines = ParentLines;
+  } else if (ParentLines) {
+    std::set<std::pair<uint16_t, uint32_t>> Intersection;
+    std::set_intersection(Lines->begin(), Lines->end(), ParentLines->begin(),
+                          ParentLines->end(),
+                          std::inserter(Intersection, Intersection.begin()));
+    Lines = Intersection;
+  }
+
+  return Lines;
+}
+
+static const SmallVector<DWARFDie> getParentSubroutines(DWARFDie DIE) {
+  SmallVector<DWARFDie> Parents;
+  DWARFDie Parent = DIE;
+  do
+    if (Parent.getTag() == DW_TAG_subprogram ||
+        Parent.getTag() == DW_TAG_inlined_subroutine)
+      Parents.push_back(Parent);
+  while ((Parent = Parent.getParent()));
+  return Parents;
+}
+
+struct VarKey {
+  const char *const SubprogramName;
+  const char *const Name;
+  std::string DeclFile;
+  unsigned long DeclLine;
+
+  bool operator==(const VarKey &Other) const {
+    return DeclLine == Other.DeclLine &&
+           !strcmp(SubprogramName, Other.SubprogramName) &&
+           !strcmp(Name, Other.Name) && !DeclFile.compare(Other.DeclFile);
+  }
+
+  bool operator<(const VarKey &Other) const {
+    int A = strcmp(SubprogramName, Other.SubprogramName);
+    if (A)
+      return A < 0;
+    int B = strcmp(Name, Other.Name);
+    if (B)
+      return B < 0;
+    int C = DeclFile.compare(Other.DeclFile);
+    if (C)
+      return C < 0;
+    return DeclLine < Other.DeclLine;
+  }
+};
+
+struct VarCoverage {
+  SmallVector<DWARFDie> Parents;
+  size_t Cov;
+  size_t Instances;
+};
+
+typedef std::multimap<VarKey, VarCoverage, std::less<>> VarMap;
+
+static std::optional<const VarKey> getVarKey(DWARFDie Die, DWARFDie Parent) {
+  const auto *const DieName = Die.getName(DINameKind::LinkageName);
+  const auto DieFile =
+      Die.getDeclFile(DILineInfoSpecifier::FileLineInfoKind::RelativeFilePath);
+  const auto *const ParentName = Parent.getName(DINameKind::LinkageName);
+  if (!DieName || !ParentName)
+    return std::nullopt;
+  return VarKey{ParentName, DieName, DieFile, Die.getDeclLine()};
+}
+
+static void displayParents(SmallVector<DWARFDie> Parents, raw_ostream &OS) {
+  bool First = true;
+  for (const auto Parent : Parents) {
+    if (auto FormValue = Parent.find(DW_AT_call_file)) {
+      if (auto OptString = FormValue->getAsFile(
+              DILineInfoSpecifier::FileLineInfoKind::RelativeFilePath)) {
+        if (First)
+          First = false;
+        else
+          OS << ", ";
+        OS << *OptString << ":" << toUnsigned(Parent.find(DW_AT_call_line), 0);
+      }
+    }
+  }
+}
+
+static void displayVariableCoverage(const VarKey &Key, const VarCoverage &Var,
+                                    bool CombineInstances, raw_ostream &OS) {
+  WithColor(OS, HighlightColor::String) << Key.SubprogramName;
+  OS << "\t";
+  if (CombineInstances)
+    OS << Var.Instances;
+  else if (Var.Parents.size())
+    displayParents(Var.Parents, OS);
+  OS << "\t";
+  WithColor(OS, HighlightColor::String) << Key.Name;
+  OS << "\t" << Key.DeclFile << ":" << Key.DeclLine;
+  OS << "\t" << format("%.3g", ((float)Var.Cov / Var.Instances));
+  OS << "\n";
+}
+
+bool dwarfdump::showVariableCoverage(ObjectFile &Obj, DWARFContext &DICtx,
+                                     bool CombineInstances, raw_ostream &OS) {
+  VarMap Vars;
+
+  WithColor(errs(), HighlightColor::Remark) << "Processing DIEs...\n";
+
+  for (const auto &U : DICtx.info_section_units()) {
+    const auto *const LT = DICtx.getLineTableForUnit(U.get());
+    for (const auto &Entry : U->dies()) {
+      DWARFDie Die = {U.get(), &Entry};
+      if (Die.getTag() != DW_TAG_variable &&
+          Die.getTag() != DW_TAG_formal_parameter)
+        continue;
+
+      const auto Parents = getParentSubroutines(Die);
+      if (!Parents.size())
+        continue;
+      const auto Parent = Parents.front();
+      auto Key = getVarKey(Die, Parent);
+      if (!Key)
+        continue;
+
+      const auto Cov = computeVariableCoverage(DICtx, Die, LT);
+      if (!Cov || Cov->empty())
+        continue;
+
+      VarCoverage VarCov = {Parents, Cov->size(), 1};
+
+      Vars.insert({*Key, VarCov});
+    }
+  }
+
+  std::pair<VarMap::iterator, VarMap::iterator> Range;
+
+  OS << "\nVariable coverage statistics:\nFunction\t"
+     << (CombineInstances ? "InstanceCount" : "InlChain")
+     << "\tVariable\tDecl\tLinesCovered\n";
+
+  if (CombineInstances) {
+    for (auto FirstVar = Vars.begin(); FirstVar != Vars.end();
+         FirstVar = Range.second) {
+      Range = Vars.equal_range(FirstVar->first);
+      VarCoverage CombinedCov = {{}, 0, 0};
+      for (auto Var = Range.first; Var != Range.second; ++Var) {
+        ++CombinedCov.Instances;
+        CombinedCov.Cov += Var->second.Cov;
+      }
+      displayVariableCoverage(FirstVar->first, CombinedCov, true, OS);
+    }
+  } else {
+    for (auto Var : Vars)
+      displayVariableCoverage(Var.first, Var.second, false, OS);
+  }
+
+  return true;
+}

--- a/llvm/tools/llvm-dwarfdump/Coverage.cpp
+++ b/llvm/tools/llvm-dwarfdump/Coverage.cpp
@@ -115,7 +115,7 @@ struct VarKey {
   const char *const SubprogramName;
   const char *const Name;
   std::string DeclFile;
-  unsigned long DeclLine;
+  uint64_t DeclLine;
 
   bool operator==(const VarKey &Other) const {
     return DeclLine == Other.DeclLine &&

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -339,7 +339,7 @@ static opt<bool>
                          desc("Show per-variable coverage metrics."),
                          cat(DwarfDumpCategory));
 static opt<bool> CombineInstances(
-    "combine-instances",
+    "combine-inline-variable-instances",
     desc(
         "Use with --show-variable-coverage to average variable coverage across "
         "inlined subroutine instances instead of printing them separately."),

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -334,6 +334,16 @@ static opt<bool> Verbose("verbose",
                          cat(DwarfDumpCategory));
 static alias VerboseAlias("v", desc("Alias for --verbose."), aliasopt(Verbose),
                           cat(DwarfDumpCategory), cl::NotHidden);
+static opt<bool>
+    ShowVariableCoverage("show-variable-coverage",
+                         desc("Show per-variable coverage metrics."),
+                         cat(DwarfDumpCategory));
+static opt<bool> CombineInstances(
+    "combine-instances",
+    desc(
+        "Use with --show-variable-coverage to average variable coverage across "
+        "inlined subroutine instances instead of printing them separately."),
+    cat(DwarfDumpCategory));
 static cl::extrahelp
     HelpResponse("\nPass @FILE as argument to read options from FILE.\n");
 } // namespace
@@ -905,7 +915,7 @@ int main(int argc, char **argv) {
     DumpType |= DIDT_UUID;
   if (DumpAll)
     DumpType = DIDT_All;
-  if (DumpType == DIDT_Null) {
+  if (DumpType == DIDT_Null && !ShowVariableCoverage) {
     if (Verbose || Verify)
       DumpType = DIDT_All;
     else
@@ -955,6 +965,15 @@ int main(int argc, char **argv) {
   } else {
     for (StringRef Object : Objects)
       Success &= handleFile(Object, dumpObjectFile, OutputFile.os());
+  }
+
+  if (ShowVariableCoverage) {
+    auto showCoverage = [&](ObjectFile &Obj, DWARFContext &DICtx,
+                            const Twine &Filename, raw_ostream &OS) {
+      return showVariableCoverage(Obj, DICtx, CombineInstances, OS);
+    };
+    for (StringRef Object : Objects)
+      Success &= handleFile(Object, showCoverage, OutputFile.os());
   }
 
   return Success ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.h
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.h
@@ -39,6 +39,8 @@ bool collectStatsForObjectFile(object::ObjectFile &Obj, DWARFContext &DICtx,
 bool collectObjectSectionSizes(object::ObjectFile &Obj, DWARFContext &DICtx,
                                const Twine &Filename, raw_ostream &OS);
 
+bool showVariableCoverage(object::ObjectFile &Obj, DWARFContext &DICtx,
+                          bool CombineInstances, raw_ostream &OS);
 } // namespace dwarfdump
 } // namespace llvm
 


### PR DESCRIPTION
Patch 1 of 3 to add to llvm-dwarfdump the ability to measure DWARF coverage of local variables in terms of source lines, as discussed in [this RFC](https://discourse.llvm.org/t/rfc-debug-info-coverage-tool-v2/83266).

This patch adds the basic variable coverage implementation. By default, inlined instances are shown separately (displaying the full inlining chain). Alternatively, a combined view that averages across all inlined instances can be returned using `--combine-instances`.

In this patch, we simply print a count of source lines over which each variable is covered. Later patches in the series will add the comparison against a baseline.

Example output:
```
$ llvm-dwarfdump --show-variable-coverage somefile
Variable coverage statistics:
Function InlChain                   Variable Decl                  LinesCovered
foo                                 bar      path/to/somefile.h:54 3
foo      path/to/someotherfile.c:32 bar      path/to/somefile.h:54 2
foo                                 baz      main.c:76             9
```

```
$ llvm-dwarfdump --show-variable-coverage somefile --combine-instances
Variable coverage statistics:
Function InstanceCount Variable Decl                  LinesCovered
foo      2             bar      path/to/somefile.h:54 2.5
foo      1             baz      main.c:76             9
```