### PR TITLE
Fix handling of asm string literals 

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -28,6 +28,7 @@
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SyncScope.h"
 #include "clang/Basic/TypeTraits.h"
+#include "clang/Lex/TextEncodingConfig.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/SmallVector.h"
@@ -2065,6 +2066,11 @@ public:
   StringRef getIdentKindName() const {
     return getIdentKindName(getIdentKind());
   }
+
+  static std::string
+  ComputeNameAndTranslate(PredefinedIdentKind IK, const Decl *CurrentDecl,
+                          TextEncodingConfig &TEC,
+                          bool ForceElaboratedPrinting = false);
 
   static std::string ComputeName(PredefinedIdentKind IK,
                                  const Decl *CurrentDecl,

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -330,7 +330,7 @@ public:
 
   virtual ~TargetInfo();
 
-  std::unique_ptr<llvm::TextEncodingConverter> TargetStrConverter;
+  std::unique_ptr<llvm::TextEncodingConverter> FromSystemEncodingConverter;
 
   /// Retrieve the target options.
   TargetOptions &getTargetOpts() const {

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -38,6 +38,7 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/TextEncoding.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cassert>
@@ -328,6 +329,8 @@ public:
                                       TargetOptions &Opts);
 
   virtual ~TargetInfo();
+
+  std::unique_ptr<llvm::TextEncodingConverter> TargetStrConverter;
 
   /// Retrieve the target options.
   TargetOptions &getTargetOpts() const {

--- a/clang/include/clang/Lex/TextEncoding.h
+++ b/clang/include/clang/Lex/TextEncoding.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_LEX_TEXTENCODING_H
 
 #include "clang/Basic/LangOptions.h"
+#include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace llvm {
@@ -17,16 +18,22 @@ class TextEncodingConverter;
 } // namespace llvm
 
 namespace clang {
-enum ConversionAction { CA_NoConversion, CA_ToLiteralEncoding };
+enum ConversionAction {
+  CA_NoConversion,
+  CA_ToSystemEncoding,
+  CA_ToLiteralEncoding
+};
 
 class TextEncoding {
   llvm::StringRef LiteralEncoding;
   std::unique_ptr<llvm::TextEncodingConverter> ToLiteralEncodingConverter;
+  std::unique_ptr<llvm::TextEncodingConverter> ToSystemEncodingConverter;
 
 public:
   llvm::TextEncodingConverter *getConverter(ConversionAction Action) const;
   static std::error_code
-  setConvertersFromOptions(TextEncoding &TE, const clang::LangOptions &Opts);
+  setConvertersFromOptions(TextEncoding &TE, const clang::LangOptions &Opts,
+                           clang::TargetInfo &TInfo);
 
   llvm::StringRef getLiteralEncoding() { return LiteralEncoding; }
 };

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -5715,6 +5715,7 @@ private:
     bool Finished;
   };
   ObjCImplParsingDataRAII *CurParsedObjCImpl;
+  ConversionAction ParserConversionAction;
 
   /// StashAwayMethodOrFunctionBodyTokens -  Consume the tokens and store them
   /// for later parsing.

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -5716,6 +5716,7 @@ private:
     bool Finished;
   };
   ObjCImplParsingDataRAII *CurParsedObjCImpl;
+  ConversionAction ParserConversionAction;
 
   /// StashAwayMethodOrFunctionBodyTokens -  Consume the tokens and store them
   /// for later parsing.

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3867,8 +3867,9 @@ private:
   /// associated with the class's definition.
   void PopParsingClass(Sema::ParsingClassState);
 
-  ExprResult ParseStringLiteralExpression(bool AllowUserDefinedLiteral,
-                                          bool Unevaluated);
+  ExprResult
+  ParseStringLiteralExpression(bool AllowUserDefinedLiteral, bool Unevaluated,
+                               ConversionAction CA = CA_ToLiteralEncoding);
 
   /// This routine is called when the '@' is seen and consumed.
   /// Current token is an Identifier and is not a 'try'. This
@@ -5716,7 +5717,6 @@ private:
     bool Finished;
   };
   ObjCImplParsingDataRAII *CurParsedObjCImpl;
-  ConversionAction ParserConversionAction;
 
   /// StashAwayMethodOrFunctionBodyTokens -  Consume the tokens and store them
   /// for later parsing.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -55,7 +55,6 @@
 #include "clang/Basic/TemplateKinds.h"
 #include "clang/Basic/TokenKinds.h"
 #include "clang/Basic/TypeTraits.h"
-#include "clang/Lex/LiteralConverter.h"
 #include "clang/Sema/AnalysisBasedWarnings.h"
 #include "clang/Sema/Attr.h"
 #include "clang/Sema/CleanupInfo.h"

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -55,6 +55,7 @@
 #include "clang/Basic/TemplateKinds.h"
 #include "clang/Basic/TokenKinds.h"
 #include "clang/Basic/TypeTraits.h"
+#include "clang/Lex/LiteralConverter.h"
 #include "clang/Sema/AnalysisBasedWarnings.h"
 #include "clang/Sema/Attr.h"
 #include "clang/Sema/CleanupInfo.h"
@@ -7374,7 +7375,8 @@ public:
   /// from multiple tokens.  However, the common case is that StringToks points
   /// to one string.
   ExprResult ActOnStringLiteral(ArrayRef<Token> StringToks,
-                                Scope *UDLScope = nullptr);
+                                Scope *UDLScope = nullptr,
+                                ConversionAction Action = CA_ToExecEncoding);
 
   ExprResult ActOnUnevaluatedStringLiteral(ArrayRef<Token> StringToks);
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -55,6 +55,7 @@
 #include "clang/Basic/TemplateKinds.h"
 #include "clang/Basic/TokenKinds.h"
 #include "clang/Basic/TypeTraits.h"
+#include "clang/Lex/TextEncodingConfig.h"
 #include "clang/Sema/AnalysisBasedWarnings.h"
 #include "clang/Sema/Attr.h"
 #include "clang/Sema/CleanupInfo.h"

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11429,7 +11429,8 @@ private:
   ///@{
 
 public:
-  ExprResult ActOnGCCAsmStmtString(Expr *Stm, bool ForAsmLabel);
+  ExprResult ActOnGCCAsmStmtString(Expr *Stm, bool ForAsmLabel,
+                                   bool IsConstExpr = false);
   StmtResult ActOnGCCAsmStmt(SourceLocation AsmLoc, bool IsSimple,
                              bool IsVolatile, unsigned NumOutputs,
                              unsigned NumInputs, IdentifierInfo **Names,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -54,6 +54,7 @@
 #include "clang/Basic/StackExhaustionHandler.h"
 #include "clang/Basic/TemplateKinds.h"
 #include "clang/Basic/TokenKinds.h"
+#include "clang/Lex/TextEncoding.h"
 #include "clang/Sema/AnalysisBasedWarnings.h"
 #include "clang/Sema/Attr.h"
 #include "clang/Sema/CleanupInfo.h"
@@ -7397,7 +7398,8 @@ public:
   /// from multiple tokens.  However, the common case is that StringToks points
   /// to one string.
   ExprResult ActOnStringLiteral(ArrayRef<Token> StringToks,
-                                Scope *UDLScope = nullptr);
+                                Scope *UDLScope = nullptr,
+                                ConversionAction Action = CA_ToLiteralEncoding);
 
   ExprResult ActOnUnevaluatedStringLiteral(ArrayRef<Token> StringToks);
 

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -673,6 +673,20 @@ StringRef PredefinedExpr::getIdentKindName(PredefinedIdentKind IK) {
   llvm_unreachable("Unknown ident kind for PredefinedExpr");
 }
 
+std::string PredefinedExpr::ComputeNameAndTranslate(
+    PredefinedIdentKind IK, const Decl *CurrentDecl, TextEncodingConfig &TEC,
+    bool ForceElaboratedPrinting) {
+  using namespace clang::charinfo;
+  std::string Result = ComputeName(IK, CurrentDecl, ForceElaboratedPrinting);
+  llvm::TextEncodingConverter *Converter = TEC.getConverter(CA_ToExecEncoding);
+  if (Converter) {
+    SmallString<128> Converted;
+    Converter->convert(Result, Converted);
+    Result = std::string(Converted);
+  }
+  return Result;
+}
+
 // FIXME: Maybe this should use DeclPrinter with a special "print predefined
 // expr" policy instead.
 std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -198,6 +198,8 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : Triple(T) {
   MaxOpenCLWorkGroupSize = 1024;
 
   MaxBitIntWidth.reset();
+
+  TargetStrConverter = nullptr;
 }
 
 // Out of line virtual dtor for TargetInfo.

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -199,7 +199,7 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : Triple(T) {
 
   MaxBitIntWidth.reset();
 
-  TargetStrConverter = nullptr;
+  FromSystemEncodingConverter = nullptr;
 }
 
 // Out of line virtual dtor for TargetInfo.

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -563,8 +563,8 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
   if (GetDependencyDirectives)
     PP->setDependencyDirectivesGetter(*GetDependencyDirectives);
 
-  if (auto EC = TextEncoding::setConvertersFromOptions(PP->getTextEncoding(),
-                                                       getLangOpts()))
+  if (auto EC = TextEncoding::setConvertersFromOptions(
+          PP->getTextEncoding(), getLangOpts(), getTarget()))
     PP->getDiagnostics().Report(clang::diag::err_fe_text_encoding_config)
         << PP->getTextEncoding().getLiteralEncoding();
 }

--- a/clang/lib/Lex/TextEncoding.cpp
+++ b/clang/lib/Lex/TextEncoding.cpp
@@ -17,6 +17,8 @@ TextEncoding::getConverter(ConversionAction Action) const {
   switch (Action) {
   case CA_ToLiteralEncoding:
     return ToLiteralEncodingConverter.get();
+  case CA_ToSystemEncoding:
+    return ToSystemEncodingConverter.get();
   default:
     return nullptr;
   }
@@ -24,23 +26,46 @@ TextEncoding::getConverter(ConversionAction Action) const {
 
 std::error_code
 TextEncoding::setConvertersFromOptions(TextEncoding &TE,
-                                       const clang::LangOptions &Opts) {
+                                       const clang::LangOptions &Opts,
+                                       clang::TargetInfo &TInfo) {
   using namespace llvm;
 
   const char *UTF8 = "UTF-8";
   TE.LiteralEncoding =
       Opts.LiteralEncoding.empty() ? UTF8 : Opts.LiteralEncoding.c_str();
 
-  // Create converter between internal and literal encoding specified
-  // in fexec-charset option.
-  if (TE.LiteralEncoding == UTF8)
+  if (TE.LiteralEncoding != UTF8) {
+    ErrorOr<TextEncodingConverter> ErrorOrLiteralConverter =
+        llvm::TextEncodingConverter::create(UTF8, TE.LiteralEncoding);
+    if (ErrorOrLiteralConverter)
+      TE.ToLiteralEncodingConverter = std::make_unique<TextEncodingConverter>(
+          std::move(*ErrorOrLiteralConverter));
+    else
+      return ErrorOrLiteralConverter.getError();
+  }
+
+  if (TInfo.getDefaultOrdinaryLiteralEncoding() == UTF8)
     return std::error_code();
+
+  // Create converter between internal and default ordinary encoding for the
+  // target
   ErrorOr<TextEncodingConverter> ErrorOrConverter =
-      llvm::TextEncodingConverter::create(UTF8, TE.LiteralEncoding);
+      llvm::TextEncodingConverter::create(
+          UTF8, TInfo.getDefaultOrdinaryLiteralEncoding());
   if (ErrorOrConverter)
-    TE.ToLiteralEncodingConverter =
+    TE.ToSystemEncodingConverter =
         std::make_unique<TextEncodingConverter>(std::move(*ErrorOrConverter));
   else
     return ErrorOrConverter.getError();
+
+  ErrorOrConverter = llvm::TextEncodingConverter::create(
+      TInfo.getDefaultOrdinaryLiteralEncoding(), UTF8);
+
+  if (ErrorOrConverter)
+    TInfo.TargetStrConverter =
+        std::make_unique<TextEncodingConverter>(std::move(*ErrorOrConverter));
+  else
+    return ErrorOrConverter.getError();
+
   return std::error_code();
 }

--- a/clang/lib/Lex/TextEncoding.cpp
+++ b/clang/lib/Lex/TextEncoding.cpp
@@ -62,7 +62,7 @@ TextEncoding::setConvertersFromOptions(TextEncoding &TE,
       TInfo.getDefaultOrdinaryLiteralEncoding(), UTF8);
 
   if (ErrorOrConverter)
-    TInfo.TargetStrConverter =
+    TInfo.FromSystemEncodingConverter =
         std::make_unique<TextEncodingConverter>(std::move(*ErrorOrConverter));
   else
     return ErrorOrConverter.getError();

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -564,6 +564,9 @@ unsigned Parser::ParseAttributeArgsCommon(
               nullptr,
               Sema::ExpressionEvaluationContextRecord::EK_AttrArgument);
 
+          SaveAndRestore<ConversionAction> SavedTranslationState(
+              ParserConversionAction, CA_NoConversion);
+
           ExprResult ArgExpr = ParseAssignmentExpression();
           if (ArgExpr.isInvalid()) {
             SkipUntil(tok::r_paren, StopAtSemi);
@@ -644,6 +647,9 @@ void Parser::ParseGNUAttributeArgs(
   ParsedAttr::Kind AttrKind =
       ParsedAttr::getParsedKind(AttrName, ScopeName, Form.getSyntax());
 
+  SaveAndRestore<ConversionAction> SavedTranslationState(ParserConversionAction,
+                                                         CA_NoConversion);
+
   if (AttrKind == ParsedAttr::AT_Availability) {
     ParseAvailabilityAttribute(*AttrName, AttrNameLoc, Attrs, EndLoc, ScopeName,
                                ScopeLoc, Form);
@@ -722,6 +728,9 @@ unsigned Parser::ParseClangAttributeArgs(
 
   ParsedAttr::Kind AttrKind =
       ParsedAttr::getParsedKind(AttrName, ScopeName, Form.getSyntax());
+
+  SaveAndRestore<ConversionAction> SavedTranslationState(ParserConversionAction,
+                                                         CA_NoConversion);
 
   switch (AttrKind) {
   default:
@@ -1546,6 +1555,7 @@ void Parser::ParseExternalSourceSymbolAttribute(
       SkipUntil(tok::comma, tok::r_paren, StopAtSemi | StopBeforeMatch);
       continue;
     }
+
     if (Keyword == Ident_language) {
       if (HadLanguage) {
         Diag(KeywordLoc, diag::err_external_source_symbol_duplicate_clause)

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -565,9 +565,6 @@ unsigned Parser::ParseAttributeArgsCommon(
               nullptr,
               Sema::ExpressionEvaluationContextRecord::EK_AttrArgument);
 
-          SaveAndRestore<ConversionAction> SavedTranslationState(
-              ParserConversionAction, CA_NoConversion);
-
           ExprResult ArgExpr = ParseAssignmentExpression();
           if (ArgExpr.isInvalid()) {
             SkipUntil(tok::r_paren, StopAtSemi);
@@ -648,9 +645,6 @@ void Parser::ParseGNUAttributeArgs(
   ParsedAttr::Kind AttrKind =
       ParsedAttr::getParsedKind(AttrName, ScopeName, Form.getSyntax());
 
-  SaveAndRestore<ConversionAction> SavedTranslationState(ParserConversionAction,
-                                                         CA_NoConversion);
-
   if (AttrKind == ParsedAttr::AT_Availability) {
     ParseAvailabilityAttribute(*AttrName, AttrNameLoc, Attrs, EndLoc, ScopeName,
                                ScopeLoc, Form);
@@ -729,9 +723,6 @@ unsigned Parser::ParseClangAttributeArgs(
 
   ParsedAttr::Kind AttrKind =
       ParsedAttr::getParsedKind(AttrName, ScopeName, Form.getSyntax());
-
-  SaveAndRestore<ConversionAction> SavedTranslationState(ParserConversionAction,
-                                                         CA_NoConversion);
 
   switch (AttrKind) {
   default:

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -565,6 +565,9 @@ unsigned Parser::ParseAttributeArgsCommon(
               nullptr,
               Sema::ExpressionEvaluationContextRecord::EK_AttrArgument);
 
+          SaveAndRestore<ConversionAction> SavedTranslationState(
+              ParserConversionAction, CA_NoConversion);
+
           ExprResult ArgExpr = ParseAssignmentExpression();
           if (ArgExpr.isInvalid()) {
             SkipUntil(tok::r_paren, StopAtSemi);
@@ -645,6 +648,9 @@ void Parser::ParseGNUAttributeArgs(
   ParsedAttr::Kind AttrKind =
       ParsedAttr::getParsedKind(AttrName, ScopeName, Form.getSyntax());
 
+  SaveAndRestore<ConversionAction> SavedTranslationState(ParserConversionAction,
+                                                         CA_NoConversion);
+
   if (AttrKind == ParsedAttr::AT_Availability) {
     ParseAvailabilityAttribute(*AttrName, AttrNameLoc, Attrs, EndLoc, ScopeName,
                                ScopeLoc, Form);
@@ -723,6 +729,9 @@ unsigned Parser::ParseClangAttributeArgs(
 
   ParsedAttr::Kind AttrKind =
       ParsedAttr::getParsedKind(AttrName, ScopeName, Form.getSyntax());
+
+  SaveAndRestore<ConversionAction> SavedTranslationState(ParserConversionAction,
+                                                         CA_NoConversion);
 
   switch (AttrKind) {
   default:

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1001,6 +1001,8 @@ Decl *Parser::ParseStaticAssertDeclaration(SourceLocation &DeclEnd) {
         return nullptr;
       }
     } else if (tokenIsLikeStringLiteral(Tok, getLangOpts())) {
+      SaveAndRestore<ConversionAction> SavedTranslationState(
+          ParserConversionAction, CA_NoConversion);
       AssertMessage = ParseUnevaluatedStringLiteralExpression();
     } else {
       Diag(Tok, diag::err_expected_string_literal)

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -3021,7 +3021,8 @@ ExprResult Parser::ParseUnevaluatedStringLiteralExpression() {
 }
 
 ExprResult Parser::ParseStringLiteralExpression(bool AllowUserDefinedLiteral,
-                                                bool Unevaluated) {
+                                                bool Unevaluated,
+                                                ConversionAction CA) {
   assert(tokenIsLikeStringLiteral(Tok, getLangOpts()) &&
          "Not a string-literal-like token!");
 
@@ -3042,8 +3043,7 @@ ExprResult Parser::ParseStringLiteralExpression(bool AllowUserDefinedLiteral,
 
   // Pass the set of string tokens, ready for concatenation, to the actions.
   return Actions.ActOnStringLiteral(
-      StringToks, AllowUserDefinedLiteral ? getCurScope() : nullptr,
-      ParserConversionAction);
+      StringToks, AllowUserDefinedLiteral ? getCurScope() : nullptr, CA);
 }
 
 ExprResult Parser::ParseGenericSelectionExpression() {

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -3059,9 +3059,9 @@ ExprResult Parser::ParseStringLiteralExpression(bool AllowUserDefinedLiteral,
   }
 
   // Pass the set of string tokens, ready for concatenation, to the actions.
-  return Actions.ActOnStringLiteral(StringToks,
-                                    AllowUserDefinedLiteral ? getCurScope()
-                                                            : nullptr);
+  return Actions.ActOnStringLiteral(
+      StringToks, AllowUserDefinedLiteral ? getCurScope() : nullptr,
+      ParserConversionAction);
 }
 
 ExprResult Parser::ParseGenericSelectionExpression() {

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -3041,9 +3041,9 @@ ExprResult Parser::ParseStringLiteralExpression(bool AllowUserDefinedLiteral,
   }
 
   // Pass the set of string tokens, ready for concatenation, to the actions.
-  return Actions.ActOnStringLiteral(StringToks,
-                                    AllowUserDefinedLiteral ? getCurScope()
-                                                            : nullptr);
+  return Actions.ActOnStringLiteral(
+      StringToks, AllowUserDefinedLiteral ? getCurScope() : nullptr,
+      ParserConversionAction);
 }
 
 ExprResult Parser::ParseGenericSelectionExpression() {

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -70,6 +70,8 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
   NumCachedScopes = 0;
   CurParsedObjCImpl = nullptr;
 
+  ParserConversionAction = CA_ToExecEncoding;
+
   // Add #pragma handlers. These are removed and destroyed in the
   // destructor.
   initializePragmaHandlers();
@@ -1551,6 +1553,8 @@ void Parser::ParseKNRParamDeclarations(Declarator &D) {
 }
 
 ExprResult Parser::ParseAsmStringLiteral(bool ForAsmLabel) {
+  SaveAndRestore<ConversionAction> SavedTranslationState(ParserConversionAction,
+                                                         CA_NoConversion);
 
   ExprResult AsmString;
   if (isTokenStringLiteral()) {

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -70,6 +70,8 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
   NumCachedScopes = 0;
   CurParsedObjCImpl = nullptr;
 
+  ParserConversionAction = CA_ToLiteralEncoding;
+
   // Add #pragma handlers. These are removed and destroyed in the
   // destructor.
   initializePragmaHandlers();
@@ -1552,6 +1554,8 @@ void Parser::ParseKNRParamDeclarations(Declarator &D) {
 }
 
 ExprResult Parser::ParseAsmStringLiteral(bool ForAsmLabel) {
+  SaveAndRestore<ConversionAction> SavedTranslationState(ParserConversionAction,
+                                                         CA_NoConversion);
 
   ExprResult AsmString;
   if (isTokenStringLiteral()) {

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -70,8 +70,6 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
   NumCachedScopes = 0;
   CurParsedObjCImpl = nullptr;
 
-  ParserConversionAction = CA_ToLiteralEncoding;
-
   // Add #pragma handlers. These are removed and destroyed in the
   // destructor.
   initializePragmaHandlers();
@@ -1554,12 +1552,12 @@ void Parser::ParseKNRParamDeclarations(Declarator &D) {
 }
 
 ExprResult Parser::ParseAsmStringLiteral(bool ForAsmLabel) {
-  SaveAndRestore<ConversionAction> SavedTranslationState(ParserConversionAction,
-                                                         CA_NoConversion);
 
   ExprResult AsmString;
   if (isTokenStringLiteral()) {
-    AsmString = ParseStringLiteralExpression();
+    AsmString = ParseStringLiteralExpression(/*AllowUserDefinedLiteral=*/false,
+                                             /*Unevaluated=*/false,
+                                             CA_ToSystemEncoding);
     if (AsmString.isInvalid())
       return AsmString;
 

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1554,6 +1554,7 @@ void Parser::ParseKNRParamDeclarations(Declarator &D) {
 ExprResult Parser::ParseAsmStringLiteral(bool ForAsmLabel) {
 
   ExprResult AsmString;
+  bool IsConstExpr = false;
   if (isTokenStringLiteral()) {
     AsmString = ParseStringLiteralExpression(/*AllowUserDefinedLiteral=*/false,
                                              /*Unevaluated=*/false,
@@ -1569,6 +1570,7 @@ ExprResult Parser::ParseAsmStringLiteral(bool ForAsmLabel) {
     }
   } else if (!ForAsmLabel && getLangOpts().CPlusPlus11 &&
              Tok.is(tok::l_paren)) {
+    IsConstExpr = true;
     ParenParseOption ExprType = ParenParseOption::SimpleExpr;
     SourceLocation RParenLoc;
     ParsedType CastTy;
@@ -1588,7 +1590,8 @@ ExprResult Parser::ParseAsmStringLiteral(bool ForAsmLabel) {
         (getLangOpts().CPlusPlus11 && !ForAsmLabel) ? 0 : 1);
   }
 
-  return Actions.ActOnGCCAsmStmtString(AsmString.get(), ForAsmLabel);
+  return Actions.ActOnGCCAsmStmtString(AsmString.get(), ForAsmLabel,
+                                       IsConstExpr);
 }
 
 ExprResult Parser::ParseSimpleAsm(bool ForAsmLabel, SourceLocation *EndLoc) {

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3636,8 +3636,9 @@ ExprResult Sema::BuildPredefinedExpr(SourceLocation Loc,
     // the string.
     bool ForceElaboratedPrinting =
         IK == PredefinedIdentKind::Function && getLangOpts().MSVCCompat;
-    auto Str =
-        PredefinedExpr::ComputeName(IK, currentDecl, ForceElaboratedPrinting);
+    auto Str = PredefinedExpr::ComputeNameAndTranslate(
+        IK, currentDecl, getPreprocessor().getTextEncodingConfig(),
+        ForceElaboratedPrinting);
     unsigned Length = Str.length();
 
     llvm::APInt LengthI(32, Length + 1);

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2159,8 +2159,8 @@ ExprResult Sema::ActOnUnevaluatedStringLiteral(ArrayRef<Token> StringToks) {
   if (getLangOpts().MicrosoftExt)
     StringToks = ExpandedToks = ExpandFunctionLocalPredefinedMacros(StringToks);
 
-  StringLiteralParser Literal(StringToks, PP,
-                              StringLiteralEvalMethod::Unevaluated);
+  StringLiteralParser Literal(
+      StringToks, PP, StringLiteralEvalMethod::Unevaluated, CA_NoConversion);
   if (Literal.hadError)
     return ExprError();
 
@@ -2231,8 +2231,8 @@ Sema::ExpandFunctionLocalPredefinedMacros(ArrayRef<Token> Toks) {
   return ExpandedToks;
 }
 
-ExprResult
-Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
+ExprResult Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope,
+                                    ConversionAction Action) {
   assert(!StringToks.empty() && "Must have at least one string!");
 
   // StringToks needs backing storage as it doesn't hold array elements itself
@@ -2240,7 +2240,8 @@ Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
   if (getLangOpts().MicrosoftExt)
     StringToks = ExpandedToks = ExpandFunctionLocalPredefinedMacros(StringToks);
 
-  StringLiteralParser Literal(StringToks, PP);
+  StringLiteralParser Literal(StringToks, PP,
+                              StringLiteralEvalMethod::Evaluated, Action);
   if (Literal.hadError)
     return ExprError();
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2259,8 +2259,8 @@ Sema::ExpandFunctionLocalPredefinedMacros(ArrayRef<Token> Toks) {
   return ExpandedToks;
 }
 
-ExprResult
-Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
+ExprResult Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope,
+                                    ConversionAction Action) {
   assert(!StringToks.empty() && "Must have at least one string!");
 
   // StringToks needs backing storage as it doesn't hold array elements itself
@@ -2268,8 +2268,8 @@ Sema::ActOnStringLiteral(ArrayRef<Token> StringToks, Scope *UDLScope) {
   if (getLangOpts().MicrosoftExt)
     StringToks = ExpandedToks = ExpandFunctionLocalPredefinedMacros(StringToks);
 
-  StringLiteralParser Literal(
-      StringToks, PP, StringLiteralEvalMethod::Evaluated, CA_ToLiteralEncoding);
+  StringLiteralParser Literal(StringToks, PP,
+                              StringLiteralEvalMethod::Evaluated, Action);
   if (Literal.hadError)
     return ExprError();
 

--- a/clang/lib/Sema/SemaStmtAsm.cpp
+++ b/clang/lib/Sema/SemaStmtAsm.cpp
@@ -245,6 +245,14 @@ ExprResult Sema::ActOnGCCAsmStmtString(Expr *Expr, bool ForAsmLabel) {
       Diag(Expr->getBeginLoc(), diag::err_asm_operand_empty_string)
           << SL->getSourceRange();
     }
+    if (Context.getTargetInfo().TargetStrConverter) {
+      SmallString<16> ConvertedAsm;
+      Context.getTargetInfo().TargetStrConverter->convert(SL->getString(),
+                                                          ConvertedAsm);
+      return StringLiteral::Create(Context, ConvertedAsm,
+                                   StringLiteralKind::Ordinary,
+                                   /*Pascal*/ false, {}, SL->getBeginLoc());
+    }
     return SL;
   }
   if (DiagnoseUnexpandedParameterPack(Expr))

--- a/clang/lib/Sema/SemaStmtAsm.cpp
+++ b/clang/lib/Sema/SemaStmtAsm.cpp
@@ -245,13 +245,15 @@ ExprResult Sema::ActOnGCCAsmStmtString(Expr *Expr, bool ForAsmLabel) {
       Diag(Expr->getBeginLoc(), diag::err_asm_operand_empty_string)
           << SL->getSourceRange();
     }
-    if (Context.getTargetInfo().TargetStrConverter) {
+    if (Context.getTargetInfo().FromSystemEncodingConverter) {
       SmallString<16> ConvertedAsm;
-      Context.getTargetInfo().TargetStrConverter->convert(SL->getString(),
-                                                          ConvertedAsm);
+      Context.getTargetInfo().FromSystemEncodingConverter->convert(
+          SL->getString(), ConvertedAsm);
+      QualType StrTy = Context.getStringLiteralArrayType(Context.CharTy,
+                                                         ConvertedAsm.size());
       return StringLiteral::Create(Context, ConvertedAsm,
                                    StringLiteralKind::Ordinary,
-                                   /*Pascal*/ false, {}, SL->getBeginLoc());
+                                   /*Pascal*/ false, StrTy, SL->getBeginLoc());
     }
     return SL;
   }

--- a/clang/lib/Sema/SemaStmtAsm.cpp
+++ b/clang/lib/Sema/SemaStmtAsm.cpp
@@ -245,7 +245,7 @@ ExprResult Sema::ActOnGCCAsmStmtString(Expr *Expr, bool ForAsmLabel) {
       Diag(Expr->getBeginLoc(), diag::err_asm_operand_empty_string)
           << SL->getSourceRange();
     }
-    if (Context.getTargetInfo().FromSystemEncodingConverter) {
+    if (Context.getTargetInfo().FromSystemEncodingConverter != nullptr) {
       SmallString<16> ConvertedAsm;
       Context.getTargetInfo().FromSystemEncodingConverter->convert(
           SL->getString(), ConvertedAsm);

--- a/clang/lib/Sema/SemaStmtAsm.cpp
+++ b/clang/lib/Sema/SemaStmtAsm.cpp
@@ -235,7 +235,8 @@ getClobberConflictLocation(MultiExprArg Exprs, Expr **Constraints,
   return SourceLocation();
 }
 
-ExprResult Sema::ActOnGCCAsmStmtString(Expr *Expr, bool ForAsmLabel) {
+ExprResult Sema::ActOnGCCAsmStmtString(Expr *Expr, bool ForAsmLabel,
+                                       bool IsConstExpr) {
   if (!Expr)
     return ExprError();
 
@@ -245,7 +246,8 @@ ExprResult Sema::ActOnGCCAsmStmtString(Expr *Expr, bool ForAsmLabel) {
       Diag(Expr->getBeginLoc(), diag::err_asm_operand_empty_string)
           << SL->getSourceRange();
     }
-    if (Context.getTargetInfo().FromSystemEncodingConverter != nullptr) {
+    if (!IsConstExpr &&
+        Context.getTargetInfo().FromSystemEncodingConverter != nullptr) {
       SmallString<16> ConvertedAsm;
       Context.getTargetInfo().FromSystemEncodingConverter->convert(
           SL->getString(), ConvertedAsm);
@@ -272,6 +274,7 @@ ExprResult Sema::ActOnGCCAsmStmtString(Expr *Expr, bool ForAsmLabel) {
 
   ConstantExpr *Res = ConstantExpr::Create(getASTContext(), Expr,
                                            ConstantResultStorageKind::APValue);
+
   Res->SetResult(V, getASTContext());
   return Res;
 }

--- a/clang/test/CodeGen/systemz-charset-diag.cpp
+++ b/clang/test/CodeGen/systemz-charset-diag.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple s390x-none-zos -fexec-charset IBM-1047 %s -std=c++17 -emit-llvm -o - -verify
+
+static_assert(false, "Error string"); // expected-error {{static assertion failed: Error string}}
+
+[[deprecated("message")]] void test_deprecated() {return;} // expected-note {{'test_deprecated' has been explicitly marked deprecated here}}
+
+int main() {
+  test_deprecated(); // expected-warning {{'test_deprecated' is deprecated: message}}
+}

--- a/clang/test/CodeGen/systemz-charset-diag.cpp
+++ b/clang/test/CodeGen/systemz-charset-diag.cpp
@@ -1,3 +1,11 @@
 // RUN: %clang_cc1 -triple s390x-none-zos -fexec-charset IBM-1047 %s -std=c++17 -emit-llvm -o - -verify
 
 const char* Computer = "🖥️"; // expected-error-re {{conversion to literal encoding failed: {{.*}}}}
+
+static_assert(false, "Error string"); // expected-error {{static assertion failed: Error string}}
+
+[[deprecated("message")]] void test_deprecated() {return;} // expected-note {{'test_deprecated' has been explicitly marked deprecated here}}
+
+int main() {
+  test_deprecated(); // expected-warning {{'test_deprecated' is deprecated: message}}
+}

--- a/clang/test/CodeGen/systemz-charset-diag.cpp
+++ b/clang/test/CodeGen/systemz-charset-diag.cpp
@@ -1,11 +1,3 @@
 // RUN: %clang_cc1 -triple s390x-none-zos -fexec-charset IBM-1047 %s -std=c++17 -emit-llvm -o - -verify
 
 const char* Computer = "🖥️"; // expected-error-re {{conversion to literal encoding failed: {{.*}}}}
-
-static_assert(false, "Error string"); // expected-error {{static assertion failed: Error string}}
-
-[[deprecated("message")]] void test_deprecated() {return;} // expected-note {{'test_deprecated' has been explicitly marked deprecated here}}
-
-int main() {
-  test_deprecated(); // expected-warning {{'test_deprecated' is deprecated: message}}
-}

--- a/clang/test/CodeGen/systemz-charset.c
+++ b/clang/test/CodeGen/systemz-charset.c
@@ -1,6 +1,8 @@
 // RUN: %clang_cc1 %s -emit-llvm -triple s390x-none-zos -fexec-charset IBM-1047 -o - | FileCheck %s
 // RUN: %clang_cc1 %s -emit-llvm -triple s390x-none-zos -fexec-charset UTF-8 -DIBM1047_ONLY=1 -o - | FileCheck %s --check-prefix=CHECK-UTF8
 
+int printf(char const *, ...);
+
 const char *UpperCaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 //CHECK: c"\C1\C2\C3\C4\C5\C6\C7\C8\C9\D1\D2\D3\D4\D5\D6\D7\D8\D9\E2\E3\E4\E5\E6\E7\E8\E9\00"
 //CHECK-UTF8: c"ABCDEFGHIJKLMNOPQRSTUVWXYZ\00"

--- a/clang/test/CodeGen/systemz-charset.c
+++ b/clang/test/CodeGen/systemz-charset.c
@@ -71,3 +71,7 @@ void asm_labeled_fn(void) __asm__("\174asm_sym");
 void asm_labeled_fn(void) {}
 //CHECK: define{{.*}}void @"@asm_sym"(
 //CHECK-UTF8: define{{.*}}void @"@asm_sym"(
+
+void asm_stmt_fn(void) { __asm__("\225\226\227nop"); }
+//CHECK: call void asm{{.*}}"nopnop"
+//CHECK-UTF8: call void asm{{.*}}"nopnop"

--- a/clang/test/CodeGen/systemz-charset.c
+++ b/clang/test/CodeGen/systemz-charset.c
@@ -56,3 +56,18 @@ const char *Unicode = "ÿ";
 // RUN: not %clang_cc1 -fexec-charset invalid %s 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 // CHECK-ERROR: error: failed to set fexec-charset to 'invalid'
 
+void test1() {
+  printf(__FUNCTION__);
+}
+//CHECK: @__FUNCTION__.test1 = private unnamed_addr constant [6 x i8] c"\A3\85\A2\A3\F1\00"
+
+#define HELLO "Hello "
+#define WORLD "World!"
+#define HELLO_WORLD HELLO WORLD
+const char* hello_macro = HELLO;
+//CHECK: c"\C8\85\93\93\96@\00"
+//CHECK-UTF8 = c"Hello\00"
+
+const char* preprocessor_concatenation = HELLO_WORLD;
+//CHECK: c"\C8\85\93\93\96@\E6\96\99\93\84Z\00"
+//CHECK-UTF8: c"Hello World!\00"

--- a/clang/test/CodeGen/systemz-charset.c
+++ b/clang/test/CodeGen/systemz-charset.c
@@ -67,7 +67,7 @@ const char* preprocessor_concatenation = HELLO_WORLD;
 //CHECK: c"\C8\85\93\93\96@\E6\96\99\93\84Z\00"
 //CHECK-UTF8: c"Hello World!\00"
 
-void asm_labeled_fn(void) __asm__("asm_sym");
+void asm_labeled_fn(void) __asm__("\174asm_sym");
 void asm_labeled_fn(void) {}
-//CHECK: define{{.*}} void @asm_sym(
-//CHECK-UTF8: define{{.*}} void @asm_sym(
+//CHECK: define{{.*}}void @"@asm_sym"(
+//CHECK-UTF8: define{{.*}}void @"@asm_sym"(

--- a/clang/test/CodeGen/systemz-charset.c
+++ b/clang/test/CodeGen/systemz-charset.c
@@ -66,3 +66,8 @@ const char* hello_macro = HELLO;
 const char* preprocessor_concatenation = HELLO_WORLD;
 //CHECK: c"\C8\85\93\93\96@\E6\96\99\93\84Z\00"
 //CHECK-UTF8: c"Hello World!\00"
+
+void asm_labeled_fn(void) __asm__("asm_sym");
+void asm_labeled_fn(void) {}
+//CHECK: define{{.*}} void @asm_sym(
+//CHECK-UTF8: define{{.*}} void @asm_sym(

--- a/clang/test/CodeGen/systemz-charset.cpp
+++ b/clang/test/CodeGen/systemz-charset.cpp
@@ -72,3 +72,27 @@ const char16_t *UnicodeUCNString16 = u"\u00E2\u00AC\U000000DF";
 const char32_t *UnicodeUCNString32 = U"\u00E2\u00AC\U000000DF";
 //CHECK: [4 x i32] [i32 226, i32 172, i32 223, i32 0]
 //CHECK-UTF8: [4 x i32] [i32 226, i32 172, i32 223, i32 0]
+
+
+struct string_view {
+    int S;
+    const char* D;
+    constexpr string_view() : S(0), D(0){}
+    constexpr string_view(const char* Str) : S(__builtin_strlen(Str)), D(Str) {}
+    constexpr string_view(int Size, const char* Str) : S(Size), D(Str) {}
+    constexpr int size() const {
+        return S;
+    }
+    constexpr const char* data() const {
+        return D;
+    }
+};
+
+constexpr string_view getfoo() { return "\174foo"; }
+
+void function()
+{
+  asm((getfoo()));
+}
+// CHECK: asm{{.*}}|\86\96\96
+// CHECK-UTF8: asm{{.*}}|foo


### PR DESCRIPTION
This patch builds upon https://github.com/llvm/llvm-project/pull/138895 and introduces a new ConversionAction parameter to ParseStringLiteralExpression to allow asm strings to be parsed in the target default encoding initially to convert escape sequences, and then back to UTF8 when printed in the IR.

For example, on z/OS we want \174 to map to the '@' character in IBM-1047 regardless of fexec-charset.
`__asm__("\174asm_sym")` This is required because there are variant characters in the ebcdic family and it is common on the z/OS platform to compile with an fexec-charset set to an ebcdic (non-IBM-1047) codepage. This would result in different values for ("@asm_sym")

If there is a constexpr in the asm string, it will be parsed in the literal encoding.