### PR TITLE
[flang][OpenMP] Make OmpDirectiveSpecification::Flags an EnumSet

### DIFF
--- a/flang/include/flang/Common/enum-set.h
+++ b/flang/include/flang/Common/enum-set.h
@@ -217,6 +217,16 @@ public:
 private:
   bitsetType bitset_{};
 };
+
+namespace detail {
+template <typename...> struct IsEnumSetTest {
+  static constexpr bool value{false};
+};
+template <typename E, size_t B> struct IsEnumSetTest<EnumSet<E, B>> {
+  static constexpr bool value{true};
+};
+} // namespace detail
+template <typename T> constexpr bool IsEnumSet{detail::IsEnumSetTest<T>::value};
 } // namespace Fortran::common
 
 template <typename ENUM, std::size_t values>

--- a/flang/include/flang/Parser/dump-parse-tree.h
+++ b/flang/include/flang/Parser/dump-parse-tree.h
@@ -14,10 +14,12 @@
 #include "parse-tree.h"
 #include "tools.h"
 #include "unparse.h"
+#include "flang/Common/enum-set.h"
 #include "flang/Common/idioms.h"
 #include "flang/Common/indirection.h"
 #include "flang/Support/Fortran.h"
 #include "llvm/Frontend/OpenMP/OMP.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include <string>
 #include <type_traits>
@@ -35,6 +37,19 @@ public:
       : out_(out), asFortran_{asFortran} {}
 
   static constexpr const char *GetNodeName(const char *) { return "char *"; }
+
+  template <typename T, typename E, size_t B>
+  static std::string GetMemberNames(const common::EnumSet<E, B> &x) {
+    llvm::ListSeparator sep;
+    std::string s;
+    llvm::raw_string_ostream stream(s);
+    x.IterateOverMembers([&](E e) { stream << sep << T::EnumToString(e); });
+    return stream.str();
+  }
+#define NODE_ENUMSET(T, S) \
+  static std::string GetNodeName(const T::S &x) { \
+    return #S " = {"s + GetMemberNames<T>(x) + "}"s; \
+  }
 #define NODE_NAME(T, N) \
   static constexpr const char *GetNodeName(const T &) { return N; }
 #define NODE_ENUM(T, E) \
@@ -572,7 +587,8 @@ public:
   NODE_ENUM(OmpDeviceTypeClause, DeviceTypeDescription)
   NODE(parser, OmpDirectiveName)
   NODE(parser, OmpDirectiveSpecification)
-  NODE_ENUM(OmpDirectiveSpecification, Flags)
+  NODE_ENUM(OmpDirectiveSpecification, Flag)
+  NODE_ENUMSET(OmpDirectiveSpecification, Flags)
   NODE(parser, OmpDoacross)
   NODE(OmpDoacross, Sink)
   NODE(OmpDoacross, Source)

--- a/flang/include/flang/Parser/dump-parse-tree.h
+++ b/flang/include/flang/Parser/dump-parse-tree.h
@@ -18,8 +18,8 @@
 #include "flang/Common/idioms.h"
 #include "flang/Common/indirection.h"
 #include "flang/Support/Fortran.h"
-#include "llvm/Frontend/OpenMP/OMP.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Frontend/OpenMP/OMP.h"
 #include "llvm/Support/raw_ostream.h"
 #include <string>
 #include <type_traits>

--- a/flang/include/flang/Parser/parse-tree-visitor.h
+++ b/flang/include/flang/Parser/parse-tree-visitor.h
@@ -10,6 +10,7 @@
 #define FORTRAN_PARSER_PARSE_TREE_VISITOR_H_
 
 #include "parse-tree.h"
+#include "flang/Common/enum-set.h"
 #include "flang/Common/visit.h"
 #include <cstddef>
 #include <optional>
@@ -33,6 +34,7 @@ template <typename A, typename V> void Walk(const A &x, V &visitor);
 template <typename A, typename M> void Walk(A &x, M &mutator);
 
 namespace detail {
+
 // A number of the Walk functions below call other Walk functions. Define
 // a dummy class, and put all of them in it to ensure that name lookup for
 // Walk considers all overloads (not just those defined prior to the call
@@ -41,7 +43,7 @@ struct ParseTreeVisitorLookupScope {
   // Default case for visitation of non-class data members, strings, and
   // any other non-decomposable values.
   template <typename A, typename V>
-  static std::enable_if_t<!std::is_class_v<A> ||
+  static std::enable_if_t<!std::is_class_v<A> || common::IsEnumSet<A> ||
       std::is_same_v<std::string, A> || std::is_same_v<CharBlock, A>>
   Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {

--- a/flang/include/flang/Parser/parse-tree-visitor.h
+++ b/flang/include/flang/Parser/parse-tree-visitor.h
@@ -34,7 +34,6 @@ template <typename A, typename V> void Walk(const A &x, V &visitor);
 template <typename A, typename M> void Walk(A &x, M &mutator);
 
 namespace detail {
-
 // A number of the Walk functions below call other Walk functions. Define
 // a dummy class, and put all of them in it to ensure that name lookup for
 // Walk considers all overloads (not just those defined prior to the call

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -22,6 +22,7 @@
 #include "format-specification.h"
 #include "message.h"
 #include "provenance.h"
+#include "flang/Common/enum-set.h"
 #include "flang/Common/idioms.h"
 #include "flang/Common/indirection.h"
 #include "flang/Common/reference.h"
@@ -4975,7 +4976,9 @@ struct OmpClauseList {
 // --- Directives and constructs
 
 struct OmpDirectiveSpecification {
-  ENUM_CLASS(Flags, None, DeprecatedSyntax);
+  ENUM_CLASS(Flag, DeprecatedSyntax)
+  using Flags = common::EnumSet<Flag, Flag_enumSize>;
+
   TUPLE_CLASS_BOILERPLATE(OmpDirectiveSpecification);
   const OmpDirectiveName &DirName() const {
     return std::get<OmpDirectiveName>(t);

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -1633,7 +1633,8 @@ TYPE_PARSER(
             maybe(Parser<OmpClauseList>{}),
             maybe(parenthesized(
                 OmpArgumentListParser<llvm::omp::Directive::OMPD_flush>{})),
-            pure(OmpDirectiveSpecification::Flags::DeprecatedSyntax)))) ||
+            pure(OmpDirectiveSpecification::Flags(
+                {OmpDirectiveSpecification::Flag::DeprecatedSyntax}))))) ||
     // Parse DECLARE_VARIANT individually, because the "[base:]variant"
     // argument will conflict with DECLARE_REDUCTION's "ident:types...".
     predicated(Parser<OmpDirectiveName>{},
@@ -1643,13 +1644,13 @@ TYPE_PARSER(
             maybe(parenthesized(OmpArgumentListParser<
                 llvm::omp::Directive::OMPD_declare_variant>{})),
             maybe(Parser<OmpClauseList>{}),
-            pure(OmpDirectiveSpecification::Flags::None))) ||
+            pure(OmpDirectiveSpecification::Flags()))) ||
     // Parse the standard syntax: directive [(arguments)] [clauses]
     sourced(construct<OmpDirectiveSpecification>( //
         sourced(OmpDirectiveNameParser{}),
         maybe(parenthesized(OmpArgumentListParser<>{})),
         maybe(Parser<OmpClauseList>{}),
-        pure(OmpDirectiveSpecification::Flags::None))))
+        pure(OmpDirectiveSpecification::Flags()))))
 
 static bool IsStandaloneOrdered(const OmpDirectiveSpecification &dirSpec) {
   // An ORDERED construct is standalone if it has DOACROSS or DEPEND clause.

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -2142,7 +2142,7 @@ public:
 
     Walk(std::get<OmpDirectiveName>(x.t));
     auto flags{std::get<OmpDirectiveSpecification::Flags>(x.t)};
-    if (flags == OmpDirectiveSpecification::Flags::DeprecatedSyntax) {
+    if (flags.test(OmpDirectiveSpecification::Flag::DeprecatedSyntax)) {
       if (x.DirId() == llvm::omp::Directive::OMPD_flush) {
         // FLUSH clause arglist
         unparseClauses();
@@ -2539,8 +2539,8 @@ public:
   void Unparse(const OpenMPInteropConstruct &x) {
     BeginOpenMP();
     Word("!$OMP INTEROP");
-    using Flags = OmpDirectiveSpecification::Flags;
-    if (std::get<Flags>(x.v.t) == Flags::DeprecatedSyntax) {
+    auto flags{std::get<OmpDirectiveSpecification::Flags>(x.v.t)};
+    if (flags.test(OmpDirectiveSpecification::Flag::DeprecatedSyntax)) {
       Walk("(", std::get<std::optional<OmpArgumentList>>(x.v.t), ")");
       Walk(" ", std::get<std::optional<OmpClauseList>>(x.v.t));
     } else {
@@ -2679,8 +2679,8 @@ public:
   void Unparse(const OpenMPFlushConstruct &x) {
     BeginOpenMP();
     Word("!$OMP FLUSH");
-    using Flags = OmpDirectiveSpecification::Flags;
-    if (std::get<Flags>(x.v.t) == Flags::DeprecatedSyntax) {
+    auto flags{std::get<OmpDirectiveSpecification::Flags>(x.v.t)};
+    if (flags.test(OmpDirectiveSpecification::Flag::DeprecatedSyntax)) {
       Walk("(", std::get<std::optional<OmpArgumentList>>(x.v.t), ")");
       Walk(" ", std::get<std::optional<OmpClauseList>>(x.v.t));
     } else {

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2748,8 +2748,8 @@ void OmpStructureChecker::Leave(const parser::OpenMPFlushConstruct &x) {
 
   unsigned version{context_.langOptions().OpenMPVersion};
   if (version >= 52) {
-    using Flags = parser::OmpDirectiveSpecification::Flags;
-    if (std::get<Flags>(x.v.t) == Flags::DeprecatedSyntax) {
+    auto &flags{std::get<parser::OmpDirectiveSpecification::Flags>(x.v.t)};
+    if (flags.test(parser::OmpDirectiveSpecification::Flag::DeprecatedSyntax)) {
       context_.Say(x.source,
           "The syntax \"FLUSH clause (object, ...)\" has been deprecated, use \"FLUSH(object, ...) clause\" instead"_warn_en_US);
     }

--- a/flang/test/Parser/OpenMP/allocate-align-tree.f90
+++ b/flang/test/Parser/OpenMP/allocate-align-tree.f90
@@ -28,7 +28,7 @@ end program allocate_align_tree
 !CHECK-NEXT: | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'j'
 !CHECK-NEXT: | | OmpClauseList -> OmpClause -> Align -> OmpAlignClause -> Scalar -> Integer -> Constant -> Expr = '16_4'
 !CHECK-NEXT: | | | LiteralConstant -> IntLiteralConstant = '16'
-!CHECK-NEXT: | | Flags = None
+!CHECK-NEXT: | | Flags = {}
 !CHECK-NEXT: | Block
 !CHECK-NEXT: | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OmpAllocateDirective
 !CHECK-NEXT: | | | OmpBeginDirective
@@ -38,7 +38,7 @@ end program allocate_align_tree
 !CHECK-NEXT: | | | | | LiteralConstant -> IntLiteralConstant = '32'
 !CHECK-NEXT: | | | | OmpClause -> Allocator -> Scalar -> Integer -> Expr = '2_8'
 !CHECK-NEXT: | | | | | Designator -> DataRef -> Name = 'omp_large_cap_mem_alloc'
-!CHECK-NEXT: | | | | Flags = None
+!CHECK-NEXT: | | | | Flags = {}
 !CHECK-NEXT: | | | Block
 !CHECK-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AllocateStmt
 

--- a/flang/test/Parser/OpenMP/allocate-tree-spec-part.f90
+++ b/flang/test/Parser/OpenMP/allocate-tree-spec-part.f90
@@ -23,7 +23,7 @@ end program allocate_tree
 !CHECK-NEXT: | | | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'f'
 !CHECK-NEXT: | | | | OmpClauseList -> OmpClause -> Allocator -> Scalar -> Integer -> Expr = '1_8'
 !CHECK-NEXT: | | | | | Designator -> DataRef -> Name = 'omp_default_mem_alloc'
-!CHECK-NEXT: | | | | Flags = None
+!CHECK-NEXT: | | | | Flags = {}
 !CHECK-NEXT: | | | Block
 !CHECK-NEXT: | ExecutionPart -> Block
 !CHECK-NEXT: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'f=2_4'
@@ -37,7 +37,7 @@ end program allocate_tree
 !CHECK-NEXT: | | | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'w'
 !CHECK-NEXT: | | | | OmpClauseList -> OmpClause -> Allocator -> Scalar -> Integer -> Expr = '3_8'
 !CHECK-NEXT: | | | | | Designator -> DataRef -> Name = 'omp_const_mem_alloc'
-!CHECK-NEXT: | | | | Flags = None
+!CHECK-NEXT: | | | | Flags = {}
 !CHECK-NEXT: | | | Block
 !CHECK-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OmpAllocateDirective
 !CHECK-NEXT: | | | | | OmpBeginDirective
@@ -45,7 +45,7 @@ end program allocate_tree
 !CHECK-NEXT: | | | | | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'xarray'
 !CHECK-NEXT: | | | | | | OmpClauseList -> OmpClause -> Allocator -> Scalar -> Integer -> Expr = '2_8'
 !CHECK-NEXT: | | | | | | | Designator -> DataRef -> Name = 'omp_large_cap_mem_alloc'
-!CHECK-NEXT: | | | | | | Flags = None
+!CHECK-NEXT: | | | | | | Flags = {}
 !CHECK-NEXT: | | | | | Block
 !CHECK-NEXT: | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OmpAllocateDirective
 !CHECK-NEXT: | | | | | | | OmpBeginDirective
@@ -53,12 +53,12 @@ end program allocate_tree
 !CHECK-NEXT: | | | | | | | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'zarray'
 !CHECK-NEXT: | | | | | | | | OmpClauseList -> OmpClause -> Allocator -> Scalar -> Integer -> Expr = '1_8'
 !CHECK-NEXT: | | | | | | | | | Designator -> DataRef -> Name = 'omp_default_mem_alloc'
-!CHECK-NEXT: | | | | | | | | Flags = None
+!CHECK-NEXT: | | | | | | | | Flags = {}
 !CHECK-NEXT: | | | | | | | Block
 !CHECK-NEXT: | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OmpAllocateDirective
 !CHECK-NEXT: | | | | | | | | | OmpBeginDirective
 !CHECK-NEXT: | | | | | | | | | | OmpDirectiveName -> llvm::omp::Directive = allocate
 !CHECK-NEXT: | | | | | | | | | | OmpClauseList ->
-!CHECK-NEXT: | | | | | | | | | | Flags = None
+!CHECK-NEXT: | | | | | | | | | | Flags = {}
 !CHECK-NEXT: | | | | | | | | | Block
 !CHECK-NEXT: | | | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AllocateStmt

--- a/flang/test/Parser/OpenMP/allocate-tree.f90
+++ b/flang/test/Parser/OpenMP/allocate-tree.f90
@@ -24,7 +24,7 @@ end program allocate_tree
 !CHECK-NEXT: | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'w'
 !CHECK-NEXT: | | OmpClauseList -> OmpClause -> Allocator -> Scalar -> Integer -> Expr = '3_8'
 !CHECK-NEXT: | | | Designator -> DataRef -> Name = 'omp_const_mem_alloc'
-!CHECK-NEXT: | | Flags = None
+!CHECK-NEXT: | | Flags = {}
 !CHECK-NEXT: | Block
 
 !CHECK:      ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OmpAllocateDirective
@@ -33,7 +33,7 @@ end program allocate_tree
 !CHECK-NEXT: | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'xarray'
 !CHECK-NEXT: | | OmpClauseList -> OmpClause -> Allocator -> Scalar -> Integer -> Expr = '2_8'
 !CHECK-NEXT: | | | Designator -> DataRef -> Name = 'omp_large_cap_mem_alloc'
-!CHECK-NEXT: | | Flags = None
+!CHECK-NEXT: | | Flags = {}
 !CHECK-NEXT: | Block
 !CHECK-NEXT: | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OmpAllocateDirective
 !CHECK-NEXT: | | | OmpBeginDirective
@@ -41,13 +41,13 @@ end program allocate_tree
 !CHECK-NEXT: | | | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'zarray'
 !CHECK-NEXT: | | | | OmpClauseList -> OmpClause -> Allocator -> Scalar -> Integer -> Expr = '1_8'
 !CHECK-NEXT: | | | | | Designator -> DataRef -> Name = 'omp_default_mem_alloc'
-!CHECK-NEXT: | | | | Flags = None
+!CHECK-NEXT: | | | | Flags = {}
 !CHECK-NEXT: | | | Block
 !CHECK-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OmpAllocateDirective
 !CHECK-NEXT: | | | | | OmpBeginDirective
 !CHECK-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = allocate
 !CHECK-NEXT: | | | | | | OmpClauseList ->
-!CHECK-NEXT: | | | | | | Flags = None
+!CHECK-NEXT: | | | | | | Flags = {}
 !CHECK-NEXT: | | | | | Block
 !CHECK-NEXT: | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AllocateStmt
 

--- a/flang/test/Parser/OpenMP/allocators-unparse.f90
+++ b/flang/test/Parser/OpenMP/allocators-unparse.f90
@@ -33,7 +33,7 @@ end subroutine allocate
 !PARSE-TREE-NEXT: | | OmpClauseList -> OmpClause -> Allocate -> OmpAllocateClause
 !PARSE-TREE-NEXT: | | | Modifier -> OmpAllocatorSimpleModifier -> Scalar -> Integer -> Expr -> Designator -> DataRef -> Name = 'omp_default_mem_alloc'
 !PARSE-TREE-NEXT: | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'arr1'
-!PARSE-TREE-NEXT: | | Flags = None
+!PARSE-TREE-NEXT: | | Flags = {}
 !PARSE-TREE-NEXT: | Block
 !PARSE-TREE-NEXT: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AllocateStmt
 !PARSE-TREE-NEXT: | | | Allocation
@@ -49,7 +49,7 @@ end subroutine allocate
 !PARSE-TREE-NEXT: | | OmpClause -> Allocate -> OmpAllocateClause
 !PARSE-TREE-NEXT: | | | Modifier -> OmpAllocatorSimpleModifier -> Scalar -> Integer -> Expr -> Designator -> DataRef -> Name = 'omp_default_mem_alloc'
 !PARSE-TREE-NEXT: | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'arr2'
-!PARSE-TREE-NEXT: | | Flags = None
+!PARSE-TREE-NEXT: | | Flags = {}
 !PARSE-TREE-NEXT: | Block
 !PARSE-TREE-NEXT: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AllocateStmt
 !PARSE-TREE-NEXT: | | | Allocation
@@ -61,7 +61,7 @@ end subroutine allocate
 !PARSE-TREE-NEXT: | | OmpClauseList -> OmpClause -> Allocate -> OmpAllocateClause
 !PARSE-TREE-NEXT: | | | Modifier -> OmpAlignModifier -> Scalar -> Integer -> Expr -> LiteralConstant -> IntLiteralConstant = '32'
 !PARSE-TREE-NEXT: | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'arr2'
-!PARSE-TREE-NEXT: | | Flags = None
+!PARSE-TREE-NEXT: | | Flags = {}
 !PARSE-TREE-NEXT: | Block
 !PARSE-TREE-NEXT: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AllocateStmt
 !PARSE-TREE-NEXT: | | | Allocation
@@ -73,4 +73,4 @@ end subroutine allocate
 !PARSE-TREE-NEXT: | OmpEndDirective
 !PARSE-TREE-NEXT: | | OmpDirectiveName -> llvm::omp::Directive = allocators
 !PARSE-TREE-NEXT: | | OmpClauseList ->
-!PARSE-TREE-NEXT: | | Flags = None
+!PARSE-TREE-NEXT: | | Flags = {}

--- a/flang/test/Parser/OpenMP/assumption.f90
+++ b/flang/test/Parser/OpenMP/assumption.f90
@@ -43,39 +43,39 @@ end subroutine sub1
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = assume
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> NoOpenmp
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = assume
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPAssumeConstruct
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = assume
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> NoParallelism
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = assume
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPAssumeConstruct
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = assume
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> NoOpenmpRoutines
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = assume
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPAssumeConstruct
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = assume
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Absent -> OmpAbsentClause -> llvm::omp::Directive = allocate
 !PARSE-TREE: | | OmpClause -> Contains -> OmpContainsClause -> llvm::omp::Directive = workshare
 !PARSE-TREE: | | llvm::omp::Directive = task
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> BlockConstruct
 !PARSE-TREE: | | | BlockStmt ->
@@ -89,7 +89,7 @@ end subroutine sub1
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Holds -> OmpHoldsClause -> Expr -> EQ
 !PARSE-TREE: | | | Expr -> LiteralConstant -> IntLiteralConstant = '1'
 !PARSE-TREE: | | | Expr -> LiteralConstant -> IntLiteralConstant = '1'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> BlockConstruct
 !PARSE-TREE: | | | BlockStmt ->
@@ -124,7 +124,7 @@ end subroutine sub2
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = assume
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> NoOpenmp
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt
 !PARSE-TREE: | | | Variable -> Designator -> DataRef -> Name = 'r'
@@ -134,7 +134,7 @@ end subroutine sub2
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = assume
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 program p
   !$omp assumes no_openmp
@@ -147,5 +147,5 @@ end program p
 !PARSE-TREE: OpenMPDeclarativeConstruct -> OpenMPDeclarativeAssumes -> OmpDirectiveSpecification
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = assumes
 !PARSE-TREE: | OmpClauseList -> OmpClause -> NoOpenmp
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 !PARSE-TREE: ImplicitPart ->

--- a/flang/test/Parser/OpenMP/atomic-compare.f90
+++ b/flang/test/Parser/OpenMP/atomic-compare.f90
@@ -20,7 +20,7 @@ end
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Update ->
 !PARSE-TREE: | | OmpClause -> Compare
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> IfStmt
 !PARSE-TREE: | | | Scalar -> Logical -> Expr = 'x<a'
@@ -58,7 +58,7 @@ end
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Update ->
 !PARSE-TREE: | | OmpClause -> Compare
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> IfConstruct
 !PARSE-TREE: | | | IfThenStmt
@@ -112,7 +112,7 @@ end
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Update ->
 !PARSE-TREE: | | OmpClause -> Compare
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> IfConstruct
 !PARSE-TREE: | | | IfThenStmt
@@ -150,7 +150,7 @@ end
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Update ->
 !PARSE-TREE: | | OmpClause -> Capture
 !PARSE-TREE: | | OmpClause -> Compare
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'v=x'
 !PARSE-TREE: | | | Variable = 'v'
@@ -172,7 +172,7 @@ end
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 subroutine g01(a, b)
   integer :: a, b
@@ -202,7 +202,7 @@ end
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Update ->
 !PARSE-TREE: | | OmpClause -> Capture
 !PARSE-TREE: | | OmpClause -> Compare
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'v=x'
 !PARSE-TREE: | | | Variable = 'v'
@@ -227,7 +227,7 @@ end
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 subroutine g02(a, b)
   integer :: a, b
@@ -259,7 +259,7 @@ end
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Update ->
 !PARSE-TREE: | | OmpClause -> Capture
 !PARSE-TREE: | | OmpClause -> Compare
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> IfConstruct
 !PARSE-TREE: | | | IfThenStmt
@@ -287,4 +287,4 @@ end
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}

--- a/flang/test/Parser/OpenMP/atomic-end.f90
+++ b/flang/test/Parser/OpenMP/atomic-end.f90
@@ -19,7 +19,7 @@ end
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Read
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'v=x'
 !PARSE-TREE: | | | Variable = 'v'
@@ -29,7 +29,7 @@ end
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 
 subroutine f01
@@ -50,7 +50,7 @@ end
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Read
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'v=x'
 !PARSE-TREE: | | | Variable = 'v'
@@ -60,4 +60,4 @@ end
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}

--- a/flang/test/Parser/OpenMP/atomic-label-do.f90
+++ b/flang/test/Parser/OpenMP/atomic-label-do.f90
@@ -29,7 +29,7 @@ end
 !PARSE-TREE: | | | OmpBeginDirective
 !PARSE-TREE: | | | | OmpDirectiveName -> llvm::omp::Directive = atomic
 !PARSE-TREE: | | | | OmpClauseList -> OmpClause -> Write
-!PARSE-TREE: | | | | Flags = None
+!PARSE-TREE: | | | | Flags = {}
 !PARSE-TREE: | | | Block
 !PARSE-TREE: | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt = 'x=i'
 !PARSE-TREE: | | | | | Variable = 'x'

--- a/flang/test/Parser/OpenMP/bind-clause.f90
+++ b/flang/test/Parser/OpenMP/bind-clause.f90
@@ -21,6 +21,6 @@ end
 !PARSE-TREE: | OmpBeginLoopDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = loop
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Bind -> OmpBindClause -> Binding = Parallel
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 

--- a/flang/test/Parser/OpenMP/construct-prefix-conflict.f90
+++ b/flang/test/Parser/OpenMP/construct-prefix-conflict.f90
@@ -79,7 +79,7 @@ end
 !PARSE-TREE: | | | OmpClauseList -> OmpClause -> Map -> OmpMapClause
 !PARSE-TREE: | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | | | bool = 'true'
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt
 !PARSE-TREE: | | | Variable -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | | Expr -> Add
@@ -118,7 +118,7 @@ end
 !PARSE-TREE: | | | OmpClauseList -> OmpClause -> Map -> OmpMapClause
 !PARSE-TREE: | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | | | bool = 'true'
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt
 !PARSE-TREE: | | | Variable -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | | Expr -> Add
@@ -157,7 +157,7 @@ end
 !PARSE-TREE: | | | OmpClauseList -> OmpClause -> To -> OmpToClause
 !PARSE-TREE: | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | | | bool = 'true'
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt
 !PARSE-TREE: | | | Variable -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | | Expr -> Add

--- a/flang/test/Parser/OpenMP/cross-label-do.f90
+++ b/flang/test/Parser/OpenMP/cross-label-do.f90
@@ -32,7 +32,7 @@ end
 !PARSE-TREE: | | | OmpBeginLoopDirective
 !PARSE-TREE: | | | | OmpDirectiveName -> llvm::omp::Directive = do
 !PARSE-TREE: | | | | OmpClauseList ->
-!PARSE-TREE: | | | | Flags = None
+!PARSE-TREE: | | | | Flags = {}
 !PARSE-TREE: | | | Block
 !PARSE-TREE: | | | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !PARSE-TREE: | | | | | NonLabelDoStmt

--- a/flang/test/Parser/OpenMP/declare-reduction-multi.f90
+++ b/flang/test/Parser/OpenMP/declare-reduction-multi.f90
@@ -63,7 +63,7 @@ program omp_examples
 !PARSE-TREE: | | | | | Name = 'r'
 !PARSE-TREE: | | | Expr = '0_4'
 !PARSE-TREE: | | | | LiteralConstant -> IntLiteralConstant = '0'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
   !$omp declare reduction(*:tt:omp_out%r = omp_out%r * omp_in%r) initializer(omp_priv%r = 1)
 !CHECK-NEXT: !$OMP DECLARE REDUCTION(*:tt: omp_out%r = omp_out%r * omp_in%r) INITIALIZER(om&
@@ -103,7 +103,7 @@ program omp_examples
 !PARSE-TREE: | | | | | Name = 'r'
 !PARSE-TREE: | | | Expr = '1_4'
 !PARSE-TREE: | | | | LiteralConstant -> IntLiteralConstant = '1'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
   !$omp declare reduction(max:tt:omp_out = mymax(omp_out, omp_in)) initializer(omp_priv%r = 0)
 !CHECK-NEXT: !$OMP DECLARE REDUCTION(max:tt: omp_out = mymax(omp_out, omp_in)) INITIALIZER(&
@@ -140,7 +140,7 @@ program omp_examples
 !PARSE-TREE: | | | | | Name = 'r'
 !PARSE-TREE: | | | Expr = '0_4'
 !PARSE-TREE: | | | | LiteralConstant -> IntLiteralConstant = '0'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
   !$omp declare reduction(min:tt:omp_out%r = min(omp_out%r, omp_in%r)) initializer(omp_priv%r = 1)
 !CHECK-NEXT: !$OMP DECLARE REDUCTION(min:tt: omp_out%r = min(omp_out%r, omp_in%r)) INITIALI&
@@ -183,7 +183,7 @@ program omp_examples
 !PARSE-TREE: | | | | | Name = 'r'
 !PARSE-TREE: | | | Expr = '1_4'
 !PARSE-TREE: | | | | LiteralConstant -> IntLiteralConstant = '1'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
   call random_number(values%r)
 
@@ -197,7 +197,7 @@ program omp_examples
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
 !PARSE-TREE: | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
 !PARSE-TREE: | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'sum'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 
@@ -215,7 +215,7 @@ program omp_examples
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
 !PARSE-TREE: | | | Modifier -> OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Multiply
 !PARSE-TREE: | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'prod'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 
@@ -233,7 +233,7 @@ program omp_examples
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
 !PARSE-TREE: | | | Modifier -> OmpReductionIdentifier -> ProcedureDesignator -> Name = 'max'
 !PARSE-TREE: | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'big'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 
@@ -251,7 +251,7 @@ program omp_examples
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
 !PARSE-TREE: | | | Modifier -> OmpReductionIdentifier -> ProcedureDesignator -> Name = 'min'
 !PARSE-TREE: | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'small'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 

--- a/flang/test/Parser/OpenMP/declare-reduction-operator.f90
+++ b/flang/test/Parser/OpenMP/declare-reduction-operator.f90
@@ -73,7 +73,7 @@ subroutine reduce_1 ( n, tts )
 !PARSE-TREE: | | | | | ComponentSpec
 !PARSE-TREE: | | | | | | ComponentDataSource -> Expr = '0_4'
 !PARSE-TREE: | | | | | | | LiteralConstant -> IntLiteralConstant = '0'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
   !$omp declare reduction(+ : tt :  omp_out = tt(omp_out%x - omp_in%x , omp_out%y - omp_in%y)) initializer(omp_priv = tt(0,0))
 
   
@@ -134,7 +134,7 @@ subroutine reduce_1 ( n, tts )
 !PARSE-TREE: | | | | | ComponentSpec
 !PARSE-TREE: | | | | | | ComponentDataSource -> Expr = '0_4'
 !PARSE-TREE: | | | | | | | LiteralConstant -> IntLiteralConstant = '0'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
   !$omp declare reduction(+ :tt2 :  omp_out = tt2(omp_out%x - omp_in%x , omp_out%y - omp_in%y)) initializer(omp_priv = tt2(0,0))
   
   type(tt) :: diffp = tt( 0, 0 )

--- a/flang/test/Parser/OpenMP/declare-reduction-unparse.f90
+++ b/flang/test/Parser/OpenMP/declare-reduction-unparse.f90
@@ -52,7 +52,7 @@ function func(x, n, init)
 !PARSE-TREE: | | | | ActualArgSpec
 !PARSE-TREE: | | | | | ActualArg -> Expr = '0_4'
 !PARSE-TREE: | | | | | | LiteralConstant -> IntLiteralConstant = '0'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
   res=init
 !$omp simd reduction(red_add:res)
@@ -69,7 +69,7 @@ function func(x, n, init)
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Reduction -> OmpReductionClause
 !PARSE-TREE: | | | Modifier -> OmpReductionIdentifier -> ProcedureDesignator -> Name = 'red_add'
 !PARSE-TREE: | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'res'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 
@@ -119,4 +119,4 @@ end program main
 !PARSE-TREE: | | | | Designator -> DataRef -> Name = 'omp_priv'
 !PARSE-TREE: | | | Expr = '0_4'
 !PARSE-TREE: | | | | LiteralConstant -> IntLiteralConstant = '0'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/declare-target-indirect-tree.f90
+++ b/flang/test/Parser/OpenMP/declare-target-indirect-tree.f90
@@ -20,7 +20,7 @@ contains
     !CHECK-NEXT: | OmpClause -> Indirect -> OmpIndirectClause -> Scalar -> Logical -> Expr = '.true._4'
     !CHECK-NEXT: | | LiteralConstant -> LogicalLiteralConstant
     !CHECK-NEXT: | | | bool = 'true'
-    !CHECK-NEXT: | Flags = None
+    !CHECK-NEXT: | Flags = {}
     character(1) :: i
     i = 'a'
     return
@@ -33,7 +33,7 @@ contains
     !CHECK-NEXT: | OmpClauseList -> OmpClause -> Enter -> OmpEnterClause
     !CHECK-NEXT: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'func2'
     !CHECK-NEXT: | OmpClause -> Indirect -> OmpIndirectClause ->
-    !CHECK-NEXT: | Flags = None
+    !CHECK-NEXT: | Flags = {}
     character(1) :: i
     i = 'b'
     return

--- a/flang/test/Parser/OpenMP/declare-target-to-clause.f90
+++ b/flang/test/Parser/OpenMP/declare-target-to-clause.f90
@@ -18,4 +18,4 @@ end
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | OmpObject -> Designator -> DataRef -> Name = 'y'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/declare-variant.f90
+++ b/flang/test/Parser/OpenMP/declare-variant.f90
@@ -13,7 +13,7 @@ subroutine sub0
 !PARSE-TREE: | | OmpTraitSetSelectorName -> Value = Construct
 !PARSE-TREE: | | OmpTraitSelector
 !PARSE-TREE: | | | OmpTraitSelectorName -> llvm::omp::Directive = parallel
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
   !$omp declare variant (sub:vsub) match (construct={parallel})
 contains
@@ -43,7 +43,7 @@ contains
 !PARSE-TREE: | | OmpTraitSetSelectorName -> Value = Construct
 !PARSE-TREE: | | OmpTraitSelector
 !PARSE-TREE: | | | OmpTraitSelectorName -> llvm::omp::Directive = dispatch
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
     !$omp declare variant(vsub), match(construct={dispatch})
     integer, value :: v1
@@ -75,7 +75,7 @@ contains
 !PARSE-TREE: | | | OmpTraitSelectorName -> llvm::omp::Directive = dispatch
 !PARSE-TREE: | OmpClause -> AppendArgs -> OmpAppendArgsClause -> OmpAppendOp -> OmpInteropType -> Value = Target
 !PARSE-TREE: | OmpAppendOp -> OmpInteropType -> Value = Target
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
     !$omp declare variant(vsub), match(construct={dispatch}), append_args (interop(target), interop(target))
     integer, value :: v1
@@ -107,7 +107,7 @@ contains
 !PARSE-TREE: | OmpClause -> AdjustArgs -> OmpAdjustArgsClause
 !PARSE-TREE: | | OmpAdjustOp -> Value = Need_Device_Ptr
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'v2'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
     !$omp declare variant(vsub) match ( construct = { dispatch } ) adjust_args(nothing : v1 ) adjust_args(need_device_ptr : v2)
   end
@@ -143,4 +143,4 @@ end subroutine
 !PARSE-TREE: | | | OmpTraitSelectorName -> Value = Simd
 !PARSE-TREE: | | | Properties
 !PARSE-TREE: | | | | OmpTraitProperty -> OmpClause -> Uniform -> Name = 'y'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/declare_target-device_type.f90
+++ b/flang/test/Parser/OpenMP/declare_target-device_type.f90
@@ -10,7 +10,7 @@ subroutine openmp_declare_target
 !PARSE-TREE: | OmpClauseList -> OmpClause -> DeviceType -> OmpDeviceTypeClause -> DeviceTypeDescription = Host
 !PARSE-TREE: | OmpClause -> Enter -> OmpEnterClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
     !$omp declare target device_type(host) enter(x)
 
 !CHECK: !$omp declare target device_type(nohost) enter(x)
@@ -20,7 +20,7 @@ subroutine openmp_declare_target
 !PARSE-TREE: | OmpClauseList -> OmpClause -> DeviceType -> OmpDeviceTypeClause -> DeviceTypeDescription = Nohost
 !PARSE-TREE: | OmpClause -> Enter -> OmpEnterClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
     !$omp declare target device_type(nohost) enter(x)
 
 !CHECK: !$omp declare target device_type(any) enter(x)
@@ -30,7 +30,7 @@ subroutine openmp_declare_target
 !PARSE-TREE: | OmpClauseList -> OmpClause -> DeviceType -> OmpDeviceTypeClause -> DeviceTypeDescription = Any
 !PARSE-TREE: | OmpClause -> Enter -> OmpEnterClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
     !$omp declare target device_type(any) enter(x)
 
 !CHECK: !$omp declare target device_type(host) to(x)
@@ -41,7 +41,7 @@ subroutine openmp_declare_target
 !PARSE-TREE: | OmpClause -> To -> OmpToClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
     !$omp declare target device_type(host) to(x)
 
 !CHECK: !$omp declare target device_type(nohost) to(x)
@@ -52,7 +52,7 @@ subroutine openmp_declare_target
 !PARSE-TREE: | OmpClause -> To -> OmpToClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
     !$omp declare target device_type(nohost) to(x)
 
 !CHECK: !$omp declare target device_type(any) to(x)
@@ -63,7 +63,7 @@ subroutine openmp_declare_target
 !PARSE-TREE: | OmpClause -> To -> OmpToClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
     !$omp declare target device_type(any) to(x)
 
 !CHECK: !$omp declare target device_type(host) enter(y) to(x)
@@ -76,7 +76,7 @@ subroutine openmp_declare_target
 !PARSE-TREE: | OmpClause -> To -> OmpToClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
     !$omp declare target device_type(host) enter(y) to(x)
 
 !CHECK: !$omp declare target device_type(nohost) enter(y) to(x)
@@ -89,7 +89,7 @@ subroutine openmp_declare_target
 !PARSE-TREE: | OmpClause -> To -> OmpToClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
     !$omp declare target device_type(nohost) enter(y) to(x)
 
 !CHECK: !$omp declare target device_type(any) enter(y) to(x)
@@ -102,7 +102,7 @@ subroutine openmp_declare_target
 !PARSE-TREE: | OmpClause -> To -> OmpToClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
     !$omp declare target device_type(any) enter(y) to(x)
 
     integer :: a(1024), i

--- a/flang/test/Parser/OpenMP/dispatch.f90
+++ b/flang/test/Parser/OpenMP/dispatch.f90
@@ -33,14 +33,14 @@ subroutine sub(x)
 !PARSE-TREE: | | | | | LiteralConstant -> IntLiteralConstant = '1'
 !PARSE-TREE: | | | | Expr = '1_4'
 !PARSE-TREE: | | | | | LiteralConstant -> IntLiteralConstant = '1'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt
 ![...]
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = dispatch
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
   !$omp dispatch device(3) nowait nocontext(.false.) novariants(1.eq.1)
   r = func(a, b, c)
@@ -57,7 +57,7 @@ subroutine sub(x)
 !PARSE-TREE: | | | Scalar -> Integer -> Expr = '3_4'
 !PARSE-TREE: | | | | LiteralConstant -> IntLiteralConstant = '3'
 !PARSE-TREE: | | OmpClause -> IsDevicePtr -> OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> AssignmentStmt
 !PARSE-TREE-NOT: OmpEndDirective

--- a/flang/test/Parser/OpenMP/dyn-groupprivate-clause.f90
+++ b/flang/test/Parser/OpenMP/dyn-groupprivate-clause.f90
@@ -20,7 +20,7 @@ end
 !PARSE-TREE: | OmpClauseList -> OmpClause -> DynGroupprivate -> OmpDynGroupprivateClause
 !PARSE-TREE: | | Scalar -> Integer -> Expr = 'n'
 !PARSE-TREE: | | | Designator -> DataRef -> Name = 'n'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 
 subroutine f01(n)
@@ -43,7 +43,7 @@ end
 !PARSE-TREE: | | Modifier -> OmpFallbackModifier -> Value = Abort
 !PARSE-TREE: | | Scalar -> Integer -> Expr = 'n'
 !PARSE-TREE: | | | Designator -> DataRef -> Name = 'n'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 
 subroutine f02(n)
@@ -67,4 +67,4 @@ end
 !PARSE-TREE: | | Modifier -> OmpAccessGroup -> Value = Cgroup
 !PARSE-TREE: | | Scalar -> Integer -> Expr = 'n'
 !PARSE-TREE: | | | Designator -> DataRef -> Name = 'n'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/enter-automap-modifier.f90
+++ b/flang/test/Parser/OpenMP/enter-automap-modifier.f90
@@ -16,4 +16,4 @@ end program
 !PARSE-TREE: | OmpClauseList -> OmpClause -> Enter -> OmpEnterClause
 !PARSE-TREE: | | Modifier -> OmpAutomapModifier -> Value = Automap
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/fuse02.f90
+++ b/flang/test/Parser/OpenMP/fuse02.f90
@@ -28,13 +28,13 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = fuse
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | Block
 !CHECK-PARSE-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPLoopConstruct
 !CHECK-PARSE-NEXT: | | | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = fuse
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | | | Block
 !CHECK-PARSE-NEXT: | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !CHECK-PARSE-NEXT: | | | | | | | NonLabelDoStmt
@@ -61,7 +61,7 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = fuse
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !CHECK-PARSE-NEXT: | | | | | NonLabelDoStmt
 !CHECK-PARSE-NEXT: | | | | | | LoopControl -> LoopBounds
@@ -76,7 +76,7 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = fuse
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 
 !CHECK-UNPARSE: SUBROUTINE fuse_on_fuse
 !CHECK-UNPARSE-NEXT:  IMPLICIT NONE

--- a/flang/test/Parser/OpenMP/groupprivate.f90
+++ b/flang/test/Parser/OpenMP/groupprivate.f90
@@ -22,9 +22,9 @@ end module
 !PARSE-TREE: | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'y'
 !PARSE-TREE: | OmpClauseList -> OmpClause -> DeviceType -> OmpDeviceTypeClause -> DeviceTypeDescription = Nohost
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 !PARSE-TREE: DeclarationConstruct -> SpecificationConstruct -> OpenMPDeclarativeConstruct -> OpenMPGroupprivate -> OmpDirectiveSpecification
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = groupprivate
 !PARSE-TREE: | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'z'
 !PARSE-TREE: | OmpClauseList ->
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/in-reduction-clause.f90
+++ b/flang/test/Parser/OpenMP/in-reduction-clause.f90
@@ -46,7 +46,7 @@ end subroutine omp_in_reduction_taskgroup
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> InReduction -> OmpInReductionClause
 !PARSE-TREE-NEXT: OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
 !PARSE-TREE-NEXT: OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'z'
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine omp_in_reduction_parallel()
     integer :: z
@@ -77,5 +77,5 @@ end subroutine omp_in_reduction_parallel
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> InReduction -> OmpInReductionClause
 !PARSE-TREE-NEXT: OmpReductionIdentifier -> DefinedOperator -> IntrinsicOperator = Add
 !PARSE-TREE-NEXT: OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'z'
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 

--- a/flang/test/Parser/OpenMP/interop-construct.f90
+++ b/flang/test/Parser/OpenMP/interop-construct.f90
@@ -21,7 +21,7 @@ END SUBROUTINE test_interop_01
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = interop
 !PARSE-TREE: | | | OmpClauseList -> OmpClause -> Device -> OmpDeviceClause
 !PARSE-TREE: | | | | Scalar -> Integer -> Expr -> LiteralConstant -> IntLiteralConstant = '1'
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> PrintStmt
 !PARSE-TREE: | | | Format -> Star
 !PARSE-TREE: | | | OutputItem -> Expr -> LiteralConstant -> CharLiteralConstant
@@ -64,7 +64,7 @@ END SUBROUTINE test_interop_02
 !PARSE-TREE: | | | | OmpObject -> Designator -> DataRef -> Name = 'obj'
 !PARSE-TREE: | | | OmpClause -> Use -> OmpUseClause -> OmpObject -> Designator -> DataRef -> Name = 'obj1'
 !PARSE-TREE: | | | OmpClause -> Destroy -> OmpDestroyClause -> OmpObject -> Designator -> DataRef -> Name = 'obj3'
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> PrintStmt
 !PARSE-TREE: | | | Format -> Star
 !PARSE-TREE: | | | OutputItem -> Expr -> LiteralConstant -> CharLiteralConstant
@@ -104,7 +104,7 @@ END SUBROUTINE test_interop_03
 !PARSE-TREE: | | | OmpClause -> Depend -> OmpDependClause -> TaskDep
 !PARSE-TREE: | | | | Modifier -> OmpTaskDependenceType -> Value = Inout
 !PARSE-TREE: | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'obj'
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> PrintStmt
 !PARSE-TREE: | | | Format -> Star
 !PARSE-TREE: | | | OutputItem -> Expr -> LiteralConstant -> CharLiteralConstant
@@ -159,7 +159,7 @@ END SUBROUTINE test_interop_04
 !PARSE-TREE: | | | | Modifier -> OmpTaskDependenceType -> Value = Inout
 !PARSE-TREE: | | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'arr'
 !PARSE-TREE: | | | OmpClause -> Nowait
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> PrintStmt
 !PARSE-TREE: | | | Format -> Star
 !PARSE-TREE: | | | OutputItem -> Expr -> LiteralConstant -> CharLiteralConstant
@@ -200,7 +200,7 @@ END SUBROUTINE test_interop_05
 !PARSE-TREE: | | | OmpClause -> Device -> OmpDeviceClause
 !PARSE-TREE: | | | | Modifier -> OmpDeviceModifier -> Value = Device_Num
 !PARSE-TREE: | | | | Scalar -> Integer -> Expr -> LiteralConstant -> IntLiteralConstant = '0'
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> PrintStmt
 !PARSE-TREE: | | | Format -> Star
 !PARSE-TREE: | | | OutputItem -> Expr -> LiteralConstant -> CharLiteralConstant

--- a/flang/test/Parser/OpenMP/linear-clause.f90
+++ b/flang/test/Parser/OpenMP/linear-clause.f90
@@ -22,7 +22,7 @@ end
 !PARSE-TREE: | OmpClauseList -> OmpClause -> Linear -> OmpLinearClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 !PARSE-TREE: DoConstruct
 
 subroutine f01(x)
@@ -48,7 +48,7 @@ end
 !PARSE-TREE: | | Modifier -> OmpStepSimpleModifier -> Scalar -> Integer -> Expr = '2_4'
 !PARSE-TREE: | | | LiteralConstant -> IntLiteralConstant = '2'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 !PARSE-TREE: DoConstruct
 
 subroutine f02(x)
@@ -74,7 +74,7 @@ end
 !PARSE-TREE: | | Modifier -> OmpStepComplexModifier -> Scalar -> Integer -> Expr = '3_4'
 !PARSE-TREE: | | | LiteralConstant -> IntLiteralConstant = '3'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 !PARSE-TREE: DoConstruct
 
 subroutine f03(x)
@@ -93,7 +93,7 @@ end
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | Modifier -> OmpLinearModifier -> Value = Uval
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 subroutine f04(x)
   integer :: x
@@ -113,4 +113,4 @@ end
 !PARSE-TREE: | | Modifier -> OmpStepComplexModifier -> Scalar -> Integer -> Expr = '3_4'
 !PARSE-TREE: | | | LiteralConstant -> IntLiteralConstant = '3'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/loop-transformation-construct01.f90
+++ b/flang/test/Parser/OpenMP/loop-transformation-construct01.f90
@@ -23,14 +23,14 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = do
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | Block
 !CHECK-PARSE-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPLoopConstruct
 !CHECK-PARSE-NEXT: | | | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = unroll
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList -> OmpClause -> Partial -> Scalar -> Integer -> Constant -> Expr = '1_4'
 !CHECK-PARSE-NEXT: | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | | | Block
 !CHECK-PARSE-NEXT: | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !CHECK-PARSE-NEXT: | | | | | | | NonLabelDoStmt
@@ -60,11 +60,11 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = unroll
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = do
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 
 !CHECK-UNPARSE: SUBROUTINE loop_transformation_construct
 !CHECK-UNPARSE-NEXT:  IMPLICIT NONE

--- a/flang/test/Parser/OpenMP/loop-transformation-construct02.f90
+++ b/flang/test/Parser/OpenMP/loop-transformation-construct02.f90
@@ -25,21 +25,21 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = do
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | Block
 !CHECK-PARSE-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPLoopConstruct
 !CHECK-PARSE-NEXT: | | | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = unroll
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList -> OmpClause -> Partial -> Scalar -> Integer -> Constant -> Expr = '1_4'
 !CHECK-PARSE-NEXT: | | | | | | | LiteralConstant -> IntLiteralConstant = '1'
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | | | Block
 !CHECK-PARSE-NEXT: | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPLoopConstruct
 !CHECK-PARSE-NEXT: | | | | | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | | | OmpDirectiveName -> llvm::omp::Directive = tile
 !CHECK-PARSE-NEXT: | | | | | | | | OmpClauseList -> OmpClause -> Sizes -> Scalar -> Integer -> Expr = '2_4'
 !CHECK-PARSE-NEXT: | | | | | | | | | LiteralConstant -> IntLiteralConstant = '2'
-!CHECK-PARSE-NEXT: | | | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | | | | | Block
 !CHECK-PARSE-NEXT: | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !CHECK-PARSE-NEXT: | | | | | | | | | NonLabelDoStmt
@@ -69,15 +69,15 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | | | OmpDirectiveName -> llvm::omp::Directive = tile
 !CHECK-PARSE-NEXT: | | | | | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = unroll
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = do
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 
 !CHECK-UNPARSE: SUBROUTINE loop_transformation_construct
 !CHECK-UNPARSE-NEXT:  IMPLICIT NONE

--- a/flang/test/Parser/OpenMP/loop-transformation-construct03.f90
+++ b/flang/test/Parser/OpenMP/loop-transformation-construct03.f90
@@ -25,7 +25,7 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | OmpClauseList -> OmpClause -> Collapse -> Scalar -> Integer -> Constant -> Expr = '2_4'
 !CHECK-PARSE-NEXT: | | | | | LiteralConstant -> IntLiteralConstant = '2'
 !CHECK-PARSE-NEXT: | | | | OmpClause -> Private -> OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'b'
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | Block
 !CHECK-PARSE-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !CHECK-PARSE-NEXT: | | | | | NonLabelDoStmt

--- a/flang/test/Parser/OpenMP/loop-transformation-construct04.f90
+++ b/flang/test/Parser/OpenMP/loop-transformation-construct04.f90
@@ -25,13 +25,13 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = do
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | Block
 !CHECK-PARSE-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPLoopConstruct
 !CHECK-PARSE-NEXT: | | | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = fuse
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | | | Block
 !CHECK-PARSE-NEXT: | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !CHECK-PARSE-NEXT: | | | | | | | NonLabelDoStmt
@@ -58,11 +58,11 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = fuse
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = do
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 
 !CHECK-UNPARSE: SUBROUTINE loop_transformation_construct
 !CHECK-UNPARSE-NEXT:  IMPLICIT NONE

--- a/flang/test/Parser/OpenMP/loop-transformation-construct05.f90
+++ b/flang/test/Parser/OpenMP/loop-transformation-construct05.f90
@@ -27,13 +27,13 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = do
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | Block
 !CHECK-PARSE-NEXT: | | | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPLoopConstruct
 !CHECK-PARSE-NEXT: | | | | | OmpBeginLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = fuse
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | | | Block
 !CHECK-PARSE-NEXT: | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !CHECK-PARSE-NEXT: | | | | | | | NonLabelDoStmt
@@ -51,7 +51,7 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | | | | | OmpDirectiveName -> llvm::omp::Directive = tile
 !CHECK-PARSE-NEXT: | | | | | | | | OmpClauseList -> OmpClause -> Sizes -> Scalar -> Integer -> Expr = '2_4'
 !CHECK-PARSE-NEXT: | | | | | | | | | LiteralConstant -> IntLiteralConstant = '2'
-!CHECK-PARSE-NEXT: | | | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | | | | | Block
 !CHECK-PARSE-NEXT: | | | | | | | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !CHECK-PARSE-NEXT: | | | | | | | | | NonLabelDoStmt
@@ -67,11 +67,11 @@ end subroutine
 !CHECK-PARSE-NEXT: | | | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | | | OmpDirectiveName -> llvm::omp::Directive = fuse
 !CHECK-PARSE-NEXT: | | | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | | | Flags = {}
 !CHECK-PARSE-NEXT: | | | OmpEndLoopDirective
 !CHECK-PARSE-NEXT: | | | | OmpDirectiveName -> llvm::omp::Directive = do
 !CHECK-PARSE-NEXT: | | | | OmpClauseList ->
-!CHECK-PARSE-NEXT: | | | | Flags = None
+!CHECK-PARSE-NEXT: | | | | Flags = {}
 
 !CHECK-UNPARSE: SUBROUTINE loop_transformation_construct
 !CHECK-UNPARSE-NEXT:  IMPLICIT NONE

--- a/flang/test/Parser/OpenMP/map-modifiers-v61.f90
+++ b/flang/test/Parser/OpenMP/map-modifiers-v61.f90
@@ -19,7 +19,7 @@ end
 !PARSE-TREE: | | Modifier -> OmpAttachModifier -> Value = Always
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 
 subroutine f01(x)
@@ -40,7 +40,7 @@ end
 !PARSE-TREE: | | Modifier -> OmpAttachModifier -> Value = Auto
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 
 subroutine f02(x)
@@ -61,4 +61,4 @@ end
 !PARSE-TREE: | | Modifier -> OmpAttachModifier -> Value = Never
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/metadirective-dirspec.f90
+++ b/flang/test/Parser/OpenMP/metadirective-dirspec.f90
@@ -164,7 +164,7 @@ end
 !PARSE-TREE: | | | | | | | | | | DataRef -> Name = 'omp_out'
 !PARSE-TREE: | | | | | | | | | | Name = 'x'
 !PARSE-TREE: | | | OmpClauseList ->
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 
 subroutine f04
   !$omp metadirective when(user={condition(.true.)}: &

--- a/flang/test/Parser/OpenMP/metadirective-flush.f90
+++ b/flang/test/Parser/OpenMP/metadirective-flush.f90
@@ -25,7 +25,7 @@ end
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = flush
 !PARSE-TREE: | | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | | OmpClauseList -> OmpClause -> SeqCst
-!PARSE-TREE: | | | Flags = DeprecatedSyntax
+!PARSE-TREE: | | | Flags = {DeprecatedSyntax}
 
 subroutine f01()
   integer :: x
@@ -51,4 +51,4 @@ end
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = flush
 !PARSE-TREE: | | | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | | OmpClauseList -> OmpClause -> SeqCst
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}

--- a/flang/test/Parser/OpenMP/openmp6-directive-spellings.f90
+++ b/flang/test/Parser/OpenMP/openmp6-directive-spellings.f90
@@ -38,7 +38,7 @@ end
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = cancellation point
 !PARSE-TREE: | OmpClauseList -> OmpClause -> CancellationConstructType -> OmpCancellationConstructTypeClause
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = parallel
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 subroutine f01
   type :: t
@@ -66,7 +66,7 @@ end
 !PARSE-TREE: | | | DataRef -> Name = 'v'
 !PARSE-TREE: | | | Name = 'x'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 subroutine f02
   type :: t
@@ -107,7 +107,7 @@ end
 !PARSE-TREE: | | | | | | | | DataRef -> Name = 'omp_in'
 !PARSE-TREE: | | | | | | | | Name = 'x'
 !PARSE-TREE: | OmpClauseList ->
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 subroutine f03
   !$omp declare_simd
@@ -120,7 +120,7 @@ end
 !PARSE-TREE: OpenMPDeclarativeConstruct -> OpenMPDeclareSimdConstruct -> OmpDirectiveSpecification
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = declare simd
 !PARSE-TREE: | OmpClauseList ->
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 subroutine f04
   !$omp declare_target
@@ -133,7 +133,7 @@ end
 !PARSE-TREE: OpenMPDeclarativeConstruct -> OpenMPDeclareTargetConstruct -> OmpDirectiveSpecification
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = declare target
 !PARSE-TREE: | OmpClauseList ->
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 subroutine f05
   implicit none
@@ -164,7 +164,7 @@ end
 !PARSE-TREE: | | | | OmpTraitProperty -> Scalar -> Expr = '.true._4'
 !PARSE-TREE: | | | | | LiteralConstant -> LogicalLiteralConstant
 !PARSE-TREE: | | | | | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 subroutine f06
   implicit none
@@ -217,7 +217,7 @@ end
 !PARSE-TREE: | | Modifier -> OmpMapType -> Value = To
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'i'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 subroutine f08
   implicit none
@@ -237,7 +237,7 @@ end
 !PARSE-TREE: | | Modifier -> OmpMapType -> Value = From
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'i'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 subroutine f09
   implicit none
@@ -256,4 +256,4 @@ end
 !PARSE-TREE: | OmpClauseList -> OmpClause -> To -> OmpToClause
 !PARSE-TREE: | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'i'
 !PARSE-TREE: | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/order-clause01.f90
+++ b/flang/test/Parser/OpenMP/order-clause01.f90
@@ -18,7 +18,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = do
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_simd_order_reproducible()
  integer :: i, j = 1
@@ -36,7 +36,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Reproducible
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_do_simd_order_unconstrained()
  integer :: i, j = 1
@@ -54,7 +54,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Unconstrained
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_parallel_do_order()
  integer :: i, j = 1
@@ -71,7 +71,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = parallel do
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_parallel_do_simd_order_reproducible()
  integer :: i, j = 1
@@ -89,7 +89,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Reproducible
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_target_simd_order_unconstrained()
  integer :: i, j = 1
@@ -107,7 +107,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Unconstrained
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_target_parallel_do_order()
  integer :: i, j = 1
@@ -124,7 +124,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = target parallel do
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_target_parallel_do_simd_order_reproducible()
  integer :: i, j = 1
@@ -142,7 +142,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Reproducible
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_teams_distribute_simd_order_unconstrained()
  integer :: i, j = 1
@@ -160,7 +160,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Unconstrained
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_teams_distribute_parallel_do_order()
  integer :: i, j = 1
@@ -177,7 +177,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = teams distribute parallel do
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_teams_distribute_parallel_do_simd_order_reproducible()
  integer :: i, j = 1
@@ -195,7 +195,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Reproducible
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_target_teams_distribute_simd_order_unconstrained()
  integer :: i, j = 1
@@ -213,7 +213,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Unconstrained
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_target_teams_distribute_parallel_do_order()
  integer :: i, j = 1
@@ -230,7 +230,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpDirectiveName -> llvm::omp::Directive = target teams distribute parallel do
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_target_teams_distribute_parallel_do_simd_order_reproducible()
  integer :: i, j = 1
@@ -248,7 +248,7 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Reproducible
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}
 
 subroutine test_taskloop_simd_order_unconstrained()
  integer :: i, j = 1
@@ -266,4 +266,4 @@ end subroutine
 !PARSE-TREE-NEXT: OmpClauseList -> OmpClause -> Order -> OmpOrderClause
 !PARSE-TREE-NEXT: OmpOrderModifier -> Value = Unconstrained
 !PARSE-TREE-NEXT: Ordering = Concurrent
-!PARSE-TREE-NEXT: Flags = None
+!PARSE-TREE-NEXT: Flags = {}

--- a/flang/test/Parser/OpenMP/ordered-block-vs-standalone.f90
+++ b/flang/test/Parser/OpenMP/ordered-block-vs-standalone.f90
@@ -11,7 +11,7 @@ subroutine standalone
       ! CHECK:      OpenMPConstruct -> OpenMPStandaloneConstruct
       ! CHECK-NEXT: | OmpDirectiveName -> llvm::omp::Directive = ordered
       ! CHECK-NEXT: | OmpClauseList ->
-      ! CHECK-NEXT: | Flags = None
+      ! CHECK-NEXT: | Flags = {}
       !$omp ordered depend(source)
       x(i, j) = i + j
     end do
@@ -29,7 +29,7 @@ subroutine strict_block
       ! CHECK-NEXT: | OmpBeginDirective
       ! CHECK-NEXT: | | OmpDirectiveName -> llvm::omp::Directive = ordered
       ! CHECK-NEXT: | | OmpClauseList ->
-      ! CHECK-NEXT: | | Flags = None
+      ! CHECK-NEXT: | | Flags = {}
       !$omp ordered
       block
         tmp = i + j
@@ -50,7 +50,7 @@ subroutine loose_block
       ! CHECK-NEXT: | OmpBeginDirective
       ! CHECK-NEXT: | | OmpDirectiveName -> llvm::omp::Directive = ordered
       ! CHECK-NEXT: | | OmpClauseList ->
-      ! CHECK-NEXT: | | Flags = None
+      ! CHECK-NEXT: | | Flags = {}
       !$omp ordered
         tmp = i + j
         x(i, j) = tmp

--- a/flang/test/Parser/OpenMP/replayable-clause.f90
+++ b/flang/test/Parser/OpenMP/replayable-clause.f90
@@ -17,7 +17,7 @@ end
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = task
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Replayable ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 
 
@@ -41,7 +41,7 @@ end
 !PARSE-TREE: | OmpClause -> Replayable -> OmpReplayableClause -> Scalar -> Logical -> Constant -> Expr = '.true._4'
 !PARSE-TREE: | | LiteralConstant -> LogicalLiteralConstant
 !PARSE-TREE: | | | bool = 'true'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 
 subroutine f02
@@ -57,4 +57,4 @@ end
 !PARSE-TREE: | OmpClauseList -> OmpClause -> Replayable -> OmpReplayableClause -> Scalar -> Logical -> Constant -> Expr = '.false._4'
 !PARSE-TREE: | | LiteralConstant -> LogicalLiteralConstant
 !PARSE-TREE: | | | bool = 'false'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/requires.f90
+++ b/flang/test/Parser/OpenMP/requires.f90
@@ -8,7 +8,7 @@
 !PARSE-TREE: OpenMPDeclarativeConstruct -> OpenMPRequiresConstruct -> OmpDirectiveSpecification
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = requires
 !PARSE-TREE: | OmpClauseList -> OmpClause -> AtomicDefaultMemOrder -> OmpAtomicDefaultMemOrderClause -> OmpMemoryOrderType = Seq_Cst
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 !$omp requires unified_shared_memory unified_address
 
@@ -18,7 +18,7 @@
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = requires
 !PARSE-TREE: | OmpClauseList -> OmpClause -> UnifiedSharedMemory
 !PARSE-TREE: | OmpClause -> UnifiedAddress
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 !$omp requires dynamic_allocators reverse_offload
 
@@ -28,7 +28,7 @@
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = requires
 !PARSE-TREE: | OmpClauseList -> OmpClause -> DynamicAllocators
 !PARSE-TREE: | OmpClause -> ReverseOffload
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 !$omp requires self_maps(.true.) unified_address(.false.)
 
@@ -42,7 +42,7 @@
 !PARSE-TREE: | OmpClause -> UnifiedAddress -> OmpUnifiedAddressClause -> Scalar -> Logical -> Constant -> Expr = '.false._4'
 !PARSE-TREE: | | LiteralConstant -> LogicalLiteralConstant
 !PARSE-TREE: | | | bool = 'false'
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 !$omp requires device_safesync
 
@@ -51,6 +51,6 @@
 !PARSE-TREE: OpenMPDeclarativeConstruct -> OpenMPRequiresConstruct -> OmpDirectiveSpecification
 !PARSE-TREE: | OmpDirectiveName -> llvm::omp::Directive = requires
 !PARSE-TREE: | OmpClauseList -> OmpClause -> DeviceSafesync
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}
 
 end

--- a/flang/test/Parser/OpenMP/sections.f90
+++ b/flang/test/Parser/OpenMP/sections.f90
@@ -17,13 +17,13 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | OmpBeginSectionsDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | OpenMPConstruct -> OpenMPSectionConstruct
 !PARSE-TREE: | | Block
 !PARSE-TREE: | OmpEndSectionsDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 !==============================================================================
 ! single section, without `!$omp section`
@@ -39,7 +39,7 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | OmpBeginSectionsDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | OpenMPConstruct -> OpenMPSectionConstruct
 !PARSE-TREE: | | Block
 !PARSE-TREE: | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL f1()'
@@ -48,7 +48,7 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | OmpEndSectionsDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 !==============================================================================
 ! single section with `!$omp section`
@@ -66,12 +66,12 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | OmpBeginSectionsDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | OpenMPConstruct -> OpenMPSectionConstruct
 !PARSE-TREE: | | OmpDirectiveSpecification
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = section
 !PARSE-TREE: | | | OmpClauseList ->
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | Block
 !PARSE-TREE: | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL f1()'
 !PARSE-TREE: | | | | Call
@@ -79,7 +79,7 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | OmpEndSectionsDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 !==============================================================================
 ! multiple sections
@@ -105,12 +105,12 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | OmpBeginSectionsDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | OpenMPConstruct -> OpenMPSectionConstruct
 !PARSE-TREE: | | OmpDirectiveSpecification
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = section
 !PARSE-TREE: | | | OmpClauseList ->
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | Block
 !PARSE-TREE: | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL f1()'
 !PARSE-TREE: | | | | Call
@@ -119,7 +119,7 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | | OmpDirectiveSpecification
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = section
 !PARSE-TREE: | | | OmpClauseList ->
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | Block
 !PARSE-TREE: | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL f2()'
 !PARSE-TREE: | | | | Call
@@ -128,7 +128,7 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | | OmpDirectiveSpecification
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = section
 !PARSE-TREE: | | | OmpClauseList ->
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | Block
 !PARSE-TREE: | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL f3()'
 !PARSE-TREE: | | | | Call
@@ -136,7 +136,7 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | OmpEndSectionsDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 !==============================================================================
 ! multiple sections with clauses
@@ -163,12 +163,12 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Private -> OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | OmpClause -> Firstprivate -> OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'y'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | OpenMPConstruct -> OpenMPSectionConstruct
 !PARSE-TREE: | | OmpDirectiveSpecification
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = section
 !PARSE-TREE: | | | OmpClauseList ->
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | Block
 !PARSE-TREE: | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL f1()'
 !PARSE-TREE: | | | | Call
@@ -177,7 +177,7 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | | OmpDirectiveSpecification
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = section
 !PARSE-TREE: | | | OmpClauseList ->
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | Block
 !PARSE-TREE: | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL f2()'
 !PARSE-TREE: | | | | Call
@@ -186,7 +186,7 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | | OmpDirectiveSpecification
 !PARSE-TREE: | | | OmpDirectiveName -> llvm::omp::Directive = section
 !PARSE-TREE: | | | OmpClauseList ->
-!PARSE-TREE: | | | Flags = None
+!PARSE-TREE: | | | Flags = {}
 !PARSE-TREE: | | Block
 !PARSE-TREE: | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> CallStmt = 'CALL f3()'
 !PARSE-TREE: | | | | Call
@@ -194,6 +194,6 @@ subroutine openmp_sections(x, y)
 !PARSE-TREE: | OmpEndSectionsDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = sections
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Nowait
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 END subroutine openmp_sections

--- a/flang/test/Parser/OpenMP/taskgraph.f90
+++ b/flang/test/Parser/OpenMP/taskgraph.f90
@@ -17,7 +17,7 @@ end
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = taskgraph
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> BlockConstruct
 !PARSE-TREE: | | | BlockStmt ->
@@ -54,23 +54,23 @@ end
 !PARSE-TREE: | | | Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | OmpClause -> GraphReset -> OmpGraphResetClause -> Scalar -> Logical -> Expr = 'y'
 !PARSE-TREE: | | | Designator -> DataRef -> Name = 'y'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OmpBlockConstruct
 !PARSE-TREE: | | | OmpBeginDirective
 !PARSE-TREE: | | | | OmpDirectiveName -> llvm::omp::Directive = task
 !PARSE-TREE: | | | | OmpClauseList ->
-!PARSE-TREE: | | | | Flags = None
+!PARSE-TREE: | | | | Flags = {}
 !PARSE-TREE: | | | Block
 !PARSE-TREE: | | | | ExecutionPartConstruct -> ExecutableConstruct -> ActionStmt -> ContinueStmt
 !PARSE-TREE: | | | OmpEndDirective
 !PARSE-TREE: | | | | OmpDirectiveName -> llvm::omp::Directive = task
 !PARSE-TREE: | | | | OmpClauseList ->
-!PARSE-TREE: | | | | Flags = None
+!PARSE-TREE: | | | | Flags = {}
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = taskgraph
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 
 subroutine f02
@@ -87,9 +87,9 @@ end
 !PARSE-TREE: | OmpBeginDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = taskgraph
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> GraphReset ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = taskgraph
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}

--- a/flang/test/Parser/OpenMP/threadprivate.f90
+++ b/flang/test/Parser/OpenMP/threadprivate.f90
@@ -22,4 +22,4 @@ end module
 !PARSE-TREE: | OmpArgumentList -> OmpArgument -> OmpLocator -> OmpObject -> Name = 'blk'
 !PARSE-TREE: | OmpArgument -> OmpLocator -> OmpObject -> Designator -> DataRef -> Name = 'b'
 !PARSE-TREE: | OmpClauseList ->
-!PARSE-TREE: | Flags = None
+!PARSE-TREE: | Flags = {}

--- a/flang/test/Parser/OpenMP/tile.f90
+++ b/flang/test/Parser/OpenMP/tile.f90
@@ -19,7 +19,7 @@ subroutine openmp_tiles(x)
 !PARSE-TREE: OmpBeginLoopDirective
 !PARSE-TREE:   OmpClauseList -> OmpClause -> Sizes -> Scalar -> Integer -> Expr = '2_4'
 !PARSE-TREE:     LiteralConstant -> IntLiteralConstant = '2'
-!PARSE-TREE:     Flags = None
+!PARSE-TREE:     Flags = {}
 !PARSE-TREE:   DoConstruct
 !PARSE-TREE:   EndDoStmt
 !PARSE-TREE: OmpEndLoopDirective

--- a/flang/test/Parser/OpenMP/transparent-clause.f90
+++ b/flang/test/Parser/OpenMP/transparent-clause.f90
@@ -25,7 +25,7 @@ end
 !PARSE-TREE: | | | OmpObjectList -> OmpObject -> Designator -> DataRef -> Name = 'x'
 !PARSE-TREE: | | | bool = 'true'
 !PARSE-TREE: | | OmpClause -> Transparent ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 
 
@@ -44,12 +44,12 @@ end
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = task
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Transparent -> OmpTransparentClause -> Scalar -> Integer -> Expr = '0_4'
 !PARSE-TREE: | | | LiteralConstant -> IntLiteralConstant = '0'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | OmpEndDirective
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = task
 !PARSE-TREE: | | OmpClauseList ->
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 
 
 subroutine f02
@@ -73,6 +73,6 @@ end
 !PARSE-TREE: | | OmpDirectiveName -> llvm::omp::Directive = taskloop
 !PARSE-TREE: | | OmpClauseList -> OmpClause -> Transparent -> OmpTransparentClause -> Scalar -> Integer -> Expr = '2_4'
 !PARSE-TREE: | | | LiteralConstant -> IntLiteralConstant = '2'
-!PARSE-TREE: | | Flags = None
+!PARSE-TREE: | | Flags = {}
 !PARSE-TREE: | Block
 !PARSE-TREE: | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct

--- a/flang/test/Parser/OpenMP/unroll-heuristic.f90
+++ b/flang/test/Parser/OpenMP/unroll-heuristic.f90
@@ -22,7 +22,7 @@ END subroutine openmp_parse_unroll_heuristic
 !PTREE-NEXT: | OmpBeginLoopDirective
 !PTREE-NEXT: | | OmpDirectiveName -> llvm::omp::Directive = unroll
 !PTREE-NEXT: | | OmpClauseList ->
-!PTREE-NEXT: | | Flags = None
+!PTREE-NEXT: | | Flags = {}
 !PTREE-NEXT: | Block
 !PTREE-NEXT: | | ExecutionPartConstruct -> ExecutableConstruct -> DoConstruct
 !PTREE-NEXT: | | | NonLabelDoStmt
@@ -43,4 +43,4 @@ END subroutine openmp_parse_unroll_heuristic
 !PTREE-NEXT: | OmpEndLoopDirective
 !PTREE-NEXT: | | OmpDirectiveName -> llvm::omp::Directive = unroll
 !PTREE-NEXT: | | OmpClauseList ->
-!PTREE-NEXT: | | Flags = None
+!PTREE-NEXT: | | Flags = {}


### PR DESCRIPTION
The idea is that there can be multiple flags on a given directive. When "Flags" was a simple enum, only one flag could have been set at a time.