### PR TITLE
[clang] Add [[clang::returns_argument]]

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2682,6 +2682,13 @@ def NoEscape : Attr {
   let Documentation = [NoEscapeDocs];
 }
 
+def ReturnsArgument : InheritableAttr {
+  let Spellings = [Clang<"returns_argument">];
+  let Subjects = SubjectList<[Function]>;
+  let Args = [ParamIdxArgument<"ReturnedVal">];
+  let Documentation = [ReturnsArgumentDocs];
+}
+
 def MaybeUndef : InheritableAttr {
   let Spellings = [Clang<"maybe_undef">];
   let Subjects = SubjectList<[ParmVar]>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -287,6 +287,22 @@ applies to copies of the block. For example:
   }];
 }
 
+def ReturnsArgumentDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``returns_argument`` attribute can be placed on a function to indicate when
+an argument is returned identically. This allows the compiler to use the
+returned value instead of the argument, potentially decreasing register
+pressure. This attribute can currently only be applied to arguments that are
+pointers or references to the same type as the returned pointer or reference.
+
+Sample usage:
+.. code-block:: c
+
+  [[clang::returns_argument(1)]] void* memcpy(void*, const void*, size_t);
+  }];
+}
+
 def MaybeUndefDocs : Documentation {
   let Category = DocCatVariable;
   let Content = [{

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3439,6 +3439,9 @@ def err_attribute_only_once_per_parameter : Error<
   "%0 attribute can only be applied once per parameter">;
 def err_mismatched_uuid : Error<"uuid does not match previous declaration">;
 def note_previous_uuid : Note<"previous uuid specified here">;
+def err_return_type_mismatch : Error<
+  "returned parameter has to reference the same type as the return type">;
+def note_return_type : Note<"return type is %0">;
 def warn_attribute_pointers_only : Warning<
   "%0 attribute only applies to%select{| constant}1 pointer arguments">,
   InGroup<IgnoredAttributes>;
@@ -3473,6 +3476,8 @@ def warn_attribute_return_pointers_refs_only : Warning<
 def warn_attribute_pointer_or_reference_only : Warning<
   "%0 attribute only applies to a pointer or reference (%1 is invalid)">,
   InGroup<IgnoredAttributes>;
+def err_attribute_pointer_or_reference_only : Error<
+  warn_attribute_pointer_or_reference_only.Summary>;
 def err_attribute_no_member_pointers : Error<
   "%0 attribute cannot be used with pointers to members">;
 def err_attribute_invalid_implicit_this_argument : Error<

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -3009,6 +3009,15 @@ void CodeGenModule::ConstructAttributeList(StringRef Name,
             getLLVMContext(), llvm::AttributeSet::get(getLLVMContext(), Attrs));
     }
   }
+
+  if (TargetDecl) {
+    if (const auto *Returns = TargetDecl->getAttr<ReturnsArgumentAttr>()) {
+      llvm::AttributeSet &Attrs =
+          ArgAttrs[Returns->getReturnedVal().getLLVMIndex()];
+      Attrs = Attrs.addAttribute(getLLVMContext(), llvm::Attribute::Returned);
+    }
+  }
+
   assert(ArgNo == FI.arg_size());
 
   ArgNo = 0;

--- a/clang/test/CodeGenCXX/attr-returns-argument.cpp
+++ b/clang/test/CodeGenCXX/attr-returns-argument.cpp
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -triple=x86_64-apple-darwin -std=c++11 -emit-llvm -o - %s | FileCheck %s
+
+[[clang::returns_argument(1)]] int* test3(int* i) {
+  // CHECK: @_Z5test3Pi(ptr noundef returned
+  return i;
+}
+
+[[clang::returns_argument(1)]] int& test4(int& i) {
+  // CHECK: @_Z5test4Ri(ptr noundef nonnull returned
+  return i;
+}
+
+[[clang::returns_argument(1)]] int* test5(int* const i) {
+  // CHECK: _Z5test5Pi(ptr noundef returned
+  return i;
+}
+
+[[clang::returns_argument(2)]] int* test6(int*, int* i) {
+  // CHECK: @_Z5test6PiS_(ptr noundef %{{.*}}, ptr noundef returned
+  return i;
+}
+
+[[clang::returns_argument(1)]] int& test7(int* i) {
+  //CHECK: @_Z5test7Pi(ptr noundef returned
+  return *i;
+}
+
+struct S {
+  [[clang::returns_argument(1)]] S& func1();
+  [[clang::returns_argument(1)]] static S& func4(S*);
+};
+
+S& S::func1() {
+  // CHECK: @_ZN1S5func1Ev(ptr noundef nonnull returned
+  return *this;
+}
+
+S& S::func4(S* i) {
+  // CHECK: @_ZN1S5func4EPS_(ptr noundef returned
+  return *i;
+}

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -185,6 +185,7 @@
 // CHECK-NEXT: ReqdWorkGroupSize (SubjectMatchRule_function)
 // CHECK-NEXT: Restrict (SubjectMatchRule_function)
 // CHECK-NEXT: ReturnTypestate (SubjectMatchRule_function, SubjectMatchRule_variable_is_parameter)
+// CHECK-NEXT: ReturnsArgument (SubjectMatchRule_function)
 // CHECK-NEXT: ReturnsNonNull (SubjectMatchRule_objc_method, SubjectMatchRule_function)
 // CHECK-NEXT: ReturnsTwice (SubjectMatchRule_function)
 // CHECK-NEXT: SYCLExternal (SubjectMatchRule_function)

--- a/clang/test/SemaCXX/attr-returns-argument.cpp
+++ b/clang/test/SemaCXX/attr-returns-argument.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+[[clang::returns_argument(1)]] int test1(int); // expected-error {{'clang::returns_argument' attribute only applies to a pointer or reference ('int' is invalid)}}
+[[clang::returns_argument(1)]] int* test2(long*); // expected-error {{returned parameter has to reference the same type as the return type}} \
+                                            expected-note {{return type is 'int *'}}
+[[clang::returns_argument(1)]] int* test3(int*);
+[[clang::returns_argument(1)]] int& test4(int&);
+[[clang::returns_argument(1)]] int* test5(int* const);
+[[clang::returns_argument(1)]] int& test6(int*);
+[[clang::returns_argument(2)]] int& test7(int*); // expected-error {{'clang::returns_argument' attribute parameter 1 is out of bounds}}
+
+struct S {
+  [[clang::returns_argument(1)]] S& func1();
+  [[clang::returns_argument(2)]] S& func2(); // expected-error {{'clang::returns_argument' attribute parameter 1 is out of bounds}}
+  [[clang::returns_argument(1)]] int* func3(int*); // expected-error {{returned parameter has to reference the same type as the return type}} \
+                                             expected-note {{return type is 'int *'}}
+  [[clang::returns_argument(1)]] static S& func4(S*);
+};


### PR DESCRIPTION
This attributes indicates than an argument to a function is returned identically. Currently this only applies to pointers and references.