### PR TITLE
[MC][RISCV] Add missing Predicates for NDS_FMV_BF16_X

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
@@ -838,7 +838,6 @@ def : Pat<(fpextend (bf16 FPR16:$rs)),
           (NDS_FCVT_S_BF16 (bf16 FPR16:$rs))>;
 def : Pat<(bf16 (fpround FPR32:$rs)),
           (NDS_FCVT_BF16_S FPR32:$rs)>;
-} // Predicates = [HasVendorXAndesBFHCvt]
 
 let isCodeGenOnly = 1 in {
 def NDS_FMV_BF16_X : FPUnaryOp_r<0b1111000, 0b00000, 0b000, FPR16, GPR, "fmv.w.x">,
@@ -847,7 +846,6 @@ def NDS_FMV_X_BF16 : FPUnaryOp_r<0b1110000, 0b00000, 0b000, GPR, FPR16, "fmv.x.w
                      Sched<[WriteFMovF32ToI32, ReadFMovF32ToI32]>;
 }
 
-let Predicates = [HasVendorXAndesBFHCvt] in {
 def : Pat<(riscv_nds_fmv_bf16_x GPR:$src), (NDS_FMV_BF16_X GPR:$src)>;
 def : Pat<(riscv_nds_fmv_x_anyextbf16 (bf16 FPR16:$src)),
           (NDS_FMV_X_BF16 (bf16 FPR16:$src))>;


### PR DESCRIPTION
run 
```shell
build/bin/llvm-exegesis -mode=latency -mtriple=riscv64-unknown-linux-gnu --mcpu=generic --benchmark-phase=assemble-measured-code -opcode-index=-1
```

error:
```
---
mode:            latency
key:
  instructions:
    - 'NDS_FMV_BF16_X F2_H X11'
    - 'NDS_FMV_X_BF16 X26 F2_H'
  config:          ''
  register_initial_values:
    - 'X11=0x0'
cpu_name:        generic
llvm_triple:     riscv64-unknown-linux-gnu
min_instructions: 10000
measurements:    []
error:           actual measurements skipped.
info:            Repeating two instructions
assembled_snippet: 41116AE48145538105F0530D01E0538105F0530D01E0538105F0530D01E0538105F0530D01E0226D41018280
...
LLVM ERROR: Attempting to emit FMV_H_X instruction but the Feature_HasHalfFPLoadStoreMove predicate(s) are not met
```