### PR TITLE
[LLDB][PDB] Access object file through module

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -1126,7 +1126,8 @@ lldb::LanguageType SymbolFileNativePDB::ParseLanguage(CompileUnit &comp_unit) {
 }
 
 void SymbolFileNativePDB::AddSymbols(Symtab &symtab) {
-  auto *section_list = m_objfile_sp->GetSectionList();
+  auto *section_list =
+      m_objfile_sp->GetModule()->GetObjectFile()->GetSectionList();
   if (!section_list)
     return;
 

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -287,8 +287,10 @@ uint32_t SymbolFilePDB::CalculateAbilities() {
 }
 
 void SymbolFilePDB::InitializeObject() {
-  lldb::addr_t obj_load_address =
-      m_objfile_sp->GetBaseAddress().GetFileAddress();
+  lldb::addr_t obj_load_address = m_objfile_sp->GetModule()
+                                      ->GetObjectFile()
+                                      ->GetBaseAddress()
+                                      .GetFileAddress();
   lldbassert(obj_load_address && obj_load_address != LLDB_INVALID_ADDRESS);
   m_session_up->setLoadAddress(obj_load_address);
   if (!m_global_scope_up)
@@ -1479,7 +1481,8 @@ void SymbolFilePDB::AddSymbols(lldb_private::Symtab &symtab) {
   if (!results)
     return;
 
-  auto section_list = m_objfile_sp->GetSectionList();
+  auto section_list =
+      m_objfile_sp->GetModule()->GetObjectFile()->GetSectionList();
   if (!section_list)
     return;
 

--- a/lldb/test/Shell/SymbolFile/PDB/add-symbols.cpp
+++ b/lldb/test/Shell/SymbolFile/PDB/add-symbols.cpp
@@ -1,0 +1,39 @@
+// REQUIRES: lld, target-windows
+
+// Test that `target symbols add <pdb>` works.
+// RUN: %build --compiler=clang-cl --nodefaultlib --output=%t.exe %s
+// RUN: mv %t.pdb %t-renamed.pdb
+
+// RUN: env LLDB_USE_NATIVE_PDB_READER=0 %lldb \
+// RUN:   -o "b main" \
+// RUN:   -o "target symbols add %t-renamed.pdb" \
+// RUN:   -o r \
+// RUN:   -o "target variable a" \
+// RUN:   -o "target modules dump symtab" \
+// RUN:   -b %t.exe | FileCheck %s
+
+// RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb \
+// RUN:   -o "b main" \
+// RUN:   -o "target symbols add %t-renamed.pdb" \
+// RUN:   -o r \
+// RUN:   -o "target variable a" \
+// RUN:   -o "target modules dump symtab" \
+// RUN:   -b %t.exe | FileCheck %s
+
+// CHECK: target create
+// CHECK: (lldb) b main
+// CHECK-NEXT: Breakpoint 1: no locations (pending).
+// CHECK: (lldb) target symbols add
+// CHECK: 1 location added to breakpoint 1
+// CHECK: (lldb) r
+// CHECK: * thread #1, stop reason = breakpoint 1.1
+// CHECK: (lldb) target variable a
+// CHECK-NEXT: (A) a = (x = 47)
+// CHECK: (lldb) target modules dump symtab
+// CHECK: [{{.*}} main
+
+struct A {
+  int x = 47;
+};
+A a;
+int main() {}


### PR DESCRIPTION
When a PDB is loaded through `target symbols add <pdb-path>`, its `m_objectfile_sp` is an `ObjectFilePDB` instead of `ObjectFilePECOFF` (the debugged module). In both the native and DIA plugin, some paths assumed that `m_objectfile_sp` is the debugged module. With this PR, they go through `m_objfile_sp->GetModule()->GetObjectFile()`.

For the DIA plugin, this lead to an assertion failure (https://github.com/llvm/llvm-project/issues/169628#issuecomment-3582555277) and for both plugins, it meant that the symbol table wasn't loaded.