### PR TITLE
[SPIRV][AMD] Disable SPV_KHR_float_control2 for AMD flavored SPIRV

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -248,5 +248,11 @@ SPIRVExtensionsParser::getValidExtensions(const Triple &TT) {
       R.insert(ExtensionEnum);
   }
 
+  if (TT.getVendor() == Triple::AMD) {
+    // AMD uses the translator to recover LLVM-IR from SPIRV. Currently, the
+    // translator doesn't implement the SPV_KHR_float_controls2 extension.
+    R.erase(SPIRV::Extension::SPV_KHR_float_controls2);
+  }
+
   return R;
 }

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_float_controls2/disabled-on-amd.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_float_controls2/disabled-on-amd.ll
@@ -1,0 +1,22 @@
+; RUN: llc -mtriple=spirv64-- --spirv-ext=all < %s | FileCheck %s --check-prefix=CHECK
+; No need to validate the output of the first command, we just want to ensure that we are on a path that triggers the use of SPV_KHR_float_controls2
+
+; RUN: llc -mtriple=spirv64-amd-amdhsa --spirv-ext=all < %s | FileCheck %s --check-prefix=CHECK-AMD
+; RUN: %if spirv-tools %{ llc -mtriple=spirv64-amd-amdhsa --spirv-ext=all < %s -filetype=obj | spirv-val %}
+
+; RUN: llc -mtriple=spirv64-amd-amdhsa --spirv-ext=+SPV_KHR_float_controls2 < %s | FileCheck %s --check-prefix=CHECK-AMD
+; RUN: %if spirv-tools %{ llc -mtriple=spirv64-amd-amdhsa --spirv-ext=+SPV_KHR_float_controls2 < %s -filetype=obj | spirv-val %}
+
+; Check that SPV_KHR_float_controls2 is not present when the target is AMD.
+; AMD's SPIRV implementation uses the translator to get bitcode from SPIRV,
+; which at the moment doesn't implement the SPV_KHR_float_controls2 extension.
+
+; CHECK: SPV_KHR_float_controls2
+; CHECK-AMD-NOT: SPV_KHR_float_controls2
+
+define spir_kernel void @foo(float %a, float %b) {
+entry:
+  ; Use contract to trigger a use of SPV_KHR_float_controls2
+  %r1 = fadd contract float %a, %b
+  ret void
+}


### PR DESCRIPTION
AMD uses the translator to recover LLVM-IR from SPIRV.

Currently, the translator doesn't implement the `SPV_KHR_float_controls2` extension (I'm working on it).
If this extension is used by the SPIRV module, we cannot translate it back to LLVM-IR.

I'm working on the extension, but in the meantime, lets just disable it when the target triple's vendor is `amd`.