### PR TITLE
[lldb-dap] Add breakpoints after debugger initialization in DExTer

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -763,22 +763,27 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
 
         launch_request = self._get_launch_params(cmdline)
 
-        # For some reason, we *must* submit in the order launch->configurationDone, and then we will receive responses
-        # in the order configurationDone->launch.
+        # Per DAP protocol, the correct sequence is:
+        # 1. Send launch request
+        # 2. Wait for launch response and "initialized" event
+        # 3. Set breakpoints
+        # 4. Send configurationDone to start the process
         launch_req_id = self.send_message(self.make_request("launch", launch_request))
-        config_done_req_id = self.send_message(self.make_request("configurationDone"))
-        config_done_response = self._await_response(config_done_req_id)
-        assert config_done_response["success"], "Should simply receive an affirmative?"
         launch_response = self._await_response(launch_req_id)
-
-        # Flush breakpoints after launch completes, as the debugger is now available.
-        self._flush_breakpoints()
         if not launch_response["success"]:
             raise DebuggerException(
                 f"failure launching debugger: \"{launch_response['body']['error']['format']}\""
             )
-        # We can't interact meaningfully with the process until we have the thread ID and confirmation that the process
-        # has finished launching.
+
+        # Set breakpoints after receiving launch response but before configurationDone.
+        self._flush_breakpoints()
+
+        # Send configurationDone to allow the process to start running.
+        config_done_req_id = self.send_message(self.make_request("configurationDone"))
+        config_done_response = self._await_response(config_done_req_id)
+        assert config_done_response["success"]
+
+        # Wait for the process to launch and obtain a thread ID.
         while self._debugger_state.thread is None or not self._debugger_state.launched:
             time.sleep(0.001)
 

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -765,12 +765,14 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
 
         # For some reason, we *must* submit in the order launch->configurationDone, and then we will receive responses
         # in the order configurationDone->launch.
-        self._flush_breakpoints()
         launch_req_id = self.send_message(self.make_request("launch", launch_request))
         config_done_req_id = self.send_message(self.make_request("configurationDone"))
         config_done_response = self._await_response(config_done_req_id)
         assert config_done_response["success"], "Should simply receive an affirmative?"
         launch_response = self._await_response(launch_req_id)
+
+        # Flush breakpoints after launch completes, as the debugger is now available.
+        self._flush_breakpoints()
         if not launch_response["success"]:
             raise DebuggerException(
                 f"failure launching debugger: \"{launch_response['body']['error']['format']}\""


### PR DESCRIPTION
# Summary
This is a forward fix for test errors from https://github.com/llvm/llvm-project/pull/163653.

The PR moved debugger initialization outside of InitializeRequestHandler, and into Launch/AttachRequestHandlers to support DAP sessions sharing debugger instances for dynamically created targets. However, DExTer's DAP class seemed to set breakpoints before the debugger was initialized, which caused the tests to hang waiting for a breakpoint to hit due to none of the breakpoints getting resolved.

# Tests
```
bin/llvm-lit -v /home/qxy11/llvm/llvm-project/cross-project-tests/debuginfo-tests/dexter-tests/
```
