### PR TITLE
[lldb-dap] Fix format string on Mac OS

### DIFF
--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -87,8 +87,10 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
     // Use the unique target ID to get the target.
     target = dap.debugger.FindTargetByGloballyUniqueID(*target_id);
     if (!target.IsValid()) {
-      error.SetErrorStringWithFormat("invalid target_id %llu in attach config",
-                                     (unsigned long long)*target_id);
+      error.SetErrorString(
+          llvm::formatv("invalid target_id {0} in attach config", *target_id)
+              .str()
+              .c_str());
     }
   } else {
     target = dap.CreateTarget(error);

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -87,8 +87,8 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
     // Use the unique target ID to get the target.
     target = dap.debugger.FindTargetByGloballyUniqueID(*target_id);
     if (!target.IsValid()) {
-      error.SetErrorStringWithFormat("invalid target_id %lu in attach config",
-                                     *target_id);
+      error.SetErrorStringWithFormat("invalid target_id %llu in attach config",
+                                     (unsigned long long)*target_id);
     }
   } else {
     target = dap.CreateTarget(error);


### PR DESCRIPTION
On Mac `unsigned long long` corresponds to `uint64_t` so `%llu` is needed.

Simply always using `%llu` and upcasting to `unsigned long long` should make it work fine.