### PR TITLE
[libc++][deque] Applied `[[nodiscard]]`

### DIFF
--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -715,45 +715,53 @@ public:
 
   // iterators:
 
-  _LIBCPP_HIDE_FROM_ABI iterator begin() _NOEXCEPT {
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator begin() _NOEXCEPT {
     __map_pointer __mp = __map_.begin() + __start_ / __block_size;
     return iterator(__mp, __map_.empty() ? 0 : *__mp + __start_ % __block_size);
   }
 
-  _LIBCPP_HIDE_FROM_ABI const_iterator begin() const _NOEXCEPT {
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator begin() const _NOEXCEPT {
     __map_const_pointer __mp = static_cast<__map_const_pointer>(__map_.begin() + __start_ / __block_size);
     return const_iterator(__mp, __map_.empty() ? 0 : *__mp + __start_ % __block_size);
   }
 
-  _LIBCPP_HIDE_FROM_ABI iterator end() _NOEXCEPT {
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI iterator end() _NOEXCEPT {
     size_type __p      = size() + __start_;
     __map_pointer __mp = __map_.begin() + __p / __block_size;
     return iterator(__mp, __map_.empty() ? 0 : *__mp + __p % __block_size);
   }
 
-  _LIBCPP_HIDE_FROM_ABI const_iterator end() const _NOEXCEPT {
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator end() const _NOEXCEPT {
     size_type __p            = size() + __start_;
     __map_const_pointer __mp = static_cast<__map_const_pointer>(__map_.begin() + __p / __block_size);
     return const_iterator(__mp, __map_.empty() ? 0 : *__mp + __p % __block_size);
   }
 
-  _LIBCPP_HIDE_FROM_ABI reverse_iterator rbegin() _NOEXCEPT { return reverse_iterator(end()); }
-  _LIBCPP_HIDE_FROM_ABI const_reverse_iterator rbegin() const _NOEXCEPT { return const_reverse_iterator(end()); }
-  _LIBCPP_HIDE_FROM_ABI reverse_iterator rend() _NOEXCEPT { return reverse_iterator(begin()); }
-  _LIBCPP_HIDE_FROM_ABI const_reverse_iterator rend() const _NOEXCEPT { return const_reverse_iterator(begin()); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reverse_iterator rbegin() _NOEXCEPT { return reverse_iterator(end()); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reverse_iterator rbegin() const _NOEXCEPT {
+    return const_reverse_iterator(end());
+  }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reverse_iterator rend() _NOEXCEPT { return reverse_iterator(begin()); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reverse_iterator rend() const _NOEXCEPT {
+    return const_reverse_iterator(begin());
+  }
 
-  _LIBCPP_HIDE_FROM_ABI const_iterator cbegin() const _NOEXCEPT { return begin(); }
-  _LIBCPP_HIDE_FROM_ABI const_iterator cend() const _NOEXCEPT { return end(); }
-  _LIBCPP_HIDE_FROM_ABI const_reverse_iterator crbegin() const _NOEXCEPT { return const_reverse_iterator(end()); }
-  _LIBCPP_HIDE_FROM_ABI const_reverse_iterator crend() const _NOEXCEPT { return const_reverse_iterator(begin()); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator cbegin() const _NOEXCEPT { return begin(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_iterator cend() const _NOEXCEPT { return end(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reverse_iterator crbegin() const _NOEXCEPT {
+    return const_reverse_iterator(end());
+  }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reverse_iterator crend() const _NOEXCEPT {
+    return const_reverse_iterator(begin());
+  }
 
   // capacity:
-  _LIBCPP_HIDE_FROM_ABI size_type size() const _NOEXCEPT { return __size(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type size() const _NOEXCEPT { return __size(); }
 
   _LIBCPP_HIDE_FROM_ABI size_type& __size() _NOEXCEPT { return __size_; }
   _LIBCPP_HIDE_FROM_ABI const size_type& __size() const _NOEXCEPT { return __size_; }
 
-  _LIBCPP_HIDE_FROM_ABI size_type max_size() const _NOEXCEPT {
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type max_size() const _NOEXCEPT {
     return std::min<size_type>(__alloc_traits::max_size(__alloc()), numeric_limits<difference_type>::max());
   }
   _LIBCPP_HIDE_FROM_ABI void resize(size_type __n);
@@ -762,14 +770,14 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const _NOEXCEPT { return size() == 0; }
 
   // element access:
-  _LIBCPP_HIDE_FROM_ABI reference operator[](size_type __i) _NOEXCEPT;
-  _LIBCPP_HIDE_FROM_ABI const_reference operator[](size_type __i) const _NOEXCEPT;
-  _LIBCPP_HIDE_FROM_ABI reference at(size_type __i);
-  _LIBCPP_HIDE_FROM_ABI const_reference at(size_type __i) const;
-  _LIBCPP_HIDE_FROM_ABI reference front() _NOEXCEPT;
-  _LIBCPP_HIDE_FROM_ABI const_reference front() const _NOEXCEPT;
-  _LIBCPP_HIDE_FROM_ABI reference back() _NOEXCEPT;
-  _LIBCPP_HIDE_FROM_ABI const_reference back() const _NOEXCEPT;
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reference operator[](size_type __i) _NOEXCEPT;
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reference operator[](size_type __i) const _NOEXCEPT;
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reference at(size_type __i);
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reference at(size_type __i) const;
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reference front() _NOEXCEPT;
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reference front() const _NOEXCEPT;
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reference back() _NOEXCEPT;
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reference back() const _NOEXCEPT;
 
   // 23.2.2.3 modifiers:
   _LIBCPP_HIDE_FROM_ABI void push_front(const value_type& __v);

--- a/libcxx/test/libcxx/diagnostics/deque.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/deque.nodiscard.verify.cpp
@@ -13,6 +13,32 @@
 #include <deque>
 
 void test() {
-  std::deque<int> deque;
-  deque.empty(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::deque<int> d;
+  const std::deque<int> cd;
+
+  d.begin();    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.begin();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  d.end();      // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.end();     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  d.rbegin();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.rbegin();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  d.rend();     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.rend();    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.cbegin();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.cend();    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.crbegin(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.crend();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  d.size();     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  d.max_size(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  d.empty();    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  d[0];       // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd[0];      // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  d.at(0);    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.at(0);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  d.front();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.front(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  d.back();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  cd.back();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
 }


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

- https://libcxx.llvm.org/CodingGuidelines.html#apply-nodiscard-where-relevant