### PR TITLE
[C-API] LLVMOrcCreateObjectLinkingLayerWithInProcessMemoryManager

### DIFF
--- a/llvm/include/llvm-c/OrcEE.h
+++ b/llvm/include/llvm-c/OrcEE.h
@@ -45,12 +45,11 @@ typedef void (*LLVMMemoryManagerNotifyTerminatingCallback)(void *CtxCtx);
 
 /**
  * Create a ObjectLinkingLayer instance using the standard JITLink
- * InProcessMemoryManager for memory management.  Result is NULL on failure to
- * determine system page size.
+ * InProcessMemoryManager for memory management.
  */
-LLVMOrcObjectLayerRef
+LLVM_C_ABI LLVMErrorRef
 LLVMOrcCreateObjectLinkingLayerWithInProcessMemoryManager(
-    LLVMOrcExecutionSessionRef ES);
+    LLVMOrcObjectLayerRef *Result, LLVMOrcExecutionSessionRef ES);
 
 /**
  * Create a RTDyldObjectLinkingLayer instance using the standard

--- a/llvm/include/llvm-c/OrcEE.h
+++ b/llvm/include/llvm-c/OrcEE.h
@@ -44,6 +44,15 @@ typedef void (*LLVMMemoryManagerNotifyTerminatingCallback)(void *CtxCtx);
  */
 
 /**
+ * Create a ObjectLinkingLayer instance using the standard JITLink
+ * InProcessMemoryManager for memory management.  Result is NULL on failure to
+ * determine system page size.
+ */
+LLVMOrcObjectLayerRef
+LLVMOrcCreateObjectLinkingLayerWithInProcessMemoryManager(
+    LLVMOrcExecutionSessionRef ES);
+
+/**
  * Create a RTDyldObjectLinkingLayer instance using the standard
  * SectionMemoryManager for memory management.
  */

--- a/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
@@ -1024,9 +1024,8 @@ LLVMErrorRef LLVMOrcCreateObjectLinkingLayerWithInProcessMemoryManager(
   assert(Result && "Result must not be null");
   assert(ES && "ES must not be null");
   auto MM = jitlink::InProcessMemoryManager::Create();
-  if (!MM) {
+  if (!MM)
     return wrap(MM.takeError());
-  }
   *Result = wrap(new ObjectLinkingLayer(*unwrap(ES), std::move(*MM)));
   return LLVMErrorSuccess;
 }

--- a/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
@@ -1019,16 +1019,16 @@ LLVMOrcLLJITGetObjTransformLayer(LLVMOrcLLJITRef J) {
   return wrap(&unwrap(J)->getObjTransformLayer());
 }
 
-LLVMOrcObjectLayerRef
-LLVMOrcCreateObjectLinkingLayerWithInProcessMemoryManager(
-    LLVMOrcExecutionSessionRef ES) {
+LLVMErrorRef LLVMOrcCreateObjectLinkingLayerWithInProcessMemoryManager(
+    LLVMOrcObjectLayerRef *Result, LLVMOrcExecutionSessionRef ES) {
+  assert(Result && "Result must not be null");
   assert(ES && "ES must not be null");
-  auto mm = jitlink::InProcessMemoryManager::Create();
-  if (!mm) {
-    unwrap(ES)->reportError(mm.takeError());
-    return nullptr;
+  auto MM = jitlink::InProcessMemoryManager::Create();
+  if (!MM) {
+    return wrap(MM.takeError());
   }
-  return wrap(new ObjectLinkingLayer(*unwrap(ES), std::move(*mm)));
+  *Result = wrap(new ObjectLinkingLayer(*unwrap(ES), std::move(*MM)));
+  return LLVMErrorSuccess;
 }
 
 LLVMOrcObjectLayerRef


### PR DESCRIPTION
Allow C programs to use JITLink with trivial new C-API wrapper.  Modeled on `LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager` except that it has to deal with failure of `jitlink::InProcessMemoryManager::Create()`.  Function name suggested by @lhames in https://github.com/llvm/llvm-project/issues/106203.

I suppose failure of underlying platform-specific things like `sysconf(_SC_PAGESIZE)` shouldn't really happen.  An alternative error reporting style might be to follow `LLVMOrcCreateDynamicLibrarySearchGeneratorForProcess` and return `LLVMErrorRef` with an output parameter for the `LLVMOrcObjectLayerRef`, but then it wouldn't be a drop-in replacement for `LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager`.  Thoughts?

This is wanted by PostgreSQL (branch using this API: https://github.com/macdice/postgres/tree/llvm-22-proposed-c-api).  (We're also using `LLVMCreatePerfJITEventListener`, `LLVMCreatePerfJITEventListener`, `LLVMOrcRTDyldObjectLinkingLayerRegisterJITEventListener`, so it looks like we'll need to research `PerfSupportPlugin`, `DebuggerSupportPlugin`, `ObjectLinkingLayer::addPlugin()`...)