### PR TITLE
[analyzer][scan-build-py] Fix windows compatibility

### DIFF
--- a/clang/tools/scan-build-py/lib/libscanbuild/analyze.py
+++ b/clang/tools/scan-build-py/lib/libscanbuild/analyze.py
@@ -23,6 +23,7 @@ import contextlib
 import datetime
 import shutil
 import glob
+import platform
 from collections import defaultdict
 
 from libscanbuild import (
@@ -563,7 +564,7 @@ def report_failure(opts):
         handle.write(opts["file"] + os.linesep)
         handle.write(error.title().replace("_", " ") + os.linesep)
         handle.write(" ".join(cmd) + os.linesep)
-        handle.write(" ".join(os.uname()) + os.linesep)
+        handle.write(" ".join(platform.uname()) + os.linesep)
         handle.write(get_version(opts["clang"]))
         handle.close()
     # write the captured output too

--- a/clang/tools/scan-build-py/lib/libscanbuild/compilation.py
+++ b/clang/tools/scan-build-py/lib/libscanbuild/compilation.py
@@ -135,7 +135,7 @@ def compiler_language(command):
     cplusplus = re.compile(r"^(.+)(\+\+)(-.+|)$")
 
     if command:
-        executable = os.path.basename(command[0])
+        executable = os.path.basename(command[0]).removesuffix('.exe')
         if any(pattern.match(executable) for pattern in COMPILER_PATTERNS):
             return "c++" if cplusplus.match(executable) else "c"
     return None


### PR DESCRIPTION
It fails on windows 10 otherwise with:
```
Traceback (most recent call last):
 ...
  File "C:\Dev\LLVM\lib\libscanbuild\analyze.py", line 567, in
report_failure
    handle.write(" ".join(os.uname()) + os.linesep)
                          ^^^^^^^^
AttributeError: module 'os' has no attribute 'uname'. Did you mean:
'name'?
```

There was also a problem identifying the actual compiler on Windows because the program name have an ".exe" suffix.