### PR TITLE
[lldb-dap] Fix segfault in JSONUtils.cpp when GetUUIDString() returns nullptr

### DIFF
--- a/lldb/tools/lldb-dap/Handler/CompileUnitsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/CompileUnitsRequestHandler.cpp
@@ -10,6 +10,7 @@
 #include "EventHelper.h"
 #include "JSONUtils.h"
 #include "RequestHandler.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace lldb_dap {
 
@@ -60,12 +61,12 @@ void CompileUnitsRequestHandler::operator()(
   llvm::json::Object body;
   llvm::json::Array units;
   const auto *arguments = request.getObject("arguments");
-  const std::string module_id =
-      GetString(arguments, "moduleId").value_or("").str();
+  const llvm::StringRef module_id =
+      GetString(arguments, "moduleId").value_or("");
   int num_modules = dap.target.GetNumModules();
   for (int i = 0; i < num_modules; i++) {
     auto curr_module = dap.target.GetModuleAtIndex(i);
-    if (module_id == curr_module.GetUUIDString()) {
+    if (module_id == llvm::StringRef(curr_module.GetUUIDString())) {
       int num_units = curr_module.GetNumCompileUnits();
       for (int j = 0; j < num_units; j++) {
         auto curr_unit = curr_module.GetCompileUnitAtIndex(j);

--- a/lldb/tools/lldb-dap/Handler/CompileUnitsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/CompileUnitsRequestHandler.cpp
@@ -10,7 +10,6 @@
 #include "EventHelper.h"
 #include "JSONUtils.h"
 #include "RequestHandler.h"
-#include "llvm/ADT/StringRef.h"
 
 namespace lldb_dap {
 

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -554,10 +554,8 @@ llvm::json::Value CreateStackFrame(DAP &dap, lldb::SBFrame &frame,
 
   lldb::SBModule module = frame.GetModule();
   if (module.IsValid()) {
-    const char *uuid_cstr = module.GetUUIDString();
-    std::string uuid = uuid_cstr ? uuid_cstr : "";
-    if (!uuid.empty())
-      object.try_emplace("moduleId", uuid);
+    if (const llvm::StringRef uuid = module.GetUUIDString(); !uuid.empty())
+      object.try_emplace("moduleId", uuid.str());
   }
 
   return llvm::json::Value(std::move(object));

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -554,7 +554,8 @@ llvm::json::Value CreateStackFrame(DAP &dap, lldb::SBFrame &frame,
 
   lldb::SBModule module = frame.GetModule();
   if (module.IsValid()) {
-    std::string uuid = module.GetUUIDString();
+    const char *uuid_cstr = module.GetUUIDString();
+    std::string uuid = uuid_cstr ? uuid_cstr : "";
     if (!uuid.empty())
       object.try_emplace("moduleId", uuid);
   }


### PR DESCRIPTION
When creating a stack frame in JSONUtils.cpp CreateStackFrame() the code constructs a std::string from module.GetUUIDString(), which can return nullptr in some cases (as documented in the implementation of SBModule::GetUUIDString()). This causes a segmentation fault when passed to the std::string constructor.

This fix adds a null check before constructing the UUID string, falling back to an empty string if nullptr is returned. The existing empty check ensures the moduleId field is omitted from the JSON when no UUID exists.