### PR TITLE
[ubsan] Change "Type mismatch in operation" trap reason to "Alignment, null, or object-size error"

### DIFF
--- a/clang/lib/CodeGen/SanitizerHandler.h
+++ b/clang/lib/CodeGen/SanitizerHandler.h
@@ -64,7 +64,7 @@
   SANITIZER_CHECK(SubOverflow, sub_overflow, 0,                                \
                   "Integer subtraction overflowed")                            \
   SANITIZER_CHECK(TypeMismatch, type_mismatch, 1,                              \
-                  "Alignment, null and/or object-size error")                  \
+                  "Alignment, null, or object-size error")                     \
   SANITIZER_CHECK(AlignmentAssumption, alignment_assumption, 0,                \
                   "Alignment assumption violated")                             \
   SANITIZER_CHECK(                                                             \

--- a/clang/lib/CodeGen/SanitizerHandler.h
+++ b/clang/lib/CodeGen/SanitizerHandler.h
@@ -64,7 +64,7 @@
   SANITIZER_CHECK(SubOverflow, sub_overflow, 0,                                \
                   "Integer subtraction overflowed")                            \
   SANITIZER_CHECK(TypeMismatch, type_mismatch, 1,                              \
-                  "Type mismatch in operation")                                \
+                  "Alignment, null and/or object-size error")                  \
   SANITIZER_CHECK(AlignmentAssumption, alignment_assumption, 0,                \
                   "Alignment assumption violated")                             \
   SANITIZER_CHECK(                                                             \

--- a/clang/test/DebugInfo/Generic/ubsan-trap-reason-type-mismatch.c
+++ b/clang/test/DebugInfo/Generic/ubsan-trap-reason-type-mismatch.c
@@ -6,4 +6,4 @@ int type_mismatch(int *p) { return *p; }
 // CHECK-LABEL: @type_mismatch
 // CHECK: call void @llvm.ubsantrap(i8 22) {{.*}}!dbg [[LOC:![0-9]+]]
 // CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Type mismatch in operation"
+// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Alignment, null and/or object-size error"

--- a/clang/test/DebugInfo/Generic/ubsan-trap-reason-type-mismatch.c
+++ b/clang/test/DebugInfo/Generic/ubsan-trap-reason-type-mismatch.c
@@ -6,4 +6,4 @@ int type_mismatch(int *p) { return *p; }
 // CHECK-LABEL: @type_mismatch
 // CHECK: call void @llvm.ubsantrap(i8 22) {{.*}}!dbg [[LOC:![0-9]+]]
 // CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Alignment, null and/or object-size error"
+// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Alignment, null, or object-size error"


### PR DESCRIPTION
I originally proposed this rewording when trap reasons were introduced in https://github.com/llvm/llvm-project/pull/145967#discussion_r2196212344. This was not adopted because there was a counter-proposal to split the enum; however, that work appears to have stalled (https://github.com/llvm/llvm-project/pull/151243). In the meantime, there has been an additional datapoint that the current wording is confusing to users. Thus, let's reword it now to prevent further confusion.