### PR TITLE
[LoongArch] Legalize BUILD_VECTOR into a broadcast when all non-undef elements are identical

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -3673,6 +3673,36 @@ SDValue LoongArchTargetLowering::lowerBUILD_VECTOR(SDValue Op,
   }
 
   if (!IsConstant) {
+    SmallVector<SDValue> Sequence;
+    BitVector UndefElements;
+    bool IsRepeated = Node->getRepeatedSequence(Sequence, &UndefElements);
+    unsigned SeqLen = Sequence.size();
+    unsigned NumUndefElts = UndefElements.count();
+
+    // When a BUILD_VECTOR consists of the same element (ignoring undefs),
+    // prefer emitting a broadcast instead of multiple insertions.
+    if (IsRepeated && SeqLen == 1) {
+      // Integer vectors benefit from splat unconditionally.
+      if (ResTy.isInteger())
+        return DAG.getSplatBuildVector(ResTy, DL, Sequence[0]);
+
+      // Only certain floating-point cases suffer performance regressions,
+      // exclude those specific cases.
+      bool IsSplatBetter = true;
+      if (NumUndefElts == NumElts - 1)
+        IsSplatBetter = false;
+      if (NumUndefElts == NumElts - 2 && !UndefElements[0])
+        IsSplatBetter = false;
+      if (ResTy == MVT::v8f32 && NumUndefElts == NumElts - 2 &&
+          ((!UndefElements[1] && !UndefElements[2]) ||
+           (!UndefElements[1] && !UndefElements[3]) ||
+           (!UndefElements[2] && !UndefElements[3])))
+        IsSplatBetter = false;
+
+      if (IsSplatBetter)
+        return DAG.getSplatBuildVector(ResTy, DL, Sequence[0]);
+    }
+
     // If the BUILD_VECTOR has a repeated pattern, use INSERT_VECTOR_ELT to fill
     // the sub-sequence of the vector and then broadcast the sub-sequence.
     //
@@ -3680,10 +3710,7 @@ SDValue LoongArchTargetLowering::lowerBUILD_VECTOR(SDValue Op,
     // back to use INSERT_VECTOR_ELT to materialize the vector, because it
     // generates worse code in some cases. This could be further optimized
     // with more consideration.
-    SmallVector<SDValue> Sequence;
-    BitVector UndefElements;
-    if (Node->getRepeatedSequence(Sequence, &UndefElements) &&
-        UndefElements.count() == 0) {
+    if (IsRepeated && NumUndefElts == 0) {
       // Using LSX instructions to fill the sub-sequence of 256-bits vector,
       // because the high part can be simply treated as undef.
       SDValue Vector = DAG.getUNDEF(ResTy);
@@ -3695,7 +3722,6 @@ SDValue LoongArchTargetLowering::lowerBUILD_VECTOR(SDValue Op,
 
       fillVector(Sequence, DAG, DL, Subtarget, FillVec, FillTy);
 
-      unsigned SeqLen = Sequence.size();
       unsigned SplatLen = NumElts / SeqLen;
       MVT SplatEltTy = MVT::getIntegerVT(VT.getScalarSizeInBits() * SeqLen);
       MVT SplatTy = MVT::getVectorVT(SplatEltTy, SplatLen);

--- a/llvm/test/CodeGen/LoongArch/lasx/build-vector.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/build-vector.ll
@@ -93,22 +93,7 @@ entry:
 define void @buildvector_v32i8_splat_with_undef(ptr %dst, i8 %a0) nounwind {
 ; CHECK-LABEL: buildvector_v32i8_splat_with_undef:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 0
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 1
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 2
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 3
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 4
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 5
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 6
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 7
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 8
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 9
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 10
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 11
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 12
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 13
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 15
+; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a1
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -135,15 +120,7 @@ entry:
 define void @buildvector_v16i16_splat_with_undef(ptr %dst, i16 %a0) nounwind {
 ; CHECK-LABEL: buildvector_v16i16_splat_with_undef:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 0
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 1
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 2
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 3
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 4
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 5
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 6
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 7
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 2
+; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a1
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -162,9 +139,7 @@ entry:
 define void @buildvector_v8i32_splat_with_undef(ptr %dst, i32 %a0) nounwind {
 ; CHECK-LABEL: buildvector_v8i32_splat_with_undef:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vinsgr2vr.w $vr0, $a1, 0
-; CHECK-NEXT:    vinsgr2vr.w $vr0, $a1, 2
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 2
+; CHECK-NEXT:    xvreplgr2vr.w $xr0, $a1
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -189,8 +164,7 @@ define void @buildvector_v4i64_splat_with_undef(ptr %dst, i64 %a0) nounwind {
 ;
 ; LA64-LABEL: buildvector_v4i64_splat_with_undef:
 ; LA64:       # %bb.0: # %entry
-; LA64-NEXT:    xvinsgr2vr.d $xr0, $a1, 0
-; LA64-NEXT:    xvinsgr2vr.d $xr0, $a1, 3
+; LA64-NEXT:    xvreplgr2vr.d $xr0, $a1
 ; LA64-NEXT:    xvst $xr0, $a0, 0
 ; LA64-NEXT:    ret
 entry:
@@ -232,9 +206,8 @@ define void @buildvector_v8f32_splat_with_undef_2(ptr %dst, float %a0) nounwind 
 ; CHECK-LABEL: buildvector_v8f32_splat_with_undef_2:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    # kill: def $f0 killed $f0 def $xr0
-; CHECK-NEXT:    xvinsve0.w $xr1, $xr0, 1
-; CHECK-NEXT:    xvinsve0.w $xr1, $xr0, 4
-; CHECK-NEXT:    xvst $xr1, $a0, 0
+; CHECK-NEXT:    xvreplve0.w $xr0, $xr0
+; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
   %ins1 = insertelement <8 x float> undef, float %a0, i32 1
@@ -246,11 +219,9 @@ entry:
 define void @buildvector_v8f32_splat_with_undef_3(ptr %dst, float %a0) nounwind {
 ; CHECK-LABEL: buildvector_v8f32_splat_with_undef_3:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    # kill: def $f0 killed $f0 def $vr0
-; CHECK-NEXT:    vextrins.w $vr1, $vr0, 16
-; CHECK-NEXT:    vextrins.w $vr1, $vr0, 48
-; CHECK-NEXT:    xvpermi.q $xr1, $xr1, 2
-; CHECK-NEXT:    xvst $xr1, $a0, 0
+; CHECK-NEXT:    # kill: def $f0 killed $f0 def $xr0
+; CHECK-NEXT:    xvreplve0.w $xr0, $xr0
+; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
   %ins1 = insertelement <8 x float> undef, float %a0, i32 1
@@ -292,8 +263,7 @@ define void @buildvector_v4f64_splat_with_undef_2(ptr %dst, double %a0) nounwind
 ; CHECK-LABEL: buildvector_v4f64_splat_with_undef_2:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    # kill: def $f0_64 killed $f0_64 def $xr0
-; CHECK-NEXT:    vextrins.d $vr0, $vr0, 16
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 2
+; CHECK-NEXT:    xvreplve0.d $xr0, $xr0
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/insertelement.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/insertelement.ll
@@ -35,7 +35,7 @@ define void @insert_32xi8_upper(ptr %src, ptr %dst, i8 %in) nounwind {
 define void @insert_32xi8_undef(ptr %dst, i8 %in) nounwind {
 ; CHECK-LABEL: insert_32xi8_undef:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 1
+; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a1
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
   %v = insertelement <32 x i8> poison, i8 %in, i32 1
@@ -46,8 +46,7 @@ define void @insert_32xi8_undef(ptr %dst, i8 %in) nounwind {
 define void @insert_32xi8_undef_upper(ptr %dst, i8 %in) nounwind {
 ; CHECK-LABEL: insert_32xi8_undef_upper:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 6
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 2
+; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a1
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
   %v = insertelement <32 x i8> poison, i8 %in, i32 22
@@ -88,7 +87,7 @@ define void @insert_16xi16_upper(ptr %src, ptr %dst, i16 %in) nounwind {
 define void @insert_16xi16_undef(ptr %dst, i16 %in) nounwind {
 ; CHECK-LABEL: insert_16xi16_undef:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 1
+; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a1
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
   %v = insertelement <16 x i16> poison, i16 %in, i32 1
@@ -99,8 +98,7 @@ define void @insert_16xi16_undef(ptr %dst, i16 %in) nounwind {
 define void @insert_16xi16_undef_upper(ptr %dst, i16 %in) nounwind {
 ; CHECK-LABEL: insert_16xi16_undef_upper:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 2
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 2
+; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a1
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
   %v = insertelement <16 x i16> poison, i16 %in, i32 10

--- a/llvm/test/CodeGen/LoongArch/lasx/rotl-rotr.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/rotl-rotr.ll
@@ -168,9 +168,7 @@ define void @rotl_v4i64(ptr %dst, ptr %src, i64 %a0) nounwind {
 ; LA32-LABEL: rotl_v4i64:
 ; LA32:       # %bb.0:
 ; LA32-NEXT:    xvld $xr0, $a1, 0
-; LA32-NEXT:    vinsgr2vr.w $vr1, $a2, 0
-; LA32-NEXT:    vinsgr2vr.w $vr1, $a2, 2
-; LA32-NEXT:    xvpermi.q $xr1, $xr1, 2
+; LA32-NEXT:    xvreplgr2vr.w $xr1, $a2
 ; LA32-NEXT:    xvneg.d $xr1, $xr1
 ; LA32-NEXT:    xvrotr.d $xr0, $xr0, $xr1
 ; LA32-NEXT:    xvst $xr0, $a0, 0
@@ -199,9 +197,7 @@ define void @rotr_v4i64(ptr %dst, ptr %src, i64 %a0) nounwind {
 ; LA32-LABEL: rotr_v4i64:
 ; LA32:       # %bb.0:
 ; LA32-NEXT:    xvld $xr0, $a1, 0
-; LA32-NEXT:    vinsgr2vr.w $vr1, $a2, 0
-; LA32-NEXT:    vinsgr2vr.w $vr1, $a2, 2
-; LA32-NEXT:    xvpermi.q $xr1, $xr1, 2
+; LA32-NEXT:    xvreplgr2vr.w $xr1, $a2
 ; LA32-NEXT:    xvrotr.d $xr0, $xr0, $xr1
 ; LA32-NEXT:    xvst $xr0, $a0, 0
 ; LA32-NEXT:    ret

--- a/llvm/test/CodeGen/LoongArch/lasx/scalar-to-vector.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/scalar-to-vector.ll
@@ -7,7 +7,7 @@
 define <32 x i8> @scalar_to_32xi8(i8 %val) {
 ; CHECK-LABEL: scalar_to_32xi8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a0, 0
+; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a0
 ; CHECK-NEXT:    ret
   %ret = insertelement <32 x i8> poison, i8 %val, i32 0
   ret <32 x i8> %ret
@@ -16,7 +16,7 @@ define <32 x i8> @scalar_to_32xi8(i8 %val) {
 define <16 x i16> @scalar_to_16xi16(i16 %val) {
 ; CHECK-LABEL: scalar_to_16xi16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a0, 0
+; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a0
 ; CHECK-NEXT:    ret
   %ret = insertelement <16 x i16> poison, i16 %val, i32 0
   ret <16 x i16> %ret
@@ -25,7 +25,7 @@ define <16 x i16> @scalar_to_16xi16(i16 %val) {
 define <8 x i32> @scalar_to_8xi32(i32 %val) {
 ; CHECK-LABEL: scalar_to_8xi32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.w $vr0, $a0, 0
+; CHECK-NEXT:    xvreplgr2vr.w $xr0, $a0
 ; CHECK-NEXT:    ret
   %ret = insertelement <8 x i32> poison, i32 %val, i32 0
   ret <8 x i32> %ret
@@ -40,7 +40,7 @@ define <4 x i64> @scalar_to_4xi64(i64 %val) {
 ;
 ; LA64-LABEL: scalar_to_4xi64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    vinsgr2vr.d $vr0, $a0, 0
+; LA64-NEXT:    xvreplgr2vr.d $xr0, $a0
 ; LA64-NEXT:    ret
   %ret = insertelement <4 x i64> poison, i64 %val, i32 0
   ret <4 x i64> %ret

--- a/llvm/test/CodeGen/LoongArch/lsx/build-vector.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/build-vector.ll
@@ -93,14 +93,7 @@ entry:
 define void @buildvector_v16i8_splat_with_undef(ptr %dst, i8 %a0) nounwind {
 ; CHECK-LABEL: buildvector_v16i8_splat_with_undef:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 0
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 2
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 4
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 6
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 8
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 10
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 12
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 14
+; CHECK-NEXT:    vreplgr2vr.b $vr0, $a1
 ; CHECK-NEXT:    vst $vr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -119,10 +112,7 @@ entry:
 define void @buildvector_v8i16_splat_with_undef(ptr %dst, i16 %a0) nounwind {
 ; CHECK-LABEL: buildvector_v8i16_splat_with_undef:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 1
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 3
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 5
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 7
+; CHECK-NEXT:    vreplgr2vr.h $vr0, $a1
 ; CHECK-NEXT:    vst $vr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -137,8 +127,7 @@ entry:
 define void @buildvector_v4i32_splat_with_undef(ptr %dst, i32 %a0) nounwind {
 ; CHECK-LABEL: buildvector_v4i32_splat_with_undef:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vinsgr2vr.w $vr0, $a1, 1
-; CHECK-NEXT:    vinsgr2vr.w $vr0, $a1, 2
+; CHECK-NEXT:    vreplgr2vr.w $vr0, $a1
 ; CHECK-NEXT:    vst $vr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -158,7 +147,7 @@ define void @buildvector_v2i64_splat_with_undef(ptr %dst, i64 %a0) nounwind {
 ;
 ; LA64-LABEL: buildvector_v2i64_splat_with_undef:
 ; LA64:       # %bb.0: # %entry
-; LA64-NEXT:    vinsgr2vr.d $vr0, $a1, 0
+; LA64-NEXT:    vreplgr2vr.d $vr0, $a1
 ; LA64-NEXT:    vst $vr0, $a0, 0
 ; LA64-NEXT:    ret
 entry:
@@ -197,9 +186,8 @@ define void @buildvector_v4f32_splat_with_undef_2(ptr %dst, float %a0) nounwind 
 ; CHECK-LABEL: buildvector_v4f32_splat_with_undef_2:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    # kill: def $f0 killed $f0 def $vr0
-; CHECK-NEXT:    vextrins.w $vr1, $vr0, 16
-; CHECK-NEXT:    vextrins.w $vr1, $vr0, 32
-; CHECK-NEXT:    vst $vr1, $a0, 0
+; CHECK-NEXT:    vreplvei.w $vr0, $vr0, 0
+; CHECK-NEXT:    vst $vr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
   %ins1 = insertelement <4 x float> undef, float %a0, i32 1
@@ -969,7 +957,7 @@ define void @buildvector_v2i64_partial(ptr %dst, i64 %a0) nounwind {
 ;
 ; LA64-LABEL: buildvector_v2i64_partial:
 ; LA64:       # %bb.0: # %entry
-; LA64-NEXT:    vinsgr2vr.d $vr0, $a1, 0
+; LA64-NEXT:    vreplgr2vr.d $vr0, $a1
 ; LA64-NEXT:    vst $vr0, $a0, 0
 ; LA64-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/LoongArch/lsx/rotl-rotr.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/rotl-rotr.ll
@@ -168,8 +168,7 @@ define void @rotl_v2i64(ptr %dst, ptr %src, i64 %a0) nounwind {
 ; LA32-LABEL: rotl_v2i64:
 ; LA32:       # %bb.0:
 ; LA32-NEXT:    vld $vr0, $a1, 0
-; LA32-NEXT:    vinsgr2vr.w $vr1, $a2, 0
-; LA32-NEXT:    vinsgr2vr.w $vr1, $a2, 2
+; LA32-NEXT:    vreplgr2vr.w $vr1, $a2
 ; LA32-NEXT:    vneg.d $vr1, $vr1
 ; LA32-NEXT:    vrotr.d $vr0, $vr0, $vr1
 ; LA32-NEXT:    vst $vr0, $a0, 0
@@ -198,8 +197,7 @@ define void @rotr_v2i64(ptr %dst, ptr %src, i64 %a0) nounwind {
 ; LA32-LABEL: rotr_v2i64:
 ; LA32:       # %bb.0:
 ; LA32-NEXT:    vld $vr0, $a1, 0
-; LA32-NEXT:    vinsgr2vr.w $vr1, $a2, 0
-; LA32-NEXT:    vinsgr2vr.w $vr1, $a2, 2
+; LA32-NEXT:    vreplgr2vr.w $vr1, $a2
 ; LA32-NEXT:    vrotr.d $vr0, $vr0, $vr1
 ; LA32-NEXT:    vst $vr0, $a0, 0
 ; LA32-NEXT:    ret

--- a/llvm/test/CodeGen/LoongArch/lsx/scalar-to-vector.ll
+++ b/llvm/test/CodeGen/LoongArch/lsx/scalar-to-vector.ll
@@ -7,7 +7,7 @@
 define <16 x i8> @scalar_to_16xi8(i8 %val) {
 ; CHECK-LABEL: scalar_to_16xi8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a0, 0
+; CHECK-NEXT:    vreplgr2vr.b $vr0, $a0
 ; CHECK-NEXT:    ret
   %ret = insertelement <16 x i8> poison, i8 %val, i32 0
   ret <16 x i8> %ret
@@ -16,7 +16,7 @@ define <16 x i8> @scalar_to_16xi8(i8 %val) {
 define <8 x i16> @scalar_to_8xi16(i16 %val) {
 ; CHECK-LABEL: scalar_to_8xi16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a0, 0
+; CHECK-NEXT:    vreplgr2vr.h $vr0, $a0
 ; CHECK-NEXT:    ret
   %ret = insertelement <8 x i16> poison, i16 %val, i32 0
   ret <8 x i16> %ret
@@ -25,7 +25,7 @@ define <8 x i16> @scalar_to_8xi16(i16 %val) {
 define <4 x i32> @scalar_to_4xi32(i32 %val) {
 ; CHECK-LABEL: scalar_to_4xi32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.w $vr0, $a0, 0
+; CHECK-NEXT:    vreplgr2vr.w $vr0, $a0
 ; CHECK-NEXT:    ret
   %ret = insertelement <4 x i32> poison, i32 %val, i32 0
   ret <4 x i32> %ret
@@ -40,7 +40,7 @@ define <2 x i64> @scalar_to_2xi64(i64 %val) {
 ;
 ; LA64-LABEL: scalar_to_2xi64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    vinsgr2vr.d $vr0, $a0, 0
+; LA64-NEXT:    vreplgr2vr.d $vr0, $a0
 ; LA64-NEXT:    ret
   %ret = insertelement <2 x i64> poison, i64 %val, i32 0
   ret <2 x i64> %ret


### PR DESCRIPTION
When a BUILD_VECTOR consists of the same element (ignoring undefs),
it is better emitting a broadcast instead of multiple insertions.

Some floating-point cases suffer performance regressions or
have no benefits, those specific cases are excluded in this
commit. Including when:

- only one element is non-undef,
- only two elements are non-undef, and one of them must at index 0,
- for v8f32 vector type, specially exclude the cases when the only
two non-undefs are at index (1,2)/(1,3)/(2,3).