### PR TITLE
[AMDGPU] Emit amdgpu.max_num_named_barrier resource symbol

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -534,10 +534,9 @@ bool AMDGPUAsmPrinter::doFinalization(Module &M) {
   MCSectionELF *MaxGPRSection =
       OutContext.getELFSection(".AMDGPU.gpr_maximums", ELF::SHT_PROGBITS, 0);
   OutStreamer->switchSection(MaxGPRSection);
-  getTargetStreamer()->EmitMCResourceMaximums(RI.getMaxVGPRSymbol(OutContext),
-                                              RI.getMaxAGPRSymbol(OutContext),
-                                              RI.getMaxSGPRSymbol(OutContext),
-                                              RI.getMaxNamedBarrierSymbol(OutContext));
+  getTargetStreamer()->EmitMCResourceMaximums(
+      RI.getMaxVGPRSymbol(OutContext), RI.getMaxAGPRSymbol(OutContext),
+      RI.getMaxSGPRSymbol(OutContext), RI.getMaxNamedBarrierSymbol(OutContext));
   OutStreamer->popSection();
 
   for (Function &F : M.functions())

--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -536,7 +536,8 @@ bool AMDGPUAsmPrinter::doFinalization(Module &M) {
   OutStreamer->switchSection(MaxGPRSection);
   getTargetStreamer()->EmitMCResourceMaximums(RI.getMaxVGPRSymbol(OutContext),
                                               RI.getMaxAGPRSymbol(OutContext),
-                                              RI.getMaxSGPRSymbol(OutContext));
+                                              RI.getMaxSGPRSymbol(OutContext),
+                                              RI.getMaxNamedBarrierSymbol(OutContext));
   OutStreamer->popSection();
 
   for (Function &F : M.functions())

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -302,10 +302,9 @@ void AMDGPUTargetAsmStreamer::EmitMCResourceInfo(
 #undef PRINT_RES_INFO
 }
 
-void AMDGPUTargetAsmStreamer::EmitMCResourceMaximums(const MCSymbol *MaxVGPR,
-                                                     const MCSymbol *MaxAGPR,
-                                                     const MCSymbol *MaxSGPR,
-                                                     const MCSymbol *MaxNamedBarrier) {
+void AMDGPUTargetAsmStreamer::EmitMCResourceMaximums(
+    const MCSymbol *MaxVGPR, const MCSymbol *MaxAGPR, const MCSymbol *MaxSGPR,
+    const MCSymbol *MaxNamedBarrier) {
 #define PRINT_RES_INFO(ARG)                                                    \
   OS << "\t.set ";                                                             \
   ARG->print(OS, getContext().getAsmInfo());                                   \

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -304,7 +304,8 @@ void AMDGPUTargetAsmStreamer::EmitMCResourceInfo(
 
 void AMDGPUTargetAsmStreamer::EmitMCResourceMaximums(const MCSymbol *MaxVGPR,
                                                      const MCSymbol *MaxAGPR,
-                                                     const MCSymbol *MaxSGPR) {
+                                                     const MCSymbol *MaxSGPR,
+                                                     const MCSymbol *MaxNamedBarrier) {
 #define PRINT_RES_INFO(ARG)                                                    \
   OS << "\t.set ";                                                             \
   ARG->print(OS, getContext().getAsmInfo());                                   \
@@ -315,6 +316,7 @@ void AMDGPUTargetAsmStreamer::EmitMCResourceMaximums(const MCSymbol *MaxVGPR,
   PRINT_RES_INFO(MaxVGPR);
   PRINT_RES_INFO(MaxAGPR);
   PRINT_RES_INFO(MaxSGPR);
+  PRINT_RES_INFO(MaxNamedBarrier);
 #undef PRINT_RES_INFO
 }
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.h
@@ -69,7 +69,8 @@ public:
 
   virtual void EmitMCResourceMaximums(const MCSymbol *MaxVGPR,
                                       const MCSymbol *MaxAGPR,
-                                      const MCSymbol *MaxSGPR) {};
+                                      const MCSymbol *MaxSGPR,
+                                      const MCSymbol *MaxNamedBarrier) {};
 
   /// \returns True on success, false on failure.
   virtual bool EmitISAVersion() { return true; }
@@ -149,7 +150,8 @@ public:
       const MCSymbol *HasRecursion, const MCSymbol *HasIndirectCall) override;
 
   void EmitMCResourceMaximums(const MCSymbol *MaxVGPR, const MCSymbol *MaxAGPR,
-                              const MCSymbol *MaxSGPR) override;
+                              const MCSymbol *MaxSGPR,
+                              const MCSymbol *MaxNamedBarrier) override;
 
   /// \returns True on success, false on failure.
   bool EmitISAVersion() override;

--- a/llvm/test/CodeGen/AMDGPU/function-resource-usage.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-resource-usage.ll
@@ -674,10 +674,21 @@ entry:
   ret void
 }
 
+; Test that amdgcn.device.init correctly references amdgpu.max_num_named_barrier
+; GCN-LABEL: {{^}}amdgcn.device.init:
+; GCN: .set amdgcn.device.init.num_named_barrier, max(0, amdgpu.max_num_named_barrier)
+
+@llvm.global_ctors = appending addrspace(1) global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 1, ptr @ctor_func, ptr null }]
+
+define internal void @ctor_func() {
+  ret void
+}
+
 ; Added at the of the .s are the module level maximums
 ; GCN:	.set amdgpu.max_num_vgpr, 50
 ; GCN:	.set amdgpu.max_num_agpr, 0
 ; GCN:	.set amdgpu.max_num_sgpr, 80
+; GCN:	.set amdgpu.max_num_named_barrier, 0
 
 attributes #0 = { nounwind noinline norecurse }
 attributes #1 = { nounwind noinline norecurse }


### PR DESCRIPTION
Emit `amdgpu.max_num_named_barrier` resource symbol which is referenced by `amdgcn.device.init.num_named_barrier, max(0, amdgpu.max_num_named_barrier)`. Fixes `LLVM ERROR: cannot evaluate equated symbol 'amdgcn.device.init.num_named_barrier'` when using ASan.