### PR TITLE
[lldb][dotest] use unused variable

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -1108,11 +1108,7 @@ def run_suite():
     checkDAPSupport()
 
     skipped_categories_list = ", ".join(configuration.skip_categories)
-    print(
-        "Skipping the following test categories: {}".format(
-            configuration.skip_categories
-        )
-    )
+    print(f"Skipping the following test categories: {skipped_categories_list}")
 
     for testdir in configuration.testdirs:
         for dirpath, dirnames, filenames in os.walk(testdir):


### PR DESCRIPTION
`skipped_categories_list` was unused in `dotest.py`. This patch ensures it's used where intended.

2238dcc39358353cac21df75c3c3286ab20b8f53 switched to using `configuration.skip_categories` directly when reformatting the code, making `skipped_categories_list` unused.