### PR TITLE
[clang][bytecode] Support different integral types (e.g. addresses)

### DIFF
--- a/clang/lib/AST/ByteCode/Boolean.h
+++ b/clang/lib/AST/ByteCode/Boolean.h
@@ -52,9 +52,13 @@ public:
   APSInt toAPSInt(unsigned NumBits) const {
     return APSInt(toAPSInt().zextOrTrunc(NumBits), true);
   }
-  APValue toAPValue(const ASTContext &) const { return APValue(toAPSInt()); }
+  APValue toAPValue(const ASTContext &, const Program &) const {
+    return APValue(toAPSInt());
+  }
 
   Boolean toUnsigned() const { return *this; }
+
+  static IntegralKind getKind() { return IntegralKind::Number; }
 
   constexpr static unsigned bitWidth() { return 1; }
   bool isZero() const { return !V; }
@@ -84,7 +88,7 @@ public:
   void bitcastToMemory(std::byte *Buff) { std::memcpy(Buff, &V, sizeof(V)); }
 
   void print(llvm::raw_ostream &OS) const { OS << (V ? "true" : "false"); }
-  std::string toDiagnosticString(const ASTContext &Ctx) const {
+  std::string toDiagnosticString(const ASTContext &Ctx, const Program &) const {
     std::string NameStr;
     llvm::raw_string_ostream OS(NameStr);
     print(OS);

--- a/clang/lib/AST/ByteCode/Descriptor.cpp
+++ b/clang/lib/AST/ByteCode/Descriptor.cpp
@@ -483,3 +483,10 @@ bool Descriptor::hasTrivialDtor() const {
 }
 
 bool Descriptor::isUnion() const { return isRecord() && ElemRecord->isUnion(); }
+
+unsigned Descriptor::getElemDataSize() const {
+  if ((isPrimitive() || isPrimitiveArray()) && isIntegralType(getPrimType())) {
+    FIXED_SIZE_INT_TYPE_SWITCH(getPrimType(), { return T::bitWidth() / 8; });
+  }
+  return ElemSize;
+}

--- a/clang/lib/AST/ByteCode/Descriptor.h
+++ b/clang/lib/AST/ByteCode/Descriptor.h
@@ -246,6 +246,11 @@ public:
   unsigned getAllocSize() const { return AllocSize; }
   /// returns the size of an element when the structure is viewed as an array.
   unsigned getElemSize() const { return ElemSize; }
+  /// Returns the element data size, i.e. not what the size of
+  /// our primitive data type is, but what the data size of that is.
+  /// E.g., for PT_SInt32, that's 4 bytes.
+  unsigned getElemDataSize() const;
+
   /// Returns the size of the metadata.
   unsigned getMetadataSize() const { return MDSize; }
 

--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -184,7 +184,7 @@ template <PrimType OpType> bool EvalEmitter::emitRet(SourceInfo Info) {
     return true;
 
   using T = typename PrimConv<OpType>::T;
-  EvalResult.takeValue(S.Stk.pop<T>().toAPValue(Ctx.getASTContext()));
+  EvalResult.takeValue(S.Stk.pop<T>().toAPValue(Ctx.getASTContext(), S.P));
   return true;
 }
 
@@ -193,6 +193,7 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(SourceInfo Info) {
     return true;
 
   const Pointer &Ptr = S.Stk.pop<Pointer>();
+
   // If we're returning a raw pointer, call our callback.
   if (this->PtrCB)
     return (*this->PtrCB)(Ptr);
@@ -204,7 +205,7 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(SourceInfo Info) {
 
   // Function pointers are always returned as lvalues.
   if (Ptr.isFunctionPointer()) {
-    EvalResult.takeValue(Ptr.toAPValue(Ctx.getASTContext()));
+    EvalResult.takeValue(Ptr.toAPValue(Ctx.getASTContext(), S.P));
     return true;
   }
 
@@ -226,7 +227,7 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(SourceInfo Info) {
       return false;
 
     if (std::optional<APValue> V =
-            Ptr.toRValue(Ctx, EvalResult.getSourceType())) {
+            Ptr.toRValue(Ctx, EvalResult.getSourceType(), P)) {
       EvalResult.takeValue(std::move(*V));
     } else {
       return false;
@@ -236,14 +237,14 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(SourceInfo Info) {
     // the result, even if the pointer is dead.
     // This will later be diagnosed by CheckLValueConstantExpression.
     if (Ptr.isBlockPointer() && !Ptr.block()->isStatic()) {
-      EvalResult.takeValue(Ptr.toAPValue(Ctx.getASTContext()));
+      EvalResult.takeValue(Ptr.toAPValue(Ctx.getASTContext(), S.P));
       return true;
     }
 
     if (!Ptr.isLive() && !Ptr.isTemporary())
       return false;
 
-    EvalResult.takeValue(Ptr.toAPValue(Ctx.getASTContext()));
+    EvalResult.takeValue(Ptr.toAPValue(Ctx.getASTContext(), S.P));
   }
 
   return true;
@@ -263,7 +264,7 @@ bool EvalEmitter::emitRetValue(SourceInfo Info) {
     return false;
 
   if (std::optional<APValue> APV =
-          Ptr.toRValue(S.getASTContext(), EvalResult.getSourceType())) {
+          Ptr.toRValue(S.getASTContext(), EvalResult.getSourceType(), P)) {
     EvalResult.takeValue(std::move(*APV));
     return true;
   }
@@ -362,11 +363,12 @@ void EvalEmitter::updateGlobalTemporaries() {
     const Pointer &Ptr = P.getPtrGlobal(*GlobalIndex);
     APValue *Cached = Temp->getOrCreateValue(true);
     if (OptPrimType T = Ctx.classify(E->getType())) {
-      TYPE_SWITCH(*T,
-                  { *Cached = Ptr.deref<T>().toAPValue(Ctx.getASTContext()); });
+      TYPE_SWITCH(*T, {
+        *Cached = Ptr.deref<T>().toAPValue(Ctx.getASTContext(), S.P);
+      });
     } else {
       if (std::optional<APValue> APV =
-              Ptr.toRValue(Ctx, Temp->getTemporaryExpr()->getType()))
+              Ptr.toRValue(Ctx, Temp->getTemporaryExpr()->getType(), P))
         *Cached = *APV;
     }
   }

--- a/clang/lib/AST/ByteCode/FixedPoint.h
+++ b/clang/lib/AST/ByteCode/FixedPoint.h
@@ -9,12 +9,15 @@
 #ifndef LLVM_CLANG_AST_INTERP_FIXED_POINT_H
 #define LLVM_CLANG_AST_INTERP_FIXED_POINT_H
 
+#include "Primitives.h"
 #include "clang/AST/APValue.h"
 #include "clang/AST/ComparisonCategories.h"
 #include "llvm/ADT/APFixedPoint.h"
 
 namespace clang {
 namespace interp {
+
+class Program;
 
 using APInt = llvm::APInt;
 using APSInt = llvm::APSInt;
@@ -49,7 +52,9 @@ public:
   operator bool() const { return V.getBoolValue(); }
   void print(llvm::raw_ostream &OS) const { OS << V; }
 
-  APValue toAPValue(const ASTContext &) const { return APValue(V); }
+  APValue toAPValue(const ASTContext &, const Program &) const {
+    return APValue(V);
+  }
   APSInt toAPSInt(unsigned BitWidth = 0) const { return V.getValue(); }
 
   unsigned bitWidth() const { return V.getWidth(); }
@@ -78,9 +83,10 @@ public:
     return V.convertToInt(BitWidth, Signed, Overflow);
   }
 
-  std::string toDiagnosticString(const ASTContext &Ctx) const {
+  std::string toDiagnosticString(const ASTContext &Ctx, const Program &) const {
     return V.toString();
   }
+  static IntegralKind getKind() { return IntegralKind::Number; }
 
   ComparisonCategoryResult compare(const FixedPoint &Other) const {
     int c = V.compare(Other.V);

--- a/clang/lib/AST/ByteCode/Floating.h
+++ b/clang/lib/AST/ByteCode/Floating.h
@@ -24,6 +24,7 @@
 namespace clang {
 namespace interp {
 
+class Program;
 using APFloat = llvm::APFloat;
 using APSInt = llvm::APSInt;
 using APInt = llvm::APInt;
@@ -86,14 +87,16 @@ public:
   APSInt toAPSInt(unsigned NumBits = 0) const {
     return APSInt(getValue().bitcastToAPInt());
   }
-  APValue toAPValue(const ASTContext &) const { return APValue(getValue()); }
+  APValue toAPValue(const ASTContext &, const Program &) const {
+    return APValue(getValue());
+  }
   void print(llvm::raw_ostream &OS) const {
     // Can't use APFloat::print() since it appends a newline.
     SmallVector<char, 16> Buffer;
     getValue().toString(Buffer);
     OS << Buffer;
   }
-  std::string toDiagnosticString(const ASTContext &Ctx) const {
+  std::string toDiagnosticString(const ASTContext &Ctx, const Program &) const {
     std::string NameStr;
     llvm::raw_string_ostream OS(NameStr);
     print(OS);

--- a/clang/lib/AST/ByteCode/IntegralAP.h
+++ b/clang/lib/AST/ByteCode/IntegralAP.h
@@ -26,6 +26,8 @@
 namespace clang {
 namespace interp {
 
+class Program;
+
 using APInt = llvm::APInt;
 using APSInt = llvm::APSInt;
 
@@ -150,7 +152,9 @@ public:
     else
       return APSInt(getValue().zext(Bits), !Signed);
   }
-  APValue toAPValue(const ASTContext &) const { return APValue(toAPSInt()); }
+  APValue toAPValue(const ASTContext &, const Program &) const {
+    return APValue(toAPSInt());
+  }
 
   bool isZero() const { return getValue().isZero(); }
   bool isPositive() const {
@@ -179,12 +183,13 @@ public:
   unsigned countLeadingZeros() const { return getValue().countl_zero(); }
 
   void print(llvm::raw_ostream &OS) const { getValue().print(OS, Signed); }
-  std::string toDiagnosticString(const ASTContext &Ctx) const {
+  std::string toDiagnosticString(const ASTContext &Ctx, const Program &) const {
     std::string NameStr;
     llvm::raw_string_ostream OS(NameStr);
     print(OS);
     return NameStr;
   }
+  static IntegralKind getKind() { return IntegralKind::Number; }
 
   IntegralAP truncate(unsigned BitWidth) const {
     if constexpr (Signed)

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1174,7 +1174,7 @@ bool CheckDeleteSource(InterpState &S, CodePtr OpPC, const Expr *Source,
   // Whatever this is, we didn't heap allocate it.
   const SourceInfo &Loc = S.Current->getSource(OpPC);
   S.FFDiag(Loc, diag::note_constexpr_delete_not_heap_alloc)
-      << Ptr.toDiagnosticString(S.getASTContext());
+      << Ptr.toDiagnosticString(S.getASTContext(), S.P);
 
   if (Ptr.isTemporary())
     S.Note(Ptr.getDeclLoc(), diag::note_constexpr_temporary_here);
@@ -1361,7 +1361,8 @@ bool Free(InterpState &S, CodePtr OpPC, bool DeleteIsArrayForm,
         (Ptr.isArrayElement() && Ptr.getIndex() != 0)) {
       const SourceInfo &Loc = S.Current->getSource(OpPC);
       S.FFDiag(Loc, diag::note_constexpr_delete_subobject)
-          << Ptr.toDiagnosticString(S.getASTContext()) << Ptr.isOnePastEnd();
+          << Ptr.toDiagnosticString(S.getASTContext(), S.P)
+          << Ptr.isOnePastEnd();
       return false;
     }
 
@@ -1489,7 +1490,7 @@ static bool getField(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
     // `typeid(int).name`, but we currently diagnose `&typeid(int)`.
     S.FFDiag(S.Current->getSource(OpPC),
              diag::note_constexpr_access_unreadable_object)
-        << AK_Read << Ptr.toDiagnosticString(S.getASTContext());
+        << AK_Read << Ptr.toDiagnosticString(S.getASTContext(), S.P);
     return false;
   }
 
@@ -1773,7 +1774,7 @@ static bool GetDynamicDecl(InterpState &S, CodePtr OpPC, Pointer TypePtr,
     if (const VarDecl *VD = TypePtr.getDeclDesc()->asVarDecl();
         VD && !VD->isConstexpr()) {
       const Expr *E = S.Current->getExpr(OpPC);
-      APValue V = TypePtr.toAPValue(S.getASTContext());
+      APValue V = TypePtr.toAPValue(S.getASTContext(), S.P);
       QualType TT = S.getASTContext().getLValueReferenceType(DynamicType);
       S.FFDiag(E, diag::note_constexpr_polymorphic_unknown_dynamic_type)
           << AccessKinds::AK_MemberCall << V.getAsString(S.getASTContext(), TT);
@@ -2166,10 +2167,10 @@ bool handleFixedPointOverflow(InterpState &S, CodePtr OpPC,
   if (S.checkingForUndefinedBehavior()) {
     S.getASTContext().getDiagnostics().Report(
         E->getExprLoc(), diag::warn_fixedpoint_constant_overflow)
-        << FP.toDiagnosticString(S.getASTContext()) << E->getType();
+        << FP.toDiagnosticString(S.getASTContext(), S.P) << E->getType();
   }
   S.CCEDiag(E, diag::note_constexpr_overflow)
-      << FP.toDiagnosticString(S.getASTContext()) << E->getType();
+      << FP.toDiagnosticString(S.getASTContext(), S.P) << E->getType();
   return S.noteUndefinedBehavior();
 }
 
@@ -2187,18 +2188,23 @@ bool CheckPointerToIntegralCast(InterpState &S, CodePtr OpPC,
   S.CCEDiag(E, diag::note_constexpr_invalid_cast)
       << 2 << S.getLangOpts().CPlusPlus << S.Current->getRange(OpPC);
 
-  if (Ptr.isDummy())
+  if (S.getLangOpts().CPlusPlus && Ptr.isDummy() && !Ptr.pointsToLabel())
     return false;
-  if (Ptr.isFunctionPointer())
+  if (Ptr.isIntegralPointer())
     return true;
 
-  if (Ptr.isBlockPointer() && !Ptr.isZero()) {
+  if (!Ptr.isZero()) {
     // Only allow based lvalue casts if they are lossless.
     if (S.getASTContext().getTargetInfo().getPointerWidth(LangAS::Default) !=
         BitWidth)
       return Invalid(S, OpPC);
   }
   return true;
+}
+
+bool CheckIntegralAddressCast(InterpState &S, CodePtr OpPC, unsigned BitWidth) {
+  return (S.getASTContext().getTargetInfo().getPointerWidth(LangAS::Default) ==
+          BitWidth);
 }
 
 bool CastPointerIntegralAP(InterpState &S, CodePtr OpPC, uint32_t BitWidth) {
@@ -2286,13 +2292,19 @@ bool DiagTypeid(InterpState &S, CodePtr OpPC) {
 
 bool arePotentiallyOverlappingStringLiterals(const Pointer &LHS,
                                              const Pointer &RHS) {
+  if (!LHS.pointsToStringLiteral() || !RHS.pointsToStringLiteral())
+    return false;
+
   unsigned LHSOffset = LHS.isOnePastEnd() ? LHS.getNumElems() : LHS.getIndex();
   unsigned RHSOffset = RHS.isOnePastEnd() ? RHS.getNumElems() : RHS.getIndex();
-  unsigned LHSLength = (LHS.getNumElems() - 1) * LHS.elemSize();
-  unsigned RHSLength = (RHS.getNumElems() - 1) * RHS.elemSize();
+  const auto *LHSLit = cast<StringLiteral>(LHS.getDeclDesc()->asExpr());
+  const auto *RHSLit = cast<StringLiteral>(RHS.getDeclDesc()->asExpr());
 
-  StringRef LHSStr((const char *)LHS.atIndex(0).getRawAddress(), LHSLength);
-  StringRef RHSStr((const char *)RHS.atIndex(0).getRawAddress(), RHSLength);
+  StringRef LHSStr(LHSLit->getBytes());
+  unsigned LHSLength = LHSStr.size();
+  StringRef RHSStr(RHSLit->getBytes());
+  unsigned RHSLength = RHSStr.size();
+
   int32_t IndexDiff = RHSOffset - LHSOffset;
   if (IndexDiff < 0) {
     if (static_cast<int32_t>(LHSLength) < -IndexDiff)
@@ -2308,11 +2320,11 @@ bool arePotentiallyOverlappingStringLiterals(const Pointer &LHS,
   StringRef Shorter;
   StringRef Longer;
   if (LHSLength < RHSLength) {
-    ShorterCharWidth = LHS.elemSize();
+    ShorterCharWidth = LHS.getFieldDesc()->getElemDataSize();
     Shorter = LHSStr;
     Longer = RHSStr;
   } else {
-    ShorterCharWidth = RHS.elemSize();
+    ShorterCharWidth = RHS.getFieldDesc()->getElemDataSize();
     Shorter = RHSStr;
     Longer = LHSStr;
   }
@@ -2489,7 +2501,7 @@ bool Destroy(InterpState &S, CodePtr OpPC, uint32_t I) {
       } else {
         S.FFDiag(Ptr.getDeclDesc()->getLocation(),
                  diag::note_constexpr_destroy_out_of_lifetime)
-            << Ptr.toDiagnosticString(S.getASTContext());
+            << Ptr.toDiagnosticString(S.getASTContext(), S.P);
       }
       return false;
     }

--- a/clang/lib/AST/ByteCode/InterpHelpers.h
+++ b/clang/lib/AST/ByteCode/InterpHelpers.h
@@ -127,10 +127,10 @@ bool CheckArraySize(InterpState &S, CodePtr OpPC, SizeT *NumElements,
 
       if (NumElements->isSigned() && NumElements->isNegative()) {
         S.FFDiag(Loc, diag::note_constexpr_new_negative)
-            << NumElements->toDiagnosticString(S.getASTContext());
+            << NumElements->toDiagnosticString(S.getASTContext(), S.P);
       } else {
         S.FFDiag(Loc, diag::note_constexpr_new_too_large)
-            << NumElements->toDiagnosticString(S.getASTContext());
+            << NumElements->toDiagnosticString(S.getASTContext(), S.P);
       }
     }
     return false;

--- a/clang/lib/AST/ByteCode/InterpStack.h
+++ b/clang/lib/AST/ByteCode/InterpStack.h
@@ -173,29 +173,21 @@ private:
       return PT_Ptr;
     else if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, Boolean>)
       return PT_Bool;
-    else if constexpr (std::is_same_v<T, int8_t> ||
-                       std::is_same_v<T, Integral<8, true>>)
+    else if constexpr (std::is_same_v<T, Integral<8, true>>)
       return PT_Sint8;
-    else if constexpr (std::is_same_v<T, uint8_t> ||
-                       std::is_same_v<T, Integral<8, false>>)
+    else if constexpr (std::is_same_v<T, Integral<8, false>>)
       return PT_Uint8;
-    else if constexpr (std::is_same_v<T, int16_t> ||
-                       std::is_same_v<T, Integral<16, true>>)
+    else if constexpr (std::is_same_v<T, Integral<16, true>>)
       return PT_Sint16;
-    else if constexpr (std::is_same_v<T, uint16_t> ||
-                       std::is_same_v<T, Integral<16, false>>)
+    else if constexpr (std::is_same_v<T, Integral<16, false>>)
       return PT_Uint16;
-    else if constexpr (std::is_same_v<T, int32_t> ||
-                       std::is_same_v<T, Integral<32, true>>)
+    else if constexpr (std::is_same_v<T, Integral<32, true>>)
       return PT_Sint32;
-    else if constexpr (std::is_same_v<T, uint32_t> ||
-                       std::is_same_v<T, Integral<32, false>>)
+    else if constexpr (std::is_same_v<T, Integral<32, false>>)
       return PT_Uint32;
-    else if constexpr (std::is_same_v<T, int64_t> ||
-                       std::is_same_v<T, Integral<64, true>>)
+    else if constexpr (std::is_same_v<T, Integral<64, true>>)
       return PT_Sint64;
-    else if constexpr (std::is_same_v<T, uint64_t> ||
-                       std::is_same_v<T, Integral<64, false>>)
+    else if constexpr (std::is_same_v<T, Integral<64, false>>)
       return PT_Uint64;
     else if constexpr (std::is_same_v<T, Floating>)
       return PT_Float;

--- a/clang/lib/AST/ByteCode/MemberPointer.cpp
+++ b/clang/lib/AST/ByteCode/MemberPointer.cpp
@@ -81,13 +81,14 @@ FunctionPointer MemberPointer::toFunctionPointer(const Context &Ctx) const {
       Ctx.getProgram().getFunction(cast<FunctionDecl>(getDecl())));
 }
 
-APValue MemberPointer::toAPValue(const ASTContext &ASTCtx) const {
+APValue MemberPointer::toAPValue(const ASTContext &ASTCtx,
+                                 const Program &P) const {
   if (isZero())
     return APValue(static_cast<ValueDecl *>(nullptr), /*IsDerivedMember=*/false,
                    /*Path=*/{});
 
   if (hasBase())
-    return Base.toAPValue(ASTCtx);
+    return Base.toAPValue(ASTCtx, P);
 
   return APValue(getDecl(), /*IsDerivedMember=*/isDerivedMember(),
                  /*Path=*/ArrayRef(Path, PathLength));

--- a/clang/lib/AST/ByteCode/MemberPointer.h
+++ b/clang/lib/AST/ByteCode/MemberPointer.h
@@ -152,7 +152,7 @@ public:
                          this->PtrOffset);
   }
 
-  APValue toAPValue(const ASTContext &) const;
+  APValue toAPValue(const ASTContext &, const Program &) const;
 
   void print(llvm::raw_ostream &OS) const {
     OS << "MemberPtr(" << Base << " " << (const void *)getDecl() << " + "
@@ -160,8 +160,9 @@ public:
        << ". IsDerived: " << isDerivedMember() << ")";
   }
 
-  std::string toDiagnosticString(const ASTContext &Ctx) const {
-    return toAPValue(Ctx).getAsString(Ctx, getDecl()->getType());
+  std::string toDiagnosticString(const ASTContext &Ctx,
+                                 const Program &P) const {
+    return toAPValue(Ctx, P).getAsString(Ctx, getDecl()->getType());
   }
 };
 

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -137,10 +137,10 @@ public:
   bool operator!=(const Pointer &P) const { return !(P == *this); }
 
   /// Converts the pointer to an APValue.
-  APValue toAPValue(const ASTContext &ASTCtx) const;
+  APValue toAPValue(const ASTContext &ASTCtx, const Program &) const;
 
   /// Converts the pointer to a string usable in diagnostics.
-  std::string toDiagnosticString(const ASTContext &Ctx) const;
+  std::string toDiagnosticString(const ASTContext &Ctx, const Program &) const;
 
   uint64_t getIntegerRepresentation() const {
     if (isIntegralPointer())
@@ -151,8 +151,8 @@ public:
   }
 
   /// Converts the pointer to an APValue that is an rvalue.
-  std::optional<APValue> toRValue(const Context &Ctx,
-                                  QualType ResultType) const;
+  std::optional<APValue> toRValue(const Context &Ctx, QualType ResultType,
+                                  const Program &) const;
 
   /// Offsets a pointer inside an array.
   [[nodiscard]] Pointer atIndex(uint64_t Idx) const {
@@ -366,7 +366,7 @@ public:
     if (isIntegralPointer()) {
       if (!Int.Desc)
         return 1;
-      return Int.Desc->getElemSize();
+      return Int.Desc->getElemDataSize();
     }
 
     if (BS.Base == RootPtrMark)
@@ -809,6 +809,7 @@ public:
   /// i.e. a non-MaterializeTemporaryExpr Expr.
   bool pointsToLiteral() const;
   bool pointsToStringLiteral() const;
+  bool pointsToLabel() const;
 
   /// Prints the pointer.
   void print(llvm::raw_ostream &OS) const;

--- a/clang/lib/AST/ByteCode/PrimType.h
+++ b/clang/lib/AST/ByteCode/PrimType.h
@@ -249,6 +249,22 @@ static inline bool aligned(const void *P) {
     }                                                                          \
   } while (0)
 
+#define FIXED_SIZE_INT_TYPE_SWITCH(Expr, B)                                    \
+  do {                                                                         \
+    switch (Expr) {                                                            \
+      TYPE_SWITCH_CASE(PT_Sint8, B)                                            \
+      TYPE_SWITCH_CASE(PT_Uint8, B)                                            \
+      TYPE_SWITCH_CASE(PT_Sint16, B)                                           \
+      TYPE_SWITCH_CASE(PT_Uint16, B)                                           \
+      TYPE_SWITCH_CASE(PT_Sint32, B)                                           \
+      TYPE_SWITCH_CASE(PT_Uint32, B)                                           \
+      TYPE_SWITCH_CASE(PT_Sint64, B)                                           \
+      TYPE_SWITCH_CASE(PT_Uint64, B)                                           \
+    default:                                                                   \
+      llvm_unreachable("Not an integer value");                                \
+    }                                                                          \
+  } while (0)
+
 #define INT_TYPE_SWITCH_NO_BOOL(Expr, B)                                       \
   do {                                                                         \
     switch (Expr) {                                                            \

--- a/clang/lib/AST/ByteCode/Primitives.h
+++ b/clang/lib/AST/ByteCode/Primitives.h
@@ -21,6 +21,14 @@
 namespace clang {
 namespace interp {
 
+enum class IntegralKind : uint8_t {
+  Number = 0,
+  Address,
+  BlockAddress,
+  LabelAddress,
+  AddrLabelDiff
+};
+
 /// Helper to compare two comparable types.
 template <typename T> ComparisonCategoryResult Compare(const T &X, const T &Y) {
   if (X < Y)

--- a/clang/lib/AST/ByteCode/Program.cpp
+++ b/clang/lib/AST/ByteCode/Program.cpp
@@ -31,6 +31,20 @@ const void *Program::getNativePointer(unsigned Idx) const {
   return NativePointers[Idx];
 }
 
+unsigned Program::getOrCreateAddrLabelDiff(const AddrLabelExpr *LHS,
+                                           const AddrLabelExpr *RHS) {
+  auto [It, Inserted] = AddrLabelDiffIndices.try_emplace(
+      AddrLabelDiff{LHS, RHS}, AddrLabelDiffs.size());
+  if (Inserted)
+    AddrLabelDiffs.push_back(AddrLabelDiff{LHS, RHS});
+
+  return It->second;
+}
+
+AddrLabelDiff Program::getLabelDiff(unsigned Index) const {
+  return AddrLabelDiffs[Index];
+}
+
 unsigned Program::createGlobalString(const StringLiteral *S, const Expr *Base) {
   const size_t CharWidth = S->getCharByteWidth();
   const size_t BitWidth = CharWidth * Ctx.getCharBit();
@@ -49,7 +63,6 @@ unsigned Program::createGlobalString(const StringLiteral *S, const Expr *Base) {
                                         /*IsConst=*/true,
                                         /*isTemporary=*/false,
                                         /*isMutable=*/false);
-
   // Allocate storage for the string.
   // The byte length does not include the null terminator.
   unsigned GlobalIndex = Globals.size();
@@ -63,15 +76,10 @@ unsigned Program::createGlobalString(const StringLiteral *S, const Expr *Base) {
   Globals.push_back(G);
 
   const Pointer Ptr(G->block());
-  if (CharWidth == 1) {
-    std::memcpy(&Ptr.elem<char>(0), S->getString().data(), StringLength);
-  } else {
-    // Construct the string in storage.
-    for (unsigned I = 0; I <= StringLength; ++I) {
-      uint32_t CodePoint = I == StringLength ? 0 : S->getCodeUnit(I);
-      INT_TYPE_SWITCH_NO_BOOL(*CharType,
-                              Ptr.elem<T>(I) = T::from(CodePoint, BitWidth););
-    }
+  for (unsigned I = 0; I <= StringLength; ++I) {
+    uint32_t CodePoint = I == StringLength ? 0 : S->getCodeUnit(I);
+    INT_TYPE_SWITCH_NO_BOOL(*CharType,
+                            Ptr.elem<T>(I) = T::from(CodePoint, BitWidth););
   }
   Ptr.initializeAllElements();
 

--- a/clang/test/AST/ByteCode/addr-label-diff.c
+++ b/clang/test/AST/ByteCode/addr-label-diff.c
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -triple x86_64 -emit-llvm %s -o -                                         | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64 -emit-llvm %s -o - -fexperimental-new-constant-interpreter | FileCheck %s
+
+typedef __typeof((int*) 0 - (int*) 0) intptr_t;
+
+// CHECK: @f1.l0 = internal global i64 ptrtoint (ptr @f1 to i64)
+void f1(void) { static intptr_t l0 = (intptr_t) f1; }
+
+// CHECK: @FoldableAddrLabelDiff.x = internal global i64 sub (i64 ptrtoint (ptr blockaddress(@FoldableAddrLabelDiff, %a) to i64), i64 ptrtoint (ptr blockaddress(@FoldableAddrLabelDiff, %b) to i64)), align 8
+void FoldableAddrLabelDiff() { static long x = (long)&&a-(long)&&b; a:b:return;}
+
+// CHECK: @c.ar = internal global {{.*}} sub (i{{..}} ptrtoint (ptr blockaddress(@c, %l2) to i{{..}}), i{{..}} ptrtoint (ptr blockaddress(@c, %l1) to i{{..}}))
+int c(void) {
+  static int ar = &&l2 - &&l1;
+l1:
+  return 10;
+l2:
+  return 11;
+}

--- a/clang/test/AST/ByteCode/addr-label-diff.cpp
+++ b/clang/test/AST/ByteCode/addr-label-diff.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -triple x86_64 -emit-llvm %s -o -                                         | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64 -emit-llvm %s -o - -fexperimental-new-constant-interpreter | FileCheck %s
+
+
+// Make sure we don't try to fold this either.
+// CHECK: @_ZZ23UnfoldableAddrLabelDiffvE1x = internal global i128 0
+void UnfoldableAddrLabelDiff() { static __int128_t x = (long)&&a-(long)&&b; a:b:return;}
+
+// CHECK: @_ZZ24UnfoldableAddrLabelDiff2vE1x = internal global i16 0
+void UnfoldableAddrLabelDiff2() { static short x = (long)&&a-(long)&&b; a:b:return;}
+
+
+// But make sure we do fold this.
+// CHECK: @_ZZ21FoldableAddrLabelDiffvE1x = internal global i64 sub (i64 ptrtoint (ptr blockaddress(@_Z21FoldableAddrLabelDiffv
+void FoldableAddrLabelDiff() { static long x = (long)&&a-(long)&&b; a:b:return;}
+

--- a/clang/test/AST/ByteCode/const-eval.c
+++ b/clang/test/AST/ByteCode/const-eval.c
@@ -173,6 +173,9 @@ _Static_assert(A > B, "");
 int * GH149500_p = &(*(int *)0x400);
 static const void *GH149500_q = &(*(const struct sysrq_key_op *)0);
 
+
+void f0(void) { static intptr_t l0 = (unsigned)(intptr_t) f0;} // both-error {{initializer element is not a compile-time constant}}
+
 #else
 #error :(
 #endif

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -423,3 +423,15 @@ namespace DummyToGlobalBlockMove {
   Baz Bar::_m[] = {{0}};
   const AP m = {&Bar ::m};
 }
+
+namespace AddSubMulNonNumber {
+#define fold(x) (__builtin_constant_p(x) ? (x) : (x))
+
+  typedef decltype(sizeof(int)) LabelDiffTy;
+  constexpr LabelDiffTy mulBy3(LabelDiffTy x) { return x * 3; } // both-note {{subexpression}}
+  void LabelDiffTest() {
+    static_assert(mulBy3(fold((LabelDiffTy)&&a-(LabelDiffTy)&&b)) == 3, ""); // both-error {{constant expression}} \
+                                                                             // both-note {{call to 'mulBy3(&&a - &&b)'}}
+    a:b:return;
+  }
+}

--- a/clang/test/CodeGen/const-init.c
+++ b/clang/test/CodeGen/const-init.c
@@ -1,5 +1,6 @@
 // setting strict FP behaviour in the run line below tests that the compiler
 // does the right thing for global compound literals (compoundliteral test)
+// RUN: %clang_cc1 -triple i386-pc-linux-gnu -ffreestanding -Wno-pointer-to-int-cast -Wno-int-conversion -ffp-exception-behavior=strict -emit-llvm -o - %s -fexperimental-new-constant-interpreter | FileCheck %s
 // RUN: %clang_cc1 -triple i386-pc-linux-gnu -ffreestanding -Wno-pointer-to-int-cast -Wno-int-conversion -ffp-exception-behavior=strict -emit-llvm -o - %s | FileCheck %s
 
 #include <stdint.h>

--- a/clang/test/CodeGen/const-label-addr.c
+++ b/clang/test/CodeGen/const-label-addr.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -emit-llvm -o - -fexperimental-new-constant-interpreter | FileCheck %s
 // REQUIRES: asserts
 
 // CHECK: @a.a = internal global ptr blockaddress(@a, %A)

--- a/clang/test/CodeGen/statements.c
+++ b/clang/test/CodeGen/statements.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -Wno-error=return-type -Wno-error=int-conversion %s -emit-llvm-only
+// RUN: %clang_cc1 -Wno-error=return-type -Wno-error=int-conversion %s -emit-llvm-only -fexperimental-new-constant-interpreter
 // REQUIRES: LP64
 
 // Mismatched type between return and function result.

--- a/clang/test/CodeGen/staticinit.c
+++ b/clang/test/CodeGen/staticinit.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple i386-pc-linux-gnu -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple i386-pc-linux-gnu -emit-llvm -o - %s -fexperimental-new-constant-interpreter | FileCheck %s
 
 struct AStruct { 
   int i;

--- a/clang/test/CodeGenCXX/2008-05-07-CrazyOffsetOf.cpp
+++ b/clang/test/CodeGenCXX/2008-05-07-CrazyOffsetOf.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple=x86_64-unknown-linux -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple=x86_64-unknown-linux -emit-llvm %s -o - -fexperimental-new-constant-interpreter | FileCheck %s
 
 struct bork {
   struct bork *next_local;

--- a/clang/test/CodeGenCXX/const-init-cxx11.cpp
+++ b/clang/test/CodeGenCXX/const-init-cxx11.cpp
@@ -1,6 +1,9 @@
 // RUN: %clang_cc1 -w -fmerge-all-constants -triple x86_64-elf-gnu -emit-llvm -o - %s -std=c++11 | FileCheck %s
 // RUN: %clang_cc1 -w -fmerge-all-constants -triple x86_64-elf-gnu -emit-llvm -o - %s -std=c++20 | FileCheck -check-prefix=CHECK20 %s
 
+// RUN: %clang_cc1 -w -fmerge-all-constants -triple x86_64-elf-gnu -emit-llvm -o - %s -std=c++11 -fexperimental-new-constant-interpreter | FileCheck %s
+// RUN: %clang_cc1 -w -fmerge-all-constants -triple x86_64-elf-gnu -emit-llvm -o - %s -std=c++20 -fexperimental-new-constant-interpreter | FileCheck -check-prefix=CHECK20 %s
+
 // FIXME: The padding in all these objects should be zero-initialized.
 namespace StructUnion {
   struct A {

--- a/clang/test/CodeGenCXX/const-init.cpp
+++ b/clang/test/CodeGenCXX/const-init.cpp
@@ -2,6 +2,12 @@
 // RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-llvm -std=c++98 -o - %s | FileCheck %s
 // RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-llvm -std=c++11 -o - %s | FileCheck %s
 
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-llvm -o - %s -fexperimental-new-constant-interpreter | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-llvm -std=c++98 -o - %s -fexperimental-new-constant-interpreter | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-llvm -std=c++11 -o - %s -fexperimental-new-constant-interpreter | FileCheck %s
+
+
+
 // CHECK: @a = global i32 10
 int a = 10;
 // CHECK: @ar = constant ptr @a

--- a/clang/test/Sema/array-init.c
+++ b/clang/test/Sema/array-init.c
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -std=gnu99 -fsyntax-only -pedantic -verify=expected,pedantic %s
 // RUN: %clang_cc1 -std=gnu99 -fsyntax-only -Wgnu -Wc11-extensions -verify %s
+// RUN: %clang_cc1 -std=gnu99 -fsyntax-only -pedantic -verify=expected,pedantic %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=gnu99 -fsyntax-only -Wgnu -Wc11-extensions -verify %s -fexperimental-new-constant-interpreter
 // REQUIRES: LP64
 
 extern int foof(void) = 1; // expected-error{{illegal initializer (only variables can be initialized)}}

--- a/clang/test/Sema/compound-literal.c
+++ b/clang/test/Sema/compound-literal.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -fblocks -pedantic %s
+// RUN: %clang_cc1 -fsyntax-only -verify -fblocks -pedantic %s -fexperimental-new-constant-interpreter
 // REQUIRES: LP64
 
 struct foo { int a, b; };

--- a/clang/test/Sema/const-ptr-int-ptr-cast.c
+++ b/clang/test/Sema/const-ptr-int-ptr-cast.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -ffreestanding %s
+// RUN: %clang_cc1 -fsyntax-only -verify -ffreestanding %s -fexperimental-new-constant-interpreter
 // expected-no-diagnostics
 
 typedef __UINTPTR_TYPE__ uintptr_t;

--- a/clang/test/SemaCXX/constexpr-string.cpp
+++ b/clang/test/SemaCXX/constexpr-string.cpp
@@ -8,6 +8,7 @@
 // RUN: %clang_cc1 %s -triple armebv7-unknown-linux -std=c++2a -fsyntax-only -verify -pedantic -Wno-vla-extension -fno-wchar -DNO_PREDEFINED_WCHAR_T
 
 // RUN: %clang_cc1 %s -triple armebv7-unknown-linux -std=c++2a -fsyntax-only -verify -pedantic -Wno-vla-extension -fno-signed-char -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 %s -triple armebv7-unknown-linux -std=c++2a -fsyntax-only -verify -pedantic -Wno-vla-extension -fno-wchar -DNO_PREDEFINED_WCHAR_T -fexperimental-new-constant-interpreter
 
 # 9 "/usr/include/string.h" 1 3 4  // expected-warning {{this style of line directive is a GNU extension}}
 extern "C" {

--- a/clang/unittests/AST/ByteCode/toAPValue.cpp
+++ b/clang/unittests/AST/ByteCode/toAPValue.cpp
@@ -50,7 +50,7 @@ TEST(ToAPValue, Pointers) {
     const Pointer &GP = getGlobalPtr("b");
     const Pointer &P = GP.deref<Pointer>();
     ASSERT_TRUE(P.isLive());
-    APValue A = P.toAPValue(ASTCtx);
+    APValue A = P.toAPValue(ASTCtx, Prog);
     ASSERT_TRUE(A.isLValue());
     ASSERT_TRUE(A.hasLValuePath());
     const auto &Path = A.getLValuePath();
@@ -65,7 +65,7 @@ TEST(ToAPValue, Pointers) {
     const Pointer &GP = getGlobalPtr("p");
     const Pointer &P = GP.deref<Pointer>();
     ASSERT_TRUE(P.isIntegralPointer());
-    APValue A = P.toAPValue(ASTCtx);
+    APValue A = P.toAPValue(ASTCtx, Prog);
     ASSERT_TRUE(A.isLValue());
     ASSERT_TRUE(A.getLValueBase().isNull());
     APSInt I;
@@ -80,7 +80,7 @@ TEST(ToAPValue, Pointers) {
     const Pointer &GP = getGlobalPtr("nullp");
     const Pointer &P = GP.deref<Pointer>();
     ASSERT_TRUE(P.isIntegralPointer());
-    APValue A = P.toAPValue(ASTCtx);
+    APValue A = P.toAPValue(ASTCtx, Prog);
     ASSERT_TRUE(A.isLValue());
     ASSERT_TRUE(A.getLValueBase().isNull());
     ASSERT_TRUE(A.isNullPointer());
@@ -95,7 +95,7 @@ TEST(ToAPValue, Pointers) {
     const ValueDecl *D = getDecl("arrp");
     ASSERT_NE(D, nullptr);
     const Pointer &GP = getGlobalPtr("arrp").deref<Pointer>();
-    APValue A = GP.toAPValue(ASTCtx);
+    APValue A = GP.toAPValue(ASTCtx, Prog);
     ASSERT_TRUE(A.isLValue());
     ASSERT_TRUE(A.hasLValuePath());
     ASSERT_EQ(A.getLValuePath().size(), 2u);
@@ -137,7 +137,7 @@ TEST(ToAPValue, FunctionPointers) {
     const Pointer &GP = getGlobalPtr("func");
     const Pointer &FP = GP.deref<Pointer>();
     ASSERT_FALSE(FP.isZero());
-    APValue A = FP.toAPValue(ASTCtx);
+    APValue A = FP.toAPValue(ASTCtx, Prog);
     ASSERT_TRUE(A.hasValue());
     ASSERT_TRUE(A.isLValue());
     ASSERT_TRUE(A.hasLValuePath());
@@ -195,7 +195,7 @@ TEST(ToAPValue, FunctionPointersC) {
     ASSERT_TRUE(GP.isLive());
     const Pointer &FP = GP.deref<Pointer>();
     ASSERT_FALSE(FP.isZero());
-    APValue A = FP.toAPValue(ASTCtx);
+    APValue A = FP.toAPValue(ASTCtx, Prog);
     ASSERT_TRUE(A.hasValue());
     ASSERT_TRUE(A.isLValue());
     const auto &Path = A.getLValuePath();
@@ -254,7 +254,7 @@ TEST(ToAPValue, MemberPointers) {
     const Pointer &GP = getGlobalPtr("pm");
     ASSERT_TRUE(GP.isLive());
     const MemberPointer &FP = GP.deref<MemberPointer>();
-    APValue A = FP.toAPValue(ASTCtx);
+    APValue A = FP.toAPValue(ASTCtx, Prog);
     ASSERT_EQ(A.getMemberPointerDecl(), getDecl("m"));
     ASSERT_EQ(A.getKind(), APValue::MemberPointer);
     ASSERT_EQ(A.getMemberPointerPath().size(), 0u);
@@ -266,7 +266,7 @@ TEST(ToAPValue, MemberPointers) {
     ASSERT_TRUE(GP.isLive());
     const MemberPointer &NP = GP.deref<MemberPointer>();
     ASSERT_TRUE(NP.isZero());
-    APValue A = NP.toAPValue(ASTCtx);
+    APValue A = NP.toAPValue(ASTCtx, Prog);
     ASSERT_EQ(A.getKind(), APValue::MemberPointer);
     ASSERT_EQ(A.getMemberPointerPath().size(), 0u);
     ASSERT_FALSE(A.isMemberPointerToDerivedMember());
@@ -277,7 +277,7 @@ TEST(ToAPValue, MemberPointers) {
     ASSERT_TRUE(GP.isLive());
     const MemberPointer &MP = GP.deref<MemberPointer>();
     ASSERT_FALSE(MP.isZero());
-    APValue A = MP.toAPValue(ASTCtx);
+    APValue A = MP.toAPValue(ASTCtx, Prog);
     ASSERT_EQ(A.getKind(), APValue::MemberPointer);
     ASSERT_EQ(A.getMemberPointerPath().size(), 1u);
     ASSERT_FALSE(A.isMemberPointerToDerivedMember());
@@ -288,7 +288,7 @@ TEST(ToAPValue, MemberPointers) {
     ASSERT_TRUE(GP.isLive());
     const MemberPointer &MP = GP.deref<MemberPointer>();
     ASSERT_FALSE(MP.isZero());
-    APValue A = MP.toAPValue(ASTCtx);
+    APValue A = MP.toAPValue(ASTCtx, Prog);
     ASSERT_EQ(A.getKind(), APValue::MemberPointer);
     ASSERT_EQ(A.getMemberPointerPath().size(), 0u);
     ASSERT_FALSE(A.isMemberPointerToDerivedMember());
@@ -299,7 +299,7 @@ TEST(ToAPValue, MemberPointers) {
     ASSERT_TRUE(GP.isLive());
     const MemberPointer &MP = GP.deref<MemberPointer>();
     ASSERT_FALSE(MP.isZero());
-    APValue A = MP.toAPValue(ASTCtx);
+    APValue A = MP.toAPValue(ASTCtx, Prog);
     ASSERT_EQ(A.getKind(), APValue::MemberPointer);
     ASSERT_EQ(A.getMemberPointerPath().size(), 20u);
     ASSERT_TRUE(A.isMemberPointerToDerivedMember());
@@ -310,7 +310,7 @@ TEST(ToAPValue, MemberPointers) {
     ASSERT_TRUE(GP.isLive());
     const MemberPointer &MP = GP.deref<MemberPointer>();
     ASSERT_FALSE(MP.isZero());
-    APValue A = MP.toAPValue(ASTCtx);
+    APValue A = MP.toAPValue(ASTCtx, Prog);
     ASSERT_EQ(A.getKind(), APValue::MemberPointer);
     ASSERT_EQ(A.getMemberPointerPath().size(), 19u);
     ASSERT_TRUE(A.isMemberPointerToDerivedMember());
@@ -321,7 +321,7 @@ TEST(ToAPValue, MemberPointers) {
     ASSERT_TRUE(GP.isLive());
     const MemberPointer &MP = GP.deref<MemberPointer>();
     ASSERT_FALSE(MP.isZero());
-    APValue A = MP.toAPValue(ASTCtx);
+    APValue A = MP.toAPValue(ASTCtx, Prog);
     ASSERT_EQ(A.getKind(), APValue::MemberPointer);
     ASSERT_EQ(A.getMemberPointerPath().size(), 10u);
     ASSERT_TRUE(A.isMemberPointerToDerivedMember());
@@ -332,7 +332,7 @@ TEST(ToAPValue, MemberPointers) {
     ASSERT_TRUE(GP.isLive());
     const MemberPointer &MP = GP.deref<MemberPointer>();
     ASSERT_FALSE(MP.isZero());
-    APValue A = MP.toAPValue(ASTCtx);
+    APValue A = MP.toAPValue(ASTCtx, Prog);
     ASSERT_EQ(A.getKind(), APValue::MemberPointer);
     ASSERT_EQ(A.getMemberPointerPath().size(), 10u);
     ASSERT_FALSE(A.isMemberPointerToDerivedMember());


### PR DESCRIPTION
This adds an `IntegralKind` to `clang::interp::Integral` (not `IntegralAP` yet).

As a result, the size of such an integral is now different (larger) than that of its underlying representation type. 
If the type is now `IntegralKind::Number`, the value of the underlying type is used as an internal value for a pointer or an address label difference (similar to the existing "native pointer" mechanism in `Program`).

Another unfortunate side-effect is that we need to pass around the `Program` instance more often.