### PR TITLE
[Exegesis][RISCV] Support C_LDSP for llvm-exegesis

### DIFF
--- a/llvm/test/tools/llvm-exegesis/RISCV/latency-by-extension-C.s
+++ b/llvm/test/tools/llvm-exegesis/RISCV/latency-by-extension-C.s
@@ -53,5 +53,5 @@ C_LDSP:      ---
 C_LDSP-NEXT: mode: latency
 C_LDSP-NEXT: key:
 C_LDSP-NEXT:   instructions:
-C_LDSP-NEXT:     - 'C_LDSP [[REG111:X[0-9]+]] X2 [[IMM11:i_0x[0-9]+]]'
+C_LDSP-NEXT:     - 'C_LDSP X2 X2 [[IMM11:i_0x[0-9]+]]'
 C_LDSP-DAG: ...

--- a/llvm/test/tools/llvm-exegesis/RISCV/latency-by-extension-C.s
+++ b/llvm/test/tools/llvm-exegesis/RISCV/latency-by-extension-C.s
@@ -53,5 +53,5 @@ C_LDSP:      ---
 C_LDSP-NEXT: mode: latency
 C_LDSP-NEXT: key:
 C_LDSP-NEXT:   instructions:
-C_LDSP-NEXT:     - 'C_LDSP [[REG101:X[0-9]+]] [[REG102:X[0-9]+]] [[IMM10:i_0x[0-9]+]]'
+C_LDSP-NEXT:     - 'C_LDSP [[REG111:X[0-9]+]] X2 [[IMM11:i_0x[0-9]+]]'
 C_LDSP-DAG: ...

--- a/llvm/test/tools/llvm-exegesis/RISCV/latency-by-extension-C.s
+++ b/llvm/test/tools/llvm-exegesis/RISCV/latency-by-extension-C.s
@@ -46,3 +46,12 @@ C_SRLI-NEXT: key:
 C_SRLI-NEXT:   instructions:
 C_SRLI-NEXT:     - 'C_SRLI [[REG101:X[0-9]+]] [[REG102:X[0-9]+]] [[IMM10:i_0x[0-9]+]]'
 C_SRLI-DAG: ...
+
+# RUN: llvm-exegesis -mode=latency -mtriple=riscv64-unknown-linux-gnu --mcpu=generic --benchmark-phase=assemble-measured-code -opcode-name=C_LDSP -mattr=+c | FileCheck --check-prefix=C_LDSP %s
+
+C_LDSP:      ---
+C_LDSP-NEXT: mode: latency
+C_LDSP-NEXT: key:
+C_LDSP-NEXT:   instructions:
+C_LDSP-NEXT:     - 'C_LDSP [[REG101:X[0-9]+]] [[REG102:X[0-9]+]] [[IMM10:i_0x[0-9]+]]'
+C_LDSP-DAG: ...

--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -823,6 +823,7 @@ void ExegesisRISCVTarget::fillMemoryOperands(InstructionTemplate &IT,
   if (Opcode == RISCV::C_LDSP || Opcode == RISCV::C_LWSP ||
       Opcode == RISCV::C_SDSP || Opcode == RISCV::C_SWSP) {
     // Force base register to SP (X2)
+    IT.getValueFor(I.Operands[0]) = MCOperand::createReg(RISCV::X2);
     IT.getValueFor(MemOp) = MCOperand::createReg(RISCV::X2);
     return;
   }

--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -822,8 +822,8 @@ void ExegesisRISCVTarget::fillMemoryOperands(InstructionTemplate &IT,
   unsigned Opcode = I.getOpcode();
   if (Opcode == RISCV::C_LDSP || Opcode == RISCV::C_LWSP ||
       Opcode == RISCV::C_SDSP || Opcode == RISCV::C_SWSP) {
-    // Force base register to SP (X2)
     IT.getValueFor(I.Operands[0]) = MCOperand::createReg(RISCV::X2);
+    // Force base register to SP (X2)
     IT.getValueFor(MemOp) = MCOperand::createReg(RISCV::X2);
     return;
   }

--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -819,6 +819,14 @@ void ExegesisRISCVTarget::fillMemoryOperands(InstructionTemplate &IT,
 
   assert(MemOp.isReg() && "Memory operand expected to be register");
 
+  unsigned Opcode = I.getOpcode();
+  if (Opcode == RISCV::C_LDSP || Opcode == RISCV::C_LWSP ||
+      Opcode == RISCV::C_SDSP || Opcode == RISCV::C_SWSP) {
+    // Force base register to SP (X2)
+    IT.getValueFor(MemOp) = MCOperand::createReg(RISCV::X2);
+    return;
+  }
+
   IT.getValueFor(MemOp) = MCOperand::createReg(Reg);
 }
 

--- a/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
@@ -142,7 +142,12 @@ static void appendCodeTemplates(const LLVMState &State,
         return;
 
       ET.fillMemoryOperands(Variant, ScratchMemoryRegister, 0);
-      Variant.getValueFor(DefOp) = MCOperand::createReg(ScratchMemoryRegister);
+
+      // Only force the def register to ScratchMemoryRegister if the target
+      // hasn't assigned a value yet.
+      MCOperand &DefVal = Variant.getValueFor(DefOp);
+      if (!DefVal.isValid())
+        DefVal = MCOperand::createReg(ScratchMemoryRegister);
 
       CodeTemplate CT;
       CT.Execution = ExecutionModeBit;


### PR DESCRIPTION
Fix error:
```
*** Bad machine code: Illegal physical register for instruction ***
- function:    foo
- basic block: %bb.0  (0x5e2262bd3f20)
- instruction: $x10 = C_LDSP $x10, 0
- operand 1:   $x10
$x10 is not a SP register.
llvm-exegesis error: The machine function failed verification.
```