### PR TITLE
[lldb] Fix duplicate test class name causing lldb-dotest conflict

### DIFF
--- a/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/TestFrameVarDILExprPointerArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/TestFrameVarDILExprPointerArithmetic.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test import lldbutil
 
 
-class TestFrameVarDILPointerArithmetic(TestBase):
+class TestFrameVarDILExprPointerArithmetic(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     def test_pointer_arithmetic(self):


### PR DESCRIPTION
Duplicate test class name `TestFrameVarDILPointerArithmetic` prevents lldb-dotest from running any tests.
The conflict exists between:
- lldb/test/API/commands/frame/vardil/expr/PointerArithmetic/
- lldb/test/API/commands/frame/vardil/basics/PointerArithmetic/

Rename the expr variant to `TestFrameVarDILExprPointerArithmetic`.