### PR TITLE
[CIR][NFC] Fix build problem inside an assert

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -1142,7 +1142,7 @@ CIRGenFunction::VlaSizePair
 CIRGenFunction::getVLAElements1D(const VariableArrayType *vla) {
   mlir::Value vlaSize = vlaSizeMap[vla->getSizeExpr()];
   assert(vlaSize && "no size for VLA!");
-  assert(vlaSize->getType() == sizeTy);
+  assert(vlaSize.getType() == sizeTy);
   return {vlaSize, vla->getElementType()};
 }
 


### PR DESCRIPTION
A recent change introduced a failure in debug builds due to an incorrect level of indirection inside an assert. This fixes that.