### PR TITLE
[MLIR] Zero-extend unsigned and 1-bit values when translating IntegerAttr

### DIFF
--- a/clang/test/CIR/CodeGen/globals.cpp
+++ b/clang/test/CIR/CodeGen/globals.cpp
@@ -35,3 +35,9 @@ int *constArrAddr = &arr[2][1];
 // LLVM: @constArrAddr = global ptr getelementptr inbounds nuw (i8, ptr @arr, i64 132), align 8
 
 // OGCG: @constArrAddr = global ptr getelementptr (i8, ptr @arr, i64 132), align 8
+
+bool bool_global = true;
+
+// CIR: cir.global external @bool_global = #true {alignment = 1 : i64}
+// LLVM: @bool_global = global i8 1, align 1
+// OGCG: @bool_global = global i8 1, align 1

--- a/flang/test/Fir/global.fir
+++ b/flang/test/Fir/global.fir
@@ -50,7 +50,7 @@ fir.global internal @_QEmultiarray : !fir.array<32x32xi32> {
   fir.has_value %2 : !fir.array<32x32xi32>
 }
 
-// CHECK: @_QEmasklogical = internal global [32768 x i32] [i32 -1, i32 -1,
+// CHECK: @_QEmasklogical = internal global [32768 x i32] [i32 1, i32 1,
 fir.global internal @_QEmasklogical : !fir.array<32768x!fir.logical<4>> {
   %true = arith.constant true
   %0 = fir.undefined !fir.array<32768x!fir.logical<4>>

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -588,10 +588,17 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
   }
   // For integer types, we allow a mismatch in sizes as the index type in
   // MLIR might have a different size than the index type in the LLVM module.
-  if (auto intAttr = dyn_cast<IntegerAttr>(attr))
-    return llvm::ConstantInt::get(
-        llvmType,
-        intAttr.getValue().sextOrTrunc(llvmType->getIntegerBitWidth()));
+  if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
+    // If the attribute is an unsigned integer or a 1-bit integer, zero-extend
+    // the value to the bit width of the LLVM type. Otherwise, sign-extend.
+    auto intTy = mlir::dyn_cast<IntegerType>(intAttr.getType());
+    APInt value;
+    if (intTy && (intTy.isUnsigned() || intTy.getWidth() == 1))
+      value = intAttr.getValue().zextOrTrunc(llvmType->getIntegerBitWidth());
+    else
+      value = intAttr.getValue().sextOrTrunc(llvmType->getIntegerBitWidth());
+    return llvm::ConstantInt::get(llvmType, value);
+  }
   if (auto floatAttr = dyn_cast<FloatAttr>(attr)) {
     const llvm::fltSemantics &sem = floatAttr.getValue().getSemantics();
     // Special case for 8-bit floats, which are represented by integers due to

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -591,7 +591,7 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
   if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
     // If the attribute is an unsigned integer or a 1-bit integer, zero-extend
     // the value to the bit width of the LLVM type. Otherwise, sign-extend.
-    auto intTy = mlir::dyn_cast<IntegerType>(intAttr.getType());
+    auto intTy = dyn_cast<IntegerType>(intAttr.getType());
     APInt value;
     if (intTy && (intTy.isUnsigned() || intTy.getWidth() == 1))
       value = intAttr.getValue().zextOrTrunc(llvmType->getIntegerBitWidth());

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -78,6 +78,9 @@ llvm.mlir.global internal @f8E8M0FNU_global_as_i8(1.0 : f8E8M0FNU) : i8
 // CHECK: @bf16_global_as_i16 = internal global i16 16320
 llvm.mlir.global internal @bf16_global_as_i16(1.5 : bf16) : i16
 
+// CHECK: @bool_global_as_i8 = internal global i8 1
+llvm.mlir.global internal @bool_global_as_i8(true) : i8
+
 // CHECK: @explicit_undef = global i32 undef
 llvm.mlir.global external @explicit_undef() : i32 {
   %0 = llvm.mlir.undef : i32


### PR DESCRIPTION
This updates the LLVM IR ConstantInt creation from mlir::IntegerAttr so that unsigned integers and 1-bit integers are zero-extended rather than sign-extended.