### PR TITLE
[clang][Tooling] Fix `getFileRange` returning a range spanning macro invocation

### DIFF
--- a/clang/lib/Tooling/Transformer/SourceCode.cpp
+++ b/clang/lib/Tooling/Transformer/SourceCode.cpp
@@ -114,12 +114,7 @@ static bool spelledInMacroDefinition(CharSourceRange Range,
     return B.isInvalid() || B != E;
   }
 
-  if (Range.getBegin().isMacroID())
-    return getMacroArgumentSpellingLoc(Range.getBegin(), SM).isInvalid();
-  if (Range.getEnd().isMacroID())
-    return getMacroArgumentSpellingLoc(Range.getEnd(), SM).isInvalid();
-
-  return false;
+  return Range.getBegin().isMacroID() || Range.getEnd().isMacroID();
 }
 
 // Returns the expansion char-range of `Loc` if `Loc` is a split token. For

--- a/clang/unittests/Tooling/SourceCodeTest.cpp
+++ b/clang/unittests/Tooling/SourceCodeTest.cpp
@@ -511,11 +511,13 @@ TEST(SourceCodeTest, EditInvolvingExpansionIgnoringExpansionShouldFail) {
 #define M2(x, y) x ## y
 #define M3(x) foobar(x)
 #define M4(x, y) x y
+#define M5(x) x
 int foobar(int);
 int a = M1(foobar);
 int b = M2(foo, bar(2));
 int c = M3(3);
 int d = M4(foobar, (4));
+int e = M5(foobar) (5);
 )cpp");
 
   CallsVisitor Visitor;


### PR DESCRIPTION
A followup to 40991215f4aba37fd43b65d96ad0a445dcd041b2.

When the start or end token is inside a macro argument and the other is outside of the macro, we want to reject the range for a similar reason. The range will include half of the macro call, either the closing paren or the macro name and open paren.