### PR TITLE
[benchmark][NFC] Update cc_binary load

### DIFF
--- a/third-party/benchmark/bindings/python/build_defs.bzl
+++ b/third-party/benchmark/bindings/python/build_defs.bzl
@@ -2,6 +2,8 @@
 This file contains some build definitions for C++ extensions used in the Google Benchmark Python bindings.
 """
 
+load("//third_party/bazel_rules/rules_cc/cc:cc_binary.bzl", "cc_binary")
+
 _SHARED_LIB_SUFFIX = {
     "//conditions:default": ".so",
     "//:windows": ".dll",
@@ -10,7 +12,7 @@ _SHARED_LIB_SUFFIX = {
 def py_extension(name, srcs, hdrs = [], copts = [], features = [], deps = []):
     for shared_lib_suffix in _SHARED_LIB_SUFFIX.values():
         shared_lib_name = name + shared_lib_suffix
-        native.cc_binary(
+        cc_binary(
             name = shared_lib_name,
             linkshared = True,
             linkstatic = True,


### PR DESCRIPTION
cc_binary now needs to be loaded from the rules_cc repo

I don't think this file is actually used, but updating it to be more syntactically correct anyway.