### PR TITLE
[clang-tidy][NFC] Fix option highlighting and list style in documentation

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signal-handler.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signal-handler.rst
@@ -45,11 +45,11 @@ Options
   Selects which set of functions is considered as asynchronous-safe
   (and therefore allowed in signal handlers). It can be set to the following values:
 
-  ``minimal``
+  - `minimal`
      Selects a minimal set that is defined in the CERT SIG30-C rule.
      and includes functions ``abort()``, ``_Exit()``, ``quick_exit()`` and
      ``signal()``.
-  ``POSIX``
+  - `POSIX`
      Selects a larger set of functions that is listed in POSIX.1-2017 (see `this
      link
      <https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03>`_
@@ -94,4 +94,4 @@ Options
      The function ``quick_exit`` is not included in the POSIX list but it
      is included here in the set of safe functions.
 
-  The default value is ``POSIX``.
+  The default value is `POSIX`.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/use-internal-linkage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/use-internal-linkage.rst
@@ -41,8 +41,8 @@ Options
 
   Selects what kind of a fix the check should provide. The default is `UseStatic`.
 
-  ``None``
+  - `None`
     Don't fix automatically.
 
-  ``UseStatic``
+  - `UseStatic`
     Add ``static`` for internal linkage variable and function.


### PR DESCRIPTION
The related discussion can be found at: https://github.com/llvm/llvm-project/pull/168324#discussion_r2569455701