### PR TITLE
[ProfData] Improve efficiency of reader

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -1658,6 +1658,7 @@ public:
   }
 
   unsigned size() { return Syms.size(); }
+  void reserve(size_t Size) { Syms.reserve(Size); }
 
   void setToCompress(bool TC) { ToCompress = TC; }
   bool toCompress() { return ToCompress; }

--- a/llvm/lib/ProfileData/SampleProf.cpp
+++ b/llvm/lib/ProfileData/SampleProf.cpp
@@ -420,8 +420,6 @@ std::error_code ProfileSymbolList::read(const uint8_t *Data,
     StrNum++;
   }
 
-  assert(ExpectedCount == StrNum);
-
   if (Size != ListSize && StrNum != ProfileSymbolListCutOff)
     return sampleprof_error::malformed;
   return sampleprof_error::success;

--- a/llvm/lib/ProfileData/SampleProf.cpp
+++ b/llvm/lib/ProfileData/SampleProf.cpp
@@ -404,9 +404,10 @@ std::error_code ProfileSymbolList::read(const uint8_t *Data,
   uint64_t ExpectedCount = 0;
 
   // Scan forward to see how many elements we expect.
-  while (Offset < ListSize) {
-    if (ListStart[Offset] == '\0') ExpectedCount++;
-    Offset++;
+  while (Size < ListSize) {
+    if (ListStart[Size] == '\0') ExpectedCount++;
+    Size++;
+  }
 
   reserve(ExpectedCount);
 

--- a/llvm/lib/ProfileData/SampleProf.cpp
+++ b/llvm/lib/ProfileData/SampleProf.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Support/LEB128.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+#include <cstdint>
 #include <string>
 #include <system_error>
 
@@ -400,8 +401,8 @@ LLVM_DUMP_METHOD void FunctionSamples::dump() const { print(dbgs(), 0); }
 std::error_code ProfileSymbolList::read(const uint8_t *Data,
                                         uint64_t ListSize) {
   // Scan forward to see how many elements we expect.
-  uint64_t ExpectedCount = std::count(Data, Data + ListSize, 0);
-  reserve(ExpectedCount);
+  reserve(std::min<uint64_t>(ProfileSymbolListCutOff,
+                             std::count(Data, Data + ListSize, 0)));
 
   const char *ListStart = reinterpret_cast<const char *>(Data);
   uint64_t Size = 0;

--- a/llvm/lib/ProfileData/SampleProf.cpp
+++ b/llvm/lib/ProfileData/SampleProf.cpp
@@ -403,7 +403,7 @@ std::error_code ProfileSymbolList::read(const uint8_t *Data,
   uint64_t StrNum = 0;
   uint64_t ExpectedCount = 0;
 
-  Scan forward to see how many elements we expect.
+  // Scan forward to see how many elements we expect.
   while (Offset < ListSize) {
     if (ListStart[Offset] == '\0') ExpectedCount++;
     Offset++;

--- a/llvm/lib/ProfileData/SampleProf.cpp
+++ b/llvm/lib/ProfileData/SampleProf.cpp
@@ -399,7 +399,7 @@ LLVM_DUMP_METHOD void FunctionSamples::dump() const { print(dbgs(), 0); }
 std::error_code ProfileSymbolList::read(const uint8_t *Data,
                                         uint64_t ListSize) {
   const char *ListStart = reinterpret_cast<const char *>(Data);
-  uint64_t Offset = 0;
+  uint64_t Size = 0;
   uint64_t StrNum = 0;
   uint64_t ExpectedCount = 0;
 
@@ -407,22 +407,21 @@ std::error_code ProfileSymbolList::read(const uint8_t *Data,
   while (Offset < ListSize) {
     if (ListStart[Offset] == '\0') ExpectedCount++;
     Offset++;
-  }
 
   reserve(ExpectedCount);
 
-  Offset = 0;
+  Size = 0;
 
-  while (Offset < ListSize && StrNum < ProfileSymbolListCutOff) {
-    StringRef Str(ListStart + Offset);
+  while (Size < ListSize && StrNum < ProfileSymbolListCutOff) {
+    StringRef Str(ListStart + Size);
     add(Str);
-    Offset += Str.size() + 1;
+    Size += Str.size() + 1;
     StrNum++;
   }
 
   assert(ExpectedCount == StrNum);
 
-  if (Offset != ListSize && StrNum != ProfileSymbolListCutOff)
+  if (Size != ListSize && StrNum != ProfileSymbolListCutOff)
     return sampleprof_error::malformed;
   return sampleprof_error::success;
 }


### PR DESCRIPTION
Pre-reserve space in the map before inserting. In release builds, 9.4% of all CPU time is spent in llvm::sampleprof::ProfileSymbolList::add. Of that 9.4%, roughly half is in llvm::DenseMapBase::grow.