### PR TITLE
[CIR] Upstream support for cir.indirectbr

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1466,10 +1466,10 @@ def CIR_BrCondOp : CIR_Op<"brcond", [
 // IndirectBrOp
 //===----------------------------------------------------------------------===//
 
-def CIR_IndirectBrOp : CIR_Op<"indirectbr", [
+def CIR_IndirectBrOp : CIR_Op<"indirect_br", [
   DeclareOpInterfaceMethods<BranchOpInterface>,
-  SameVariadicOperandSize, Terminator, Pure]
-> {
+  SameVariadicOperandSize, Terminator, Pure
+]> {
   let summary = "Indirect branch";
   let description = [{
     The `cir.indirectbr` operation represents an indirect branch to one of
@@ -1486,22 +1486,9 @@ def CIR_IndirectBrOp : CIR_Op<"indirectbr", [
     Example:
 
     ```mlir
-      %0 = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr", init]
-      %1 = cir.block_address <@A, "A"> : !cir.ptr<!void>
-      cir.store align(8) %1, %0 : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
-      %2 = cir.load align(8) %0 : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
-      cir.br ^bb1(%2 : !cir.ptr<!void>)
-    ^bb1(%3: !cir.ptr<!void>):
-      cir.indirectbr %3 : <!void>, [
-      ^bb2
-      ]
-    ```
-    or with a poison:
-
-    ```mlir
+      %0 = cir.block_address <@A, "A"> : !cir.ptr<!void>
       cir.indirectbr %0 poison : <!void>, [
-      ^bb3,
-      ^bb2
+      ^bb1
       ]
     ```
   }];
@@ -1509,17 +1496,17 @@ def CIR_IndirectBrOp : CIR_Op<"indirectbr", [
   let arguments = (ins
     CIR_VoidPtrType:$addr,
     UnitAttr:$poison,
-    VariadicOfVariadic<AnyType, "indbr_operand_segments">:$succOperands,
-    DenseI32ArrayAttr:$indbr_operand_segments
+    VariadicOfVariadic<AnyType, "operand_segments">:$succ_operands,
+    DenseI32ArrayAttr:$operand_segments
     );
 
   let successors = (successor VariadicSuccessor<AnySuccessor>:$successors);
   let assemblyFormat = [{
-    $addr ( `poison` $poison^ )? `:` type($addr) `,`
+    $addr ( `poison` $poison^ )? `:` qualified(type($addr)) `,`
     custom<IndirectBrOpSucessors>(ref(type($addr)),
                                   $successors,
-                                  $succOperands,
-                                  type($succOperands))
+                                  $succ_operands,
+                                  type($succ_operands))
     attr-dict
   }];
 }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1468,7 +1468,8 @@ def CIR_BrCondOp : CIR_Op<"brcond", [
 
 def CIR_IndirectBrOp : CIR_Op<"indirectbr", [
   DeclareOpInterfaceMethods<BranchOpInterface>,
-  SameVariadicOperandSize, Terminator, Pure]> {
+  SameVariadicOperandSize, Terminator, Pure]
+> {
   let summary = "Indirect branch";
   let description = [{
     The `cir.indirectbr` operation represents an indirect branch to one of

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1467,8 +1467,8 @@ def CIR_BrCondOp : CIR_Op<"brcond", [
 //===----------------------------------------------------------------------===//
 
 def CIR_IndirectBrOp : CIR_Op<"indirectbr", [
-  DeclareOpInterfaceMethods<BranchOpInterface>
-  , SameVariadicOperandSize, Terminator, Pure]> {
+  DeclareOpInterfaceMethods<BranchOpInterface>,
+  SameVariadicOperandSize, Terminator, Pure]> {
   let summary = "Indirect branch";
   let description = [{
     The `cir.indirectbr` operation represents an indirect branch to one of
@@ -1479,7 +1479,7 @@ def CIR_IndirectBrOp : CIR_Op<"indirectbr", [
     the GCC extension `&&label` combined with an indirect `goto *ptr;`.
 
     The `poison` attribute is used to mark an `indirectbr` that was created
-    but is known to be invalid for instance, when a label address was
+    but is known to be invalid, for instance when a label address was
     taken but no indirect branch was ever emitted.
 
     Example:

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1463,6 +1463,67 @@ def CIR_BrCondOp : CIR_Op<"brcond", [
 }
 
 //===----------------------------------------------------------------------===//
+// IndirectBrOp
+//===----------------------------------------------------------------------===//
+
+def CIR_IndirectBrOp : CIR_Op<"indirectbr", [
+  DeclareOpInterfaceMethods<BranchOpInterface>
+  , SameVariadicOperandSize, Terminator, Pure]> {
+  let summary = "Indirect branch";
+  let description = [{
+    The `cir.indirectbr` operation represents an indirect branch to one of
+    several possible successor blocks. The target block is computed from
+    the value of the given address operand.
+
+    This operation is typically generated when handling constructs like
+    the GCC extension `&&label` combined with an indirect `goto *ptr;`.
+
+    The `poison` attribute is used to mark an `indirectbr` that was created
+    but is known to be invalid for instance, when a label address was
+    taken but no indirect branch was ever emitted.
+
+    Example:
+
+    ```mlir
+      %0 = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr", init]
+      %1 = cir.block_address <@A, "A"> : !cir.ptr<!void>
+      cir.store align(8) %1, %0 : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
+      %2 = cir.load align(8) %0 : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+      cir.br ^bb1(%2 : !cir.ptr<!void>)
+    ^bb1(%3: !cir.ptr<!void>):
+      cir.indirectbr %3 : <!void>, [
+      ^bb2
+      ]
+    ```
+    or with a poison:
+
+    ```mlir
+      cir.indirectbr %0 poison : <!void>, [
+      ^bb3,
+      ^bb2
+      ]
+    ```
+  }];
+
+  let arguments = (ins
+    CIR_VoidPtrType:$addr,
+    UnitAttr:$poison,
+    VariadicOfVariadic<AnyType, "indbr_operand_segments">:$succOperands,
+    DenseI32ArrayAttr:$indbr_operand_segments
+    );
+
+  let successors = (successor VariadicSuccessor<AnySuccessor>:$successors);
+  let assemblyFormat = [{
+    $addr ( `poison` $poison^ )? `:` type($addr) `,`
+    custom<IndirectBrOpSucessors>(ref(type($addr)),
+                                  $successors,
+                                  $succOperands,
+                                  type($succOperands))
+    attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Common loop op definitions
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -188,7 +188,7 @@ public:
     } else {
       cgf.cgm.mapResolvedBlockAddress(blockAddressOp, resolvedLabel);
     }
-    cgf.getIndirectGotoBlock();
+    cgf.instantiateIndirectGotoBlock();
     return blockAddressOp;
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -174,11 +174,22 @@ public:
 
   mlir::Value VisitAddrLabelExpr(const AddrLabelExpr *e) {
     auto func = cast<cir::FuncOp>(cgf.curFn);
-    auto blockInfoAttr = cir::BlockAddrInfoAttr::get(
+    cir::BlockAddrInfoAttr blockInfoAttr = cir::BlockAddrInfoAttr::get(
         &cgf.getMLIRContext(), func.getSymName(), e->getLabel()->getName());
-    return cir::BlockAddressOp::create(builder, cgf.getLoc(e->getSourceRange()),
-                                       cgf.convertType(e->getType()),
-                                       blockInfoAttr);
+    cir::BlockAddressOp blockAddressOp = cir::BlockAddressOp::create(
+        builder, cgf.getLoc(e->getSourceRange()), cgf.convertType(e->getType()),
+        blockInfoAttr);
+    cir::LabelOp resolvedLabel = cgf.cgm.lookupBlockAddressInfo(blockInfoAttr);
+    if (!resolvedLabel) {
+      cgf.cgm.mapUnresolvedBlockAddress(blockAddressOp);
+      // Still add the op to maintain insertion order it will be resolved in
+      // resolveBlockAddresses
+      cgf.cgm.mapResolvedBlockAddress(blockAddressOp, nullptr);
+    } else {
+      cgf.cgm.mapResolvedBlockAddress(blockAddressOp, resolvedLabel);
+    }
+    cgf.getIndirectGotoBlock();
+    return blockAddressOp;
   }
 
   mlir::Value VisitIntegerLiteral(const IntegerLiteral *e) {

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -531,7 +531,49 @@ void CIRGenFunction::startFunction(GlobalDecl gd, QualType returnType,
   }
 }
 
+void CIRGenFunction::resolveBlockAddresses() {
+
+  for (cir::BlockAddressOp &blockAddress : cgm.unresolvedBlockAddressToLabel) {
+    cir::LabelOp labelOp =
+        cgm.lookupBlockAddressInfo(blockAddress.getBlockAddrInfo());
+    assert(labelOp && "expected cir.labelOp to already be emitted");
+    cgm.updateResolvedBlockAddress(blockAddress, labelOp);
+  }
+  cgm.unresolvedBlockAddressToLabel.clear();
+}
+
+void CIRGenFunction::finishIndirectBranch() {
+  if (!indirectGotoBlock)
+    return;
+  llvm::SmallVector<mlir::Block *> succesors;
+  llvm::SmallVector<mlir::ValueRange> rangeOperands;
+  mlir::OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToEnd(indirectGotoBlock);
+  for (auto &[blockAdd, labelOp] : cgm.blockAddressToLabel) {
+    succesors.push_back(labelOp->getBlock());
+    rangeOperands.push_back(labelOp->getBlock()->getArguments());
+  }
+  cir::IndirectBrOp::create(builder, builder.getUnknownLoc(),
+                            indirectGotoBlock->getArgument(0), false,
+                            rangeOperands, succesors);
+  cgm.blockAddressToLabel.clear();
+}
+
 void CIRGenFunction::finishFunction(SourceLocation endLoc) {
+  // Resolve block address-to-label mappings, then emit the indirect branch
+  // with the corresponding targets.
+  resolveBlockAddresses();
+  finishIndirectBranch();
+
+  // If a label address was taken but no indirect goto was used, we can't remove
+  // the block argument here. Instead, we mark the 'indirectbr' op
+  // as poison so that the cleanup can be deferred to lowering, since the
+  // verifier doesn't allow the 'indirectbr' target address to be null.
+  if (indirectGotoBlock && indirectGotoBlock->hasNoPredecessors()) {
+    auto indrBr = cast<cir::IndirectBrOp>(indirectGotoBlock->front());
+    indrBr.setPoison(true);
+  }
+
   // Pop any cleanups that might have been associated with the
   // parameters.  Do this in whatever block we're currently in; it's
   // important to do this before we enter the return block or return
@@ -1084,6 +1126,17 @@ CIRGenFunction::emitArrayLength(const clang::ArrayType *origArrayType,
 
   baseType = eltType;
   return builder.getConstInt(*currSrcLoc, sizeTy, countFromCLAs);
+}
+
+void CIRGenFunction::getIndirectGotoBlock() {
+  // If we already made the indirect branch for indirect goto, return its block.
+  if (indirectGotoBlock)
+    return;
+
+  mlir::OpBuilder::InsertionGuard guard(builder);
+  indirectGotoBlock =
+      builder.createBlock(builder.getBlock()->getParent(), {}, {voidPtrTy},
+                          {builder.getUnknownLoc()});
 }
 
 mlir::Value CIRGenFunction::emitAlignmentAssumption(

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -532,7 +532,6 @@ void CIRGenFunction::startFunction(GlobalDecl gd, QualType returnType,
 }
 
 void CIRGenFunction::resolveBlockAddresses() {
-
   for (cir::BlockAddressOp &blockAddress : cgm.unresolvedBlockAddressToLabel) {
     cir::LabelOp labelOp =
         cgm.lookupBlockAddressInfo(blockAddress.getBlockAddrInfo());
@@ -1128,7 +1127,7 @@ CIRGenFunction::emitArrayLength(const clang::ArrayType *origArrayType,
   return builder.getConstInt(*currSrcLoc, sizeTy, countFromCLAs);
 }
 
-void CIRGenFunction::getIndirectGotoBlock() {
+void CIRGenFunction::instantiateIndirectGotoBlock() {
   // If we already made the indirect branch for indirect goto, return its block.
   if (indirectGotoBlock)
     return;

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -654,6 +654,14 @@ public:
     return JumpDest(target, ehStack.getInnermostNormalCleanup(),
                     nextCleanupDestIndex++);
   }
+  /// IndirectBranch - The first time an indirect goto is seen we create a block
+  /// reserved for the indirect branch. Unlike before,the actual 'indirectbr'
+  /// is emitted at the end of the function, once all block destinations have
+  /// been resolved.
+  mlir::Block *indirectGotoBlock = nullptr;
+
+  void resolveBlockAddresses();
+  void finishIndirectBranch();
 
   /// Perform the usual unary conversions on the specified expression and
   /// compare the result against zero, returning an Int1Ty value.
@@ -1388,6 +1396,8 @@ public:
 
   int64_t getAccessedFieldNo(unsigned idx, mlir::ArrayAttr elts);
 
+  void getIndirectGotoBlock();
+
   RValue emitCall(const CIRGenFunctionInfo &funcInfo,
                   const CIRGenCallee &callee, ReturnValueSlot returnValue,
                   const CallArgList &args, cir::CIRCallOpInterface *callOp,
@@ -1570,6 +1580,8 @@ public:
   mlir::LogicalResult emitFunctionBody(const clang::Stmt *body);
 
   mlir::LogicalResult emitGotoStmt(const clang::GotoStmt &s);
+
+  mlir::LogicalResult emitIndirectGotoStmt(const IndirectGotoStmt &s);
 
   void emitImplicitAssignmentOperatorBody(FunctionArgList &args);
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1396,7 +1396,7 @@ public:
 
   int64_t getAccessedFieldNo(unsigned idx, mlir::ArrayAttr elts);
 
-  void getIndirectGotoBlock();
+  void instantiateIndirectGotoBlock();
 
   RValue emitCall(const CIRGenFunctionInfo &funcInfo,
                   const CIRGenCallee &callee, ReturnValueSlot returnValue,

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2501,23 +2501,21 @@ DiagnosticBuilder CIRGenModule::errorNYI(SourceRange loc,
 
 void CIRGenModule::mapBlockAddress(cir::BlockAddrInfoAttr blockInfo,
                                    cir::LabelOp label) {
-  auto result = blockAddressInfoToLabel.try_emplace(blockInfo, label);
-  (void)result;
+  [[maybe_unused]] auto result =
+      blockAddressInfoToLabel.try_emplace(blockInfo, label);
   assert(result.second &&
          "attempting to map a blockaddress info that is already mapped");
 }
 
 void CIRGenModule::mapUnresolvedBlockAddress(cir::BlockAddressOp op) {
-  auto result = unresolvedBlockAddressToLabel.insert(op);
-  (void)result;
+  [[maybe_unused]] auto result = unresolvedBlockAddressToLabel.insert(op);
   assert(result.second &&
          "attempting to map a blockaddress operation that is already mapped");
 }
 
 void CIRGenModule::mapResolvedBlockAddress(cir::BlockAddressOp op,
                                            cir::LabelOp label) {
-  auto result = blockAddressToLabel.try_emplace(op, label);
-  (void)result;
+  [[maybe_unused]] auto result = blockAddressToLabel.try_emplace(op, label);
   assert(result.second &&
          "attempting to map a blockaddress operation that is already mapped");
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2498,3 +2498,41 @@ DiagnosticBuilder CIRGenModule::errorNYI(SourceRange loc,
                                          llvm::StringRef feature) {
   return errorNYI(loc.getBegin(), feature) << loc;
 }
+
+void CIRGenModule::mapBlockAddress(cir::BlockAddrInfoAttr blockInfo,
+                                   cir::LabelOp label) {
+  auto result = blockAddressInfoToLabel.try_emplace(blockInfo, label);
+  (void)result;
+  assert(result.second &&
+         "attempting to map a blockaddress info that is already mapped");
+}
+
+void CIRGenModule::mapUnresolvedBlockAddress(cir::BlockAddressOp op) {
+  auto result = unresolvedBlockAddressToLabel.insert(op);
+  (void)result;
+  assert(result.second &&
+         "attempting to map a blockaddress operation that is already mapped");
+}
+
+void CIRGenModule::mapResolvedBlockAddress(cir::BlockAddressOp op,
+                                           cir::LabelOp label) {
+  auto result = blockAddressToLabel.try_emplace(op, label);
+  (void)result;
+  assert(result.second &&
+         "attempting to map a blockaddress operation that is already mapped");
+}
+
+void CIRGenModule::updateResolvedBlockAddress(cir::BlockAddressOp op,
+                                              cir::LabelOp newLabel) {
+  auto *it = blockAddressToLabel.find(op);
+  assert(it != blockAddressToLabel.end() &&
+         "trying to update a blockaddress not previously mapped");
+  assert(!it->second && "blockaddress already has a resolved label");
+
+  it->second = newLabel;
+}
+
+cir::LabelOp
+CIRGenModule::lookupBlockAddressInfo(cir::BlockAddrInfoAttr blockInfo) {
+  return blockAddressInfoToLabel.lookup(blockInfo);
+}

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -126,7 +126,23 @@ public:
   /// the pointers are supposed to be uniqued, should be fine. Revisit this if
   /// it ends up taking too much memory.
   llvm::DenseMap<const clang::FieldDecl *, llvm::StringRef> lambdaFieldToName;
-
+  /// Map BlockAddrInfoAttr (function name, label name) to the corresponding CIR
+  /// LabelOp. This provides the main lookup table used to resolve block
+  /// addresses into their label operations.
+  llvm::DenseMap<cir::BlockAddrInfoAttr, cir::LabelOp> blockAddressInfoToLabel;
+  /// Map CIR BlockAddressOps directly to their resolved LabelOps.
+  /// Used once a block address has been successfully lowered to a label.
+  llvm::MapVector<cir::BlockAddressOp, cir::LabelOp> blockAddressToLabel;
+  /// Track CIR BlockAddressOps that cannot be resolved immediately
+  /// because their LabelOp has not yet been emitted. These entries
+  /// are solved later once the corresponding label is available.
+  llvm::DenseSet<cir::BlockAddressOp> unresolvedBlockAddressToLabel;
+  cir::LabelOp lookupBlockAddressInfo(cir::BlockAddrInfoAttr blockInfo);
+  void mapBlockAddress(cir::BlockAddrInfoAttr blockInfo, cir::LabelOp label);
+  void mapUnresolvedBlockAddress(cir::BlockAddressOp op);
+  void mapResolvedBlockAddress(cir::BlockAddressOp op, cir::LabelOp);
+  void updateResolvedBlockAddress(cir::BlockAddressOp op,
+                                  cir::LabelOp newLabel);
   /// Tell the consumer that this variable has been instantiated.
   void handleCXXStaticMemberVarInstantiation(VarDecl *vd);
 

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -203,6 +203,7 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
     return emitCoroutineBody(cast<CoroutineBodyStmt>(*s));
   case Stmt::CoreturnStmtClass:
   case Stmt::IndirectGotoStmtClass:
+    return emitIndirectGotoStmt(cast<IndirectGotoStmt>(*s));
   case Stmt::OMPParallelDirectiveClass:
   case Stmt::OMPTaskwaitDirectiveClass:
   case Stmt::OMPTaskyieldDirectiveClass:
@@ -556,6 +557,17 @@ mlir::LogicalResult CIRGenFunction::emitGotoStmt(const clang::GotoStmt &s) {
 }
 
 mlir::LogicalResult
+CIRGenFunction::emitIndirectGotoStmt(const IndirectGotoStmt &s) {
+  mlir::Value val = emitScalarExpr(s.getTarget());
+  assert(indirectGotoBlock &&
+         "If you jumping to a indirect branch should be alareadye emitted");
+  cir::BrOp::create(builder, getLoc(s.getSourceRange()), indirectGotoBlock,
+                    val);
+  builder.createBlock(builder.getBlock()->getParent());
+  return mlir::success();
+}
+
+mlir::LogicalResult
 CIRGenFunction::emitContinueStmt(const clang::ContinueStmt &s) {
   builder.createContinue(getLoc(s.getKwLoc()));
 
@@ -581,9 +593,14 @@ mlir::LogicalResult CIRGenFunction::emitLabel(const clang::LabelDecl &d) {
   }
 
   builder.setInsertionPointToEnd(labelBlock);
-  cir::LabelOp::create(builder, getLoc(d.getSourceRange()), d.getName());
+  cir::LabelOp label =
+      cir::LabelOp::create(builder, getLoc(d.getSourceRange()), d.getName());
   builder.setInsertionPointToEnd(labelBlock);
-
+  auto func = cast<cir::FuncOp>(curFn);
+  cgm.mapBlockAddress(cir::BlockAddrInfoAttr::get(builder.getContext(),
+                                                  func.getSymNameAttr(),
+                                                  label.getLabelAttr()),
+                      label);
   //  FIXME: emit debug info for labels, incrementProfileCounter
   assert(!cir::MissingFeatures::ehstackBranches());
   assert(!cir::MissingFeatures::incrementProfileCounter());

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -52,7 +52,7 @@ struct RemoveRedundantBranches : public OpRewritePattern<BrOp> {
     Block *block = op.getOperation()->getBlock();
     Block *dest = op.getDest();
 
-    if (isa<cir::LabelOp>(dest->front()))
+    if (isa<cir::LabelOp, cir::IndirectBrOp>(dest->front()))
       return failure();
     // Single edge between blocks: merge it.
     if (block->getNumSuccessors() == 1 &&

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -4103,6 +4103,12 @@ mlir::LogicalResult CIRToLLVMBlockAddressOpLowering::matchAndRewrite(
   return mlir::failure();
 }
 
+mlir::LogicalResult CIRToLLVMIndirectBrOpLowering::matchAndRewrite(
+    cir::IndirectBrOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  return mlir::failure();
+}
+
 mlir::LogicalResult CIRToLLVMAwaitOpLowering::matchAndRewrite(
     cir::AwaitOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {

--- a/clang/test/CIR/CodeGen/label-values.c
+++ b/clang/test/CIR/CodeGen/label-values.c
@@ -3,6 +3,7 @@
 
 void A(void) {
   void *ptr = &&LABEL_A;
+  goto *ptr;
 LABEL_A:
   return;
 }
@@ -10,31 +11,43 @@ LABEL_A:
 // CIR:    [[PTR:%.*]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr", init] {alignment = 8 : i64}
 // CIR:    [[BLOCK:%.*]] = cir.block_address <@A, "LABEL_A"> : !cir.ptr<!void>
 // CIR:    cir.store align(8) [[BLOCK]], [[PTR]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
-// CIR:    cir.br ^bb1
-// CIR:  ^bb1:  // pred: ^bb0
+// CIR:    [[BLOCKADD:%.*]] = cir.load align(8) [[PTR]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// CIR:    cir.br ^bb1([[BLOCKADD]] : !cir.ptr<!void>)
+// CIR:  ^bb1([[PHI:%.*]]: !cir.ptr<!void> {{.*}}):  // pred: ^bb0
+// CIR:    cir.indirectbr [[PHI]] : <!void>, [
+// CIR:    ^bb2
+// CIR:    ]
+// CIR:  ^bb2:  // pred: ^bb1
 // CIR:    cir.label "LABEL_A"
 // CIR:    cir.return
 
 void B(void) {
 LABEL_B:
   void *ptr = &&LABEL_B;
+  goto *ptr;
 }
 
 // CIR:  cir.func {{.*}} @B()
 // CIR:    [[PTR:%.*]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr", init] {alignment = 8 : i64}
 // CIR:    cir.br ^bb1
-// CIR:   ^bb1:
+// CIR:   ^bb1: // 2 preds: ^bb0, ^bb2
 // CIR:    cir.label "LABEL_B"
 // CIR:    [[BLOCK:%.*]] = cir.block_address <@B, "LABEL_B"> : !cir.ptr<!void>
 // CIR:    cir.store align(8) [[BLOCK]], [[PTR]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
-// CIR:    cir.return
+// CIR:    [[BLOCKADD:%.*]] = cir.load align(8) [[PTR]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// CIR:    cir.br ^bb2([[BLOCKADD]] : !cir.ptr<!void>)
+// CIR:  ^bb2([[PHI:%.*]]: !cir.ptr<!void> {{.*}}):  // pred: ^bb1
+// CIR:    cir.indirectbr [[PHI]] : <!void>, [
+// CIR-NEXT:    ^bb1
+// CIR:    ]
 
 void C(int x) {
-    void *ptr = (x == 0) ? &&LABEL_A : &&LABEL_B;
+  void *ptr = (x == 0) ? &&LABEL_A : &&LABEL_B;
+  goto *ptr;
 LABEL_A:
-    return;
+  return;
 LABEL_B:
-    return;
+  return;
 }
 
 // CIR:  cir.func {{.*}} @C
@@ -42,19 +55,26 @@ LABEL_B:
 // CIR:    [[BLOCK2:%.*]] = cir.block_address <@C, "LABEL_B"> : !cir.ptr<!void>
 // CIR:    [[COND:%.*]] = cir.select if [[CMP:%.*]] then [[BLOCK1]] else [[BLOCK2]] : (!cir.bool, !cir.ptr<!void>, !cir.ptr<!void>) -> !cir.ptr<!void>
 // CIR:    cir.store align(8) [[COND]], [[PTR:%.*]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
-// CIR:    cir.br ^bb1
-// CIR:  ^bb1:  // pred: ^bb0
+// CIR:    [[BLOCKADD:%.*]] = cir.load align(8) [[PTR]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// CIR:    cir.br ^bb1([[BLOCKADD]] : !cir.ptr<!void>)
+// CIR:  ^bb1([[PHI:%.*]]: !cir.ptr<!void> {{.*}}):  // pred: ^bb0
+// CIR:    cir.indirectbr [[PHI]] : <!void>, [
+// CIR-NEXT:    ^bb2,
+// CIR-NEXT:    ^bb4
+// CIR:    ]
+// CIR:  ^bb2:  // pred: ^bb1
 // CIR:    cir.label "LABEL_A"
-// CIR:    cir.br ^bb2
-// CIR:  ^bb2:  // 2 preds: ^bb1, ^bb3
+// CIR:    cir.br ^bb3
+// CIR:  ^bb3:  // 2 preds: ^bb2, ^bb4
 // CIR:    cir.return
-// CIR:  ^bb3:  // no predecessors
+// CIR:  ^bb4:  // pred: ^bb1
 // CIR:    cir.label "LABEL_B"
-// CIR:    cir.br ^bb2
+// CIR:    cir.br ^bb3
 
 void D(void) {
   void *ptr = &&LABEL_A;
   void *ptr2 = &&LABEL_A;
+  goto *ptr2;
 LABEL_A:
   void *ptr3 = &&LABEL_A;
   return;
@@ -69,8 +89,46 @@ LABEL_A:
 // CIR:    %[[BLK2:.*]] = cir.block_address <@D, "LABEL_A"> : !cir.ptr<!void>
 // CIR:    cir.store align(8) %[[BLK2]], %[[PTR2]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 // CIR:    cir.br ^bb1
-// CIR:  ^bb1:  // pred: ^bb0
+// CIR:  ^bb1([[PHI:%*.]]: !cir.ptr<!void> {{.*}}):  // pred: ^bb0
+// CIR:    cir.indirectbr [[PHI]] : <!void>, [
+// CIR-DAG:    ^bb2,
+// CIR-DAG:    ^bb2,
+// CIR-DAG:    ^bb2
+// CIR:    ]
+// CIR:  ^bb2:  // 3 preds: ^bb1, ^bb1, ^bb1
 // CIR:    cir.label "LABEL_A"
 // CIR:    %[[BLK3:.*]] = cir.block_address <@D, "LABEL_A"> : !cir.ptr<!void>
 // CIR:    cir.store align(8) %[[BLK3]], %[[PTR3]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 // CIR:    cir.return
+
+
+// This test checks that CIR preserves insertion order of blockaddresses
+// for indirectbr, even if some were resolved immediately and others later.
+void E(void) {
+  void *ptr = &&LABEL_D;
+  void *ptr2 = &&LABEL_C;
+LABEL_A:
+LABEL_B:
+  void *ptr3 = &&LABEL_B;
+  void *ptr4 = &&LABEL_A;
+LABEL_C:
+LABEL_D:
+  return;
+}
+
+//CIR:  cir.func dso_local @E()
+//CIR:  ^bb1({{.*}}: !cir.ptr<!void> {{.*}}):  // no predecessors
+//CIR:    cir.indirectbr {{.*}} poison : <!void>, [
+//CIR-NEXT:    ^bb5,
+//CIR-NEXT:    ^bb4,
+//CIR-NEXT:    ^bb3,
+//CIR-NEXT:    ^bb2
+//CIR:    ]
+//CIR:  ^bb2:  // 2 preds: ^bb0, ^bb1
+//CIR:    cir.label "LABEL_A"
+//CIR:  ^bb3:  // 2 preds: ^bb1, ^bb2
+//CIR:    cir.label "LABEL_B"
+//CIR:  ^bb4:  // 2 preds: ^bb1, ^bb3
+//CIR:    cir.label "LABEL_C"
+//CIR:  ^bb5:  // 2 preds: ^bb1, ^bb4
+//CIR:    cir.label "LABEL_D"

--- a/clang/test/CIR/CodeGen/label-values.c
+++ b/clang/test/CIR/CodeGen/label-values.c
@@ -16,7 +16,7 @@ LABEL_A:
 // CIR:    [[BLOCKADD:%.*]] = cir.load align(8) [[PTR]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
 // CIR:    cir.br ^bb1([[BLOCKADD]] : !cir.ptr<!void>)
 // CIR:  ^bb1([[PHI:%.*]]: !cir.ptr<!void> {{.*}}):  // pred: ^bb0
-// CIR:    cir.indirectbr [[PHI]] : <!void>, [
+// CIR:    cir.indirect_br [[PHI]] : !cir.ptr<!void>, [
 // CIR:    ^bb2
 // CIR:    ]
 // CIR:  ^bb2:  // pred: ^bb1
@@ -50,7 +50,7 @@ LABEL_B:
 // CIR:    [[BLOCKADD:%.*]] = cir.load align(8) [[PTR]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
 // CIR:    cir.br ^bb2([[BLOCKADD]] : !cir.ptr<!void>)
 // CIR:  ^bb2([[PHI:%.*]]: !cir.ptr<!void> {{.*}}):  // pred: ^bb1
-// CIR:    cir.indirectbr [[PHI]] : <!void>, [
+// CIR:    cir.indirect_br [[PHI]] : !cir.ptr<!void>, [
 // CIR-NEXT:    ^bb1
 // CIR:    ]
 
@@ -82,7 +82,7 @@ LABEL_B:
 // CIR:    [[BLOCKADD:%.*]] = cir.load align(8) [[PTR]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
 // CIR:    cir.br ^bb1([[BLOCKADD]] : !cir.ptr<!void>)
 // CIR:  ^bb1([[PHI:%.*]]: !cir.ptr<!void> {{.*}}):  // pred: ^bb0
-// CIR:    cir.indirectbr [[PHI]] : <!void>, [
+// CIR:    cir.indirect_br [[PHI]] : !cir.ptr<!void>, [
 // CIR-NEXT:    ^bb2,
 // CIR-NEXT:    ^bb4
 // CIR:    ]
@@ -129,7 +129,7 @@ LABEL_A:
 // CIR:    cir.store align(8) %[[BLK2]], %[[PTR2]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
 // CIR:    cir.br ^bb1
 // CIR:  ^bb1([[PHI:%*.]]: !cir.ptr<!void> {{.*}}):  // pred: ^bb0
-// CIR:    cir.indirectbr [[PHI]] : <!void>, [
+// CIR:    cir.indirect_br [[PHI]] : !cir.ptr<!void>, [
 // CIR-DAG:    ^bb2,
 // CIR-DAG:    ^bb2,
 // CIR-DAG:    ^bb2
@@ -169,9 +169,9 @@ LABEL_D:
   return;
 }
 
-//CIR:  cir.func dso_local @E()
+//CIR:  cir.func {{.*}} @E()
 //CIR:  ^bb1({{.*}}: !cir.ptr<!void> {{.*}}):  // no predecessors
-//CIR:    cir.indirectbr {{.*}} poison : <!void>, [
+//CIR:    cir.indirect_br {{.*}} poison : !cir.ptr<!void>, [
 //CIR-NEXT:    ^bb5,
 //CIR-NEXT:    ^bb4,
 //CIR-NEXT:    ^bb3,

--- a/clang/test/CIR/IR/indirect-br.cir
+++ b/clang/test/CIR/IR/indirect-br.cir
@@ -1,0 +1,46 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!void = !cir.void
+
+cir.func @E() {
+  %0 = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr", init] {alignment = 8 : i64}
+  %1 = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr2", init] {alignment = 8 : i64}
+  %2 = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr3", init] {alignment = 8 : i64}
+  %3 = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["ptr4", init] {alignment = 8 : i64}
+  %4 = cir.block_address <@E, "D"> : !cir.ptr<!void>
+  cir.store align(8) %4, %0 : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
+  %5 = cir.block_address <@E, "C"> : !cir.ptr<!void>
+  cir.store align(8) %5, %1 : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
+  %6 = cir.load align(8) %0 : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+  cir.br ^bb1(%6 : !cir.ptr<!void>)
+^bb1(%7: !cir.ptr<!void>):  // pred: ^bb0
+  cir.indirectbr %7 : <!void>, [
+  ^bb5,
+  ^bb4,
+  ^bb3,
+  ^bb2
+  ]
+^bb2:  // pred: ^bb1
+  cir.label "A"
+  cir.br ^bb3
+^bb3:  // 2 preds: ^bb1, ^bb2
+  cir.label "B"
+  %8 = cir.block_address <@E, "B"> : !cir.ptr<!void>
+  cir.store align(8) %8, %2 : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
+  %9 = cir.block_address <@E, "A"> : !cir.ptr<!void>
+  cir.store align(8) %9, %3 : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
+  cir.br ^bb4
+^bb4:  // 2 preds: ^bb1, ^bb3
+  cir.label "C"
+  cir.br ^bb5
+^bb5:  // 2 preds: ^bb1, ^bb4
+  cir.label "D"
+  cir.return
+}
+
+// CHECK: cir.indirectbr %7 : <!void>, [
+// CHECK:  ^bb5,
+// CHECK:  ^bb4,
+// CHECK:  ^bb3,
+// CHECK:  ^bb2
+// CHECK: ]

--- a/clang/test/CIR/IR/indirect-br.cir
+++ b/clang/test/CIR/IR/indirect-br.cir
@@ -14,7 +14,7 @@ cir.func @E() {
   %6 = cir.load align(8) %0 : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
   cir.br ^bb1(%6 : !cir.ptr<!void>)
 ^bb1(%7: !cir.ptr<!void>):  // pred: ^bb0
-  cir.indirectbr %7 : <!void>, [
+  cir.indirect_br %7 : !cir.ptr<!void>, [
   ^bb5,
   ^bb4,
   ^bb3,
@@ -38,7 +38,7 @@ cir.func @E() {
   cir.return
 }
 
-// CHECK: cir.indirectbr %7 : <!void>, [
+// CHECK: cir.indirect_br %7 : !cir.ptr<!void>, [
 // CHECK:  ^bb5,
 // CHECK:  ^bb4,
 // CHECK:  ^bb3,


### PR DESCRIPTION
This PR upstreams support for the `cir.indirectBr` operation, which is used to implement GCC’s labels-as-values `indirect goto`.
To ensure correct lowering, we introduce precise bookkeeping to associate each `block_address` operation with its corresponding `label` op. This is required because a `block_address` may be emitted before the `label` it refers to. In such cases, the reference is deferred and later resolved by `resolveBlockAddresses`, which guarantees that all `indirectBr` successors are emitted in the correct and fully resolved order.