### PR TITLE
[bazel][NFC] Rename third_party_build/BUILD -> BUILD.bazel

### DIFF
--- a/utils/bazel/third_party_build/BUILD
+++ b/utils/bazel/third_party_build/BUILD
@@ -1,5 +1,0 @@
-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-licenses(["notice"])

--- a/utils/bazel/third_party_build/BUILD.bazel
+++ b/utils/bazel/third_party_build/BUILD.bazel
@@ -1,0 +1,5 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+licenses(["notice"])


### PR DESCRIPTION
All other build files are named BUILD.bazel, not sure why this one is different.