### PR TITLE
[mlir:bazel] Fix build broken by #169670.

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -10118,6 +10118,7 @@ cc_binary(
         "//llvm:TableGen",
         "//llvm:TargetParser",
         "//llvm:config",
+        "//llvm:vt_gen",
     ],
 )
 


### PR DESCRIPTION
This PR adds a dependency to the `BUILD` files overlay silently added by #169670.