### PR TITLE
[OpenCL] Add missing Intel extensions to OpenCLExtensions.def

### DIFF
--- a/clang/include/clang/Basic/OpenCLExtensions.def
+++ b/clang/include/clang/Basic/OpenCLExtensions.def
@@ -140,6 +140,7 @@ OPENCL_EXTENSION(cl_amd_media_ops, true, 100)
 OPENCL_EXTENSION(cl_amd_media_ops2, true, 100)
 
 // Intel OpenCL extensions
+OPENCL_EXTENSION(cl_intel_bfloat16_conversion, false, 100)
 OPENCL_EXTENSION(cl_intel_subgroups, true, 120)
 OPENCL_EXTENSION(cl_intel_subgroups_char, true, 120)
 OPENCL_EXTENSION(cl_intel_subgroups_long, true, 120)

--- a/clang/include/clang/Basic/OpenCLExtensions.def
+++ b/clang/include/clang/Basic/OpenCLExtensions.def
@@ -141,7 +141,11 @@ OPENCL_EXTENSION(cl_amd_media_ops2, true, 100)
 
 // Intel OpenCL extensions
 OPENCL_EXTENSION(cl_intel_subgroups, true, 120)
+OPENCL_EXTENSION(cl_intel_subgroups_char, true, 120)
+OPENCL_EXTENSION(cl_intel_subgroups_long, true, 120)
 OPENCL_EXTENSION(cl_intel_subgroups_short, true, 120)
+OPENCL_EXTENSION(cl_intel_subgroup_buffer_prefetch, false, 120)
+OPENCL_EXTENSION(cl_intel_subgroup_local_block_io, false, 120)
 OPENCL_EXTENSION(cl_intel_device_side_avc_motion_estimation, true, 120)
 
 // OpenCL C 3.0 features (6.2.1. Features)

--- a/clang/test/SemaOpenCL/extension-version.cl
+++ b/clang/test/SemaOpenCL/extension-version.cl
@@ -341,6 +341,24 @@
 #pragma OPENCL EXTENSION cl_intel_subgroups : enable
 
 #if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 120)
+#ifndef cl_intel_subgroups_char
+#error "Missing cl_intel_subgroups_char define"
+#endif
+#else
+// expected-warning@+2{{unsupported OpenCL extension 'cl_intel_subgroups_char' - ignoring}}
+#endif
+#pragma OPENCL EXTENSION cl_intel_subgroups_char : enable
+
+#if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 120)
+#ifndef cl_intel_subgroups_long
+#error "Missing cl_intel_subgroups_long define"
+#endif
+#else
+// expected-warning@+2{{unsupported OpenCL extension 'cl_intel_subgroups_long' - ignoring}}
+#endif
+#pragma OPENCL EXTENSION cl_intel_subgroups_long : enable
+
+#if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 120)
 #ifndef cl_intel_subgroups_short
 #error "Missing cl_intel_subgroups_short define"
 #endif
@@ -348,6 +366,18 @@
 // expected-warning@+2{{unsupported OpenCL extension 'cl_intel_subgroups_short' - ignoring}}
 #endif
 #pragma OPENCL EXTENSION cl_intel_subgroups_short : enable
+
+#if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 120)
+#ifndef cl_intel_subgroup_buffer_prefetch
+#error "Missing cl_intel_subgroup_buffer_prefetch define"
+#endif
+#endif
+
+#if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 120)
+#ifndef cl_intel_subgroup_local_block_io
+#error "Missing cl_intel_subgroup_local_block_io define"
+#endif
+#endif
 
 #if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 120)
 #ifndef cl_intel_device_side_avc_motion_estimation

--- a/clang/test/SemaOpenCL/extension-version.cl
+++ b/clang/test/SemaOpenCL/extension-version.cl
@@ -331,6 +331,12 @@
 #endif
 #pragma OPENCL EXTENSION cl_khr_depth_images : enable
 
+#if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 100)
+#ifndef cl_intel_bfloat16_conversion
+#error "Missing cl_intel_bfloat16_conversion define"
+#endif
+#endif
+
 #if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 120)
 #ifndef cl_intel_subgroups
 #error "Missing cl_intel_subgroups define"


### PR DESCRIPTION
Add following extensions:
cl_intel_bfloat16_conversion
cl_intel_subgroup_buffer_prefetch
cl_intel_subgroup_local_block_io
cl_intel_subgroups_char
cl_intel_subgroups_long

This allows targets to expose these extensions via getSupportedOpenCLOpts and ensures macros are defined when enabled.