### PR TITLE
clangd: Extend reference search with constructor calls through forwarding

### DIFF
--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -1099,8 +1099,13 @@ public:
 
   bool VisitCXXNewExpr(CXXNewExpr *E) {
     if (auto *CE = E->getConstructExpr())
-      if (auto *Callee = CE->getConstructor())
-        Constructors.push_back(Callee);
+      if (auto *Callee = CE->getConstructor()) {
+        if (Callee->isTemplateInstantiation())
+          Constructors.push_back(llvm::dyn_cast<clang::CXXConstructorDecl>(
+              Callee->getPrimaryTemplate()->getTemplatedDecl()));
+        else
+          Constructors.push_back(Callee);
+      }
     return true;
   }
 

--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -1092,8 +1092,6 @@ public:
         SeenFunctions Next{SF.DepthLeft - 1, &SF, FD};
         ForwardingToConstructorVisitor Visitor{std::move(Next), Constructors};
         Visitor.TraverseStmt(FD->getBody());
-        std::move(Visitor.Constructors.begin(), Visitor.Constructors.end(),
-                  std::back_inserter(Constructors));
       }
     }
     return true;

--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -1104,7 +1104,7 @@ public:
     return true;
   }
 
-  // List of function stack
+  // Stack of seen functions
   SeenFunctions SF;
   // Output of this visitor
   SmallVector<CXXConstructorDecl *, 1> &Constructors;

--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -1038,7 +1038,7 @@ bool isExpandedFromParameterPack(const ParmVarDecl *D) {
   return getUnderlyingPackType(D) != nullptr;
 }
 
-bool isLikelyForwardingFunction(FunctionTemplateDecl *FT) {
+bool isLikelyForwardingFunction(const FunctionTemplateDecl *FT) {
   const auto *FD = FT->getTemplatedDecl();
   const auto NumParams = FD->getNumParams();
   // Check whether its last parameter is a parameter pack...

--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -1076,9 +1076,8 @@ bool ForwardingToConstructorVisitor::VisitCallExpr(CallExpr *E) {
 
 bool ForwardingToConstructorVisitor::VisitCXXNewExpr(CXXNewExpr *E) {
   if (auto *CE = E->getConstructExpr()) {
-    if (auto *Callee = CE->getConstructor()) {
+    if (auto *Callee = CE->getConstructor())
       Constructors.push_back(Callee);
-    }
   }
   return true;
 }

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -254,7 +254,7 @@ bool isExpandedFromParameterPack(const ParmVarDecl *D);
 
 /// Heuristic that checks if FT is likely to be forwarding a parameter pack to
 /// another function (e.g. `make_unique`).
-bool isLikelyForwardingFunction(FunctionTemplateDecl *FT);
+bool isLikelyForwardingFunction(const FunctionTemplateDecl *FT);
 
 /// Only call if FD is a likely forwarding function. Returns
 /// constructors that might be forwraded to

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -257,7 +257,7 @@ bool isExpandedFromParameterPack(const ParmVarDecl *D);
 bool isLikelyForwardingFunction(const FunctionTemplateDecl *FT);
 
 /// Only call if FD is a likely forwarding function. Returns
-/// constructors that might be forwraded to
+/// constructors that might be forwarded to.
 SmallVector<CXXConstructorDecl *, 1>
 searchConstructorsInForwardingFunction(const FunctionDecl *FD);
 

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -18,8 +18,6 @@
 #include "index/SymbolID.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
-#include "clang/AST/NestedNameSpecifier.h"
-#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Lex/MacroInfo.h"
@@ -254,22 +252,14 @@ resolveForwardingParameters(const FunctionDecl *D, unsigned MaxDepth = 10);
 /// reference to one (e.g. `Args&...` or `Args&&...`).
 bool isExpandedFromParameterPack(const ParmVarDecl *D);
 
-/// Heuristic that checks if FT is forwarding a parameter pack to another
-/// function (e.g. `make_unique`).
+/// Heuristic that checks if FT is likely to be forwarding a parameter pack to
+/// another function (e.g. `make_unique`).
 bool isLikelyForwardingFunction(FunctionTemplateDecl *FT);
 
-class ForwardingToConstructorVisitor
-    : public RecursiveASTVisitor<ForwardingToConstructorVisitor> {
-public:
-  ForwardingToConstructorVisitor() {}
-
-  bool VisitCallExpr(CallExpr *E);
-
-  bool VisitCXXNewExpr(CXXNewExpr *E);
-
-  // Output of this visitor
-  std::vector<CXXConstructorDecl *> Constructors{};
-};
+/// Only call if FD is a likely forwarding function. Returns
+/// constructors that might be forwraded to
+SmallVector<CXXConstructorDecl *, 1>
+searchConstructorsInForwardingFunction(const FunctionDecl *FD);
 
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -258,7 +258,7 @@ bool isLikelyForwardingFunction(const FunctionTemplateDecl *FT);
 
 /// Only call if FD is a likely forwarding function. Returns
 /// constructors that might be forwarded to.
-SmallVector<CXXConstructorDecl *, 1>
+SmallVector<const CXXConstructorDecl *, 1>
 searchConstructorsInForwardingFunction(const FunctionDecl *FD);
 
 } // namespace clangd

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -253,6 +253,10 @@ resolveForwardingParameters(const FunctionDecl *D, unsigned MaxDepth = 10);
 /// reference to one (e.g. `Args&...` or `Args&&...`).
 bool isExpandedFromParameterPack(const ParmVarDecl *D);
 
+/// Heuristic that checks if FT is forwarding a parameter pack to another
+/// function. (e.g. `make_unique`).
+bool isLikelyForwardingFunction(FunctionTemplateDecl *FT);
+
 } // namespace clangd
 } // namespace clang
 

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -263,14 +263,9 @@ class ForwardingToConstructorVisitor
 public:
   ForwardingToConstructorVisitor() {}
 
-  bool VisitCXXNewExpr(CXXNewExpr *E) {
-    if (auto *CE = E->getConstructExpr()) {
-      if (auto *Callee = CE->getConstructor()) {
-        Constructors.push_back(Callee);
-      }
-    }
-    return true;
-  }
+  bool VisitCallExpr(CallExpr *E);
+
+  bool VisitCXXNewExpr(CXXNewExpr *E);
 
   // Output of this visitor
   std::vector<CXXConstructorDecl *> Constructors{};

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -263,16 +263,10 @@ class ForwardingToConstructorVisitor
 public:
   ForwardingToConstructorVisitor() {}
 
-  ForwardingToConstructorVisitor(
-      llvm::DenseSet<const CXXConstructorDecl *> *TargetConstructors)
-      : Targets(TargetConstructors) {}
-
   bool VisitCXXNewExpr(CXXNewExpr *E) {
     if (auto *CE = E->getConstructExpr()) {
       if (auto *Callee = CE->getConstructor()) {
-        if (Targets == nullptr || Targets->contains(Callee)) {
-          Constructors.push_back(Callee);
-        }
+        Constructors.push_back(Callee);
       }
     }
     return true;
@@ -280,9 +274,6 @@ public:
 
   // Output of this visitor
   std::vector<CXXConstructorDecl *> Constructors{};
-
-private:
-  llvm::DenseSet<const CXXConstructorDecl *> *Targets = nullptr;
 };
 
 } // namespace clangd

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -258,7 +258,6 @@ bool isExpandedFromParameterPack(const ParmVarDecl *D);
 /// function (e.g. `make_unique`).
 bool isLikelyForwardingFunction(FunctionTemplateDecl *FT);
 
-
 class ForwardingToConstructorVisitor
     : public RecursiveASTVisitor<ForwardingToConstructorVisitor> {
 public:

--- a/clang-tools-extra/clangd/ParsedAST.h
+++ b/clang-tools-extra/clangd/ParsedAST.h
@@ -124,7 +124,7 @@ public:
   }
 
   /// Cache for constructors called through forwarding, e.g. make_unique
-  llvm::DenseMap<const FunctionDecl *, std::vector<CXXConstructorDecl *>>
+  llvm::DenseMap<const FunctionDecl *, SmallVector<CXXConstructorDecl *, 1>>
       ForwardingToConstructorCache;
 
 private:

--- a/clang-tools-extra/clangd/ParsedAST.h
+++ b/clang-tools-extra/clangd/ParsedAST.h
@@ -124,7 +124,8 @@ public:
   }
 
   /// Cache for constructors called through forwarding, e.g. make_unique
-  llvm::DenseMap<const FunctionDecl *, SmallVector<CXXConstructorDecl *, 1>>
+  llvm::DenseMap<const FunctionDecl *,
+                 SmallVector<const CXXConstructorDecl *, 1>>
       ForwardingToConstructorCache;
 
 private:

--- a/clang-tools-extra/clangd/ParsedAST.h
+++ b/clang-tools-extra/clangd/ParsedAST.h
@@ -123,6 +123,10 @@ public:
     return Resolver.get();
   }
 
+  /// Cache for constructors called through forwarding, e.g. make_unique
+  llvm::DenseMap<const FunctionDecl *, std::vector<CXXConstructorDecl *>>
+      ForwardingToConstructorCache;
+
 private:
   ParsedAST(PathRef TUPath, llvm::StringRef Version,
             std::shared_ptr<const PreambleData> Preamble,

--- a/clang-tools-extra/clangd/Preamble.cpp
+++ b/clang-tools-extra/clangd/Preamble.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Preamble.h"
+#include "AST.h"
 #include "CollectMacros.h"
 #include "Compiler.h"
 #include "Config.h"
@@ -164,27 +165,6 @@ public:
     return std::make_unique<PPChainedCallbacks>(
         std::make_unique<CollectMainFileMacros>(*PP, Macros),
         collectPragmaMarksCallback(*SourceMgr, Marks));
-  }
-
-  static bool isLikelyForwardingFunction(FunctionTemplateDecl *FT) {
-    const auto *FD = FT->getTemplatedDecl();
-    const auto NumParams = FD->getNumParams();
-    // Check whether its last parameter is a parameter pack...
-    if (NumParams > 0) {
-      const auto *LastParam = FD->getParamDecl(NumParams - 1);
-      if (const auto *PET = dyn_cast<PackExpansionType>(LastParam->getType())) {
-        // ... of the type T&&... or T...
-        const auto BaseType = PET->getPattern().getNonReferenceType();
-        if (const auto *TTPT =
-                dyn_cast<TemplateTypeParmType>(BaseType.getTypePtr())) {
-          // ... whose template parameter comes from the function directly
-          if (FT->getTemplateParameters()->getDepth() == TTPT->getDepth()) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
   }
 
   bool shouldSkipFunctionBody(Decl *D) override {

--- a/clang-tools-extra/clangd/XRefs.cpp
+++ b/clang-tools-extra/clangd/XRefs.cpp
@@ -962,7 +962,7 @@ public:
     if (FD == nullptr || !FD->isTemplateInstantiation())
       return false;
 
-    SmallVector<CXXConstructorDecl *, 1> *Constructors = nullptr;
+    SmallVector<const CXXConstructorDecl *, 1> *Constructors = nullptr;
     if (auto Entry = AST.ForwardingToConstructorCache.find(FD);
         Entry != AST.ForwardingToConstructorCache.end())
       Constructors = &Entry->getSecond();
@@ -971,17 +971,15 @@ public:
           PT == nullptr || !isLikelyForwardingFunction(PT))
         return false;
 
-      SmallVector<CXXConstructorDecl *, 1> FoundConstructors =
+      SmallVector<const CXXConstructorDecl *, 1> FoundConstructors =
           searchConstructorsInForwardingFunction(FD);
       auto Iter = AST.ForwardingToConstructorCache.try_emplace(
           FD, std::move(FoundConstructors));
-      if (Iter.second)
-        Constructors = &Iter.first->getSecond();
+      Constructors = &Iter.first->getSecond();
     }
-    if (Constructors != nullptr)
-      for (auto *Constructor : *Constructors)
-        if (TargetConstructors.contains(Constructor))
-          return true;
+    for (auto *Constructor : *Constructors)
+      if (TargetConstructors.contains(Constructor))
+        return true;
     return false;
   }
 

--- a/clang-tools-extra/clangd/index/IndexAction.cpp
+++ b/clang-tools-extra/clangd/index/IndexAction.cpp
@@ -145,6 +145,10 @@ public:
       // inside, it becomes quadratic. So we give up on nested symbols.
       if (isDeeplyNested(D))
         return false;
+      // If D is a likely forwarding function we need the body to index indirect
+      // constructor calls (e.g. `make_unique`)
+      if (Collector->potentiallyForwardInBody(D))
+        return true;
       auto &SM = D->getASTContext().getSourceManager();
       auto FID = SM.getFileID(SM.getExpansionLoc(D->getLocation()));
       if (!FID.isValid())

--- a/clang-tools-extra/clangd/index/IndexAction.cpp
+++ b/clang-tools-extra/clangd/index/IndexAction.cpp
@@ -21,7 +21,6 @@
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Index/IndexingAction.h"
 #include "clang/Index/IndexingOptions.h"
-#include <cstddef>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -220,8 +219,8 @@ std::unique_ptr<FrontendAction> createStaticIndexingAction(
       index::IndexingOptions::SystemSymbolFilterKind::All;
   // We index function-local classes and its member functions only.
   IndexOpts.IndexFunctionLocals = true;
-  // We need to delay indexing so function bodies become available, this is so
-  // we can find constructor calls through `make_unique`.
+  // We need to delay indexing so instantiations of function bodies become
+  // available, this is so we can find constructor calls through `make_unique`.
   IndexOpts.DeferIndexingToEndOfTranslationUnit = true;
   Opts.CollectIncludePath = true;
   if (Opts.Origin == SymbolOrigin::Unknown)

--- a/clang-tools-extra/clangd/index/IndexAction.cpp
+++ b/clang-tools-extra/clangd/index/IndexAction.cpp
@@ -147,7 +147,8 @@ public:
         return false;
       // If D is a likely forwarding function we need the body to index indirect
       // constructor calls (e.g. `make_unique`)
-      if (Collector->potentiallyForwardInBody(D))
+      if (auto *FT = llvm::dyn_cast<clang::FunctionTemplateDecl>(D);
+          FT && isLikelyForwardingFunction(FT))
         return true;
       auto &SM = D->getASTContext().getSourceManager();
       auto FID = SM.getFileID(SM.getExpansionLoc(D->getLocation()));

--- a/clang-tools-extra/clangd/index/IndexAction.cpp
+++ b/clang-tools-extra/clangd/index/IndexAction.cpp
@@ -220,6 +220,9 @@ std::unique_ptr<FrontendAction> createStaticIndexingAction(
       index::IndexingOptions::SystemSymbolFilterKind::All;
   // We index function-local classes and its member functions only.
   IndexOpts.IndexFunctionLocals = true;
+  // We need to delay indexing so function bodies become available, this is so
+  // we can find constructor calls through `make_unique`.
+  IndexOpts.DeferIndexingToEndOfTranslationUnit = true;
   Opts.CollectIncludePath = true;
   if (Opts.Origin == SymbolOrigin::Unknown)
     Opts.Origin = SymbolOrigin::Static;

--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -576,6 +576,29 @@ SymbolCollector::getRefContainer(const Decl *Enclosing,
   return Enclosing;
 }
 
+bool SymbolCollector::isLikelyForwardingFunctionCached(
+    const FunctionTemplateDecl *FT) {
+  if (LikelyForwardingFunctionCached.contains(FT))
+    return true;
+  if (isLikelyForwardingFunction(FT)) {
+    LikelyForwardingFunctionCached.insert(FT);
+    return true;
+  }
+  return false;
+}
+
+bool SymbolCollector::potentiallyForwardInBody(const Decl *D) {
+  if (auto *FD = llvm::dyn_cast<clang::FunctionDecl>(D);
+      FD && FD->isTemplateInstantiation())
+    if (auto *PT = FD->getPrimaryTemplate();
+        PT && isLikelyForwardingFunctionCached(PT))
+      return true;
+  if (auto *FT = llvm::dyn_cast<clang::FunctionTemplateDecl>(D);
+      FT && isLikelyForwardingFunctionCached(FT))
+    return true;
+  return false;
+}
+
 SmallVector<CXXConstructorDecl *, 1>
 SymbolCollector::findIndirectConstructors(const Decl *D) {
   auto *FD = llvm::dyn_cast<clang::FunctionDecl>(D);
@@ -585,7 +608,7 @@ SymbolCollector::findIndirectConstructors(const Decl *D) {
       Entry != ForwardingToConstructorCache.end())
     return Entry->getSecond();
   if (auto *PT = FD->getPrimaryTemplate();
-      PT == nullptr || !isLikelyForwardingFunction(PT))
+      PT == nullptr || !isLikelyForwardingFunctionCached(PT))
     return {};
 
   SmallVector<CXXConstructorDecl *, 1> FoundConstructors =

--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -581,24 +581,21 @@ SymbolCollector::getRefContainer(const Decl *Enclosing,
 std::vector<CXXConstructorDecl *>
 SymbolCollector::findIndirectConstructors(const Decl *D) {
   auto *FD = llvm::dyn_cast<clang::FunctionDecl>(D);
-  if (FD == nullptr || !FD->isTemplateInstantiation()) {
+  if (FD == nullptr || !FD->isTemplateInstantiation())
     return {};
-  }
   if (auto *PT = FD->getPrimaryTemplate();
-      PT == nullptr || !isLikelyForwardingFunction(PT)) {
+      PT == nullptr || !isLikelyForwardingFunction(PT))
     return {};
-  }
   if (auto Entry = ForwardingToConstructorCache.find(FD);
-      Entry != ForwardingToConstructorCache.end()) {
+      Entry != ForwardingToConstructorCache.end())
     return Entry->getSecond();
-  }
+
   ForwardingToConstructorVisitor Visitor{};
   Visitor.TraverseStmt(FD->getBody());
   auto Iter = ForwardingToConstructorCache.try_emplace(
       FD, std::move(Visitor.Constructors));
-  if (Iter.second) {
+  if (Iter.second)
     return Iter.first->getSecond();
-  }
   return {};
 }
 
@@ -697,15 +694,13 @@ bool SymbolCollector::handleDeclOccurrence(
                            Container, isSpelled(FileLoc, *ND)});
       // Also collect indirect constructor calls like `make_unique`
       for (auto *Constructor : findIndirectConstructors(ASTNode.OrigD)) {
-        if (!shouldCollectSymbol(*Constructor, *ASTCtx, Opts, IsMainFileOnly)) {
+        if (!shouldCollectSymbol(*Constructor, *ASTCtx, Opts, IsMainFileOnly))
           continue;
-        }
-        if (auto ConstructorID = getSymbolIDCached(Constructor)) {
+        if (auto ConstructorID = getSymbolIDCached(Constructor))
           addRef(ConstructorID,
                  SymbolRef{FileLoc, FID, Roles,
                            index::getSymbolInfo(Constructor).Kind, Container,
                            isSpelled(FileLoc, *Constructor)});
-        }
       }
     }
   }

--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -576,7 +576,7 @@ SymbolCollector::getRefContainer(const Decl *Enclosing,
   return Enclosing;
 }
 
-SmallVector<CXXConstructorDecl *, 1>
+SmallVector<const CXXConstructorDecl *, 1>
 SymbolCollector::findIndirectConstructors(const Decl *D) {
   auto *FD = llvm::dyn_cast<clang::FunctionDecl>(D);
   if (FD == nullptr || !FD->isTemplateInstantiation())
@@ -588,7 +588,7 @@ SymbolCollector::findIndirectConstructors(const Decl *D) {
       PT == nullptr || !isLikelyForwardingFunction(PT))
     return {};
 
-  SmallVector<CXXConstructorDecl *, 1> FoundConstructors =
+  SmallVector<const CXXConstructorDecl *, 1> FoundConstructors =
       searchConstructorsInForwardingFunction(FD);
   auto Iter = ForwardingToConstructorCache.try_emplace(
       FD, std::move(FoundConstructors));

--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -687,19 +687,17 @@ bool SymbolCollector::handleDeclOccurrence(
                            getRefContainer(ASTNode.Parent, Opts),
                            isSpelled(FileLoc, *ND)});
       // Also collect indirect constructor calls like `make_unique`
-      if (auto *FD = llvm::dyn_cast<clang::FunctionDecl>(D)) {
-        if (FD->isTemplateInstantiation()) {
-          if (auto *PT = FD->getPrimaryTemplate();
-              PT && isLikelyForwardingFunction(PT)) {
-            ForwardingToConstructorVisitor Visitor{};
-            Visitor.TraverseStmt(FD->getBody());
-            for (auto *Constructor : Visitor.Constructors) {
-              addRef(getSymbolIDCached(Constructor),
-                     SymbolRef{FileLoc, FID, Roles,
-                               index::getSymbolInfo(ND).Kind,
-                               getRefContainer(ASTNode.Parent, Opts),
-                               isSpelled(FileLoc, *ND)});
-            }
+      if (auto *FD = llvm::dyn_cast<clang::FunctionDecl>(ASTNode.OrigD);
+          FD && FD->isTemplateInstantiation()) {
+        if (auto *PT = FD->getPrimaryTemplate();
+            PT && isLikelyForwardingFunction(PT)) {
+          ForwardingToConstructorVisitor Visitor{};
+          Visitor.TraverseStmt(FD->getBody());
+          for (auto *Constructor : Visitor.Constructors) {
+            addRef(getSymbolIDCached(Constructor),
+                   SymbolRef{FileLoc, FID, Roles, index::getSymbolInfo(ND).Kind,
+                             getRefContainer(ASTNode.Parent, Opts),
+                             isSpelled(FileLoc, *ND)});
           }
         }
       }

--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -694,16 +694,11 @@ bool SymbolCollector::handleDeclOccurrence(
           for (auto *Specialized : FT->specializations()) {
             Visitor.TraverseStmt(Specialized->getBody());
           }
-          auto FileLoc = SM.getFileLoc(Loc);
-          auto FID = SM.getFileID(FileLoc);
-          if (Opts.RefsInHeaders || FID == SM.getMainFileID()) {
-            for (auto *Constructor : Visitor.Constructors) {
-              addRef(getSymbolIDCached(Constructor),
-                     SymbolRef{FileLoc, FID, Roles,
-                               index::getSymbolInfo(ND).Kind,
-                               getRefContainer(ASTNode.Parent, Opts),
-                               isSpelled(FileLoc, *ND)});
-            }
+          for (auto *Constructor : Visitor.Constructors) {
+            addRef(getSymbolIDCached(Constructor),
+                   SymbolRef{FileLoc, FID, Roles, index::getSymbolInfo(ND).Kind,
+                             getRefContainer(ASTNode.Parent, Opts),
+                             isSpelled(FileLoc, *ND)});
           }
         }
       }

--- a/clang-tools-extra/clangd/index/SymbolCollector.h
+++ b/clang-tools-extra/clangd/index/SymbolCollector.h
@@ -159,7 +159,10 @@ public:
   void finish() override;
 
 private:
-  std::vector<CXXConstructorDecl *> findIndirectConstructors(const Decl *D);
+  // If D is an instantiation of a likely forwarding function, return the
+  // constructors it invokes so that we can record indirect references
+  // to those as well.
+  SmallVector<CXXConstructorDecl *, 1> findIndirectConstructors(const Decl *D);
 
   const Symbol *addDeclaration(const NamedDecl &, SymbolID,
                                bool IsMainFileSymbol);
@@ -232,7 +235,7 @@ private:
   std::unique_ptr<HeaderFileURICache> HeaderFileURIs;
   llvm::DenseMap<const Decl *, SymbolID> DeclToIDCache;
   llvm::DenseMap<const MacroInfo *, SymbolID> MacroToIDCache;
-  llvm::DenseMap<const FunctionDecl *, std::vector<CXXConstructorDecl *>>
+  llvm::DenseMap<const FunctionDecl *, SmallVector<CXXConstructorDecl *, 1>>
       ForwardingToConstructorCache;
 };
 

--- a/clang-tools-extra/clangd/index/SymbolCollector.h
+++ b/clang-tools-extra/clangd/index/SymbolCollector.h
@@ -19,7 +19,6 @@
 #include "index/SymbolOrigin.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
-#include "clang/AST/DeclTemplate.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
@@ -152,10 +151,6 @@ public:
   RefSlab takeRefs() { return std::move(Refs).build(); }
   RelationSlab takeRelations() { return std::move(Relations).build(); }
 
-  /// Checks if \p D is either a likely forwarding function template or an
-  /// instation of it.
-  bool potentiallyForwardInBody(const Decl *D);
-
   /// Returns true if we are interested in references and declarations from \p
   /// FID. If this function return false, bodies of functions inside those files
   /// will be skipped to decrease indexing time.
@@ -164,8 +159,6 @@ public:
   void finish() override;
 
 private:
-  bool isLikelyForwardingFunctionCached(const FunctionTemplateDecl *FT);
-
   // If D is an instantiation of a likely forwarding function, return the
   // constructors it invokes so that we can record indirect references
   // to those as well.
@@ -242,7 +235,6 @@ private:
   std::unique_ptr<HeaderFileURICache> HeaderFileURIs;
   llvm::DenseMap<const Decl *, SymbolID> DeclToIDCache;
   llvm::DenseMap<const MacroInfo *, SymbolID> MacroToIDCache;
-  llvm::DenseSet<const FunctionTemplateDecl *> LikelyForwardingFunctionCached;
   llvm::DenseMap<const FunctionDecl *, SmallVector<CXXConstructorDecl *, 1>>
       ForwardingToConstructorCache;
 };

--- a/clang-tools-extra/clangd/index/SymbolCollector.h
+++ b/clang-tools-extra/clangd/index/SymbolCollector.h
@@ -162,7 +162,8 @@ private:
   // If D is an instantiation of a likely forwarding function, return the
   // constructors it invokes so that we can record indirect references
   // to those as well.
-  SmallVector<CXXConstructorDecl *, 1> findIndirectConstructors(const Decl *D);
+  SmallVector<const CXXConstructorDecl *, 1>
+  findIndirectConstructors(const Decl *D);
 
   const Symbol *addDeclaration(const NamedDecl &, SymbolID,
                                bool IsMainFileSymbol);
@@ -235,7 +236,8 @@ private:
   std::unique_ptr<HeaderFileURICache> HeaderFileURIs;
   llvm::DenseMap<const Decl *, SymbolID> DeclToIDCache;
   llvm::DenseMap<const MacroInfo *, SymbolID> MacroToIDCache;
-  llvm::DenseMap<const FunctionDecl *, SmallVector<CXXConstructorDecl *, 1>>
+  llvm::DenseMap<const FunctionDecl *,
+                 SmallVector<const CXXConstructorDecl *, 1>>
       ForwardingToConstructorCache;
 };
 

--- a/clang-tools-extra/clangd/index/SymbolCollector.h
+++ b/clang-tools-extra/clangd/index/SymbolCollector.h
@@ -159,6 +159,8 @@ public:
   void finish() override;
 
 private:
+  std::vector<CXXConstructorDecl *> findIndirectConstructors(const Decl *D);
+
   const Symbol *addDeclaration(const NamedDecl &, SymbolID,
                                bool IsMainFileSymbol);
   void addDefinition(const NamedDecl &, const Symbol &DeclSymbol,
@@ -230,6 +232,8 @@ private:
   std::unique_ptr<HeaderFileURICache> HeaderFileURIs;
   llvm::DenseMap<const Decl *, SymbolID> DeclToIDCache;
   llvm::DenseMap<const MacroInfo *, SymbolID> MacroToIDCache;
+  llvm::DenseMap<const FunctionDecl *, std::vector<CXXConstructorDecl *>>
+      ForwardingToConstructorCache;
 };
 
 } // namespace clangd

--- a/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
+++ b/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
@@ -282,6 +282,77 @@ TEST_F(BackgroundIndexTest, ConstructorForwarding) {
                        fileURI("unittest:///root/test.cpp")}));
 }
 
+TEST_F(BackgroundIndexTest, ConstructorForwardingMultiFile) {
+  // If a forwarding function like `make_unique` is defined in a header its body
+  // used to be skipped on the second encounter. This meant in practise we could
+  // only find constructors indirectly called by these type of functions in the
+  // first indexed file (and all files that were indexed at the same time,
+  // before a flag to skip it was set).
+  Annotations Header(R"cpp(
+    namespace std {
+    template <class T> T &&forward(T &t);
+    template <class T, class... Args> T *make_unique(Args &&...args) {
+      return new T(std::forward<Args>(args)...);
+    }
+    }
+    struct Test {
+      [[Test]](){}
+    };
+  )cpp");
+  Annotations First(R"cpp(
+    #include "header.hpp"
+    int main() {
+      auto a = std::[[make_unique]]<Test>();
+    }
+  )cpp");
+  Annotations Second(R"cpp(
+    #include "header.hpp"
+    void test() {
+      auto a = std::[[make_unique]]<Test>();
+    }
+  )cpp");
+
+  MockFS FS;
+  llvm::StringMap<std::string> Storage;
+  size_t CacheHits = 0;
+  MemoryShardStorage MSS(Storage, CacheHits);
+  OverlayCDB CDB(/*Base=*/nullptr);
+  BackgroundIndex::Options Opts;
+  BackgroundIndex Idx(FS, CDB, [&](llvm::StringRef) { return &MSS; }, Opts);
+
+  FS.Files[testPath("root/header.hpp")] = Header.code();
+  FS.Files[testPath("root/first.cpp")] = First.code();
+  FS.Files[testPath("root/second.cpp")] = Second.code();
+
+  tooling::CompileCommand Cmd;
+  Cmd.Filename = testPath("root/first.cpp");
+  Cmd.Directory = testPath("root");
+  Cmd.CommandLine = {"clang++", testPath("root/first.cpp")};
+  CDB.setCompileCommand(testPath("root/first.cpp"), Cmd);
+
+  // Make sure the first file is done indexing to make sure the flag for the
+  // header is set.
+  ASSERT_TRUE(Idx.blockUntilIdleForTest());
+
+  Cmd.Filename = testPath("root/second.cpp");
+  Cmd.Directory = testPath("root");
+  Cmd.CommandLine = {"clang++", testPath("root/second.cpp")};
+  CDB.setCompileCommand(testPath("root/second.cpp"), Cmd);
+
+  ASSERT_TRUE(Idx.blockUntilIdleForTest());
+
+  auto Syms = runFuzzyFind(Idx, "Test");
+  auto Constructor =
+      std::find_if(Syms.begin(), Syms.end(), [](const Symbol &S) {
+        return S.SymInfo.Kind == index::SymbolKind::Constructor;
+      });
+  ASSERT_TRUE(Constructor != Syms.end());
+  EXPECT_THAT(getRefs(Idx, Constructor->ID),
+              refsAre({fileURI("unittest:///root/header.hpp"),
+                       fileURI("unittest:///root/first.cpp"),
+                       fileURI("unittest:///root/second.cpp")}));
+}
+
 TEST_F(BackgroundIndexTest, MainFileRefs) {
   MockFS FS;
   FS.Files[testPath("root/A.h")] = R"cpp(

--- a/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
+++ b/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
@@ -15,7 +15,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <deque>
-#include <thread>
 
 using ::testing::_;
 using ::testing::AllOf;

--- a/clang-tools-extra/clangd/unittests/XRefsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/XRefsTests.cpp
@@ -2751,6 +2751,9 @@ TEST(FindReferences, ForwardingInASTChained) {
     template <class T, class... Args> T *make_unique2(Args &&...args) {
       return make_unique<T>(forward<Args>(args)...);
     }
+    template <class T, class... Args> T *make_unique3(Args &&...args) {
+      return make_unique2<T>(forward<Args>(args)...);
+    }
     }
 
     struct Test {
@@ -2758,7 +2761,7 @@ TEST(FindReferences, ForwardingInASTChained) {
     };
 
     int main() {
-      auto a = std::$Caller[[make_unique2]]<Test>();
+      auto a = std::$Caller[[make_unique3]]<Test>();
     }
   )cpp");
   TestTU TU;

--- a/clang-tools-extra/clangd/unittests/XRefsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/XRefsTests.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-#include "Annotations.h"
 #include "AST.h"
+#include "Annotations.h"
 #include "ParsedAST.h"
 #include "Protocol.h"
 #include "SourceCode.h"

--- a/clang/include/clang/Index/IndexingOptions.h
+++ b/clang/include/clang/Index/IndexingOptions.h
@@ -36,6 +36,9 @@ struct IndexingOptions {
   // Has no effect if IndexFunctionLocals are false.
   bool IndexParametersInDeclarations = false;
   bool IndexTemplateParameters = false;
+  // Some information might only be available at the end of a translation unit,
+  // this flag delays the indexing for this purpose.
+  bool DeferIndexingToEndOfTranslationUnit = false;
 
   // If set, skip indexing inside some declarations for performance.
   // This prevents traversal, so skipping a struct means its declaration an

--- a/clang/include/clang/Index/IndexingOptions.h
+++ b/clang/include/clang/Index/IndexingOptions.h
@@ -37,7 +37,10 @@ struct IndexingOptions {
   bool IndexParametersInDeclarations = false;
   bool IndexTemplateParameters = false;
   // Some information might only be available at the end of a translation unit,
-  // this flag delays the indexing for this purpose.
+  // this flag delays the indexing for this purpose (e.g. instantiation of
+  // function definitions). This option only takes effect on operations that
+  // actually build the AST, e.g. `createIndexingAction()` and
+  // `createIndexingASTConsumer()`.
   bool DeferIndexingToEndOfTranslationUnit = false;
 
   // If set, skip indexing inside some declarations for performance.


### PR DESCRIPTION
First step for https://github.com/clangd/clangd/issues/716 , the missing part is finding the same information directly in the AST.

Not sure about the location of the new visitor and the new references collection. Also I used `std::vector` which I see never used so if I should have used a different data structure please tell me.