### PR TITLE
[AArch64] Inline asm v0-v31 are scalar when having less than 64-bit capacity

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -13362,12 +13362,28 @@ AArch64TargetLowering::getRegForInlineAsmConstraint(
       int RegNo;
       bool Failed = Constraint.slice(2, Size - 1).getAsInteger(10, RegNo);
       if (!Failed && RegNo >= 0 && RegNo <= 31) {
-        // v0 - v31 are aliases of q0 - q31 or d0 - d31 depending on size.
+        // v0 - v31 are aliases of q0/d0/s0/h0 - ...31 depending on size.
         // By default we'll emit v0-v31 for this unless there's a modifier where
         // we'll emit the correct register as well.
-        if (VT != MVT::Other && VT.getSizeInBits() <= 64) {
-          Res.first = AArch64::FPR64RegClass.getRegister(RegNo);
-          Res.second = &AArch64::FPR64RegClass;
+        if (VT != MVT::Other) {
+          switch (VT.getSizeInBits()) {
+          default:
+            Res.first = AArch64::FPR128RegClass.getRegister(RegNo);
+            Res.second = &AArch64::FPR128RegClass;
+            break;
+          case 64:
+            Res.first = AArch64::FPR64RegClass.getRegister(RegNo);
+            Res.second = &AArch64::FPR64RegClass;
+            break;
+          case 32:
+            Res.first = AArch64::FPR32RegClass.getRegister(RegNo);
+            Res.second = &AArch64::FPR32RegClass;
+            break;
+          case 16:
+            Res.first = AArch64::FPR16RegClass.getRegister(RegNo);
+            Res.second = &AArch64::FPR16RegClass;
+            break;
+          }
         } else {
           Res.first = AArch64::FPR128RegClass.getRegister(RegNo);
           Res.second = &AArch64::FPR128RegClass;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -13367,22 +13367,24 @@ AArch64TargetLowering::getRegForInlineAsmConstraint(
         // we'll emit the correct register as well.
         if (VT != MVT::Other) {
           switch (VT.getSizeInBits()) {
-          default:
-            Res.first = AArch64::FPR128RegClass.getRegister(RegNo);
-            Res.second = &AArch64::FPR128RegClass;
-            break;
-          case 64:
-            Res.first = AArch64::FPR64RegClass.getRegister(RegNo);
-            Res.second = &AArch64::FPR64RegClass;
+          case 16:
+            Res.first = AArch64::FPR16RegClass.getRegister(RegNo);
+            Res.second = &AArch64::FPR16RegClass;
             break;
           case 32:
             Res.first = AArch64::FPR32RegClass.getRegister(RegNo);
             Res.second = &AArch64::FPR32RegClass;
             break;
-          case 16:
-            Res.first = AArch64::FPR16RegClass.getRegister(RegNo);
-            Res.second = &AArch64::FPR16RegClass;
+          case 64:
+            Res.first = AArch64::FPR64RegClass.getRegister(RegNo);
+            Res.second = &AArch64::FPR64RegClass;
             break;
+          case 128:
+            Res.first = AArch64::FPR128RegClass.getRegister(RegNo);
+            Res.second = &AArch64::FPR128RegClass;
+            break;
+          default:
+            return std::make_pair(0U, nullptr);
           }
         } else {
           Res.first = AArch64::FPR128RegClass.getRegister(RegNo);

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -13365,7 +13365,7 @@ AArch64TargetLowering::getRegForInlineAsmConstraint(
         // v0 - v31 are aliases of q0 - q31 or d0 - d31 depending on size.
         // By default we'll emit v0-v31 for this unless there's a modifier where
         // we'll emit the correct register as well.
-        if (VT != MVT::Other && VT.getSizeInBits() == 64) {
+        if (VT != MVT::Other && VT.getSizeInBits() <= 64) {
           Res.first = AArch64::FPR64RegClass.getRegister(RegNo);
           Res.second = &AArch64::FPR64RegClass;
         } else {

--- a/llvm/test/CodeGen/AArch64/inline-asm-nop-reg.ll
+++ b/llvm/test/CodeGen/AArch64/inline-asm-nop-reg.ll
@@ -1,15 +1,16 @@
 ; RUN: llc -O1 -mtriple=aarch64-linux-gnu %s -o - 2>&1 | FileCheck %s
 
-; This test checks that the code containing "nop" inline assembler instruction
-; with 16/32/64-bit FP "v0" register, will be successfully compiled
-; and generated code will contain one optimized nop-instruction
-; per each function.
+; This test contains "nop" inline assembler instruction with 16..128-bit
+; affectd FP "v0" register. It checks that the IR will be successfully
+; compiled and generated code will contain nop-instruction and proper register
+; name placed in each function.
 ;
 ; IR for this test was generated from the following source code:
 ;
 ; #define _FP16 _Float16
 ; #define _FP32 float
 ; #define _FP64 double
+; #define _FP128 long double
 ;
 ; #define FOO(BITS) \
 ; int foo##BITS(void) { \
@@ -23,98 +24,134 @@
 ; FOO(16)
 ; FOO(32)
 ; FOO(64)
+; FOO(128)
 
 
 ; test nop_fp16_reg
 ; CHECK-LABEL: foo16:
 ; CHECK: nop
-; CHECK-NOT: nop
+; CHECK: str h0
 define dso_local i32 @foo16() #0 {
-  %1 = alloca half, align 2
-  %2 = alloca i32, align 4
-  store i32 0, ptr %2, align 4
-  br label %3
+entry:
+  %a0 = alloca half, align 2
+  %i = alloca i32, align 4
+  store i32 0, ptr %i, align 4
+  br label %for.cond
 
-3:                                                ; preds = %9, %0
-  %4 = load i32, ptr %2, align 4
-  %5 = icmp slt i32 %4, 2
-  br i1 %5, label %6, label %12
+for.cond:                                         ; preds = %for.inc, %entry
+  %0 = load i32, ptr %i, align 4
+  %cmp = icmp slt i32 %0, 2
+  br i1 %cmp, label %for.body, label %for.end
 
-6:                                                ; preds = %3
-  %7 = load half, ptr %1, align 2
-  %8 = call half asm sideeffect "nop", "={v0},{v0}"(half %7) #1, !srcloc !6
-  store half %8, ptr %1, align 2
-  br label %9
+for.body:                                         ; preds = %for.cond
+  %1 = load half, ptr %a0, align 2
+  %2 = call half asm sideeffect "nop", "={v0},{v0}"(half %1) #1, !srcloc !6
+  store half %2, ptr %a0, align 2
+  br label %for.inc
 
-9:                                                ; preds = %6
-  %10 = load i32, ptr %2, align 4
-  %11 = add nsw i32 %10, 1
-  store i32 %11, ptr %2, align 4
-  br label %3, !llvm.loop !7
+for.inc:                                          ; preds = %for.body
+  %3 = load i32, ptr %i, align 4
+  %inc = add nsw i32 %3, 1
+  store i32 %inc, ptr %i, align 4
+  br label %for.cond, !llvm.loop !7
 
-12:                                               ; preds = %3
+for.end:                                          ; preds = %for.cond
   ret i32 0
 }
 
 ; test nop_fp32_reg
 ; CHECK-LABEL: foo32:
 ; CHECK: nop
-; CHECK-NOT: nop
+; CHECK: str s0
 define dso_local i32 @foo32() #0 {
-  %1 = alloca float, align 4
-  %2 = alloca i32, align 4
-  store i32 0, ptr %2, align 4
-  br label %3
+entry:
+  %a0 = alloca float, align 4
+  %i = alloca i32, align 4
+  store i32 0, ptr %i, align 4
+  br label %for.cond
 
-3:                                                ; preds = %9, %0
-  %4 = load i32, ptr %2, align 4
-  %5 = icmp slt i32 %4, 2
-  br i1 %5, label %6, label %12
+for.cond:                                         ; preds = %for.inc, %entry
+  %0 = load i32, ptr %i, align 4
+  %cmp = icmp slt i32 %0, 2
+  br i1 %cmp, label %for.body, label %for.end
 
-6:                                                ; preds = %3
-  %7 = load float, ptr %1, align 4
-  %8 = call float asm sideeffect "nop", "={v0},{v0}"(float %7) #1, !srcloc !9
-  store float %8, ptr %1, align 4
-  br label %9
+for.body:                                         ; preds = %for.cond
+  %1 = load float, ptr %a0, align 4
+  %2 = call float asm sideeffect "nop", "={v0},{v0}"(float %1) #1, !srcloc !9
+  store float %2, ptr %a0, align 4
+  br label %for.inc
 
-9:                                                ; preds = %6
-  %10 = load i32, ptr %2, align 4
-  %11 = add nsw i32 %10, 1
-  store i32 %11, ptr %2, align 4
-  br label %3, !llvm.loop !10
+for.inc:                                          ; preds = %for.body
+  %3 = load i32, ptr %i, align 4
+  %inc = add nsw i32 %3, 1
+  store i32 %inc, ptr %i, align 4
+  br label %for.cond, !llvm.loop !10
 
-12:                                               ; preds = %3
+for.end:                                          ; preds = %for.cond
   ret i32 0
 }
 
 ; test nop_fp64_reg
 ; CHECK-LABEL: foo64:
 ; CHECK: nop
-; CHECK-NOT: nop
+; CHECK: str d0
 define dso_local i32 @foo64() #0 {
-  %1 = alloca double, align 8
-  %2 = alloca i32, align 4
-  store i32 0, ptr %2, align 4
-  br label %3
+entry:
+  %a0 = alloca double, align 8
+  %i = alloca i32, align 4
+  store i32 0, ptr %i, align 4
+  br label %for.cond
 
-3:                                                ; preds = %9, %0
-  %4 = load i32, ptr %2, align 4
-  %5 = icmp slt i32 %4, 2
-  br i1 %5, label %6, label %12
+for.cond:                                         ; preds = %for.inc, %entry
+  %0 = load i32, ptr %i, align 4
+  %cmp = icmp slt i32 %0, 2
+  br i1 %cmp, label %for.body, label %for.end
 
-6:                                                ; preds = %3
-  %7 = load double, ptr %1, align 8
-  %8 = call double asm sideeffect "nop", "={v0},{v0}"(double %7) #1, !srcloc !11
-  store double %8, ptr %1, align 8
-  br label %9
+for.body:                                         ; preds = %for.cond
+  %1 = load double, ptr %a0, align 8
+  %2 = call double asm sideeffect "nop", "={v0},{v0}"(double %1) #1, !srcloc !11
+  store double %2, ptr %a0, align 8
+  br label %for.inc
 
-9:                                                ; preds = %6
-  %10 = load i32, ptr %2, align 4
-  %11 = add nsw i32 %10, 1
-  store i32 %11, ptr %2, align 4
-  br label %3, !llvm.loop !12
+for.inc:                                          ; preds = %for.body
+  %3 = load i32, ptr %i, align 4
+  %inc = add nsw i32 %3, 1
+  store i32 %inc, ptr %i, align 4
+  br label %for.cond, !llvm.loop !12
 
-12:                                               ; preds = %3
+for.end:                                          ; preds = %for.cond
+  ret i32 0
+}
+
+; test nop_fp128_reg
+; CHECK-LABEL: foo128:
+; CHECK: nop
+; CHECK: str q0
+define dso_local i32 @foo128() #0 {
+entry:
+  %a0 = alloca fp128, align 16
+  %i = alloca i32, align 4
+  store i32 0, ptr %i, align 4
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %0 = load i32, ptr %i, align 4
+  %cmp = icmp slt i32 %0, 2
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %1 = load fp128, ptr %a0, align 16
+  %2 = call fp128 asm sideeffect "nop", "={v0},{v0}"(fp128 %1) #1, !srcloc !13
+  store fp128 %2, ptr %a0, align 16
+  br label %for.inc
+
+for.inc:                                          ; preds = %for.body
+  %3 = load i32, ptr %i, align 4
+  %inc = add nsw i32 %3, 1
+  store i32 %inc, ptr %i, align 4
+  br label %for.cond, !llvm.loop !14
+
+for.end:                                          ; preds = %for.cond
   ret i32 0
 }
 
@@ -125,12 +162,14 @@ define dso_local i32 @foo64() #0 {
 !1 = !{i32 8, !"PIC Level", i32 2}
 !2 = !{i32 7, !"PIE Level", i32 2}
 !3 = !{i32 7, !"uwtable", i32 2}
-!4 = !{i32 7, !"frame-pointer", i32 1}
-!5 = !{!"clang version 22.0.0git"}
-!6 = !{i64 2147502427}
+!4 = !{i32 7, !"frame-pointer", i32 4}
+!5 = !{!"clang version 22.0.0git (https://github.com/llvm/llvm-project.git)"}
+!6 = !{i64 2147502487}
 !7 = distinct !{!7, !8}
 !8 = !{!"llvm.loop.mustprogress"}
-!9 = !{i64 2147502622}
+!9 = !{i64 2147502682}
 !10 = distinct !{!10, !8}
-!11 = !{i64 2147502814}
+!11 = !{i64 2147502874}
 !12 = distinct !{!12, !8}
+!13 = !{i64 2147503067}
+!14 = distinct !{!14, !8}

--- a/llvm/test/CodeGen/AArch64/inline-asm-nop-reg.ll
+++ b/llvm/test/CodeGen/AArch64/inline-asm-nop-reg.ll
@@ -1,158 +1,150 @@
 ; RUN: llc -O1 -mtriple=aarch64-linux-gnu %s -o - 2>&1 | FileCheck %s
 
 ; This test contains "nop" inline assembler instruction with 16..128-bit
-; affectd FP "v0" register. It checks that the IR will be successfully
+; affectd "v0" register. It checks that the IR will be successfully
 ; compiled and generated code will contain nop-instruction and proper register
 ; name placed in each function.
 ;
 ; IR for this test was generated from the following source code:
+;
+; #include <stdint.h>
 ;
 ; #define _FP16 _Float16
 ; #define _FP32 float
 ; #define _FP64 double
 ; #define _FP128 long double
 ;
-; #define FOO(BITS) \
-; int foo##BITS(void) { \
-;   register _FP##BITS a0 asm("v0"); \
-;   for (int i = 0; i < 2; ++i) { \
-;     __asm__ volatile("nop" : [a0] "+w"(a0)::); \
-;   } \
-;   return 0; \
+; #define _INT16 int16_t
+; #define _INT32 int32_t
+; #define _INT64 int64_t
+; #define _INT128 __int128
+;
+; #define FOO(TYPE) \
+; void foo_##TYPE(void) { \
+;   register _##TYPE a0 asm("v0"); \
+;   __asm__ volatile("nop" : [a0] "+w"(a0)::); \
 ; }
 ;
-; FOO(16)
-; FOO(32)
-; FOO(64)
-; FOO(128)
+; FOO(FP16)
+; FOO(FP32)
+; FOO(FP64)
+; FOO(FP128)
+;
+; FOO(INT16)
+; FOO(INT32)
+; FOO(INT64)
+; FOO(INT128)
 
-
-; test nop_fp16_reg
-; CHECK-LABEL: foo16:
+; test nop_FP16_reg
+; CHECK-LABEL: foo_FP16:
+; CHECK: ldr h0
 ; CHECK: nop
 ; CHECK: str h0
-define dso_local i32 @foo16() #0 {
+define dso_local void @foo_FP16() #0 {
 entry:
   %a0 = alloca half, align 2
-  %i = alloca i32, align 4
-  store i32 0, ptr %i, align 4
-  br label %for.cond
-
-for.cond:                                         ; preds = %for.inc, %entry
-  %0 = load i32, ptr %i, align 4
-  %cmp = icmp slt i32 %0, 2
-  br i1 %cmp, label %for.body, label %for.end
-
-for.body:                                         ; preds = %for.cond
-  %1 = load half, ptr %a0, align 2
-  %2 = call half asm sideeffect "nop", "={v0},{v0}"(half %1) #1, !srcloc !6
-  store half %2, ptr %a0, align 2
-  br label %for.inc
-
-for.inc:                                          ; preds = %for.body
-  %3 = load i32, ptr %i, align 4
-  %inc = add nsw i32 %3, 1
-  store i32 %inc, ptr %i, align 4
-  br label %for.cond, !llvm.loop !7
-
-for.end:                                          ; preds = %for.cond
-  ret i32 0
+  %0 = load half, ptr %a0, align 2
+  %1 = call half asm sideeffect "nop", "={v0},{v0}"(half %0) #1, !srcloc !6
+  store half %1, ptr %a0, align 2
+  ret void
 }
 
-; test nop_fp32_reg
-; CHECK-LABEL: foo32:
+; test nop_FP32_reg
+; CHECK-LABEL: foo_FP32:
+; CHECK: ldr s0
 ; CHECK: nop
 ; CHECK: str s0
-define dso_local i32 @foo32() #0 {
+define dso_local void @foo_FP32() #0 {
 entry:
   %a0 = alloca float, align 4
-  %i = alloca i32, align 4
-  store i32 0, ptr %i, align 4
-  br label %for.cond
-
-for.cond:                                         ; preds = %for.inc, %entry
-  %0 = load i32, ptr %i, align 4
-  %cmp = icmp slt i32 %0, 2
-  br i1 %cmp, label %for.body, label %for.end
-
-for.body:                                         ; preds = %for.cond
-  %1 = load float, ptr %a0, align 4
-  %2 = call float asm sideeffect "nop", "={v0},{v0}"(float %1) #1, !srcloc !9
-  store float %2, ptr %a0, align 4
-  br label %for.inc
-
-for.inc:                                          ; preds = %for.body
-  %3 = load i32, ptr %i, align 4
-  %inc = add nsw i32 %3, 1
-  store i32 %inc, ptr %i, align 4
-  br label %for.cond, !llvm.loop !10
-
-for.end:                                          ; preds = %for.cond
-  ret i32 0
+  %0 = load float, ptr %a0, align 4
+  %1 = call float asm sideeffect "nop", "={v0},{v0}"(float %0) #1, !srcloc !7
+  store float %1, ptr %a0, align 4
+  ret void
 }
 
-; test nop_fp64_reg
-; CHECK-LABEL: foo64:
+; test nop_FP64_reg
+; CHECK-LABEL: foo_FP64:
+; CHECK: ldr d0
 ; CHECK: nop
 ; CHECK: str d0
-define dso_local i32 @foo64() #0 {
+define dso_local void @foo_FP64() #0 {
 entry:
   %a0 = alloca double, align 8
-  %i = alloca i32, align 4
-  store i32 0, ptr %i, align 4
-  br label %for.cond
-
-for.cond:                                         ; preds = %for.inc, %entry
-  %0 = load i32, ptr %i, align 4
-  %cmp = icmp slt i32 %0, 2
-  br i1 %cmp, label %for.body, label %for.end
-
-for.body:                                         ; preds = %for.cond
-  %1 = load double, ptr %a0, align 8
-  %2 = call double asm sideeffect "nop", "={v0},{v0}"(double %1) #1, !srcloc !11
-  store double %2, ptr %a0, align 8
-  br label %for.inc
-
-for.inc:                                          ; preds = %for.body
-  %3 = load i32, ptr %i, align 4
-  %inc = add nsw i32 %3, 1
-  store i32 %inc, ptr %i, align 4
-  br label %for.cond, !llvm.loop !12
-
-for.end:                                          ; preds = %for.cond
-  ret i32 0
+  %0 = load double, ptr %a0, align 8
+  %1 = call double asm sideeffect "nop", "={v0},{v0}"(double %0) #1, !srcloc !8
+  store double %1, ptr %a0, align 8
+  ret void
 }
 
-; test nop_fp128_reg
-; CHECK-LABEL: foo128:
+; test nop_FP128_reg
+; CHECK-LABEL: foo_FP128:
+; CHECK: ldr q0
 ; CHECK: nop
 ; CHECK: str q0
-define dso_local i32 @foo128() #0 {
+define dso_local void @foo_FP128() #0 {
 entry:
   %a0 = alloca fp128, align 16
-  %i = alloca i32, align 4
-  store i32 0, ptr %i, align 4
-  br label %for.cond
+  %0 = load fp128, ptr %a0, align 16
+  %1 = call fp128 asm sideeffect "nop", "={v0},{v0}"(fp128 %0) #1, !srcloc !9
+  store fp128 %1, ptr %a0, align 16
+  ret void
+}
 
-for.cond:                                         ; preds = %for.inc, %entry
-  %0 = load i32, ptr %i, align 4
-  %cmp = icmp slt i32 %0, 2
-  br i1 %cmp, label %for.body, label %for.end
+; test nop_INT16_reg
+; CHECK-LABEL: foo_INT16:
+; CHECK: ldr h0
+; CHECK: nop
+; CHECK: str h0
+define dso_local void @foo_INT16() #0 {
+entry:
+  %a0 = alloca i16, align 2
+  %0 = load i16, ptr %a0, align 2
+  %1 = call i16 asm sideeffect "nop", "={v0},{v0}"(i16 %0) #1, !srcloc !10
+  store i16 %1, ptr %a0, align 2
+  ret void
+}
 
-for.body:                                         ; preds = %for.cond
-  %1 = load fp128, ptr %a0, align 16
-  %2 = call fp128 asm sideeffect "nop", "={v0},{v0}"(fp128 %1) #1, !srcloc !13
-  store fp128 %2, ptr %a0, align 16
-  br label %for.inc
+; test nop_INT32_reg
+; CHECK-LABEL: foo_INT32:
+; CHECK: ldr s0
+; CHECK: nop
+; CHECK: str s0
+define dso_local void @foo_INT32() #0 {
+entry:
+  %a0 = alloca i32, align 4
+  %0 = load i32, ptr %a0, align 4
+  %1 = call i32 asm sideeffect "nop", "={v0},{v0}"(i32 %0) #1, !srcloc !11
+  store i32 %1, ptr %a0, align 4
+  ret void
+}
 
-for.inc:                                          ; preds = %for.body
-  %3 = load i32, ptr %i, align 4
-  %inc = add nsw i32 %3, 1
-  store i32 %inc, ptr %i, align 4
-  br label %for.cond, !llvm.loop !14
+; test nop_INT64_reg
+; CHECK-LABEL: foo_INT64:
+; CHECK: ldr d0
+; CHECK: nop
+; CHECK: str d0
+define dso_local void @foo_INT64() #0 {
+entry:
+  %a0 = alloca i64, align 8
+  %0 = load i64, ptr %a0, align 8
+  %1 = call i64 asm sideeffect "nop", "={v0},{v0}"(i64 %0) #1, !srcloc !12
+  store i64 %1, ptr %a0, align 8
+  ret void
+}
 
-for.end:                                          ; preds = %for.cond
-  ret i32 0
+; test nop_INT128_reg
+; CHECK-LABEL: foo_INT128:
+; CHECK: ldr q0
+; CHECK: nop
+; CHECK: str q0
+define dso_local void @foo_INT128() #0 {
+entry:
+  %a0 = alloca i128, align 16
+  %0 = load i128, ptr %a0, align 16
+  %1 = call i128 asm sideeffect "nop", "={v0},{v0}"(i128 %0) #1, !srcloc !13
+  store i128 %1, ptr %a0, align 16
+  ret void
 }
 
 !llvm.module.flags = !{!0, !1, !2, !3, !4}
@@ -164,12 +156,11 @@ for.end:                                          ; preds = %for.cond
 !3 = !{i32 7, !"uwtable", i32 2}
 !4 = !{i32 7, !"frame-pointer", i32 4}
 !5 = !{!"clang version 22.0.0git (https://github.com/llvm/llvm-project.git)"}
-!6 = !{i64 2147502487}
-!7 = distinct !{!7, !8}
-!8 = !{!"llvm.loop.mustprogress"}
-!9 = !{i64 2147502682}
-!10 = distinct !{!10, !8}
-!11 = !{i64 2147502874}
-!12 = distinct !{!12, !8}
-!13 = !{i64 2147503067}
-!14 = distinct !{!14, !8}
+!6 = !{i64 2147598584}
+!7 = !{i64 2147598730}
+!8 = !{i64 2147598873}
+!9 = !{i64 2147599017}
+!10 = !{i64 2147599170}
+!11 = !{i64 2147599319}
+!12 = !{i64 2147599468}
+!13 = !{i64 2147599617}

--- a/llvm/test/CodeGen/AArch64/inline-asm-nop-reg.ll
+++ b/llvm/test/CodeGen/AArch64/inline-asm-nop-reg.ll
@@ -1,0 +1,136 @@
+; RUN: llc -O1 -mtriple=aarch64-linux-gnu %s -o - 2>&1 | FileCheck %s
+
+; This test checks that the code containing "nop" inline assembler instruction
+; with 16/32/64-bit FP "v0" register, will be successfully compiled
+; and generated code will contain one optimized nop-instruction
+; per each function.
+;
+; IR for this test was generated from the following source code:
+;
+; #define _FP16 _Float16
+; #define _FP32 float
+; #define _FP64 double
+;
+; #define FOO(BITS) \
+; int foo##BITS(void) { \
+;   register _FP##BITS a0 asm("v0"); \
+;   for (int i = 0; i < 2; ++i) { \
+;     __asm__ volatile("nop" : [a0] "+w"(a0)::); \
+;   } \
+;   return 0; \
+; }
+;
+; FOO(16)
+; FOO(32)
+; FOO(64)
+
+
+; test nop_fp16_reg
+; CHECK-LABEL: foo16:
+; CHECK: nop
+; CHECK-NOT: nop
+define dso_local i32 @foo16() #0 {
+  %1 = alloca half, align 2
+  %2 = alloca i32, align 4
+  store i32 0, ptr %2, align 4
+  br label %3
+
+3:                                                ; preds = %9, %0
+  %4 = load i32, ptr %2, align 4
+  %5 = icmp slt i32 %4, 2
+  br i1 %5, label %6, label %12
+
+6:                                                ; preds = %3
+  %7 = load half, ptr %1, align 2
+  %8 = call half asm sideeffect "nop", "={v0},{v0}"(half %7) #1, !srcloc !6
+  store half %8, ptr %1, align 2
+  br label %9
+
+9:                                                ; preds = %6
+  %10 = load i32, ptr %2, align 4
+  %11 = add nsw i32 %10, 1
+  store i32 %11, ptr %2, align 4
+  br label %3, !llvm.loop !7
+
+12:                                               ; preds = %3
+  ret i32 0
+}
+
+; test nop_fp32_reg
+; CHECK-LABEL: foo32:
+; CHECK: nop
+; CHECK-NOT: nop
+define dso_local i32 @foo32() #0 {
+  %1 = alloca float, align 4
+  %2 = alloca i32, align 4
+  store i32 0, ptr %2, align 4
+  br label %3
+
+3:                                                ; preds = %9, %0
+  %4 = load i32, ptr %2, align 4
+  %5 = icmp slt i32 %4, 2
+  br i1 %5, label %6, label %12
+
+6:                                                ; preds = %3
+  %7 = load float, ptr %1, align 4
+  %8 = call float asm sideeffect "nop", "={v0},{v0}"(float %7) #1, !srcloc !9
+  store float %8, ptr %1, align 4
+  br label %9
+
+9:                                                ; preds = %6
+  %10 = load i32, ptr %2, align 4
+  %11 = add nsw i32 %10, 1
+  store i32 %11, ptr %2, align 4
+  br label %3, !llvm.loop !10
+
+12:                                               ; preds = %3
+  ret i32 0
+}
+
+; test nop_fp64_reg
+; CHECK-LABEL: foo64:
+; CHECK: nop
+; CHECK-NOT: nop
+define dso_local i32 @foo64() #0 {
+  %1 = alloca double, align 8
+  %2 = alloca i32, align 4
+  store i32 0, ptr %2, align 4
+  br label %3
+
+3:                                                ; preds = %9, %0
+  %4 = load i32, ptr %2, align 4
+  %5 = icmp slt i32 %4, 2
+  br i1 %5, label %6, label %12
+
+6:                                                ; preds = %3
+  %7 = load double, ptr %1, align 8
+  %8 = call double asm sideeffect "nop", "={v0},{v0}"(double %7) #1, !srcloc !11
+  store double %8, ptr %1, align 8
+  br label %9
+
+9:                                                ; preds = %6
+  %10 = load i32, ptr %2, align 4
+  %11 = add nsw i32 %10, 1
+  store i32 %11, ptr %2, align 4
+  br label %3, !llvm.loop !12
+
+12:                                               ; preds = %3
+  ret i32 0
+}
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{i32 7, !"frame-pointer", i32 1}
+!5 = !{!"clang version 22.0.0git"}
+!6 = !{i64 2147502427}
+!7 = distinct !{!7, !8}
+!8 = !{!"llvm.loop.mustprogress"}
+!9 = !{i64 2147502622}
+!10 = distinct !{!10, !8}
+!11 = !{i64 2147502814}
+!12 = distinct !{!12, !8}


### PR DESCRIPTION
If 32-bit (or less) "v0" registers coming from inline asm are treated as vector ones, codegen might produce incorrect vector<->scalar conversions. This causes types mismatch assertion failures later during compile-time. The fix treats 32-bit or less v0-v31 AArch64 registers as scalar, along with 64-bit ones.

Fixes #153442