### PR TITLE
[clang-tidy][doc] Fix broken CppCoreGuidelines links

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/switch-missing-default-case.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/switch-missing-default-case.rst
@@ -51,6 +51,6 @@ Example:
    on non-enum types where the compiler warnings may not be present.
 
 .. seealso::
-   The `CppCoreGuideline ES.79 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-default>`_
+   The `CppCoreGuideline ES.79 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#res-default>`_
    provide guidelines on switch statements, including the recommendation to
    always provide a default case.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-capturing-lambda-coroutines.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-capturing-lambda-coroutines.rst
@@ -8,7 +8,7 @@ use-after-free errors and suggests avoiding captures or ensuring the lambda
 closure object has a guaranteed lifetime.
 
 This check implements `CP.51
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rcoro-capture>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rcoro-capture>`_
 from the C++ Core Guidelines.
 
 Using coroutine lambdas with non-empty capture lists can be risky, as capturing

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.rst
@@ -44,7 +44,7 @@ Examples:
   };
 
 This check implements `C.12
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-constref>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-constref>`_
 from the C++ Core Guidelines.
 
 Further reading:

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-do-while.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-do-while.rst
@@ -9,7 +9,7 @@ condition is not checked prior to the first iteration.
 This can lead to subtle bugs.
 
 This check implements `ES.75
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-do>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#res-do>`_
 from the C++ Core Guidelines.
 
 Examples:

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables.rst
@@ -6,7 +6,7 @@ cppcoreguidelines-avoid-non-const-global-variables
 Finds non-const global variables as described in `I.2
 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#i2-avoid-non-const-global-variables>`_
 of C++ Core Guidelines.
-As `R.6 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-global>`_
+As `R.6 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rr-global>`_
 of C++ Core Guidelines is a duplicate of rule `I.2
 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#i2-avoid-non-const-global-variables>`_
 it also covers that rule.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-reference-coroutine-parameters.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-reference-coroutine-parameters.rst
@@ -18,5 +18,5 @@ Examples:
   }
 
 This check implements `CP.53
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rcoro-reference-parameters>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rcoro-reference-parameters>`_
 from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/init-variables.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/init-variables.rst
@@ -8,8 +8,8 @@ value. These may lead to unexpected behavior if there is a code path that reads
 the variable before assigning to it.
 
 This rule is part of the `Type safety (Type.5)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-init>`_
-profile and `ES.20 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-always>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-init>`_
+profile and `ES.20 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#res-always>`_
 from the C++ Core Guidelines.
 
 Only integers, booleans, floats, doubles and pointers are checked. The fix

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/interfaces-global-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/interfaces-global-init.rst
@@ -7,7 +7,7 @@ This check flags initializers of globals that access extern objects,
 and therefore can lead to order-of-initialization problems.
 
 This check implements `I.22
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Ri-global-init>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#ri-global-init>`_
 from the C++ Core Guidelines.
 
 Note that currently this does not flag calls to non-constexpr functions, and

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
@@ -43,5 +43,5 @@ Options
    Specify the function used for forwarding. Default is `::std::forward`.
 
 This check implements `F.19
-<http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-forward>`_
+<http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rf-forward>`_
 from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/no-malloc.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/no-malloc.rst
@@ -10,7 +10,7 @@ Furthermore, it can be configured to check against a user-specified list of
 functions that are used for memory management (e.g. ``posix_memalign()``).
 
 This check implements `R.10
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-mallocfree>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rr-mallocfree>`_
 from the C++ Core Guidelines.
 
 There is no attempt made to provide fix-it hints, since manual resource

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/no-suspend-with-lock.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/no-suspend-with-lock.rst
@@ -36,5 +36,5 @@ Examples:
   }
 
 This check implements `CP.52
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rcoro-locks>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rcoro-locks>`_
 from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/owning-memory.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/owning-memory.rst
@@ -14,7 +14,7 @@ This check implements `I.11
 `R.3
 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r3-a-raw-pointer-a-t-is-non-owning>`_
 and `GSL.Views
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#SS-views>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#ss-views>`_
 from the C++ Core Guidelines.
 The definition of a ``gsl::owner<T*>`` is straight forward
 
@@ -23,7 +23,7 @@ The definition of a ``gsl::owner<T*>`` is straight forward
   namespace gsl { template <typename T> owner = T; }
 
 It is therefore simple to introduce the owner even without using an implementation of
-the `Guideline Support Library <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#S-gsl>`_.
+the `Guideline Support Library <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#s-gsl>`_.
 
 All checks are purely type based and not (yet) flow sensitive.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-array-to-pointer-decay.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-array-to-pointer-decay.rst
@@ -9,5 +9,5 @@ Pointers should not be used as arrays. ``span<T>`` is a bounds-checked, safe
 alternative to using pointers to access arrays.
 
 This rule is part of the `Bounds safety (Bounds 3)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-bounds-decay>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-decay>`_
 profile from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-avoid-unchecked-container-access.rst
@@ -31,7 +31,7 @@ excluded from this check (e.g.: ``std::map::operator[]``).
 This check enforces part of the `SL.con.3
 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#slcon3-avoid-bounds-errors>`
 guideline and is part of the `Bounds Safety (Bounds 4)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-bounds-arrayindex>`
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-arrayindex>`
 profile from the C++ Core Guidelines.
 
 Options

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.rst
@@ -9,7 +9,7 @@ are out of bounds (for ``std::array``). For out-of-bounds checking of static
 arrays, see the `-Warray-bounds` Clang diagnostic.
 
 This rule is part of the `Bounds safety (Bounds 2)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-bounds-arrayindex>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-arrayindex>`_
 profile from the C++ Core Guidelines.
 
 Optionally, this check can generate fixes using ``gsl::at`` for indexing.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-pointer-arithmetic.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-pointer-arithmetic.rst
@@ -11,7 +11,7 @@ and easy to get wrong. ``span<T>`` is a bounds-checked, safe type for accessing
 arrays of data.
 
 This rule is part of the `Bounds safety (Bounds 1)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-bounds-arithmetic>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-bounds-arithmetic>`_
 profile from the C++ Core Guidelines.
 
 Options

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-const-cast.rst
@@ -22,7 +22,7 @@ situations where the variable's volatility is a crucial aspect of program
 correctness and reliability.
 
 This rule is part of the `Type safety (Type 3)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-constcast>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-constcast>`_
 profile and `ES.50: Don’t cast away const
 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es50-dont-cast-away-const>`_
 rule from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.rst
@@ -15,5 +15,5 @@ the first of the following that is possible: a ``const_cast``, a
 This rule bans ``(T)expression`` only when used to perform an unsafe cast.
 
 This rule is part of the `Type safety (Type.4)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-cstylecast>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-cstylecast>`_
 profile from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
@@ -40,5 +40,5 @@ Options
    Default is `false`.
 
 This rule is part of the `Type safety (Type.6)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-memberinit>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-memberinit>`_
 profile from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-reinterpret-cast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-reinterpret-cast.rst
@@ -10,5 +10,5 @@ variable that is actually of type ``X`` to be accessed as if it were of an
 unrelated type ``Z``.
 
 This rule is part of the `Type safety (Type.1.1)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-reinterpretcast>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-reinterpretcast>`_
 profile from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.rst
@@ -12,7 +12,7 @@ variable that is actually of type ``X`` to be accessed as if it were of an
 unrelated type ``Z``.
 
 This rule is part of the `Type safety (Type.2)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-downcast>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-downcast>`_
 profile from the C++ Core Guidelines.
 
 Options

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-union-access.rst
@@ -13,5 +13,5 @@ enforced to be safe in the language and so relies on programmer discipline to
 get it right.
 
 This rule is part of the `Type safety (Type.7)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-unions>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-unions>`_
 profile from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-vararg.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-vararg.rst
@@ -15,5 +15,5 @@ because it cannot generally be enforced to be safe in the language and so
 relies on programmer discipline to get it right.
 
 This rule is part of the `Type safety (Type.8)
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-varargs>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#pro-type-varargs>`_
 profile from the C++ Core Guidelines.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/special-member-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/special-member-functions.rst
@@ -16,7 +16,7 @@ Note that defining a function with ``= delete`` is considered to be a
 definition.
 
 This check implements `C.21
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-five>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-five>`_
 from the C++ Core Guidelines.
 
 Options

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-default-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-default-member-init.rst
@@ -5,7 +5,7 @@
 cppcoreguidelines-use-default-member-init
 =========================================
 
-This check implements `C.48 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-in-class-initializer>`_
+This check implements `C.48 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-in-class-initializer>`_
 from the C++ Core Guidelines.
 
 The `cppcoreguidelines-use-default-member-init` check is an alias, please see

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-enum-class.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-enum-class.rst
@@ -7,7 +7,7 @@ Finds unscoped (non-class) ``enum`` declarations and suggests using
 ``enum class`` instead.
 
 This check implements `Enum.3
-<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Renum-class>`_
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#renum-class>`_
 from the C++ Core Guidelines."
 
 Example:

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/virtual-class-destructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/virtual-class-destructor.rst
@@ -8,7 +8,7 @@ nor protected and non-virtual. A virtual class's destructor should be specified
 in one of these ways to prevent undefined behavior.
 
 This check implements
-`C.35 <http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual>`_
+`C.35 <http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-dtor-virtual>`_
 from the C++ Core Guidelines.
 
 Note that this check will diagnose a class with a virtual method regardless of

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/magic-numbers.rst
@@ -9,7 +9,7 @@ code and not introduced via constants or symbols.
 Many coding guidelines advise replacing the magic values with symbolic
 constants to improve readability. Here are a few references:
 
-   * `Rule ES.45: Avoid "magic constants"; use symbolic constants in C++ Core Guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-magic>`_
+   * `Rule ES.45: Avoid "magic constants"; use symbolic constants in C++ Core Guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#res-magic>`_
    * `Rule 5.1.1 Use symbolic names instead of literal values in code in High Integrity C++ <https://www.perforce.com/resources/qac/high-integrity-cpp-coding-standard-expressions>`_
    * Item 17 in "C++ Coding Standards: 101 Rules, Guidelines and Best
      Practices" by Herb Sutter and Andrei Alexandrescu


### PR DESCRIPTION
They recently changed all their anchors to start with lowercase: https://github.com/isocpp/CppCoreGuidelines/pull/2304

So now our links are broken :) This patch fixes them.