### PR TITLE
[SPIRV] Error for zero-length arrays if not a shader

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -884,13 +884,10 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeArray(uint32_t NumElems,
     });
   } else {
     if (!ST.isShader()) {
-      Function &Fn = MIRBuilder.getMF().getFunction();
-      Fn.getContext().diagnose(DiagnosticInfoUnsupported(
-          Fn,
+      llvm::reportFatalUsageError(
           "Runtime arrays are not allowed in non-shader "
-          "SPIR-V modules",
-          MIRBuilder.getDebugLoc()));
-      return ElemType;
+          "SPIR-V modules");
+      return nullptr;
     }
     ArrayType = createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
       return MIRBuilder.buildInstr(SPIRV::OpTypeRuntimeArray)

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -883,10 +883,15 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeArray(uint32_t NumElems,
           .addUse(NumElementsVReg);
     });
   } else {
-    assert(ST.isShader() && "Runtime arrays are not allowed in non-shader "
-                            "SPIR-V modules.");
-    if (!ST.isShader())
-      return nullptr;
+    if (!ST.isShader()) {
+      Function &Fn = MIRBuilder.getMF().getFunction();
+      Fn.getContext().diagnose(DiagnosticInfoUnsupported(
+          Fn,
+          "Runtime arrays are not allowed in non-shader "
+          "SPIR-V modules",
+          MIRBuilder.getDebugLoc()));
+      return ElemType;
+    }
     ArrayType = createOpType(MIRBuilder, [&](MachineIRBuilder &MIRBuilder) {
       return MIRBuilder.buildInstr(SPIRV::OpTypeRuntimeArray)
           .addDef(createTypeVReg(MIRBuilder))

--- a/llvm/test/CodeGen/SPIRV/zero-length-array.ll
+++ b/llvm/test/CodeGen/SPIRV/zero-length-array.ll
@@ -15,7 +15,7 @@
 
 
 ; For non-compute, error.
-; CHECK-ERR: in function foo void (): Runtime arrays are not allowed in non-shader SPIR-V modules
+; CHECK-ERR: LLVM ERROR: Runtime arrays are not allowed in non-shader SPIR-V modules
 
 define spir_func void @foo() {
 entry:

--- a/llvm/test/CodeGen/SPIRV/zero-length-array.ll
+++ b/llvm/test/CodeGen/SPIRV/zero-length-array.ll
@@ -1,7 +1,9 @@
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute < %s | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val %}
 
-; Nothing is generated, but compilation doesn't crash.
+; RUN: not llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown < %s 2>&1 | FileCheck -check-prefix=CHECK-ERR %s
+
+; For compute, nothing is generated, but compilation doesn't crash.
 ; CHECK: OpName %[[#FOO:]] "foo"
 ; CHECK: OpName %[[#RTM:]] "reg2mem alloca point"
 ; CHECK: %[[#INT:]] = OpTypeInt 32 0
@@ -10,6 +12,10 @@
 ; CHECK-NEXT: = OpLabel
 ; CHECK-NEXT: OpReturn
 ; CHECK-NEXT: OpFunctionEnd
+
+
+; For non-compute, error.
+; CHECK-ERR: in function foo void (): Runtime arrays are not allowed in non-shader SPIR-V modules
 
 define spir_func void @foo() {
 entry:


### PR DESCRIPTION
I had a case where the frontend was generating  a zero elem array in non-shader code so it was just crashing in a release build. 
Add a real error and make it not crash.