### PR TITLE
[AArch64] Guard for 128bit vectors in mull combine.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5795,8 +5795,10 @@ SDValue AArch64TargetLowering::LowerMUL(SDValue Op, SelectionDAG &DAG) const {
   if (VT.is64BitVector()) {
     if (N0.getOpcode() == ISD::EXTRACT_SUBVECTOR &&
         isNullConstant(N0.getOperand(1)) &&
+        N0.getOperand(0).getValueType().is128BitVector() &&
         N1.getOpcode() == ISD::EXTRACT_SUBVECTOR &&
-        isNullConstant(N1.getOperand(1))) {
+        isNullConstant(N1.getOperand(1)) &&
+        N1.getOperand(0).getValueType().is128BitVector()) {
       N0 = N0.getOperand(0);
       N1 = N1.getOperand(0);
       VT = N0.getValueType();

--- a/llvm/test/CodeGen/AArch64/neon-extadd-extract.ll
+++ b/llvm/test/CodeGen/AArch64/neon-extadd-extract.ll
@@ -771,3 +771,31 @@ entry:
   %m = mul <1 x i64> %s0, %t1
   ret <1 x i64> %m
 }
+
+define <2 x i8> @extract_scalable_vec() vscale_range(1,16) "target-features"="+sve" {
+; CHECK-SD-LABEL: extract_scalable_vec:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    mov x8, xzr
+; CHECK-SD-NEXT:    index z1.s, #2, #3
+; CHECK-SD-NEXT:    ldr h0, [x8]
+; CHECK-SD-NEXT:    ushll v0.8h, v0.8b, #0
+; CHECK-SD-NEXT:    ushll v0.4s, v0.4h, #0
+; CHECK-SD-NEXT:    mul v0.2s, v0.2s, v1.2s
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: extract_scalable_vec:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    mov x8, xzr
+; CHECK-GI-NEXT:    mov x9, #1 // =0x1
+; CHECK-GI-NEXT:    ld1 { v0.b }[0], [x8]
+; CHECK-GI-NEXT:    ldr b1, [x9]
+; CHECK-GI-NEXT:    adrp x8, .LCPI36_0
+; CHECK-GI-NEXT:    mov v0.s[1], v1.s[0]
+; CHECK-GI-NEXT:    ldr d1, [x8, :lo12:.LCPI36_0]
+; CHECK-GI-NEXT:    mul v0.2s, v0.2s, v1.2s
+; CHECK-GI-NEXT:    ret
+entry:
+  %0 = load <2 x i8>, ptr null, align 2
+  %mul = mul <2 x i8> %0, <i8 2, i8 5>
+  ret <2 x i8> %mul
+}


### PR DESCRIPTION
The test case generates a extract_subvector(index) leading into a mul. Make sure we don't try and treat the scalable vector extract as a 128bit vector in the mull combine.

Fixes #168912