### PR TITLE
Revert "[libc++] Fix the locale base API on Linux with musl"

### DIFF
--- a/libcxx/include/__locale_dir/support/linux.h
+++ b/libcxx/include/__locale_dir/support/linux.h
@@ -83,30 +83,15 @@ inline _LIBCPP_HIDE_FROM_ABI __lconv_t* __localeconv(__locale_t& __loc) {
 // Strtonum functions
 //
 inline _LIBCPP_HIDE_FROM_ABI float __strtof(const char* __nptr, char** __endptr, __locale_t __loc) {
-#if !_LIBCPP_HAS_MUSL_LIBC || defined(_GNU_SOURCE)
   return ::strtof_l(__nptr, __endptr, __loc);
-#else
-  (void)__loc;
-  return ::strtof(__nptr, __endptr);
-#endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI double __strtod(const char* __nptr, char** __endptr, __locale_t __loc) {
-#if !_LIBCPP_HAS_MUSL_LIBC || defined(_GNU_SOURCE)
   return ::strtod_l(__nptr, __endptr, __loc);
-#else
-  (void)__loc;
-  return ::strtod(__nptr, __endptr);
-#endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI long double __strtold(const char* __nptr, char** __endptr, __locale_t __loc) {
-#if !_LIBCPP_HAS_MUSL_LIBC || defined(_GNU_SOURCE)
   return ::strtold_l(__nptr, __endptr, __loc);
-#else
-  (void)__loc;
-  return ::strtold(__nptr, __endptr);
-#endif
 }
 
 //


### PR DESCRIPTION
The patch has been committed without approval from the libc++ review group and is implementing the locale base API in a way it wasn't intended to be implemented. The commit also contains a no-reply github E-Mail, which is in conflict with the LLVM developer policy.

Reverts llvm/llvm-project#167980