### PR TITLE
[InstCombine] Try to infer type for `load`/`store` when replacing `memcpy`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -114,10 +114,11 @@ static bool hasUndefSource(AnyMemTransferInst *MI) {
   return isa<AllocaInst>(Src) && Src->hasOneUse();
 }
 
-// Optimistically infer a type from either the Src or Dest.
+// Optimistically infer a type from either the Src or Dest. Prefers the Src
+// over the Dest type.
 //
-// Returns the DefaultTy if unable to infer a type, if inferred types
-// disagree, or, if inferred type does not match the size of load/store.
+// Returns the DefaultTy if unable to infer a type, or, if inferred type does
+// not match the size of load/store.
 static Type *inferType(const DataLayout &DL, IntegerType *DefaultTy, Value *Src,
                        Value *Dest) {
   Type *SrcTy = nullptr;
@@ -128,9 +129,6 @@ static Type *inferType(const DataLayout &DL, IntegerType *DefaultTy, Value *Src,
 
   if (auto *DestAI = dyn_cast<AllocaInst>(Dest))
     DestTy = DestAI->getAllocatedType();
-
-  if (SrcTy && DestTy && SrcTy != DestTy)
-    return DefaultTy; // Unable to infer common type
 
   Type *InferredTy = SrcTy ? SrcTy : DestTy;
 

--- a/llvm/test/Transforms/InstCombine/alloca.ll
+++ b/llvm/test/Transforms/InstCombine/alloca.ll
@@ -189,24 +189,36 @@ define void @test9(ptr %a) {
 ; CHECK-LABEL: @test9(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[ARGMEM:%.*]] = alloca inalloca <{ [[STRUCT_TYPE:%.*]] }>, align 1
-; CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[A:%.*]], align 4
-; CHECK-NEXT:    store i64 [[TMP0]], ptr [[ARGMEM]], align 4
+; CHECK-NEXT:    [[DOTUNPACK_UNPACK:%.*]] = load i32, ptr [[A:%.*]], align 4
+; CHECK-NEXT:    [[DOTUNPACK_ELT1:%.*]] = getelementptr inbounds nuw i8, ptr [[A]], i64 4
+; CHECK-NEXT:    [[DOTUNPACK_UNPACK2:%.*]] = load i32, ptr [[DOTUNPACK_ELT1]], align 4
+; CHECK-NEXT:    store i32 [[DOTUNPACK_UNPACK]], ptr [[ARGMEM]], align 4
+; CHECK-NEXT:    [[ARGMEM_REPACK4:%.*]] = getelementptr inbounds nuw i8, ptr [[ARGMEM]], i64 4
+; CHECK-NEXT:    store i32 [[DOTUNPACK_UNPACK2]], ptr [[ARGMEM_REPACK4]], align 4
 ; CHECK-NEXT:    call void @test9_aux(ptr nonnull inalloca(<{ [[STRUCT_TYPE]] }>) [[ARGMEM]])
 ; CHECK-NEXT:    ret void
 ;
 ; P32-LABEL: @test9(
 ; P32-NEXT:  entry:
 ; P32-NEXT:    [[ARGMEM:%.*]] = alloca inalloca <{ [[STRUCT_TYPE:%.*]] }>, align 1
-; P32-NEXT:    [[TMP0:%.*]] = load i64, ptr [[A:%.*]], align 4
-; P32-NEXT:    store i64 [[TMP0]], ptr [[ARGMEM]], align 4
+; P32-NEXT:    [[DOTUNPACK_UNPACK:%.*]] = load i32, ptr [[A:%.*]], align 4
+; P32-NEXT:    [[DOTUNPACK_ELT1:%.*]] = getelementptr inbounds nuw i8, ptr [[A]], i32 4
+; P32-NEXT:    [[DOTUNPACK_UNPACK2:%.*]] = load i32, ptr [[DOTUNPACK_ELT1]], align 4
+; P32-NEXT:    store i32 [[DOTUNPACK_UNPACK]], ptr [[ARGMEM]], align 4
+; P32-NEXT:    [[ARGMEM_REPACK4:%.*]] = getelementptr inbounds nuw i8, ptr [[ARGMEM]], i32 4
+; P32-NEXT:    store i32 [[DOTUNPACK_UNPACK2]], ptr [[ARGMEM_REPACK4]], align 4
 ; P32-NEXT:    call void @test9_aux(ptr nonnull inalloca(<{ [[STRUCT_TYPE]] }>) [[ARGMEM]])
 ; P32-NEXT:    ret void
 ;
 ; NODL-LABEL: @test9(
 ; NODL-NEXT:  entry:
 ; NODL-NEXT:    [[ARGMEM:%.*]] = alloca inalloca <{ [[STRUCT_TYPE:%.*]] }>, align 8
-; NODL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[A:%.*]], align 4
-; NODL-NEXT:    store i64 [[TMP0]], ptr [[ARGMEM]], align 8
+; NODL-NEXT:    [[DOTUNPACK_UNPACK:%.*]] = load i32, ptr [[A:%.*]], align 4
+; NODL-NEXT:    [[DOTUNPACK_ELT1:%.*]] = getelementptr inbounds nuw i8, ptr [[A]], i64 4
+; NODL-NEXT:    [[DOTUNPACK_UNPACK2:%.*]] = load i32, ptr [[DOTUNPACK_ELT1]], align 4
+; NODL-NEXT:    store i32 [[DOTUNPACK_UNPACK]], ptr [[ARGMEM]], align 8
+; NODL-NEXT:    [[ARGMEM_REPACK4:%.*]] = getelementptr inbounds nuw i8, ptr [[ARGMEM]], i64 4
+; NODL-NEXT:    store i32 [[DOTUNPACK_UNPACK2]], ptr [[ARGMEM_REPACK4]], align 4
 ; NODL-NEXT:    call void @test9_aux(ptr nonnull inalloca(<{ [[STRUCT_TYPE]] }>) [[ARGMEM]])
 ; NODL-NEXT:    ret void
 ;
@@ -251,8 +263,8 @@ entry:
 
 define void @test_inalloca_with_element_count(ptr %a) {
 ; ALL-LABEL: @test_inalloca_with_element_count(
-; ALL-NEXT:    [[ALLOCA1:%.*]] = alloca inalloca [10 x %struct_type], align 4
-; ALL-NEXT:    call void @test9_aux(ptr nonnull inalloca([[STRUCT_TYPE:%.*]]) [[ALLOCA1]])
+; ALL-NEXT:    [[ALLOCA1:%.*]] = alloca inalloca [10 x [[STRUCT_TYPE:%.*]]], align 4
+; ALL-NEXT:    call void @test9_aux(ptr nonnull inalloca([[STRUCT_TYPE]]) [[ALLOCA1]])
 ; ALL-NEXT:    ret void
 ;
   %alloca = alloca inalloca %struct_type, i32 10, align 4

--- a/llvm/test/Transforms/PhaseOrdering/X86/SROA-after-final-loop-unrolling-2.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/SROA-after-final-loop-unrolling-2.ll
@@ -28,30 +28,27 @@ define dso_local void @foo(i32 noundef %arg, ptr noundef nonnull align 4 derefer
 ; CHECK-NEXT:    [[ARG_OFF:%.*]] = add i32 [[ARG]], 127
 ; CHECK-NEXT:    [[TMP0:%.*]] = icmp ult i32 [[ARG_OFF]], 255
 ; CHECK-NEXT:    br i1 [[TMP0]], label %[[BB12:.*]], label %[[BB13:.*]]
-; CHECK:       [[BB12_LOOPEXIT:.*]]:
-; CHECK-NEXT:    [[I3_SROA_8_0_INSERT_EXT:%.*]] = zext i32 [[I21_3:%.*]] to i64
-; CHECK-NEXT:    [[I3_SROA_8_0_INSERT_SHIFT:%.*]] = shl nuw i64 [[I3_SROA_8_0_INSERT_EXT]], 32
-; CHECK-NEXT:    [[I3_SROA_0_0_INSERT_EXT:%.*]] = zext i32 [[I21_2:%.*]] to i64
-; CHECK-NEXT:    [[I3_SROA_0_0_INSERT_INSERT:%.*]] = or disjoint i64 [[I3_SROA_8_0_INSERT_SHIFT]], [[I3_SROA_0_0_INSERT_EXT]]
-; CHECK-NEXT:    br label %[[BB12]]
 ; CHECK:       [[BB12]]:
-; CHECK-NEXT:    [[TMP1:%.*]] = phi i64 [ [[I3_SROA_0_0_INSERT_INSERT]], %[[BB12_LOOPEXIT]] ], [ 180388626456, %[[BB]] ]
-; CHECK-NEXT:    store i64 [[TMP1]], ptr [[ARG1]], align 4, !tbaa [[CHAR_TBAA5:![0-9]+]]
+; CHECK-NEXT:    [[TMP2:%.*]] = phi <2 x i32> [ <i32 24, i32 42>, %[[BB]] ], [ [[I3_SROA_0_4_VEC_INSERT33:%.*]], %[[BB13]] ]
+; CHECK-NEXT:    store <2 x i32> [[TMP2]], ptr [[ARG1]], align 4, !tbaa [[CHAR_TBAA5:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ; CHECK:       [[BB13]]:
-; CHECK-NEXT:    [[I3_SROA_8_0:%.*]] = phi i32 [ [[I21_3]], %[[BB13]] ], [ 42, %[[BB]] ]
-; CHECK-NEXT:    [[I3_SROA_0_0:%.*]] = phi i32 [ [[I21_2]], %[[BB13]] ], [ 24, %[[BB]] ]
+; CHECK-NEXT:    [[I3_SROA_0_1:%.*]] = phi <2 x i32> [ [[I3_SROA_0_4_VEC_INSERT33]], %[[BB13]] ], [ <i32 24, i32 42>, %[[BB]] ]
 ; CHECK-NEXT:    [[I4_05:%.*]] = phi i32 [ [[I24_3:%.*]], %[[BB13]] ], [ 0, %[[BB]] ]
+; CHECK-NEXT:    [[I3_SROA_0_0:%.*]] = extractelement <2 x i32> [[I3_SROA_0_1]], i64 0
 ; CHECK-NEXT:    [[I21:%.*]] = mul nsw i32 [[I3_SROA_0_0]], [[I4_05]]
 ; CHECK-NEXT:    [[I24:%.*]] = or disjoint i32 [[I4_05]], 1
+; CHECK-NEXT:    [[I3_SROA_8_0:%.*]] = extractelement <2 x i32> [[I3_SROA_0_1]], i64 1
 ; CHECK-NEXT:    [[I21_1:%.*]] = mul nsw i32 [[I3_SROA_8_0]], [[I24]]
 ; CHECK-NEXT:    [[I24_1:%.*]] = or disjoint i32 [[I4_05]], 2
-; CHECK-NEXT:    [[I21_2]] = mul nsw i32 [[I21]], [[I24_1]]
+; CHECK-NEXT:    [[I21_2:%.*]] = mul nsw i32 [[I21]], [[I24_1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x i32> poison, i32 [[I21_2]], i64 0
 ; CHECK-NEXT:    [[I24_2:%.*]] = or disjoint i32 [[I4_05]], 3
-; CHECK-NEXT:    [[I21_3]] = mul nsw i32 [[I21_1]], [[I24_2]]
+; CHECK-NEXT:    [[I21_3:%.*]] = mul nsw i32 [[I21_1]], [[I24_2]]
+; CHECK-NEXT:    [[I3_SROA_0_4_VEC_INSERT33]] = insertelement <2 x i32> [[TMP1]], i32 [[I21_3]], i64 1
 ; CHECK-NEXT:    [[I24_3]] = add nuw nsw i32 [[I4_05]], 4
 ; CHECK-NEXT:    [[I11_NOT_3:%.*]] = icmp eq i32 [[I24_3]], [[I10]]
-; CHECK-NEXT:    br i1 [[I11_NOT_3]], label %[[BB12_LOOPEXIT]], label %[[BB13]], !llvm.loop [[LOOP8:![0-9]+]]
+; CHECK-NEXT:    br i1 [[I11_NOT_3]], label %[[BB12]], label %[[BB13]], !llvm.loop [[LOOP8:![0-9]+]]
 ;
 bb:
   %i = alloca i32, align 4

--- a/llvm/test/Transforms/PhaseOrdering/swap-promotion.ll
+++ b/llvm/test/Transforms/PhaseOrdering/swap-promotion.ll
@@ -5,10 +5,14 @@
 
 define void @swap(ptr %p1, ptr %p2) {
 ; CHECK-LABEL: @swap(
-; CHECK-NEXT:    [[TMP1:%.*]] = load i64, ptr [[P1:%.*]], align 1
+; CHECK-NEXT:    [[DOTUNPACK:%.*]] = load i32, ptr [[P1:%.*]], align 1
+; CHECK-NEXT:    [[DOTELT1:%.*]] = getelementptr inbounds nuw i8, ptr [[P1]], i64 4
+; CHECK-NEXT:    [[DOTUNPACK2:%.*]] = load i32, ptr [[DOTELT1]], align 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = load i64, ptr [[P2:%.*]], align 1
 ; CHECK-NEXT:    store i64 [[TMP2]], ptr [[P1]], align 1
-; CHECK-NEXT:    store i64 [[TMP1]], ptr [[P2]], align 1
+; CHECK-NEXT:    store i32 [[DOTUNPACK]], ptr [[P2]], align 1
+; CHECK-NEXT:    [[P2_REPACK8:%.*]] = getelementptr inbounds nuw i8, ptr [[P2]], i64 4
+; CHECK-NEXT:    store i32 [[DOTUNPACK2]], ptr [[P2_REPACK8]], align 1
 ; CHECK-NEXT:    ret void
 ;
   %tmp = alloca [2 x i32]


### PR DESCRIPTION
This pr implements an initial simple type inference used to improve the types of a  `load`/`store` replacing a `memcpy` when the `%dest` and/or `%src` are an `alloca` instruction.

As noted within `SimplifyAnyMemTransfer`, there exists an opportunity to find a better type than the default integer type.

By  inferring the type we are able to allow for unpacking of the value which allows for further optimization opportunities that are otherwise ignored. It also has the additional benefit of generating a more understandable canonicalized form of the IR.

- Updates `InstCombineCalls::SimplifyAnyMemTransfer` to add type inference
- Adds test to demonstrate unpacking behaviour
- Adds test to ensure we don't replace with an invalid alloca type
- Updates to existing tests are all demonstrations of missed unpacking opportunities, or, a conversion of a primitive type

Incidentally, this resolves https://github.com/llvm/llvm-project/issues/165753. For more context on the HLSL specific side, please refer to [this comment](https://github.com/llvm/llvm-project/pull/169384#issuecomment-3577589275) and preceding pr description.