### PR TITLE
[NFC] [DirectX] Update DirectX codegen test `CBufferAccess/gep-ce-two-uses.ll` due to changes to ReplaceConstant

### DIFF
--- a/llvm/test/CodeGen/DirectX/CBufferAccess/gep-ce-two-uses.ll
+++ b/llvm/test/CodeGen/DirectX/CBufferAccess/gep-ce-two-uses.ll
@@ -27,6 +27,7 @@ entry:
   ret void
 }
 
+; CHECK: define void @g
 define void @g(ptr %dst) {
 entry:
   ; CHECK: [[PTR:%.*]] = call ptr addrspace(2) @llvm.dx.resource.getpointer.{{.*}}(target("dx.CBuffer", %__cblayout_CB) {{%.*}}, i32 0)

--- a/llvm/test/CodeGen/DirectX/CBufferAccess/gep-ce-two-uses.ll
+++ b/llvm/test/CodeGen/DirectX/CBufferAccess/gep-ce-two-uses.ll
@@ -21,6 +21,21 @@ entry:
   %a1 = load float, ptr addrspace(2) getelementptr inbounds nuw (i8, ptr addrspace(2) @a1, i32 16), align 4
   store float %a1, ptr %dst, align 32
 
+  %a2 = load float, ptr addrspace(2) getelementptr inbounds nuw (i8, ptr addrspace(2) @a1, i32 16), align 4
+  store float %a2, ptr %dst, align 32
+
+  ret void
+}
+
+define void @g(ptr %dst) {
+entry:
+  ; CHECK: [[PTR:%.*]] = call ptr addrspace(2) @llvm.dx.resource.getpointer.{{.*}}(target("dx.CBuffer", %__cblayout_CB) {{%.*}}, i32 0)
+  ; CHECK: getelementptr inbounds nuw i8, ptr addrspace(2) [[PTR]], i32 16
+  %a1 = load float, ptr addrspace(2) getelementptr inbounds nuw (i8, ptr addrspace(2) @a1, i32 16), align 4
+  store float %a1, ptr %dst, align 32
+  br label %next
+
+next:
   ; CHECK: [[PTR:%.*]] = call ptr addrspace(2) @llvm.dx.resource.getpointer.{{.*}}(target("dx.CBuffer", %__cblayout_CB) {{%.*}}, i32 0)
   ; CHECK: getelementptr inbounds nuw i8, ptr addrspace(2) [[PTR]], i32 16
   %a2 = load float, ptr addrspace(2) getelementptr inbounds nuw (i8, ptr addrspace(2) @a1, i32 16), align 4


### PR DESCRIPTION
Fixes an LLVM DirectX codegen test after it broke due to #169141

The CBuffer loads and GEPs are no longer duplicated when there are two or more accesses within the same basic block.
This PR removes the duplicate check for CBuffer load and GEP from the original test function `@f` and adds a new test function `@g` which places duplicate CBuffer loads into separate basic blocks.