### PR TITLE
[Flang][OpenMP] Update OpenMPSupport docs

### DIFF
--- a/flang/docs/OpenMPSupport.md
+++ b/flang/docs/OpenMPSupport.md
@@ -40,11 +40,11 @@ Note : No distinction is made between the support in Parser/Semantics, MLIR, Low
 | target data construct                                      | P      | device clause not supported |
 | target construct                                           | P      | device clause not supported |
 | target update construct                                    | P      | device clause not supported |
-| declare target directive                                   | P      | |
+| declare target directive                                   | Y      | |
 | teams construct                                            | Y      | |
-| distribute construct                                       | P      | |
+| distribute construct                                       | Y      | |
 | distribute simd construct                                  | P      | linear clauses are not supported |
-| distribute parallel loop construct                         | P      | |
+| distribute parallel loop construct                         | Y      | |
 | distribute parallel loop simd construct                    | P      | linear clauses are not supported |
 | depend clause                                              | Y      | |
 | declare reduction construct                                | N      | |
@@ -53,10 +53,10 @@ Note : No distinction is made between the support in Parser/Semantics, MLIR, Low
 | cancellation point construct                               | Y      | |
 | parallel do simd construct                                 | P      | linear clause not supported |
 | target teams construct                                     | P      | device clause not supported |
-| teams distribute construct                                 | P      | |
+| teams distribute construct                                 | Y      | |
 | teams distribute simd construct                            | P      | linear clause is not supported |
 | target teams distribute construct                          | P      | device clause is not supported |
-| teams distribute parallel loop construct                   | P      | |
+| teams distribute parallel loop construct                   | Y      | |
 | target teams distribute parallel loop construct            | P      | device clause is not supported |
 | teams distribute parallel loop simd construct              | P      | linear clause is not supported |
 | target teams distribute parallel loop simd construct       | P      | device and linear clauses are not supported |


### PR DESCRIPTION
After the merging of #152736, there are a number of OpenMP Features that are now fully supported. Missing from the initial patch was changing the status of this from `P` to `Y` to indicate they are now fully supported. The notes around not supporting `dist_schedule` were removed in the initial patch.