### PR TITLE
[LLDB][PDB] Relax check for resolving breakpoint

### DIFF
--- a/lldb/test/Shell/SymbolFile/PDB/add-symbols.cpp
+++ b/lldb/test/Shell/SymbolFile/PDB/add-symbols.cpp
@@ -25,7 +25,7 @@
 // CHECK-NEXT: Breakpoint 1: no locations (pending).
 // CHECK: (lldb) target symbols add
 // CHECK: 1 location added to breakpoint 1
-// CHECK: (lldb) r
+
 // CHECK: * thread #1, stop reason = breakpoint 1.1
 // CHECK: (lldb) target variable a
 // CHECK-NEXT: (A) a = (x = 47)


### PR DESCRIPTION
The test was flaky, because it assumed that the breakpoint was always resolved before `r` was executed (https://github.com/llvm/llvm-project/pull/169728#issuecomment-3589799783). This PR removes the check for this order. It still checks that the breakpoint is resolved before it is hit.