### PR TITLE
[libc++] Always return bool from bitset::operator[](size_t) const

### DIFF
--- a/libcxx/docs/ReleaseNotes/22.rst
+++ b/libcxx/docs/ReleaseNotes/22.rst
@@ -126,5 +126,9 @@ ABI Affecting Changes
   ``_LIBCPP_DEPRECATED_ABI_NON_TRIVIAL_ALLOCATOR``. Please inform the libc++ team if you need this flag, since it will
   be removed in LLVM 24 if there is no evidence that it's required.
 
+- ``bitset::operator[]`` now returns ``bool``, making libc++ conforming. The behaviour can be reverted by defining
+  ``_LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF``. Please inform the libc++ team if you need this flag,
+  since it will be removed in LLVM 24 if there is no evidence that it's required.
+
 Build System Changes
 --------------------

--- a/libcxx/include/__cxx03/bitset
+++ b/libcxx/include/__cxx03/bitset
@@ -612,7 +612,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI bitset& flip(size_t __pos);
 
   // element access:
-#ifdef _LIBCPP_ABI_BITSET_VECTOR_BOOL_CONST_SUBSCRIPT_RETURN_BOOL
+#ifndef _LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF
   _LIBCPP_HIDE_FROM_ABI bool operator[](size_t __p) const { return __base::__make_ref(__p); }
 #else
   _LIBCPP_HIDE_FROM_ABI __const_reference operator[](size_t __p) const { return __base::__make_ref(__p); }

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -680,7 +680,8 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset& flip(size_t __pos);
 
   // element access:
-#  ifdef _LIBCPP_ABI_BITSET_VECTOR_BOOL_CONST_SUBSCRIPT_RETURN_BOOL
+  // TODO(LLVM 24): Remove the opt-out
+#  ifndef _LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator[](size_t __p) const {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__p < _Size, "bitset::operator[] index out of bounds");
     return __base::__make_ref(__p);

--- a/libcxx/test/libcxx/utilities/template.bitset/index_const.pass.cpp
+++ b/libcxx/test/libcxx/utilities/template.bitset/index_const.pass.cpp
@@ -8,12 +8,16 @@
 
 // constexpr bool operator[](size_t pos) const; // constexpr since C++23
 
+// Make sure that `_LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF` reverts to the old behaviour.
+
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF
+
 #include <bitset>
 #include <cassert>
 #include <cstddef>
 #include <vector>
 
-#include "../bitset_test_cases.h"
+#include "../../../std/utilities/template.bitset/bitset_test_cases.h"
 #include "test_macros.h"
 
 template <std::size_t N>
@@ -25,7 +29,7 @@ TEST_CONSTEXPR_CXX23 void test_index_const() {
       assert(v[N / 2] == v.test(N / 2));
     }
   }
-  ASSERT_SAME_TYPE(decltype(cases[0][0]), bool);
+  ASSERT_SAME_TYPE(decltype(cases[0][0]), typename std::bitset<N>::__const_reference);
 }
 
 TEST_CONSTEXPR_CXX23 bool test() {
@@ -43,7 +47,7 @@ TEST_CONSTEXPR_CXX23 bool test() {
   const auto& set = set_;
   auto b          = set[0];
   set_[0]         = true;
-  assert(!b);
+  assert(b);
 
   return true;
 }


### PR DESCRIPTION
This takes an ABI break unconditionally, since it's small enough that nobody should be affected. This both simplifies `bitset` a bit and makes us more conforming.
