### PR TITLE
[RISCV] Update SpacemiT-X60 vector load/stores

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSpacemitX60.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSpacemitX60.td
@@ -125,6 +125,33 @@ class SMX60IsWorstCaseMXSEW<string mx, int sew, list<string> MxList, bit isF = 0
 defvar SMX60VLEN = 256;
 defvar SMX60DLEN = !div(SMX60VLEN, 2);
 
+class SMX60GetLMulCycles<string mx> {
+  int c = !cond(
+    !eq(mx, "M1") : 1,
+    !eq(mx, "M2") : 2,
+    !eq(mx, "M4") : 4,
+    !eq(mx, "M8") : 8,
+    !eq(mx, "MF2") : 1,
+    !eq(mx, "MF4") : 1,
+    !eq(mx, "MF8") : 1
+  );
+}
+
+class SMX60GetVLMAX<string mx, int sew> {
+  defvar LMUL = SMX60GetLMulCycles<mx>.c;
+  int val = !cond(
+    !eq(mx, "MF2") : !div(!div(SMX60VLEN, 2), sew),
+    !eq(mx, "MF4") : !div(!div(SMX60VLEN, 4), sew),
+    !eq(mx, "MF8") : !div(!div(SMX60VLEN, 8), sew),
+    true: !div(!mul(SMX60VLEN, LMUL), sew)
+  );
+}
+
+// Latency for segmented loads and stores are calculated as vl * nf.
+class SMX60SegmentedLdStCycles<string mx, int sew, int nf> {
+  int c = !mul(SMX60GetVLMAX<mx, sew>.val, nf);
+}
+
 def SpacemitX60Model : SchedMachineModel {
   let IssueWidth        = 2; // dual-issue
   let MicroOpBufferSize = 0; // in-order
@@ -367,23 +394,43 @@ foreach mx = SchedMxList in {
   defvar IsWorstCase = SMX60IsWorstCaseMX<mx, SchedMxList>.c;
 
   // Unit-stride loads and stores
-  defm "" : LMULWriteResMX<"WriteVLDE", [SMX60_VLS], mx, IsWorstCase>;
-  defm "" : LMULWriteResMX<"WriteVLDFF", [SMX60_VLS], mx, IsWorstCase>;
-  defm "" : LMULWriteResMX<"WriteVSTE", [SMX60_VLS], mx, IsWorstCase>;
+  defvar VLDELatAndOcc = ConstValueUntilLMULThenDoubleBase<"M2", 3, 4, mx>.c;
+  let Latency = VLDELatAndOcc, ReleaseAtCycles = [VLDELatAndOcc] in {
+    defm "" : LMULWriteResMX<"WriteVLDE", [SMX60_VLS], mx, IsWorstCase>;
+  }
+  defvar VSTELatAndOcc = GetLMULValue<[2, 2, 2, 3, 4, 8, 19], mx>.c;
+  let Latency = VSTELatAndOcc, ReleaseAtCycles = [VSTELatAndOcc] in {
+    defm "" : LMULWriteResMX<"WriteVSTE", [SMX60_VLS], mx, IsWorstCase>;
+  }
+  defvar VLDFFLatAndOcc = GetLMULValue<[4, 4, 4, 5, 7, 11, 19], mx>.c;
+  let Latency = VLDFFLatAndOcc, ReleaseAtCycles = [VLDFFLatAndOcc] in {
+    defm "" : LMULWriteResMX<"WriteVLDFF", [SMX60_VLS], mx, IsWorstCase>;
+  }
 
   // Mask loads and stores
-  defm "" : LMULWriteResMX<"WriteVLDM", [SMX60_VLS], mx, IsWorstCase=!eq(mx, "M1")>;
-  defm "" : LMULWriteResMX<"WriteVSTM", [SMX60_VLS], mx, IsWorstCase=!eq(mx, "M1")>;
+  let Latency = 1, ReleaseAtCycles = [2] in {
+    defm "" : LMULWriteResMX<"WriteVLDM", [SMX60_VLS], mx, IsWorstCase>;
+  }
+  let Latency = 2, ReleaseAtCycles = [2] in {
+    defm "" : LMULWriteResMX<"WriteVSTM", [SMX60_VLS], mx, IsWorstCase>;
+  }
 
   // Strided and indexed loads and stores
   foreach eew = [8, 16, 32, 64] in {
-    defm "" : LMULWriteResMX<"WriteVLDS"  # eew, [SMX60_VLS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDUX" # eew, [SMX60_VLS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX" # eew, [SMX60_VLS], mx, IsWorstCase>;
+    defvar StridedLdStLatAndOcc = SMX60GetVLMAX<mx, eew>.val;
+    let Latency = StridedLdStLatAndOcc, ReleaseAtCycles = [StridedLdStLatAndOcc] in {
+      defm "" : LMULWriteResMX<"WriteVLDS"  # eew, [SMX60_VLS], mx, IsWorstCase>;
+      defm "" : LMULWriteResMX<"WriteVSTS"  # eew, [SMX60_VLS], mx, IsWorstCase>;
+    }
 
-    defm "" : LMULWriteResMX<"WriteVSTS"  # eew, [SMX60_VLS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX" # eew, [SMX60_VLS], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX" # eew, [SMX60_VLS], mx, IsWorstCase>;
+    defvar IndexedLdStLatAndOcc = !div(SMX60GetVLMAX<mx, eew>.val, 2);
+    let Latency = IndexedLdStLatAndOcc, ReleaseAtCycles = [IndexedLdStLatAndOcc] in {
+      defm "" : LMULWriteResMX<"WriteVLDUX" # eew, [SMX60_VLS], mx, IsWorstCase>;
+      defm "" : LMULWriteResMX<"WriteVLDOX" # eew, [SMX60_VLS], mx, IsWorstCase>;
+
+      defm "" : LMULWriteResMX<"WriteVSTUX" # eew, [SMX60_VLS], mx, IsWorstCase>;
+      defm "" : LMULWriteResMX<"WriteVSTOX" # eew, [SMX60_VLS], mx, IsWorstCase>;
+    }
   }
 }
 
@@ -393,30 +440,39 @@ foreach mx = SchedMxList in {
     foreach eew = [8, 16, 32, 64] in {
       defvar IsWorstCase = SMX60IsWorstCaseMX<mx, SchedMxList>.c;
 
-      // Unit-stride segmented
-      defm "" : LMULWriteResMX<"WriteVLSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVLSEGFF" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVSSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+      defvar SegmentedLdStLatAndOcc = SMX60SegmentedLdStCycles<mx, eew, nf>.c;
+      let Latency = SegmentedLdStLatAndOcc, ReleaseAtCycles = [SegmentedLdStLatAndOcc] in {
+        // Unit-stride segmented
+        defm "" : LMULWriteResMX<"WriteVLSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVLSEGFF" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVSSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
 
-      // Strided/indexed segmented
-      defm "" : LMULWriteResMX<"WriteVLSSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVSSSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+        // Strided/indexed segmented
+        defm "" : LMULWriteResMX<"WriteVLSSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVSSSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
 
-      // Indexed segmented
-      defm "" : LMULWriteResMX<"WriteVLOXSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVSUXSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVSOXSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+        // Indexed segmented
+        defm "" : LMULWriteResMX<"WriteVLOXSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVSUXSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVSOXSEG" # nf # "e" #eew, [SMX60_VLS], mx, IsWorstCase>;
+      }
     }
   }
 }
 
 // Whole register move/load/store
 foreach LMul = [1, 2, 4, 8] in {
-  def : WriteRes<!cast<SchedWrite>("WriteVLD" # LMul # "R"), [SMX60_VLS]>;
-  def : WriteRes<!cast<SchedWrite>("WriteVST" # LMul # "R"), [SMX60_VLS]>;
+  defvar WholeRegLdStLatAndOcc = !if(!eq(LMul, 1), 3, !mul(LMul, 2));
+  let Latency = WholeRegLdStLatAndOcc, ReleaseAtCycles = [WholeRegLdStLatAndOcc] in {
+    def : WriteRes<!cast<SchedWrite>("WriteVLD" # LMul # "R"), [SMX60_VLS]>;
+    def : WriteRes<!cast<SchedWrite>("WriteVST" # LMul # "R"), [SMX60_VLS]>;
+  }
 
-  def : WriteRes<!cast<SchedWrite>("WriteVMov" # LMul # "V"), [SMX60_VIEU]>;
+  defvar VMovLatAndOcc = !if(!eq(LMul, 1), 4, !mul(LMul, 2));
+  let Latency = VMovLatAndOcc, ReleaseAtCycles = [VMovLatAndOcc] in {
+    def : WriteRes<!cast<SchedWrite>("WriteVMov" # LMul # "V"), [SMX60_VIEU]>;
+  }
 }
 
 // 11. Vector Integer Arithmetic Instructions

--- a/llvm/lib/Target/RISCV/RISCVSchedSpacemitX60.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSpacemitX60.td
@@ -408,7 +408,7 @@ foreach mx = SchedMxList in {
   }
 
   // Mask loads and stores
-  let Latency = 1, ReleaseAtCycles = [2] in {
+  let ReleaseAtCycles = [2] in {
     defm "" : LMULWriteResMX<"WriteVLDM", [SMX60_VLS], mx, IsWorstCase>;
   }
   let Latency = 2, ReleaseAtCycles = [2] in {

--- a/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/rvv-permutation.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/rvv-permutation.s
@@ -1418,181 +1418,181 @@ vfslide1up.vf v8, v16, ft0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV_S_X                    vmv.s.x	v8, s0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV1R_V                    vmv1r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV1R_V                    vmv1r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV2R_V                    vmv2r.v	v8, v8
+# CHECK-NEXT:  1      4     4.00                         4     SMX60_VIEU[4]                              VMV2R_V                    vmv2r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV4R_V                    vmv4r.v	v8, v8
+# CHECK-NEXT:  1      8     8.00                         8     SMX60_VIEU[8]                              VMV4R_V                    vmv4r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     1.00                         1     SMX60_VIEU                                 VMV8R_V                    vmv8r.v	v8, v8
+# CHECK-NEXT:  1      16    16.00                        16    SMX60_VIEU[16]                             VMV8R_V                    vmv8r.v	v8, v8
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      4     1.00                         4     SMX60_VIEU                                 VIOTA_M                    viota.m	v8, v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	t3, zero, e8, mf4, tu, mu
@@ -2354,7 +2354,7 @@ vfslide1up.vf v8, v16, ft0
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]
-# CHECK-NEXT:  -     572.00  -      -      -     303.00 5585.00  -
+# CHECK-NEXT:  -     572.00  -      -      -     303.00 6201.00  -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]    Instructions:
@@ -2579,181 +2579,181 @@ vfslide1up.vf v8, v16, ft0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv.s.x	v8, s0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv1r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv1r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv2r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     4.00    -     vmv2r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv4r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     8.00    -     vmv4r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -     1.00    -     vmv8r.v	v8, v8
+# CHECK-NEXT:  -      -      -      -      -      -     16.00   -     vmv8r.v	v8, v8
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -     1.00    -     viota.m	v8, v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	t3, zero, e8, mf4, tu, mu

--- a/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/vle-vse-vlm.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/vle-vse-vlm.s
@@ -202,165 +202,165 @@ vle64ff.v   v8, (a0)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE64_V                    vle64.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00    *                    3     SMX60_VLS[3]                               VLE64_V                    vle64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE64_V                    vle64.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE64_V                    vle64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE64_V                    vle64.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLE64_V                    vle64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE64_V                    vle64.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLE64_V                    vle64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00           *             3     SMX60_VLS[3]                               VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      19    19.00          *             19    SMX60_VLS[19]                              VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE16_V                    vse16.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE16_V                    vse16.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE16_V                    vse16.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00           *             3     SMX60_VLS[3]                               VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE16_V                    vse16.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE16_V                    vse16.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE16_V                    vse16.v	v8, (a0)
+# CHECK-NEXT:  1      19    19.00          *             19    SMX60_VLS[19]                              VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE32_V                    vse32.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE32_V                    vse32.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00           *             3     SMX60_VLS[3]                               VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE32_V                    vse32.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE32_V                    vse32.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE32_V                    vse32.v	v8, (a0)
+# CHECK-NEXT:  1      19    19.00          *             19    SMX60_VLS[19]                              VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE64_V                    vse64.v	v8, (a0)
+# CHECK-NEXT:  1      3     3.00           *             3     SMX60_VLS[3]                               VSE64_V                    vse64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE64_V                    vse64.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSE64_V                    vse64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE64_V                    vse64.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSE64_V                    vse64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSE64_V                    vse64.v	v8, (a0)
+# CHECK-NEXT:  1      19    19.00          *             19    SMX60_VLS[19]                              VSE64_V                    vse64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00    *                    1     SMX60_VLS[2]                               VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00    *                    1     SMX60_VLS[2]                               VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00    *                    1     SMX60_VLS[2]                               VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00    *                    1     SMX60_VLS[2]                               VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00    *                    1     SMX60_VLS[2]                               VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00    *                    1     SMX60_VLS[2]                               VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00    *                    1     SMX60_VLS[2]                               VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSM_V                      vsm.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSM_V                      vsm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSM_V                      vsm.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSM_V                      vsm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSM_V                      vsm.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSM_V                      vsm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSM_V                      vsm.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSM_V                      vsm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSM_V                      vsm.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSM_V                      vsm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSM_V                      vsm.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSM_V                      vsm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSM_V                      vsm.v	v8, (a0)
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSM_V                      vsm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      5     5.00    *                    5     SMX60_VLS[5]                               VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      7     7.00    *                    7     SMX60_VLS[7]                               VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      11    11.00   *                    11    SMX60_VLS[11]                              VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      19    19.00   *                    19    SMX60_VLS[19]                              VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      5     5.00    *                    5     SMX60_VLS[5]                               VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      7     7.00    *                    7     SMX60_VLS[7]                               VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      11    11.00   *                    11    SMX60_VLS[11]                              VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      19    19.00   *                    19    SMX60_VLS[19]                              VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      5     5.00    *                    5     SMX60_VLS[5]                               VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      7     7.00    *                    7     SMX60_VLS[7]                               VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      11    11.00   *                    11    SMX60_VLS[11]                              VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      19    19.00   *                    19    SMX60_VLS[19]                              VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE64FF_V                  vle64ff.v	v8, (a0)
+# CHECK-NEXT:  1      5     5.00    *                    5     SMX60_VLS[5]                               VLE64FF_V                  vle64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE64FF_V                  vle64ff.v	v8, (a0)
+# CHECK-NEXT:  1      7     7.00    *                    7     SMX60_VLS[7]                               VLE64FF_V                  vle64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE64FF_V                  vle64ff.v	v8, (a0)
+# CHECK-NEXT:  1      11    11.00   *                    11    SMX60_VLS[11]                              VLE64FF_V                  vle64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLE64FF_V                  vle64ff.v	v8, (a0)
+# CHECK-NEXT:  1      19    19.00   *                    19    SMX60_VLS[19]                              VLE64FF_V                  vle64ff.v	v8, (a0)
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SMX60_FP
@@ -374,167 +374,167 @@ vle64ff.v   v8, (a0)
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]
-# CHECK-NEXT:  -     80.00   -      -      -      -      -     80.00
+# CHECK-NEXT:  -     80.00   -      -      -      -      -     510.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vle8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vle8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vle16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vle16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vle32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vle32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vle64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vle64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vle64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vse8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vse8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vse8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vse8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vse8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vse8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     19.00  vse8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vse16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vse16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vse16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vse16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vse16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     19.00  vse16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vse32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vse32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vse32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vse32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     19.00  vse32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     3.00   vse64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vse64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vse64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vse64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     19.00  vse64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vlm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vlm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vlm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vlm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vlm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vlm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vlm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsm.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsm.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     5.00   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     7.00   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     11.00  vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     19.00  vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     5.00   vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     7.00   vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     11.00  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     19.00  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     5.00   vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     7.00   vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     11.00  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     19.00  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     5.00   vle64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     7.00   vle64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     11.00  vle64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vle64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     19.00  vle64ff.v	v8, (a0)

--- a/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/vlse-vsse.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/vlse-vsse.s
@@ -120,93 +120,93 @@ vsse64.v   v8, (a0), t0
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSSE64_V                   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSE64_V                   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSE64_V                   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSE64_V                   vsse64.v	v8, (a0), t0
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SMX60_FP
@@ -220,95 +220,95 @@ vsse64.v   v8, (a0), t0
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]
-# CHECK-NEXT:  -     44.00   -      -      -      -      -     44.00
+# CHECK-NEXT:  -     44.00   -      -      -      -      -     1888.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsse64.v	v8, (a0), t0

--- a/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/vlseg-vsseg.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/vlseg-vsseg.s
@@ -1627,1545 +1627,1545 @@ vsoxseg8ei64.v  v8, (a0), v16
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E32_V                vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSEG2E32_V                vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E32_V                vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG2E32_V                vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E32_V                vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG2E32_V                vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E32_V                vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG2E32_V                vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E64_V                vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSEG2E64_V                vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E64_V                vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG2E64_V                vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E64_V                vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG2E64_V                vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E16_V                vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSEG3E16_V                vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E16_V                vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG3E16_V                vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E16_V                vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG3E16_V                vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E16_V                vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSEG3E16_V                vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E32_V                vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSEG3E32_V                vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E32_V                vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG3E32_V                vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E32_V                vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG3E32_V                vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E64_V                vlseg3e64.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSEG3E64_V                vlseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E64_V                vlseg3e64.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG3E64_V                vlseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E16_V                vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG4E16_V                vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E16_V                vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG4E16_V                vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E16_V                vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG4E16_V                vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E16_V                vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG4E16_V                vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E32_V                vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG4E32_V                vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E32_V                vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG4E32_V                vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E32_V                vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG4E32_V                vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E64_V                vlseg4e64.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG4E64_V                vlseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E64_V                vlseg4e64.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG4E64_V                vlseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      160   160.00  *                    160   SMX60_VLS[160]                             VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E16_V                vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSEG5E16_V                vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E16_V                vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLSEG5E16_V                vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E16_V                vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLSEG5E16_V                vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E32_V                vlseg5e32.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSEG5E32_V                vlseg5e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E32_V                vlseg5e32.v	v8, (a0)
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLSEG5E32_V                vlseg5e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E64_V                vlseg5e64.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSEG5E64_V                vlseg5e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E16_V                vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG6E16_V                vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E16_V                vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG6E16_V                vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E16_V                vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSEG6E16_V                vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E32_V                vlseg6e32.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG6E32_V                vlseg6e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E32_V                vlseg6e32.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG6E32_V                vlseg6e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E64_V                vlseg6e64.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG6E64_V                vlseg6e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      224   224.00  *                    224   SMX60_VLS[224]                             VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E16_V                vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSEG7E16_V                vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E16_V                vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLSEG7E16_V                vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E16_V                vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLSEG7E16_V                vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E32_V                vlseg7e32.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSEG7E32_V                vlseg7e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E32_V                vlseg7e32.v	v8, (a0)
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLSEG7E32_V                vlseg7e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E64_V                vlseg7e64.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSEG7E64_V                vlseg7e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E16_V                vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG8E16_V                vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E16_V                vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG8E16_V                vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E16_V                vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG8E16_V                vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E32_V                vlseg8e32.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG8E32_V                vlseg8e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E32_V                vlseg8e32.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG8E32_V                vlseg8e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E64_V                vlseg8e64.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG8E64_V                vlseg8e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E32_V                vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSEG2E32_V                vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E32_V                vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSEG2E32_V                vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E32_V                vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG2E32_V                vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E32_V                vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSEG2E32_V                vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E64_V                vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSEG2E64_V                vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E64_V                vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSEG2E64_V                vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG2E64_V                vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG2E64_V                vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      192   192.00         *             192   SMX60_VLS[192]                             VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E16_V                vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E16_V                vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E16_V                vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E16_V                vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E32_V                vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSSEG3E32_V                vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E32_V                vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSEG3E32_V                vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E32_V                vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSEG3E32_V                vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E64_V                vsseg3e64.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSSEG3E64_V                vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG3E64_V                vsseg3e64.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSEG3E64_V                vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E16_V                vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E16_V                vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E16_V                vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E16_V                vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E32_V                vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSEG4E32_V                vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E32_V                vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG4E32_V                vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E32_V                vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSEG4E32_V                vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E64_V                vsseg4e64.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSEG4E64_V                vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG4E64_V                vsseg4e64.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG4E64_V                vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      80    80.00          *             80    SMX60_VLS[80]                              VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      160   160.00         *             160   SMX60_VLS[160]                             VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E16_V                vsseg5e16.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSSEG5E16_V                vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E16_V                vsseg5e16.v	v8, (a0)
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSSEG5E16_V                vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E16_V                vsseg5e16.v	v8, (a0)
+# CHECK-NEXT:  1      80    80.00          *             80    SMX60_VLS[80]                              VSSEG5E16_V                vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E32_V                vsseg5e32.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSSEG5E32_V                vsseg5e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E32_V                vsseg5e32.v	v8, (a0)
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSSEG5E32_V                vsseg5e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG5E64_V                vsseg5e64.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSSEG5E64_V                vsseg5e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      192   192.00         *             192   SMX60_VLS[192]                             VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E16_V                vsseg6e16.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSEG6E16_V                vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E16_V                vsseg6e16.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSEG6E16_V                vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E16_V                vsseg6e16.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSSEG6E16_V                vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E32_V                vsseg6e32.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSEG6E32_V                vsseg6e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E32_V                vsseg6e32.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSEG6E32_V                vsseg6e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG6E64_V                vsseg6e64.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSEG6E64_V                vsseg6e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      112   112.00         *             112   SMX60_VLS[112]                             VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      224   224.00         *             224   SMX60_VLS[224]                             VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E16_V                vsseg7e16.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSSEG7E16_V                vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E16_V                vsseg7e16.v	v8, (a0)
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSSEG7E16_V                vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E16_V                vsseg7e16.v	v8, (a0)
+# CHECK-NEXT:  1      112   112.00         *             112   SMX60_VLS[112]                             VSSEG7E16_V                vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E32_V                vsseg7e32.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSSEG7E32_V                vsseg7e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E32_V                vsseg7e32.v	v8, (a0)
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSSEG7E32_V                vsseg7e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG7E64_V                vsseg7e64.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSSEG7E64_V                vsseg7e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E16_V                vsseg8e16.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG8E16_V                vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E16_V                vsseg8e16.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSEG8E16_V                vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E16_V                vsseg8e16.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSEG8E16_V                vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E32_V                vsseg8e32.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG8E32_V                vsseg8e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E32_V                vsseg8e32.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSEG8E32_V                vsseg8e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSEG8E64_V                vsseg8e64.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSEG8E64_V                vsseg8e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      160   160.00  *                    160   SMX60_VLS[160]                             VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG5E64_V               vlsseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSSEG5E64_V               vlsseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG6E64_V               vlsseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSSEG6E64_V               vlsseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      224   224.00  *                    224   SMX60_VLS[224]                             VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG7E64_V               vlsseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSSEG7E64_V               vlsseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSSEG8E64_V               vlsseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSSEG8E64_V               vlsseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      192   192.00         *             192   SMX60_VLS[192]                             VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      80    80.00          *             80    SMX60_VLS[80]                              VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      160   160.00         *             160   SMX60_VLS[160]                             VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      80    80.00          *             80    SMX60_VLS[80]                              VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG5E64_V               vssseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSSSEG5E64_V               vssseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      192   192.00         *             192   SMX60_VLS[192]                             VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG6E64_V               vssseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSSSEG6E64_V               vssseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      112   112.00         *             112   SMX60_VLS[112]                             VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      224   224.00         *             224   SMX60_VLS[224]                             VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      112   112.00         *             112   SMX60_VLS[112]                             VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG7E64_V               vssseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSSSEG7E64_V               vssseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSSSEG8E64_V               vssseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSSSEG8E64_V               vssseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E64FF_V              vlseg3e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLSEG3E64FF_V              vlseg3e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG3E64FF_V              vlseg3e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG3E64FF_V              vlseg3e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E64FF_V              vlseg4e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLSEG4E64FF_V              vlseg4e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG4E64FF_V              vlseg4e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG4E64FF_V              vlseg4e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      160   160.00  *                    160   SMX60_VLS[160]                             VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E32FF_V              vlseg5e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSEG5E32FF_V              vlseg5e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E32FF_V              vlseg5e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLSEG5E32FF_V              vlseg5e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG5E64FF_V              vlseg5e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLSEG5E64FF_V              vlseg5e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E32FF_V              vlseg6e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG6E32FF_V              vlseg6e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E32FF_V              vlseg6e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLSEG6E32FF_V              vlseg6e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG6E64FF_V              vlseg6e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLSEG6E64FF_V              vlseg6e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      224   224.00  *                    224   SMX60_VLS[224]                             VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E32FF_V              vlseg7e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSEG7E32FF_V              vlseg7e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E32FF_V              vlseg7e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLSEG7E32FF_V              vlseg7e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG7E64FF_V              vlseg7e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLSEG7E64FF_V              vlseg7e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E32FF_V              vlseg8e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG8E32FF_V              vlseg8e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E32FF_V              vlseg8e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLSEG8E32FF_V              vlseg8e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLSEG8E64FF_V              vlseg8e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLSEG8E64FF_V              vlseg8e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      160   160.00  *                    160   SMX60_VLS[160]                             VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG5EI64_V             vluxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLUXSEG5EI64_V             vluxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG6EI64_V             vluxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLUXSEG6EI64_V             vluxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      224   224.00  *                    224   SMX60_VLS[224]                             VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG7EI64_V             vluxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLUXSEG7EI64_V             vluxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXSEG8EI64_V             vluxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXSEG8EI64_V             vluxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00   *                    12    SMX60_VLS[12]                              VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      160   160.00  *                    160   SMX60_VLS[160]                             VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      80    80.00   *                    80    SMX60_VLS[80]                              VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00   *                    40    SMX60_VLS[40]                              VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG5EI64_V             vloxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00   *                    20    SMX60_VLS[20]                              VLOXSEG5EI64_V             vloxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      192   192.00  *                    192   SMX60_VLS[192]                             VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00   *                    96    SMX60_VLS[96]                              VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00   *                    48    SMX60_VLS[48]                              VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG6EI64_V             vloxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00   *                    24    SMX60_VLS[24]                              VLOXSEG6EI64_V             vloxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      224   224.00  *                    224   SMX60_VLS[224]                             VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      112   112.00  *                    112   SMX60_VLS[112]                             VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00   *                    56    SMX60_VLS[56]                              VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG7EI64_V             vloxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00   *                    28    SMX60_VLS[28]                              VLOXSEG7EI64_V             vloxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00  *                    256   SMX60_VLS[256]                             VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXSEG8EI64_V             vloxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXSEG8EI64_V             vloxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      192   192.00         *             192   SMX60_VLS[192]                             VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      80    80.00          *             80    SMX60_VLS[80]                              VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      160   160.00         *             160   SMX60_VLS[160]                             VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      80    80.00          *             80    SMX60_VLS[80]                              VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG5EI64_V             vsuxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSUXSEG5EI64_V             vsuxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      192   192.00         *             192   SMX60_VLS[192]                             VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG6EI64_V             vsuxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSUXSEG6EI64_V             vsuxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      112   112.00         *             112   SMX60_VLS[112]                             VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      224   224.00         *             224   SMX60_VLS[224]                             VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      112   112.00         *             112   SMX60_VLS[112]                             VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG7EI64_V             vsuxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSUXSEG7EI64_V             vsuxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXSEG8EI64_V             vsuxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXSEG8EI64_V             vsuxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      192   192.00         *             192   SMX60_VLS[192]                             VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      12    12.00          *             12    SMX60_VLS[12]                              VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      80    80.00          *             80    SMX60_VLS[80]                              VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      160   160.00         *             160   SMX60_VLS[160]                             VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      80    80.00          *             80    SMX60_VLS[80]                              VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      40    40.00          *             40    SMX60_VLS[40]                              VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG5EI64_V             vsoxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      20    20.00          *             20    SMX60_VLS[20]                              VSOXSEG5EI64_V             vsoxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      192   192.00         *             192   SMX60_VLS[192]                             VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      96    96.00          *             96    SMX60_VLS[96]                              VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      48    48.00          *             48    SMX60_VLS[48]                              VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG6EI64_V             vsoxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      24    24.00          *             24    SMX60_VLS[24]                              VSOXSEG6EI64_V             vsoxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      112   112.00         *             112   SMX60_VLS[112]                             VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      224   224.00         *             224   SMX60_VLS[224]                             VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      112   112.00         *             112   SMX60_VLS[112]                             VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      56    56.00          *             56    SMX60_VLS[56]                              VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG7EI64_V             vsoxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      28    28.00          *             28    SMX60_VLS[28]                              VSOXSEG7EI64_V             vsoxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      256   256.00         *             256   SMX60_VLS[256]                             VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXSEG8EI64_V             vsoxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXSEG8EI64_V             vsoxseg8ei64.v	v8, (a0), v16
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SMX60_FP
@@ -3179,1547 +3179,1547 @@ vsoxseg8ei64.v  v8, (a0), v16
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]
-# CHECK-NEXT:  -     770.00  -      -      -      -      -     770.00
+# CHECK-NEXT:  -     770.00  -      -      -      -      -     46320.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     160.00 vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlseg5e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vlseg5e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlseg5e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg6e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg6e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg6e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     224.00 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlseg7e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vlseg7e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlseg7e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg8e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg8e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg8e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg3e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg4e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     160.00 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsseg5e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vsseg5e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg5e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsseg5e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsseg6e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsseg6e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg6e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsseg6e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     224.00 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsseg7e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vsseg7e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg7e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsseg7e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg8e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsseg8e32.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsseg8e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsseg8e64.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlsseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlsseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlsseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     160.00 vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlsseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vlsseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlsseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlsseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlsseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlsseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     224.00 vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlsseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vlsseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlsseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlsseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlsseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlsseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     160.00 vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vssseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vssseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     224.00 vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vssseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vssseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vssseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vlseg3e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg3e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg3e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vlseg4e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg4e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg4e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     160.00 vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlseg5e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vlseg5e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg5e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vlseg5e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg6e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vlseg6e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg6e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vlseg6e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     224.00 vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlseg7e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vlseg7e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg7e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vlseg7e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg8e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vlseg8e32ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vlseg8e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vlseg8e64ff.v	v8, (a0)
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     160.00 vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vluxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vluxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     224.00 vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vluxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     160.00 vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vloxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vloxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     224.00 vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vloxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsuxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsuxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     160.00 vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsuxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsuxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     224.00 vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsuxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     12.00  vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     160.00 vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     80.00  vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     40.00  vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     20.00  vsoxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     192.00 vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     96.00  vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     48.00  vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     24.00  vsoxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     224.00 vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     112.00 vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     56.00  vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     28.00  vsoxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     256.00 vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxseg8ei64.v	v8, (a0), v16

--- a/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/vlxe-vsxe.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SpacemitX60/vlxe-vsxe.s
@@ -216,181 +216,181 @@ vsoxei64.v   v8, (a0), v0
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00    *                    2     SMX60_VLS[2]                               VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00    *                    2     SMX60_VLS[2]                               VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00    *                    2     SMX60_VLS[2]                               VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00    *                    2     SMX60_VLS[2]                               VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00    *                    2     SMX60_VLS[2]                               VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      128   128.00  *                    128   SMX60_VLS[128]                             VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00    *                    2     SMX60_VLS[2]                               VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      64    64.00   *                    64    SMX60_VLS[64]                              VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00    *                    2     SMX60_VLS[2]                               VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00   *                    32    SMX60_VLS[32]                              VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00    *                    2     SMX60_VLS[2]                               VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00    *                    4     SMX60_VLS[4]                               VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00    *                    8     SMX60_VLS[8]                               VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     SMX60_VLS                                  VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00   *                    16    SMX60_VLS[16]                              VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      128   128.00         *             128   SMX60_VLS[128]                             VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      64    64.00          *             64    SMX60_VLS[64]                              VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      32    32.00          *             32    SMX60_VLS[32]                              VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      2     2.00           *             2     SMX60_VLS[2]                               VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      4     4.00           *             4     SMX60_VLS[4]                               VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      8     8.00           *             8     SMX60_VLS[8]                               VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     SMX60_IEU,SMX60_IEUA                       VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     SMX60_VLS                                  VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      16    16.00          *             16    SMX60_VLS[16]                              VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SMX60_FP
@@ -404,183 +404,183 @@ vsoxei64.v   v8, (a0), v0
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]
-# CHECK-NEXT:  -     88.00   -      -      -      -      -     88.00
+# CHECK-NEXT:  -     88.00   -      -      -      -      -     1888.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3.0]  [3.1]  [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     128.00 vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     64.00  vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     32.00  vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     2.00   vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     4.00   vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     8.00   vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -     16.00  vsoxei64.v	v8, (a0), v0


### PR DESCRIPTION
This PR adds hardware-measured latencies/Occupancy for all RVV load/stores to the SpacemiT-X60 scheduling model.