### PR TITLE
[Support] Add getAllocTokenModeAsString() helper

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3956,21 +3956,7 @@ void CompilerInvocationBase::GenerateLangArgs(const LangOptions &Opts,
                 std::to_string(*Opts.AllocTokenMax));
 
   if (Opts.AllocTokenMode) {
-    StringRef S;
-    switch (*Opts.AllocTokenMode) {
-    case llvm::AllocTokenMode::Increment:
-      S = "increment";
-      break;
-    case llvm::AllocTokenMode::Random:
-      S = "random";
-      break;
-    case llvm::AllocTokenMode::TypeHash:
-      S = "typehash";
-      break;
-    case llvm::AllocTokenMode::TypeHashPointerSplit:
-      S = "typehashpointersplit";
-      break;
-    }
+    StringRef S = llvm::getAllocTokenModeAsString(*Opts.AllocTokenMode);
     GenerateArg(Consumer, OPT_falloc_token_mode_EQ, S);
   }
 }

--- a/llvm/include/llvm/Support/AllocToken.h
+++ b/llvm/include/llvm/Support/AllocToken.h
@@ -46,6 +46,9 @@ inline constexpr AllocTokenMode DefaultAllocTokenMode =
 LLVM_ABI std::optional<AllocTokenMode>
 getAllocTokenModeFromString(StringRef Name);
 
+/// Returns the canonical string name for the given AllocTokenMode.
+LLVM_ABI StringRef getAllocTokenModeAsString(AllocTokenMode Mode);
+
 /// Metadata about an allocation used to generate a token ID.
 struct AllocTokenMetadata {
   SmallString<64> TypeName;

--- a/llvm/lib/Support/AllocToken.cpp
+++ b/llvm/lib/Support/AllocToken.cpp
@@ -28,6 +28,20 @@ llvm::getAllocTokenModeFromString(StringRef Name) {
       .Default(std::nullopt);
 }
 
+StringRef llvm::getAllocTokenModeAsString(AllocTokenMode Mode) {
+  switch (Mode) {
+  case AllocTokenMode::Increment:
+    return "increment";
+  case AllocTokenMode::Random:
+    return "random";
+  case AllocTokenMode::TypeHash:
+    return "typehash";
+  case AllocTokenMode::TypeHashPointerSplit:
+    return "typehashpointersplit";
+  }
+  llvm_unreachable("Unknown AllocTokenMode");
+}
+
 static uint64_t getStableHash(const AllocTokenMetadata &Metadata,
                               uint64_t MaxTokens) {
   return getStableSipHash(Metadata.TypeName) % MaxTokens;


### PR DESCRIPTION
Add a helper function getAllocTokenModeAsString() to convert AllocTokenMode values to their string representation.

NFC.