### PR TITLE
[CodeGenTypes] Remove explicit VT numbers from ValueTypes.td

### DIFF
--- a/llvm/include/llvm/CodeGen/ValueTypes.td
+++ b/llvm/include/llvm/CodeGen/ValueTypes.td
@@ -6,16 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// ValueTypes.td - list of ValueType instances supported by the the
+// ValueTypes.td - list of ValueType instances supported by the
 // CodeGen infrastructure.
 //
 //===----------------------------------------------------------------------===//
 
-class ValueType<int size, int value> {
+class ValueType<int size, string llvm_name = NAME> {
   string Namespace = "MVT";
-  string LLVMName = NAME;
+  string LLVMName = llvm_name;
   int Size = size;
-  int Value = value;
   int nElem = 1;
   ValueType ElementType = ?;
   bit isOverloaded = false;
@@ -31,22 +30,22 @@ class ValueType<int size, int value> {
   bit isCheriCapability = false;
 }
 
-class VTAny<int value> : ValueType<0, value> {
+class VTAny : ValueType<0> {
   let isOverloaded = true;
 }
 
-class VTInt<int size, int value>
-    : ValueType<size, value> {
+class VTInt<int size>
+    : ValueType<size> {
   let isInteger = true;
 }
 
-class VTFP<int size, int value>
-    : ValueType<size, value> {
+class VTFP<int size>
+    : ValueType<size> {
   let isFP = true;
 }
 
-class VTVec<int nelem, ValueType elt, int value>
-    : ValueType<!mul(nelem, elt.Size), value> {
+class VTVec<int nelem, ValueType elt, string llvm_name = NAME>
+    : ValueType<!mul(nelem, elt.Size), llvm_name> {
   let nElem = nelem;
   let ElementType = elt;
   let isInteger = elt.isInteger;
@@ -54,354 +53,348 @@ class VTVec<int nelem, ValueType elt, int value>
   let isVector = true;
 }
 
-class VTScalableVec<int nelem, ValueType elt, int value>
-    : VTVec<nelem, elt, value> {
+class VTScalableVec<int nelem, ValueType elt>
+    : VTVec<nelem, elt> {
   let isScalable = true;
 }
 
-class VTVecTup<int size, int nf, ValueType dummy_elt, int value>
-    : ValueType<size, value> {
+class VTVecTup<int size, int nf, ValueType dummy_elt>
+    : ValueType<size> {
   let NF = nf;
   let ElementType = dummy_elt;
   let isRISCVVecTuple = true;
 }
 
-class VTCheriCapability<int size, int value> : ValueType<size, value> {
+class VTCheriCapability<int size> : ValueType<size> {
   let isCheriCapability = true;
 }
 
 defset list<ValueType> ValueTypes = {
 
-def OtherVT : ValueType<0,   1> {  // "Other" value
-  let LLVMName = "Other";
-}
+def OtherVT : ValueType<0, "Other">; // "Other" value
 
-def i1      : VTInt<1,   2>;  // One bit boolean value
-def i2      : VTInt<2,   3>;  // 2-bit integer value
-def i4      : VTInt<4,   4>;  // 4-bit integer value
-def i8      : VTInt<8,   5>;  // 8-bit integer value
-def i16     : VTInt<16,  6>;  // 16-bit integer value
-def i32     : VTInt<32,  7>;  // 32-bit integer value
-def i64     : VTInt<64,  8>;  // 64-bit integer value
-def i128    : VTInt<128, 9>;  // 128-bit integer value
-def i256    : VTInt<256, 10>; // 256-bit integer value
-def i512    : VTInt<512, 11>; // 512-bit integer value
+def i1      : VTInt<1>;   // One bit boolean value
+def i2      : VTInt<2>;   // 2-bit integer value
+def i4      : VTInt<4>;   // 4-bit integer value
+def i8      : VTInt<8>;   // 8-bit integer value
+def i16     : VTInt<16>;  // 16-bit integer value
+def i32     : VTInt<32>;  // 32-bit integer value
+def i64     : VTInt<64>;  // 64-bit integer value
+def i128    : VTInt<128>; // 128-bit integer value
+def i256    : VTInt<256>; // 256-bit integer value
+def i512    : VTInt<512>; // 512-bit integer value
 
-def bf16    : VTFP<16,  12>;  // 16-bit brain floating point value
-def f16     : VTFP<16,  13>;  // 16-bit floating point value
-def f32     : VTFP<32,  14>;  // 32-bit floating point value
-def f64     : VTFP<64,  15>;  // 64-bit floating point value
-def f80     : VTFP<80,  16>;  // 80-bit floating point value
-def f128    : VTFP<128, 17>;  // 128-bit floating point value
-def ppcf128 : VTFP<128, 18>;  // PPC 128-bit floating point value
+def bf16    : VTFP<16>;  // 16-bit brain floating point value
+def f16     : VTFP<16>;  // 16-bit floating point value
+def f32     : VTFP<32>;  // 32-bit floating point value
+def f64     : VTFP<64>;  // 64-bit floating point value
+def f80     : VTFP<80>;  // 80-bit floating point value
+def f128    : VTFP<128>; // 128-bit floating point value
+def ppcf128 : VTFP<128>; // PPC 128-bit floating point value
 
-def v1i1    : VTVec<1,    i1, 19>;  //    1 x i1 vector value
-def v2i1    : VTVec<2,    i1, 20>;  //    2 x i1 vector value
-def v3i1    : VTVec<3,    i1, 21>;  //    3 x i1 vector value
-def v4i1    : VTVec<4,    i1, 22>;  //    4 x i1 vector value
-def v5i1    : VTVec<5,    i1, 23>;  //    5 x i1 vector value
-def v6i1    : VTVec<6,    i1, 24>;  //    6 x i1 vector value
-def v7i1    : VTVec<7,    i1, 25>;  //    7 x i1 vector value
-def v8i1    : VTVec<8,    i1, 26>;  //    8 x i1 vector value
-def v16i1   : VTVec<16,   i1, 27>;  //   16 x i1 vector value
-def v32i1   : VTVec<32,   i1, 28>;  //   32 x i1 vector value
-def v64i1   : VTVec<64,   i1, 29>;  //   64 x i1 vector value
-def v128i1  : VTVec<128,  i1, 30>;  //  128 x i1 vector value
-def v256i1  : VTVec<256,  i1, 31>;  //  256 x i1 vector value
-def v512i1  : VTVec<512,  i1, 32>;  //  512 x i1 vector value
-def v1024i1 : VTVec<1024, i1, 33>;  // 1024 x i1 vector value
-def v2048i1 : VTVec<2048, i1, 34>;  // 2048 x i1 vector value
-def v4096i1 : VTVec<4096, i1, 35>;  // 4096 x i1 vector value
+def v1i1    : VTVec<1,    i1>; //    1 x i1 vector value
+def v2i1    : VTVec<2,    i1>; //    2 x i1 vector value
+def v3i1    : VTVec<3,    i1>; //    3 x i1 vector value
+def v4i1    : VTVec<4,    i1>; //    4 x i1 vector value
+def v5i1    : VTVec<5,    i1>; //    5 x i1 vector value
+def v6i1    : VTVec<6,    i1>; //    6 x i1 vector value
+def v7i1    : VTVec<7,    i1>; //    7 x i1 vector value
+def v8i1    : VTVec<8,    i1>; //    8 x i1 vector value
+def v16i1   : VTVec<16,   i1>; //   16 x i1 vector value
+def v32i1   : VTVec<32,   i1>; //   32 x i1 vector value
+def v64i1   : VTVec<64,   i1>; //   64 x i1 vector value
+def v128i1  : VTVec<128,  i1>; //  128 x i1 vector value
+def v256i1  : VTVec<256,  i1>; //  256 x i1 vector value
+def v512i1  : VTVec<512,  i1>; //  512 x i1 vector value
+def v1024i1 : VTVec<1024, i1>; // 1024 x i1 vector value
+def v2048i1 : VTVec<2048, i1>; // 2048 x i1 vector value
+def v4096i1 : VTVec<4096, i1>; // 4096 x i1 vector value
 
-def v128i2  : VTVec<128,  i2, 36>;   //  128 x i2 vector value
-def v256i2  : VTVec<256,  i2, 37>;   //  256 x i2 vector value
+def v128i2  : VTVec<128,  i2>; //  128 x i2 vector value
+def v256i2  : VTVec<256,  i2>; //  256 x i2 vector value
 
-def v64i4   : VTVec<64,   i4, 38>;   //   64 x i4 vector value
-def v128i4  : VTVec<128,  i4, 39>;   //  128 x i4 vector value
+def v64i4   : VTVec<64,   i4>; //   64 x i4 vector value
+def v128i4  : VTVec<128,  i4>; //  128 x i4 vector value
 
-def v1i8    : VTVec<1,    i8, 40>;  //    1 x i8 vector value
-def v2i8    : VTVec<2,    i8, 41>;  //    2 x i8 vector value
-def v3i8    : VTVec<3,    i8, 42>;  //    3 x i8 vector value
-def v4i8    : VTVec<4,    i8, 43>;  //    4 x i8 vector value
-def v5i8    : VTVec<5,    i8, 44>;  //    5 x i8 vector value
-def v6i8    : VTVec<6,    i8, 45>;  //    6 x i8 vector value
-def v7i8    : VTVec<7,    i8, 46>;  //    7 x i8 vector value
-def v8i8    : VTVec<8,    i8, 47>;  //    8 x i8 vector value
-def v16i8   : VTVec<16,   i8, 48>;  //   16 x i8 vector value
-def v32i8   : VTVec<32,   i8, 49>;  //   32 x i8 vector value
-def v64i8   : VTVec<64,   i8, 50>;  //   64 x i8 vector value
-def v128i8  : VTVec<128,  i8, 51>;  //  128 x i8 vector value
-def v256i8  : VTVec<256,  i8, 52>;  //  256 x i8 vector value
-def v512i8  : VTVec<512,  i8, 53>;  //  512 x i8 vector value
-def v1024i8 : VTVec<1024, i8, 54>;  // 1024 x i8 vector value
+def v1i8    : VTVec<1,    i8>; //    1 x i8 vector value
+def v2i8    : VTVec<2,    i8>; //    2 x i8 vector value
+def v3i8    : VTVec<3,    i8>; //    3 x i8 vector value
+def v4i8    : VTVec<4,    i8>; //    4 x i8 vector value
+def v5i8    : VTVec<5,    i8>; //    5 x i8 vector value
+def v6i8    : VTVec<6,    i8>; //    6 x i8 vector value
+def v7i8    : VTVec<7,    i8>; //    7 x i8 vector value
+def v8i8    : VTVec<8,    i8>; //    8 x i8 vector value
+def v16i8   : VTVec<16,   i8>; //   16 x i8 vector value
+def v32i8   : VTVec<32,   i8>; //   32 x i8 vector value
+def v64i8   : VTVec<64,   i8>; //   64 x i8 vector value
+def v128i8  : VTVec<128,  i8>; //  128 x i8 vector value
+def v256i8  : VTVec<256,  i8>; //  256 x i8 vector value
+def v512i8  : VTVec<512,  i8>; //  512 x i8 vector value
+def v1024i8 : VTVec<1024, i8>; // 1024 x i8 vector value
 
-def v1i16    : VTVec<1,    i16, 55>;  //    1 x i16 vector value
-def v2i16    : VTVec<2,    i16, 56>;  //    2 x i16 vector value
-def v3i16    : VTVec<3,    i16, 57>;  //    3 x i16 vector value
-def v4i16    : VTVec<4,    i16, 58>;  //    4 x i16 vector value
-def v5i16    : VTVec<5,    i16, 59>;  //    5 x i16 vector value
-def v6i16    : VTVec<6,    i16, 60>;  //    6 x i16 vector value
-def v7i16    : VTVec<7,    i16, 61>;  //    7 x i16 vector value
-def v8i16    : VTVec<8,    i16, 62>;  //    8 x i16 vector value
-def v16i16   : VTVec<16,   i16, 63>;  //   16 x i16 vector value
-def v32i16   : VTVec<32,   i16, 64>;  //   32 x i16 vector value
-def v64i16   : VTVec<64,   i16, 65>;  //   64 x i16 vector value
-def v128i16  : VTVec<128,  i16, 66>;  //  128 x i16 vector value
-def v256i16  : VTVec<256,  i16, 67>;  //  256 x i16 vector value
-def v512i16  : VTVec<512,  i16, 68>;  //  512 x i16 vector value
-def v4096i16 : VTVec<4096, i16, 69>;  // 4096 x i16 vector value
+def v1i16    : VTVec<1,    i16>; //    1 x i16 vector value
+def v2i16    : VTVec<2,    i16>; //    2 x i16 vector value
+def v3i16    : VTVec<3,    i16>; //    3 x i16 vector value
+def v4i16    : VTVec<4,    i16>; //    4 x i16 vector value
+def v5i16    : VTVec<5,    i16>; //    5 x i16 vector value
+def v6i16    : VTVec<6,    i16>; //    6 x i16 vector value
+def v7i16    : VTVec<7,    i16>; //    7 x i16 vector value
+def v8i16    : VTVec<8,    i16>; //    8 x i16 vector value
+def v16i16   : VTVec<16,   i16>; //   16 x i16 vector value
+def v32i16   : VTVec<32,   i16>; //   32 x i16 vector value
+def v64i16   : VTVec<64,   i16>; //   64 x i16 vector value
+def v128i16  : VTVec<128,  i16>; //  128 x i16 vector value
+def v256i16  : VTVec<256,  i16>; //  256 x i16 vector value
+def v512i16  : VTVec<512,  i16>; //  512 x i16 vector value
+def v4096i16 : VTVec<4096, i16>; // 4096 x i16 vector value
 
-def v1i32    : VTVec<1,    i32, 70>;  //    1 x i32 vector value
-def v2i32    : VTVec<2,    i32, 71>;  //    2 x i32 vector value
-def v3i32    : VTVec<3,    i32, 72>;  //    3 x i32 vector value
-def v4i32    : VTVec<4,    i32, 73>;  //    4 x i32 vector value
-def v5i32    : VTVec<5,    i32, 74>;  //    5 x i32 vector value
-def v6i32    : VTVec<6,    i32, 75>;  //    6 x i32 vector value
-def v7i32    : VTVec<7,    i32, 76>;  //    7 x i32 vector value
-def v8i32    : VTVec<8,    i32, 77>;  //    8 x i32 vector value
-def v9i32    : VTVec<9,    i32, 78>;  //    9 x i32 vector value
-def v10i32   : VTVec<10,   i32, 79>;  //   10 x i32 vector value
-def v11i32   : VTVec<11,   i32, 80>;  //   11 x i32 vector value
-def v12i32   : VTVec<12,   i32, 81>;  //   12 x i32 vector value
-def v16i32   : VTVec<16,   i32, 82>;  //   16 x i32 vector value
-def v32i32   : VTVec<32,   i32, 83>;  //   32 x i32 vector value
-def v64i32   : VTVec<64,   i32, 84>;  //   64 x i32 vector value
-def v128i32  : VTVec<128,  i32, 85>;  //  128 x i32 vector value
-def v256i32  : VTVec<256,  i32, 86>;  //  256 x i32 vector value
-def v512i32  : VTVec<512,  i32, 87>;  //  512 x i32 vector value
-def v1024i32 : VTVec<1024, i32, 88>;  // 1024 x i32 vector value
-def v2048i32 : VTVec<2048, i32, 89>;  // 2048 x i32 vector value
-def v4096i32 : VTVec<4096, i32, 90>;  // 4096 x i32 vector value
+def v1i32    : VTVec<1,    i32>; //    1 x i32 vector value
+def v2i32    : VTVec<2,    i32>; //    2 x i32 vector value
+def v3i32    : VTVec<3,    i32>; //    3 x i32 vector value
+def v4i32    : VTVec<4,    i32>; //    4 x i32 vector value
+def v5i32    : VTVec<5,    i32>; //    5 x i32 vector value
+def v6i32    : VTVec<6,    i32>; //    6 x i32 vector value
+def v7i32    : VTVec<7,    i32>; //    7 x i32 vector value
+def v8i32    : VTVec<8,    i32>; //    8 x i32 vector value
+def v9i32    : VTVec<9,    i32>; //    9 x i32 vector value
+def v10i32   : VTVec<10,   i32>; //   10 x i32 vector value
+def v11i32   : VTVec<11,   i32>; //   11 x i32 vector value
+def v12i32   : VTVec<12,   i32>; //   12 x i32 vector value
+def v16i32   : VTVec<16,   i32>; //   16 x i32 vector value
+def v32i32   : VTVec<32,   i32>; //   32 x i32 vector value
+def v64i32   : VTVec<64,   i32>; //   64 x i32 vector value
+def v128i32  : VTVec<128,  i32>; //  128 x i32 vector value
+def v256i32  : VTVec<256,  i32>; //  256 x i32 vector value
+def v512i32  : VTVec<512,  i32>; //  512 x i32 vector value
+def v1024i32 : VTVec<1024, i32>; // 1024 x i32 vector value
+def v2048i32 : VTVec<2048, i32>; // 2048 x i32 vector value
+def v4096i32 : VTVec<4096, i32>; // 4096 x i32 vector value
 
-def v1i64   : VTVec<1,   i64, 91>;  //   1 x i64 vector value
-def v2i64   : VTVec<2,   i64, 92>;  //   2 x i64 vector value
-def v3i64   : VTVec<3,   i64, 93>;  //   3 x i64 vector value
-def v4i64   : VTVec<4,   i64, 94>;  //   4 x i64 vector value
-def v8i64   : VTVec<8,   i64, 95>;  //   8 x i64 vector value
-def v16i64  : VTVec<16,  i64, 96>;  //  16 x i64 vector value
-def v32i64  : VTVec<32,  i64, 97>;  //  32 x i64 vector value
-def v64i64  : VTVec<64,  i64, 98>;  //  64 x i64 vector value
-def v128i64 : VTVec<128, i64, 99>;  // 128 x i64 vector value
-def v256i64 : VTVec<256, i64, 100>; // 256 x i64 vector value
+def v1i64   : VTVec<1,   i64>; //   1 x i64 vector value
+def v2i64   : VTVec<2,   i64>; //   2 x i64 vector value
+def v3i64   : VTVec<3,   i64>; //   3 x i64 vector value
+def v4i64   : VTVec<4,   i64>; //   4 x i64 vector value
+def v8i64   : VTVec<8,   i64>; //   8 x i64 vector value
+def v16i64  : VTVec<16,  i64>; //  16 x i64 vector value
+def v32i64  : VTVec<32,  i64>; //  32 x i64 vector value
+def v64i64  : VTVec<64,  i64>; //  64 x i64 vector value
+def v128i64 : VTVec<128, i64>; // 128 x i64 vector value
+def v256i64 : VTVec<256, i64>; // 256 x i64 vector value
 
-def v1i128  : VTVec<1,  i128, 101>; //  1 x i128 vector value
+def v1i128  : VTVec<1,  i128>; //  1 x i128 vector value
 
-def v1f16    : VTVec<1,    f16, 102>;  //    1 x f16 vector value
-def v2f16    : VTVec<2,    f16, 103>;  //    2 x f16 vector value
-def v3f16    : VTVec<3,    f16, 104>;  //    3 x f16 vector value
-def v4f16    : VTVec<4,    f16, 105>;  //    4 x f16 vector value
-def v5f16    : VTVec<5,    f16, 106>;  //    5 x f16 vector value
-def v6f16    : VTVec<6,    f16, 107>;  //    6 x f16 vector value
-def v7f16    : VTVec<7,    f16, 108>;  //    7 x f16 vector value
-def v8f16    : VTVec<8,    f16, 109>;  //    8 x f16 vector value
-def v16f16   : VTVec<16,   f16, 110>;  //   16 x f16 vector value
-def v32f16   : VTVec<32,   f16, 111>;  //   32 x f16 vector value
-def v64f16   : VTVec<64,   f16, 112>;  //   64 x f16 vector value
-def v128f16  : VTVec<128,  f16, 113>;  //  128 x f16 vector value
-def v256f16  : VTVec<256,  f16, 114>;  //  256 x f16 vector value
-def v512f16  : VTVec<512,  f16, 115>;  //  512 x f16 vector value
-def v4096f16 : VTVec<4096, f16, 116>;  // 4096 x f16 vector value
+def v1f16    : VTVec<1,    f16>; //    1 x f16 vector value
+def v2f16    : VTVec<2,    f16>; //    2 x f16 vector value
+def v3f16    : VTVec<3,    f16>; //    3 x f16 vector value
+def v4f16    : VTVec<4,    f16>; //    4 x f16 vector value
+def v5f16    : VTVec<5,    f16>; //    5 x f16 vector value
+def v6f16    : VTVec<6,    f16>; //    6 x f16 vector value
+def v7f16    : VTVec<7,    f16>; //    7 x f16 vector value
+def v8f16    : VTVec<8,    f16>; //    8 x f16 vector value
+def v16f16   : VTVec<16,   f16>; //   16 x f16 vector value
+def v32f16   : VTVec<32,   f16>; //   32 x f16 vector value
+def v64f16   : VTVec<64,   f16>; //   64 x f16 vector value
+def v128f16  : VTVec<128,  f16>; //  128 x f16 vector value
+def v256f16  : VTVec<256,  f16>; //  256 x f16 vector value
+def v512f16  : VTVec<512,  f16>; //  512 x f16 vector value
+def v4096f16 : VTVec<4096, f16>; // 4096 x f16 vector value
 
-def v1bf16    : VTVec<1,    bf16, 117>;  //    1 x bf16 vector value
-def v2bf16    : VTVec<2,    bf16, 118>;  //    2 x bf16 vector value
-def v3bf16    : VTVec<3,    bf16, 119>;  //    3 x bf16 vector value
-def v4bf16    : VTVec<4,    bf16, 120>;  //    4 x bf16 vector value
-def v8bf16    : VTVec<8,    bf16, 121>;  //    8 x bf16 vector value
-def v16bf16   : VTVec<16,   bf16, 122>;  //   16 x bf16 vector value
-def v32bf16   : VTVec<32,   bf16, 123>;  //   32 x bf16 vector value
-def v64bf16   : VTVec<64,   bf16, 124>;  //   64 x bf16 vector value
-def v128bf16  : VTVec<128,  bf16, 125>;  //  128 x bf16 vector value
-def v4096bf16 : VTVec<4096, bf16, 126>;  // 4096 x bf16 vector value
+def v1bf16    : VTVec<1,    bf16>; //    1 x bf16 vector value
+def v2bf16    : VTVec<2,    bf16>; //    2 x bf16 vector value
+def v3bf16    : VTVec<3,    bf16>; //    3 x bf16 vector value
+def v4bf16    : VTVec<4,    bf16>; //    4 x bf16 vector value
+def v8bf16    : VTVec<8,    bf16>; //    8 x bf16 vector value
+def v16bf16   : VTVec<16,   bf16>; //   16 x bf16 vector value
+def v32bf16   : VTVec<32,   bf16>; //   32 x bf16 vector value
+def v64bf16   : VTVec<64,   bf16>; //   64 x bf16 vector value
+def v128bf16  : VTVec<128,  bf16>; //  128 x bf16 vector value
+def v4096bf16 : VTVec<4096, bf16>; // 4096 x bf16 vector value
 
-def v1f32    : VTVec<1,    f32, 127>;  //    1 x f32 vector value
-def v2f32    : VTVec<2,    f32, 128>;  //    2 x f32 vector value
-def v3f32    : VTVec<3,    f32, 129>;  //    3 x f32 vector value
-def v4f32    : VTVec<4,    f32, 130>;  //    4 x f32 vector value
-def v5f32    : VTVec<5,    f32, 131>;  //    5 x f32 vector value
-def v6f32    : VTVec<6,    f32, 132>;  //    6 x f32 vector value
-def v7f32    : VTVec<7,    f32, 133>;  //    7 x f32 vector value
-def v8f32    : VTVec<8,    f32, 134>;  //    8 x f32 vector value
-def v9f32    : VTVec<9,    f32, 135>;  //    9 x f32 vector value
-def v10f32   : VTVec<10,   f32, 136>;  //   10 x f32 vector value
-def v11f32   : VTVec<11,   f32, 137>;  //   11 x f32 vector value
-def v12f32   : VTVec<12,   f32, 138>;  //   12 x f32 vector value
-def v16f32   : VTVec<16,   f32, 139>;  //   16 x f32 vector value
-def v32f32   : VTVec<32,   f32, 140>;  //   32 x f32 vector value
-def v64f32   : VTVec<64,   f32, 141>;  //   64 x f32 vector value
-def v128f32  : VTVec<128,  f32, 142>;  //  128 x f32 vector value
-def v256f32  : VTVec<256,  f32, 143>;  //  256 x f32 vector value
-def v512f32  : VTVec<512,  f32, 144>;  //  512 x f32 vector value
-def v1024f32 : VTVec<1024, f32, 145>;  // 1024 x f32 vector value
-def v2048f32 : VTVec<2048, f32, 146>;  // 2048 x f32 vector value
+def v1f32    : VTVec<1,    f32>; //    1 x f32 vector value
+def v2f32    : VTVec<2,    f32>; //    2 x f32 vector value
+def v3f32    : VTVec<3,    f32>; //    3 x f32 vector value
+def v4f32    : VTVec<4,    f32>; //    4 x f32 vector value
+def v5f32    : VTVec<5,    f32>; //    5 x f32 vector value
+def v6f32    : VTVec<6,    f32>; //    6 x f32 vector value
+def v7f32    : VTVec<7,    f32>; //    7 x f32 vector value
+def v8f32    : VTVec<8,    f32>; //    8 x f32 vector value
+def v9f32    : VTVec<9,    f32>; //    9 x f32 vector value
+def v10f32   : VTVec<10,   f32>; //   10 x f32 vector value
+def v11f32   : VTVec<11,   f32>; //   11 x f32 vector value
+def v12f32   : VTVec<12,   f32>; //   12 x f32 vector value
+def v16f32   : VTVec<16,   f32>; //   16 x f32 vector value
+def v32f32   : VTVec<32,   f32>; //   32 x f32 vector value
+def v64f32   : VTVec<64,   f32>; //   64 x f32 vector value
+def v128f32  : VTVec<128,  f32>; //  128 x f32 vector value
+def v256f32  : VTVec<256,  f32>; //  256 x f32 vector value
+def v512f32  : VTVec<512,  f32>; //  512 x f32 vector value
+def v1024f32 : VTVec<1024, f32>; // 1024 x f32 vector value
+def v2048f32 : VTVec<2048, f32>; // 2048 x f32 vector value
 
-def v1f64    : VTVec<1,    f64, 147>;  //    1 x f64 vector value
-def v2f64    : VTVec<2,    f64, 148>;  //    2 x f64 vector value
-def v3f64    : VTVec<3,    f64, 149>;  //    3 x f64 vector value
-def v4f64    : VTVec<4,    f64, 150>;  //    4 x f64 vector value
-def v8f64    : VTVec<8,    f64, 151>;  //    8 x f64 vector value
-def v16f64   : VTVec<16,   f64, 152>;  //   16 x f64 vector value
-def v32f64   : VTVec<32,   f64, 153>;  //   32 x f64 vector value
-def v64f64   : VTVec<64,   f64, 154>;  //   64 x f64 vector value
-def v128f64  : VTVec<128,  f64, 155>;  //  128 x f64 vector value
-def v256f64  : VTVec<256,  f64, 156>;  //  256 x f64 vector value
+def v1f64    : VTVec<1,    f64>; //    1 x f64 vector value
+def v2f64    : VTVec<2,    f64>; //    2 x f64 vector value
+def v3f64    : VTVec<3,    f64>; //    3 x f64 vector value
+def v4f64    : VTVec<4,    f64>; //    4 x f64 vector value
+def v8f64    : VTVec<8,    f64>; //    8 x f64 vector value
+def v16f64   : VTVec<16,   f64>; //   16 x f64 vector value
+def v32f64   : VTVec<32,   f64>; //   32 x f64 vector value
+def v64f64   : VTVec<64,   f64>; //   64 x f64 vector value
+def v128f64  : VTVec<128,  f64>; //  128 x f64 vector value
+def v256f64  : VTVec<256,  f64>; //  256 x f64 vector value
 
-def nxv1i1  : VTScalableVec<1,  i1, 157>;  // n x  1 x i1  vector value
-def nxv2i1  : VTScalableVec<2,  i1, 158>;  // n x  2 x i1  vector value
-def nxv4i1  : VTScalableVec<4,  i1, 159>;  // n x  4 x i1  vector value
-def nxv8i1  : VTScalableVec<8,  i1, 160>;  // n x  8 x i1  vector value
-def nxv16i1 : VTScalableVec<16, i1, 161>;  // n x 16 x i1  vector value
-def nxv32i1 : VTScalableVec<32, i1, 162>;  // n x 32 x i1  vector value
-def nxv64i1 : VTScalableVec<64, i1, 163>;  // n x 64 x i1  vector value
+def nxv1i1  : VTScalableVec<1,  i1>; // n x  1 x i1  vector value
+def nxv2i1  : VTScalableVec<2,  i1>; // n x  2 x i1  vector value
+def nxv4i1  : VTScalableVec<4,  i1>; // n x  4 x i1  vector value
+def nxv8i1  : VTScalableVec<8,  i1>; // n x  8 x i1  vector value
+def nxv16i1 : VTScalableVec<16, i1>; // n x 16 x i1  vector value
+def nxv32i1 : VTScalableVec<32, i1>; // n x 32 x i1  vector value
+def nxv64i1 : VTScalableVec<64, i1>; // n x 64 x i1  vector value
 
-def nxv1i8  : VTScalableVec<1,  i8, 164>;  // n x  1 x i8  vector value
-def nxv2i8  : VTScalableVec<2,  i8, 165>;  // n x  2 x i8  vector value
-def nxv4i8  : VTScalableVec<4,  i8, 166>;  // n x  4 x i8  vector value
-def nxv8i8  : VTScalableVec<8,  i8, 167>;  // n x  8 x i8  vector value
-def nxv16i8 : VTScalableVec<16, i8, 168>;  // n x 16 x i8  vector value
-def nxv32i8 : VTScalableVec<32, i8, 169>;  // n x 32 x i8  vector value
-def nxv64i8 : VTScalableVec<64, i8, 170>;  // n x 64 x i8  vector value
+def nxv1i8  : VTScalableVec<1,  i8>; // n x  1 x i8  vector value
+def nxv2i8  : VTScalableVec<2,  i8>; // n x  2 x i8  vector value
+def nxv4i8  : VTScalableVec<4,  i8>; // n x  4 x i8  vector value
+def nxv8i8  : VTScalableVec<8,  i8>; // n x  8 x i8  vector value
+def nxv16i8 : VTScalableVec<16, i8>; // n x 16 x i8  vector value
+def nxv32i8 : VTScalableVec<32, i8>; // n x 32 x i8  vector value
+def nxv64i8 : VTScalableVec<64, i8>; // n x 64 x i8  vector value
 
-def nxv1i16  : VTScalableVec<1,  i16, 171>;  // n x  1 x i16 vector value
-def nxv2i16  : VTScalableVec<2,  i16, 172>;  // n x  2 x i16 vector value
-def nxv4i16  : VTScalableVec<4,  i16, 173>;  // n x  4 x i16 vector value
-def nxv8i16  : VTScalableVec<8,  i16, 174>;  // n x  8 x i16 vector value
-def nxv16i16 : VTScalableVec<16, i16, 175>;  // n x 16 x i16 vector value
-def nxv32i16 : VTScalableVec<32, i16, 176>;  // n x 32 x i16 vector value
+def nxv1i16  : VTScalableVec<1,  i16>; // n x  1 x i16 vector value
+def nxv2i16  : VTScalableVec<2,  i16>; // n x  2 x i16 vector value
+def nxv4i16  : VTScalableVec<4,  i16>; // n x  4 x i16 vector value
+def nxv8i16  : VTScalableVec<8,  i16>; // n x  8 x i16 vector value
+def nxv16i16 : VTScalableVec<16, i16>; // n x 16 x i16 vector value
+def nxv32i16 : VTScalableVec<32, i16>; // n x 32 x i16 vector value
 
-def nxv1i32  : VTScalableVec<1,  i32, 177>;  // n x  1 x i32 vector value
-def nxv2i32  : VTScalableVec<2,  i32, 178>;  // n x  2 x i32 vector value
-def nxv4i32  : VTScalableVec<4,  i32, 179>;  // n x  4 x i32 vector value
-def nxv8i32  : VTScalableVec<8,  i32, 180>;  // n x  8 x i32 vector value
-def nxv16i32 : VTScalableVec<16, i32, 181>;  // n x 16 x i32 vector value
-def nxv32i32 : VTScalableVec<32, i32, 182>;  // n x 32 x i32 vector value
+def nxv1i32  : VTScalableVec<1,  i32>; // n x  1 x i32 vector value
+def nxv2i32  : VTScalableVec<2,  i32>; // n x  2 x i32 vector value
+def nxv4i32  : VTScalableVec<4,  i32>; // n x  4 x i32 vector value
+def nxv8i32  : VTScalableVec<8,  i32>; // n x  8 x i32 vector value
+def nxv16i32 : VTScalableVec<16, i32>; // n x 16 x i32 vector value
+def nxv32i32 : VTScalableVec<32, i32>; // n x 32 x i32 vector value
 
-def nxv1i64  : VTScalableVec<1,  i64, 183>;  // n x  1 x i64 vector value
-def nxv2i64  : VTScalableVec<2,  i64, 184>;  // n x  2 x i64 vector value
-def nxv4i64  : VTScalableVec<4,  i64, 185>;  // n x  4 x i64 vector value
-def nxv8i64  : VTScalableVec<8,  i64, 186>;  // n x  8 x i64 vector value
-def nxv16i64 : VTScalableVec<16, i64, 187>;  // n x 16 x i64 vector value
-def nxv32i64 : VTScalableVec<32, i64, 188>;  // n x 32 x i64 vector value
+def nxv1i64  : VTScalableVec<1,  i64>; // n x  1 x i64 vector value
+def nxv2i64  : VTScalableVec<2,  i64>; // n x  2 x i64 vector value
+def nxv4i64  : VTScalableVec<4,  i64>; // n x  4 x i64 vector value
+def nxv8i64  : VTScalableVec<8,  i64>; // n x  8 x i64 vector value
+def nxv16i64 : VTScalableVec<16, i64>; // n x 16 x i64 vector value
+def nxv32i64 : VTScalableVec<32, i64>; // n x 32 x i64 vector value
 
-def nxv1f16  : VTScalableVec<1,  f16, 189>;  // n x  1 x  f16 vector value
-def nxv2f16  : VTScalableVec<2,  f16, 190>;  // n x  2 x  f16 vector value
-def nxv4f16  : VTScalableVec<4,  f16, 191>;  // n x  4 x  f16 vector value
-def nxv8f16  : VTScalableVec<8,  f16, 192>;  // n x  8 x  f16 vector value
-def nxv16f16 : VTScalableVec<16, f16, 193>;  // n x 16 x  f16 vector value
-def nxv32f16 : VTScalableVec<32, f16, 194>;  // n x 32 x  f16 vector value
+def nxv1f16  : VTScalableVec<1,  f16>; // n x  1 x  f16 vector value
+def nxv2f16  : VTScalableVec<2,  f16>; // n x  2 x  f16 vector value
+def nxv4f16  : VTScalableVec<4,  f16>; // n x  4 x  f16 vector value
+def nxv8f16  : VTScalableVec<8,  f16>; // n x  8 x  f16 vector value
+def nxv16f16 : VTScalableVec<16, f16>; // n x 16 x  f16 vector value
+def nxv32f16 : VTScalableVec<32, f16>; // n x 32 x  f16 vector value
 
-def nxv1bf16  : VTScalableVec<1,  bf16, 195>;  // n x  1 x bf16 vector value
-def nxv2bf16  : VTScalableVec<2,  bf16, 196>;  // n x  2 x bf16 vector value
-def nxv4bf16  : VTScalableVec<4,  bf16, 197>;  // n x  4 x bf16 vector value
-def nxv8bf16  : VTScalableVec<8,  bf16, 198>;  // n x  8 x bf16 vector value
-def nxv16bf16 : VTScalableVec<16, bf16, 199>;  // n x 16 x bf16 vector value
-def nxv32bf16 : VTScalableVec<32, bf16, 200>;  // n x 32 x bf16 vector value
+def nxv1bf16  : VTScalableVec<1,  bf16>; // n x  1 x bf16 vector value
+def nxv2bf16  : VTScalableVec<2,  bf16>; // n x  2 x bf16 vector value
+def nxv4bf16  : VTScalableVec<4,  bf16>; // n x  4 x bf16 vector value
+def nxv8bf16  : VTScalableVec<8,  bf16>; // n x  8 x bf16 vector value
+def nxv16bf16 : VTScalableVec<16, bf16>; // n x 16 x bf16 vector value
+def nxv32bf16 : VTScalableVec<32, bf16>; // n x 32 x bf16 vector value
 
-def nxv1f32  : VTScalableVec<1,  f32, 201>;  // n x  1 x  f32 vector value
-def nxv2f32  : VTScalableVec<2,  f32, 202>;  // n x  2 x  f32 vector value
-def nxv4f32  : VTScalableVec<4,  f32, 203>;  // n x  4 x  f32 vector value
-def nxv8f32  : VTScalableVec<8,  f32, 204>;  // n x  8 x  f32 vector value
-def nxv16f32 : VTScalableVec<16, f32, 205>;  // n x 16 x  f32 vector value
+def nxv1f32  : VTScalableVec<1,  f32>; // n x  1 x  f32 vector value
+def nxv2f32  : VTScalableVec<2,  f32>; // n x  2 x  f32 vector value
+def nxv4f32  : VTScalableVec<4,  f32>; // n x  4 x  f32 vector value
+def nxv8f32  : VTScalableVec<8,  f32>; // n x  8 x  f32 vector value
+def nxv16f32 : VTScalableVec<16, f32>; // n x 16 x  f32 vector value
 
-def nxv1f64  : VTScalableVec<1,  f64, 206>;  // n x  1 x  f64 vector value
-def nxv2f64  : VTScalableVec<2,  f64, 207>;  // n x  2 x  f64 vector value
-def nxv4f64  : VTScalableVec<4,  f64, 208>;  // n x  4 x  f64 vector value
-def nxv8f64  : VTScalableVec<8,  f64, 209>;  // n x  8 x  f64 vector value
+def nxv1f64  : VTScalableVec<1,  f64>; // n x  1 x  f64 vector value
+def nxv2f64  : VTScalableVec<2,  f64>; // n x  2 x  f64 vector value
+def nxv4f64  : VTScalableVec<4,  f64>; // n x  4 x  f64 vector value
+def nxv8f64  : VTScalableVec<8,  f64>; // n x  8 x  f64 vector value
 
 // Sz = NF * MinNumElts * 8(bits)
-def riscv_nxv1i8x2   : VTVecTup<16,  2, i8, 210>;  // RISCV vector tuple(min_num_elts=1,  nf=2)
-def riscv_nxv1i8x3   : VTVecTup<24,  3, i8, 211>;  // RISCV vector tuple(min_num_elts=1,  nf=3)
-def riscv_nxv1i8x4   : VTVecTup<32,  4, i8, 212>;  // RISCV vector tuple(min_num_elts=1,  nf=4)
-def riscv_nxv1i8x5   : VTVecTup<40,  5, i8, 213>;  // RISCV vector tuple(min_num_elts=1,  nf=5)
-def riscv_nxv1i8x6   : VTVecTup<48,  6, i8, 214>;  // RISCV vector tuple(min_num_elts=1,  nf=6)
-def riscv_nxv1i8x7   : VTVecTup<56,  7, i8, 215>;  // RISCV vector tuple(min_num_elts=1,  nf=7)
-def riscv_nxv1i8x8   : VTVecTup<64,  8, i8, 216>;  // RISCV vector tuple(min_num_elts=1,  nf=8)
-def riscv_nxv2i8x2   : VTVecTup<32,  2, i8, 217>;  // RISCV vector tuple(min_num_elts=2,  nf=2)
-def riscv_nxv2i8x3   : VTVecTup<48,  3, i8, 218>;  // RISCV vector tuple(min_num_elts=2,  nf=3)
-def riscv_nxv2i8x4   : VTVecTup<64,  4, i8, 219>;  // RISCV vector tuple(min_num_elts=2,  nf=4)
-def riscv_nxv2i8x5   : VTVecTup<80,  5, i8, 220>;  // RISCV vector tuple(min_num_elts=2,  nf=5)
-def riscv_nxv2i8x6   : VTVecTup<96,  6, i8, 221>;  // RISCV vector tuple(min_num_elts=2,  nf=6)
-def riscv_nxv2i8x7   : VTVecTup<112, 7, i8, 222>;  // RISCV vector tuple(min_num_elts=2,  nf=7)
-def riscv_nxv2i8x8   : VTVecTup<128, 8, i8, 223>;  // RISCV vector tuple(min_num_elts=2,  nf=8)
-def riscv_nxv4i8x2   : VTVecTup<64,  2, i8, 224>;  // RISCV vector tuple(min_num_elts=4,  nf=2)
-def riscv_nxv4i8x3   : VTVecTup<96,  3, i8, 225>;  // RISCV vector tuple(min_num_elts=4,  nf=3)
-def riscv_nxv4i8x4   : VTVecTup<128, 4, i8, 226>;  // RISCV vector tuple(min_num_elts=4,  nf=4)
-def riscv_nxv4i8x5   : VTVecTup<160, 5, i8, 227>;  // RISCV vector tuple(min_num_elts=4,  nf=5)
-def riscv_nxv4i8x6   : VTVecTup<192, 6, i8, 228>;  // RISCV vector tuple(min_num_elts=4,  nf=6)
-def riscv_nxv4i8x7   : VTVecTup<224, 7, i8, 229>;  // RISCV vector tuple(min_num_elts=4,  nf=7)
-def riscv_nxv4i8x8   : VTVecTup<256, 8, i8, 230>;  // RISCV vector tuple(min_num_elts=4,  nf=8)
-def riscv_nxv8i8x2   : VTVecTup<128, 2, i8, 231>;  // RISCV vector tuple(min_num_elts=8,  nf=2)
-def riscv_nxv8i8x3   : VTVecTup<192, 3, i8, 232>;  // RISCV vector tuple(min_num_elts=8,  nf=3)
-def riscv_nxv8i8x4   : VTVecTup<256, 4, i8, 233>;  // RISCV vector tuple(min_num_elts=8,  nf=4)
-def riscv_nxv8i8x5   : VTVecTup<320, 5, i8, 234>;  // RISCV vector tuple(min_num_elts=8,  nf=5)
-def riscv_nxv8i8x6   : VTVecTup<384, 6, i8, 235>;  // RISCV vector tuple(min_num_elts=8,  nf=6)
-def riscv_nxv8i8x7   : VTVecTup<448, 7, i8, 236>;  // RISCV vector tuple(min_num_elts=8,  nf=7)
-def riscv_nxv8i8x8   : VTVecTup<512, 8, i8, 237>;  // RISCV vector tuple(min_num_elts=8,  nf=8)
-def riscv_nxv16i8x2  : VTVecTup<256, 2, i8, 238>;  // RISCV vector tuple(min_num_elts=16, nf=2)
-def riscv_nxv16i8x3  : VTVecTup<384, 3, i8, 239>;  // RISCV vector tuple(min_num_elts=16, nf=3)
-def riscv_nxv16i8x4  : VTVecTup<512, 4, i8, 240>;  // RISCV vector tuple(min_num_elts=16, nf=4)
-def riscv_nxv32i8x2  : VTVecTup<512, 2, i8, 241>;  // RISCV vector tuple(min_num_elts=32, nf=2)
+def riscv_nxv1i8x2   : VTVecTup<16,  2, i8>; // RISCV vector tuple(min_num_elts=1,  nf=2)
+def riscv_nxv1i8x3   : VTVecTup<24,  3, i8>; // RISCV vector tuple(min_num_elts=1,  nf=3)
+def riscv_nxv1i8x4   : VTVecTup<32,  4, i8>; // RISCV vector tuple(min_num_elts=1,  nf=4)
+def riscv_nxv1i8x5   : VTVecTup<40,  5, i8>; // RISCV vector tuple(min_num_elts=1,  nf=5)
+def riscv_nxv1i8x6   : VTVecTup<48,  6, i8>; // RISCV vector tuple(min_num_elts=1,  nf=6)
+def riscv_nxv1i8x7   : VTVecTup<56,  7, i8>; // RISCV vector tuple(min_num_elts=1,  nf=7)
+def riscv_nxv1i8x8   : VTVecTup<64,  8, i8>; // RISCV vector tuple(min_num_elts=1,  nf=8)
+def riscv_nxv2i8x2   : VTVecTup<32,  2, i8>; // RISCV vector tuple(min_num_elts=2,  nf=2)
+def riscv_nxv2i8x3   : VTVecTup<48,  3, i8>; // RISCV vector tuple(min_num_elts=2,  nf=3)
+def riscv_nxv2i8x4   : VTVecTup<64,  4, i8>; // RISCV vector tuple(min_num_elts=2,  nf=4)
+def riscv_nxv2i8x5   : VTVecTup<80,  5, i8>; // RISCV vector tuple(min_num_elts=2,  nf=5)
+def riscv_nxv2i8x6   : VTVecTup<96,  6, i8>; // RISCV vector tuple(min_num_elts=2,  nf=6)
+def riscv_nxv2i8x7   : VTVecTup<112, 7, i8>; // RISCV vector tuple(min_num_elts=2,  nf=7)
+def riscv_nxv2i8x8   : VTVecTup<128, 8, i8>; // RISCV vector tuple(min_num_elts=2,  nf=8)
+def riscv_nxv4i8x2   : VTVecTup<64,  2, i8>; // RISCV vector tuple(min_num_elts=4,  nf=2)
+def riscv_nxv4i8x3   : VTVecTup<96,  3, i8>; // RISCV vector tuple(min_num_elts=4,  nf=3)
+def riscv_nxv4i8x4   : VTVecTup<128, 4, i8>; // RISCV vector tuple(min_num_elts=4,  nf=4)
+def riscv_nxv4i8x5   : VTVecTup<160, 5, i8>; // RISCV vector tuple(min_num_elts=4,  nf=5)
+def riscv_nxv4i8x6   : VTVecTup<192, 6, i8>; // RISCV vector tuple(min_num_elts=4,  nf=6)
+def riscv_nxv4i8x7   : VTVecTup<224, 7, i8>; // RISCV vector tuple(min_num_elts=4,  nf=7)
+def riscv_nxv4i8x8   : VTVecTup<256, 8, i8>; // RISCV vector tuple(min_num_elts=4,  nf=8)
+def riscv_nxv8i8x2   : VTVecTup<128, 2, i8>; // RISCV vector tuple(min_num_elts=8,  nf=2)
+def riscv_nxv8i8x3   : VTVecTup<192, 3, i8>; // RISCV vector tuple(min_num_elts=8,  nf=3)
+def riscv_nxv8i8x4   : VTVecTup<256, 4, i8>; // RISCV vector tuple(min_num_elts=8,  nf=4)
+def riscv_nxv8i8x5   : VTVecTup<320, 5, i8>; // RISCV vector tuple(min_num_elts=8,  nf=5)
+def riscv_nxv8i8x6   : VTVecTup<384, 6, i8>; // RISCV vector tuple(min_num_elts=8,  nf=6)
+def riscv_nxv8i8x7   : VTVecTup<448, 7, i8>; // RISCV vector tuple(min_num_elts=8,  nf=7)
+def riscv_nxv8i8x8   : VTVecTup<512, 8, i8>; // RISCV vector tuple(min_num_elts=8,  nf=8)
+def riscv_nxv16i8x2  : VTVecTup<256, 2, i8>; // RISCV vector tuple(min_num_elts=16, nf=2)
+def riscv_nxv16i8x3  : VTVecTup<384, 3, i8>; // RISCV vector tuple(min_num_elts=16, nf=3)
+def riscv_nxv16i8x4  : VTVecTup<512, 4, i8>; // RISCV vector tuple(min_num_elts=16, nf=4)
+def riscv_nxv32i8x2  : VTVecTup<512, 2, i8>; // RISCV vector tuple(min_num_elts=32, nf=2)
 
-def x86mmx    : ValueType<64,   242>;  // X86 MMX value
-def Glue      : ValueType<0,    243>;  // Pre-RA sched glue
-def isVoid    : ValueType<0,    244>;  // Produces no value
-def untyped   : ValueType<8,    245> { // Produces an untyped value
-  let LLVMName = "Untyped";
-}
-def funcref   : ValueType<0,    246>;  // WebAssembly's funcref type
-def externref : ValueType<0,    247>;  // WebAssembly's externref type
-def exnref    : ValueType<0,    248>;  // WebAssembly's exnref type
-def x86amx    : ValueType<8192, 249>;  // X86 AMX value
-def i64x8     : ValueType<512,  250>;  // 8 Consecutive GPRs (AArch64)
+def x86mmx    : ValueType<64>;           // X86 MMX value
+def Glue      : ValueType<0>;            // Pre-RA sched glue
+def isVoid    : ValueType<0>;            // Produces no value
+def untyped   : ValueType<8, "Untyped">; // Produces an untyped value
+def funcref   : ValueType<0>;            // WebAssembly's funcref type
+def externref : ValueType<0>;            // WebAssembly's externref type
+def exnref    : ValueType<0>;            // WebAssembly's exnref type
+def x86amx    : ValueType<8192>;         // X86 AMX value
+def i64x8     : ValueType<512>;          // 8 Consecutive GPRs (AArch64)
 def aarch64svcount
-              : ValueType<16,  251>;  // AArch64 predicate-as-counter
-def spirvbuiltin : ValueType<0, 252>; // SPIR-V's builtin type
+              : ValueType<16>;   // AArch64 predicate-as-counter
+def spirvbuiltin : ValueType<0>; // SPIR-V's builtin type
 // AMDGPU buffer fat pointer, buffer rsrc + offset, rewritten before MIR translation.
 // FIXME: Remove this and the getPointerType() override if MVT::i160 is added.
-def amdgpuBufferFatPointer : ValueType<160, 253>;
+def amdgpuBufferFatPointer : ValueType<160>;
 // AMDGPU buffer strided pointer, buffer rsrc + index + offset, doesn't reach MIR.
 // FIXME: Remove this and the getPointerType() override if MVT::i82 is added.
-def amdgpuBufferStridedPointer : ValueType<192, 254>;
+def amdgpuBufferStridedPointer : ValueType<192>;
 
-def aarch64mfp8 : ValueType<8,  255>;  // 8-bit value in FPR (AArch64)
+def aarch64mfp8 : ValueType<8>; // 8-bit value in FPR (AArch64)
 
 // CHERI capabilities. Pointer-like values that carry additional metadata
 // for enforcing safety guarantees on CHERI-enabled targets.
-def c64 : VTCheriCapability<64, 256>;   // 64-bit CHERI capability value
-def c128 : VTCheriCapability<128, 257>; // 128-bit CHERI capability value
+def c64 : VTCheriCapability<64>;   // 64-bit CHERI capability value
+def c128 : VTCheriCapability<128>; // 128-bit CHERI capability value
 
 let isNormalValueType = false in {
 // Pseudo valuetype mapped to the current CHERI capability pointer size.
 // Should only be used in TableGen.
-def cPTR : VTAny<503>;
+def cPTR : VTAny;
 
-def token      : ValueType<0, 504>;  // TokenTy
-def MetadataVT : ValueType<0, 505> { // Metadata
-  let LLVMName = "Metadata";
-}
+def token      : ValueType<0>;             // TokenTy
+def MetadataVT : ValueType<0, "Metadata">; // Metadata
 
 // Pseudo valuetype to represent "pointer to any address space"
 // Should only be used in TableGen.
-def pAny       : VTAny<506>;
+def pAny       : VTAny;
 
 // Pseudo valuetype to represent "vector of any size"
 // Should only be used in TableGen.
-def vAny       : VTAny<507>;
+def vAny       : VTAny;
 
 // Pseudo valuetype to represent "float of any format"
 // Should only be used in TableGen.
-def fAny       : VTAny<508>;
+def fAny       : VTAny;
 
 // Pseudo valuetype to represent "integer of any bit width"
 // Should only be used in TableGen.
-def iAny       : VTAny<509>;
+def iAny       : VTAny;
 
 // Pseudo valuetype mapped to the current pointer size.
 // Should only be used in TableGen.
-def iPTR       : ValueType<0, 510>;
+def iPTR       : ValueType<0>;
 
 // Pseudo valuetype to represent "any type of any size".
 // Should only be used in TableGen.
-def Any        : VTAny<511>;
+def Any        : VTAny;
 
 } // isNormalValueType = false
 
@@ -414,6 +407,6 @@ def Any        : VTAny<511>;
 /// e.g. def p0 : PtrValueType <i64, 0>;
 
 class PtrValueType <ValueType scalar, int addrspace> :
-    ValueType<scalar.Size, scalar.Value> {
+    ValueType<scalar.Size, scalar.LLVMName> {
   int AddrSpace = addrspace;
 }

--- a/llvm/include/llvm/CodeGenTypes/MachineValueType.h
+++ b/llvm/include/llvm/CodeGenTypes/MachineValueType.h
@@ -40,8 +40,7 @@ namespace llvm {
       // are considered extended value types.
       INVALID_SIMPLE_VALUE_TYPE = 0,
 
-#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) \
-    Ty = n,
+#define GET_VT_ATTR(Ty, sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) Ty,
 #define GET_VT_RANGES
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
@@ -187,7 +186,7 @@ namespace llvm {
     /// Return true if this is an overloaded type for TableGen.
     bool isOverloaded() const {
       switch (SimpleTy) {
-#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) \
+#define GET_VT_ATTR(Ty, sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)    \
     case Ty:                                                                   \
       return Any;
 #include "llvm/CodeGen/GenVT.inc"
@@ -270,7 +269,7 @@ namespace llvm {
     MVT getVectorElementType() const {
       assert(SimpleTy >= FIRST_VALUETYPE && SimpleTy <= LAST_VALUETYPE);
       static constexpr SimpleValueType EltTyTable[] = {
-#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) \
+#define GET_VT_ATTR(Ty, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)    \
     EltTy,
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
@@ -284,7 +283,7 @@ namespace llvm {
     unsigned getVectorMinNumElements() const {
       assert(SimpleTy >= FIRST_VALUETYPE && SimpleTy <= LAST_VALUETYPE);
       static constexpr uint16_t NElemTable[] = {
-#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) \
+#define GET_VT_ATTR(Ty, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)    \
     NElem,
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
@@ -314,7 +313,7 @@ namespace llvm {
     /// base size.
     TypeSize getSizeInBits() const {
       static constexpr TypeSize SizeTable[] = {
-#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) \
+#define GET_VT_ATTR(Ty, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)    \
     TypeSize(Sz, Sc || Tup || Ty == aarch64svcount /* FIXME: Not in the td.    \
                                                     */),
 #include "llvm/CodeGen/GenVT.inc"
@@ -437,7 +436,7 @@ namespace llvm {
     }
 
     static MVT getFloatingPointVT(unsigned BitWidth) {
-#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) \
+#define GET_VT_ATTR(Ty, sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)    \
     if (FP == 3 && sz == BitWidth)                                             \
       return Ty;
 #include "llvm/CodeGen/GenVT.inc"
@@ -447,7 +446,7 @@ namespace llvm {
     }
 
     static MVT getIntegerVT(unsigned BitWidth) {
-#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) \
+#define GET_VT_ATTR(Ty, sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)    \
     if (Int == 3 && sz == BitWidth)                                            \
       return Ty;
 #include "llvm/CodeGen/GenVT.inc"
@@ -477,7 +476,7 @@ namespace llvm {
     }
 
     static MVT getRISCVVectorTupleVT(unsigned Sz, unsigned NFields) {
-#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc, Tup, NF, nElem, EltTy) \
+#define GET_VT_ATTR(Ty, sz, Any, Int, FP, Vec, Sc, Tup, NF, nElem, EltTy)    \
     if (Tup && sz == Sz && NF == NFields)                                      \
       return Ty;
 #include "llvm/CodeGen/GenVT.inc"
@@ -491,8 +490,7 @@ namespace llvm {
       assert(isRISCVVectorTuple() && SimpleTy >= FIRST_VALUETYPE &&
              SimpleTy <= LAST_VALUETYPE);
       static constexpr uint8_t NFTable[] = {
-#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) \
-    NF,
+#define GET_VT_ATTR(Ty, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy) NF,
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
       };

--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -61,7 +61,7 @@ class HwModeSelect<list<HwMode> Ms, int ObjectsLength> {
 // objects could be used. This is specifically applicable to selection
 // patterns.
 class ValueTypeByHwMode<list<HwMode> Ms, list<ValueType> Ts>
-    : HwModeSelect<Ms, !size(Ts)>, ValueType<0, 0> {
+    : HwModeSelect<Ms, !size(Ts)>, ValueType<0, "INVALID_SIMPLE_VALUE_TYPE"> {
   // The length of this list must be the same as the length of Ms.
   list<ValueType> Objects = Ts;
 }
@@ -73,7 +73,7 @@ class ValueTypeByHwMode<list<HwMode> Ms, list<ValueType> Ts>
 // patterns.
 class PtrValueTypeByHwMode<ValueTypeByHwMode scalar, int addrspace>
     : HwModeSelect<scalar.Modes, !size(scalar.Objects)>,
-      PtrValueType<ValueType<0, 0>, addrspace> {
+      PtrValueType<ValueType<0, "INVALID_SIMPLE_VALUE_TYPE">, addrspace> {
   // The length of this list must be the same as the length of Ms.
   list<ValueType> Objects = scalar.Objects;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVRegisterInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVRegisterInfo.td
@@ -15,7 +15,7 @@ let Namespace = "SPIRV" in {
   def p64 : PtrValueType <i64, 0>;
 
   class VTPtrVec<int nelem, PtrValueType ptr>
-      : VTVec<nelem, ValueType<ptr.Size, ptr.Value>, ptr.Value> {
+      : VTVec<nelem, ValueType<ptr.Size, ptr.LLVMName>, ptr.LLVMName> {
     int isPointer = true;
   }
 

--- a/llvm/utils/TableGen/Basic/VTEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/VTEmitter.cpp
@@ -91,11 +91,14 @@ void VTEmitter::run(raw_ostream &OS) {
   emitSourceFileHeader("ValueTypes Source Fragment", OS, Records);
 
   std::vector<const Record *> VTsByNumber{512};
-  for (auto *VT : Records.getAllDerivedDefinitions("ValueType")) {
-    auto Number = VT->getValueAsInt("Value");
-    assert(0 <= Number && Number < (int)VTsByNumber.size() &&
-           "ValueType should be uint16_t");
-    assert(!VTsByNumber[Number] && "Duplicate ValueType");
+  unsigned Number = 0;
+  std::vector<const Record *> Defs(
+      Records.getAllDerivedDefinitions("ValueType"));
+  // Emit VTs in the order they were declared so that VTRanges stay contiguous.
+  llvm::sort(Defs, LessRecordByID());
+  for (auto *VT : Defs) {
+    ++Number;
+    assert(Number < VTsByNumber.size() && "ValueType should be uint16_t");
     VTsByNumber[Number] = VT;
   }
 
@@ -120,13 +123,12 @@ void VTEmitter::run(raw_ostream &OS) {
     }
   };
 
-  OS << "#ifdef GET_VT_ATTR // (Ty, n, sz, Any, Int, FP, Vec, Sc, Tup, NF, "
+  OS << "#ifdef GET_VT_ATTR // (Ty, sz, Any, Int, FP, Vec, Sc, Tup, NF, "
         "NElem, EltTy)\n";
   for (const auto *VT : VTsByNumber) {
     if (!VT)
       continue;
     auto Name = VT->getValueAsString("LLVMName");
-    auto Value = VT->getValueAsInt("Value");
     bool IsInteger = VT->getValueAsBit("isInteger");
     bool IsFP = VT->getValueAsBit("isFP");
     bool IsVector = VT->getValueAsBit("isVector");
@@ -158,7 +160,6 @@ void VTEmitter::run(raw_ostream &OS) {
     // clang-format off
     OS << "  GET_VT_ATTR("
        << Name << ", "
-       << Value << ", "
        << VT->getValueAsInt("Size") << ", "
        << VT->getValueAsBit("isOverloaded") << ", "
        << (IsInteger ? Name[0] == 'i' ? 3 : 1 : 0) << ", "

--- a/mlir/tools/mlir-tblgen/LLVMIRIntrinsicGen.cpp
+++ b/mlir/tools/mlir-tblgen/LLVMIRIntrinsicGen.cpp
@@ -14,6 +14,7 @@
 #include "mlir/TableGen/GenInfo.h"
 
 #include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/CodeGenTypes/MachineValueType.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/PrettyStackTrace.h"
@@ -60,8 +61,13 @@ using IndicesTy = llvm::SmallBitVector;
 
 /// Return a CodeGen value type entry from a type record.
 static llvm::MVT::SimpleValueType getValueType(const Record *rec) {
-  return (llvm::MVT::SimpleValueType)rec->getValueAsDef("VT")->getValueAsInt(
-      "Value");
+  return StringSwitch<llvm::MVT::SimpleValueType>(
+             rec->getValueAsDef("VT")->getValueAsString("LLVMName"))
+#define GET_VT_ATTR(Ty, Sz, Any, Int, FP, Vec, Sc, Tup, NF, NElem, EltTy)      \
+  .Case(#Ty, llvm::MVT::Ty)
+#include "llvm/CodeGen/GenVT.inc"
+#undef GET_VT_ATTR
+      .Case("INVALID_SIMPLE_VALUE_TYPE", llvm::MVT::INVALID_SIMPLE_VALUE_TYPE);
 }
 
 /// Return the indices of the definitions in a list of definitions that


### PR DESCRIPTION
Remove explicit VT numbers from ValueTypes.td so that patches that add a
new VT do not have to renumber the entire file.

In TableGen VTs are now identified by ValueType.LLVMName instead of
ValueType.Value. This is important for target-defined types (typically
based on PtrValueType) which are not mentioned in ValueTypes.td itself.
