### PR TITLE
[NFC] Remove deprecated Argument::getParamAlignment() declaration

### DIFF
--- a/llvm/include/llvm/IR/Argument.h
+++ b/llvm/include/llvm/IR/Argument.h
@@ -109,12 +109,6 @@ public:
   LLVM_ABI Type *getPointeeInMemoryValueType() const;
 
   /// If this is a byval or inalloca argument, return its alignment.
-  /// FIXME: Remove this function once transition to Align is over.
-  /// Use getParamAlign() instead.
-  LLVM_ABI LLVM_DEPRECATED("Use getParamAlign() instead",
-                           "getParamAlign") uint64_t getParamAlignment() const;
-
-  /// If this is a byval or inalloca argument, return its alignment.
   LLVM_ABI MaybeAlign getParamAlign() const;
 
   LLVM_ABI MaybeAlign getParamStackAlign() const;


### PR DESCRIPTION
The implementation of Argument::getParamAlignment() was removed in commit b55f83d013eff244f7cf6bfcd06f06f7c894ff28, but the declaration in Argument.h was left behind. Remove it.

NFC.