### PR TITLE
[Clang] Fix false positive -Wignored-qualifiers

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -392,6 +392,7 @@ Improvements to Clang's diagnostics
 - Fixed false positives in ``-Waddress-of-packed-member`` diagnostics when
   potential misaligned members get processed before they can get discarded.
   (#GH144729)
+- Fix a false positive warning in ``-Wignored-qualifiers`` when the return type is undeduced. (#GH43054)
 
 - Clang now emits a diagnostic with the correct message in case of assigning to const reference captured in lambda. (#GH105647)
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3889,6 +3889,11 @@ bool Sema::DeduceFunctionTypeFromReturnExpr(FunctionDecl *FD,
     // Update all declarations of the function to have the deduced return type.
     Context.adjustDeducedFunctionResultType(FD, Deduced);
 
+  if (!Deduced->isDependentType() && !Deduced->isRecordType() &&
+      !FD->isFunctionTemplateSpecialization())
+    diagnoseIgnoredQualifiers(
+        diag::warn_qual_return_type,
+        FD->getDeclaredReturnType().getLocalCVRQualifiers(), FD->getLocation());
   return false;
 }
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -5067,8 +5067,10 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
       // cv-qualifiers on return types are pointless except when the type is a
       // class type in C++.
       if ((T.getCVRQualifiers() || T->isAtomicType()) &&
+          // A dependent type or an undeduced type might later become a class
+          // type.
           !(S.getLangOpts().CPlusPlus &&
-            (T->isDependentType() || T->isRecordType() ||
+            (T->isRecordType() || T->isDependentType() ||
              T->isUndeducedAutoType()))) {
         if (T->isVoidType() && !S.getLangOpts().CPlusPlus &&
             D.getFunctionDefinitionKind() ==

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -5068,7 +5068,8 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
       // class type in C++.
       if ((T.getCVRQualifiers() || T->isAtomicType()) &&
           !(S.getLangOpts().CPlusPlus &&
-            (T->isDependentType() || T->isRecordType()))) {
+            (T->isDependentType() || T->isRecordType() ||
+             T->isUndeducedAutoType()))) {
         if (T->isVoidType() && !S.getLangOpts().CPlusPlus &&
             D.getFunctionDefinitionKind() ==
                 FunctionDefinitionKind::Definition) {

--- a/clang/test/SemaCXX/return.cpp
+++ b/clang/test/SemaCXX/return.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 %s -std=c++11 -fcxx-exceptions -fexceptions -fsyntax-only -Wignored-qualifiers -verify
+// RUN: %clang_cc1 %s -std=c++14 -fcxx-exceptions -fexceptions -fsyntax-only -Wignored-qualifiers -verify
 
 int test1() {
   throw;
@@ -132,3 +133,27 @@ void cxx_unresolved_expr() {
   // expr doesn't assert.
   return int(undeclared, 4; // expected-error {{use of undeclared identifier 'undeclared'}}
 }
+
+#if __cplusplus >= 201402L
+namespace GH43054 {
+struct S{};
+const auto foo() { return 0; } // expected-warning {{'const' type qualifier on return type has no effect}}
+const auto bar() { return S{}; }
+template <typename T>
+const auto baz() { return T{}; }
+
+void test() {
+  baz<int>();
+  baz<S>();
+
+  []() -> const auto { // expected-warning {{'const' type qualifier on return type has no effect}}
+    return 0;
+  }();
+
+  []() -> const auto {
+    return S{};
+  }();
+}
+}
+
+#endif


### PR DESCRIPTION
A deduced return type can be an object type, in which case `const` can have an effect.
Delay the diagnostic to the point at which the type is deduced. 
Add tests for lambdas.

Fixes #43054

Note that there is a discussion in #43054 about adding a separate warning for "const return types are weird" for the class type cases, but it would have to be a separate warning - warning which currently exists in clang-tidy as `readability-const-return-type`.