### PR TITLE
[CIR][X86] Implement lowering for AVX512 ktest builtins

### DIFF
--- a/clang/test/CIR/CodeGenBuiltins/X86/avx512bw-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/avx512bw-builtins.c
@@ -559,3 +559,212 @@ __m512i test_mm512_shufflehi_epi16(__m512i __A) {
   // OGCG: shufflevector <32 x i16> %{{.*}}, <32 x i16> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 5, i32 5, i32 4, i32 4, i32 8, i32 9, i32 10, i32 11, i32 13, i32 13, i32 12, i32 12, i32 16, i32 17, i32 18, i32 19, i32 21, i32 21, i32 20, i32 20, i32 24, i32 25, i32 26, i32 27, i32 29, i32 29, i32 28, i32 28>
   return _mm512_shufflehi_epi16(__A, 5);
 }
+
+unsigned char test_kortestc_mask32_u8(__mmask32 __A, __mmask32 __B) {
+  // CIR-LABEL: _kortestc_mask32_u8
+  // CIR: %[[ALL_ONES:.*]] = cir.const #cir.int<4294967295> : !u32i
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u32i -> !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u32i -> !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[OR:.*]]  = cir.binop(or, %[[LHS]], %[[RHS]]) : !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[OR_INT:.*]] = cir.cast bitcast %[[OR]] : !cir.vector<32 x !cir.int<u, 1>> -> !u32i
+  // CIR: %[[CMP:.*]] = cir.cmp(eq, %[[OR_INT]], %[[ALL_ONES]]) : !u32i, !cir.bool
+  // CIR: %[[B2I:.*]] = cir.cast bool_to_int %[[CMP]] : !cir.bool -> !s32i
+  // CIR: cir.cast integral %[[B2I]] : !s32i -> !u8i
+
+  // LLVM-LABEL: _kortestc_mask32_u8
+  // LLVM: %[[LHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // LLVM: %[[OR:.*]]  = or <32 x i1> %[[LHS]], %[[RHS]]
+  // LLVM: %[[CAST:.*]] = bitcast <32 x i1> %[[OR]] to i32
+  // LLVM: %[[CMP:.*]] = icmp eq i32 %[[CAST]], -1
+  // LLVM: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // LLVM: trunc i32 %[[ZEXT]] to i8
+
+  // OGCG-LABEL: _kortestc_mask32_u8
+  // OGCG: %[[LHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // OGCG: %[[OR:.*]]  = or <32 x i1> %[[LHS]], %[[RHS]]
+  // OGCG: %[[CAST:.*]] = bitcast <32 x i1> %[[OR]] to i32
+  // OGCG: %[[CMP:.*]] = icmp eq i32 %[[CAST]], -1
+  // OGCG: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // OGCG: trunc i32 %[[ZEXT]] to i8
+  return _kortestc_mask32_u8(__A, __B);
+}
+
+unsigned char test_kortestc_mask64_u8(__mmask64 __A, __mmask64 __B) {
+  // CIR-LABEL: _kortestc_mask64_u8
+  // CIR: %[[ALL_ONES:.*]] = cir.const #cir.int<18446744073709551615> : !u64i
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u64i -> !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u64i -> !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[OR:.*]]  = cir.binop(or, %[[LHS]], %[[RHS]]) : !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[OR_INT:.*]] = cir.cast bitcast %[[OR]] : !cir.vector<64 x !cir.int<u, 1>> -> !u64i
+  // CIR: %[[CMP:.*]] = cir.cmp(eq, %[[OR_INT]], %[[ALL_ONES]]) : !u64i, !cir.bool
+  // CIR: %[[B2I:.*]] = cir.cast bool_to_int %[[CMP]] : !cir.bool -> !s32i
+  // CIR: cir.cast integral %[[B2I]] : !s32i -> !u8i
+
+  // LLVM-LABEL: _kortestc_mask64_u8
+  // LLVM: %[[LHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // LLVM: %[[OR:.*]]  = or <64 x i1> %[[LHS]], %[[RHS]]
+  // LLVM: %[[CAST:.*]] = bitcast <64 x i1> %[[OR]] to i64
+  // LLVM: %[[CMP:.*]] = icmp eq i64 %[[CAST]], -1
+  // LLVM: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // LLVM: trunc i32 %[[ZEXT]] to i8
+
+  // OGCG-LABEL: _kortestc_mask64_u8
+  // OGCG: %[[LHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // OGCG: %[[OR:.*]]  = or <64 x i1> %[[LHS]], %[[RHS]]
+  // OGCG: %[[CAST:.*]] = bitcast <64 x i1> %[[OR]] to i64
+  // OGCG: %[[CMP:.*]] = icmp eq i64 %[[CAST]], -1
+  // OGCG: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // OGCG: trunc i32 %[[ZEXT]] to i8
+  return _kortestc_mask64_u8(__A, __B);
+}
+
+unsigned char test_kortestz_mask32_u8(__mmask32 __A, __mmask32 __B) {
+  // CIR-LABEL: _kortestz_mask32_u8
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !u32i
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u32i -> !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u32i -> !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[OR:.*]]  = cir.binop(or, %[[LHS]], %[[RHS]]) : !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[OR_INT:.*]] = cir.cast bitcast %[[OR]] : !cir.vector<32 x !cir.int<u, 1>> -> !u32i
+  // CIR: %[[CMP:.*]] = cir.cmp(eq, %[[OR_INT]], %[[ZERO]]) : !u32i, !cir.bool
+  // CIR: %[[B2I:.*]] = cir.cast bool_to_int %[[CMP]] : !cir.bool -> !s32i
+  // CIR: cir.cast integral %[[B2I]] : !s32i -> !u8i
+
+  // LLVM-LABEL: _kortestz_mask32_u8
+  // LLVM: %[[LHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // LLVM: %[[OR:.*]]  = or <32 x i1> %[[LHS]], %[[RHS]]
+  // LLVM: %[[CAST:.*]] = bitcast <32 x i1> %[[OR]] to i32
+  // LLVM: %[[CMP:.*]] = icmp eq i32 %[[CAST]], 0
+  // LLVM: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // LLVM: trunc i32 %[[ZEXT]] to i8
+
+  // OGCG-LABEL: _kortestz_mask32_u8
+  // OGCG: %[[LHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // OGCG: %[[OR:.*]]  = or <32 x i1> %[[LHS]], %[[RHS]]
+  // OGCG: %[[CAST:.*]] = bitcast <32 x i1> %[[OR]] to i32
+  // OGCG: %[[CMP:.*]] = icmp eq i32 %[[CAST]], 0
+  // OGCG: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // OGCG: trunc i32 %[[ZEXT]] to i8
+  return _kortestz_mask32_u8(__A, __B);
+}
+
+unsigned char test_kortestz_mask64_u8(__mmask64 __A, __mmask64 __B) {
+  // CIR-LABEL: _kortestz_mask64_u8
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !u64i
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u64i -> !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u64i -> !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[OR:.*]]  = cir.binop(or, %[[LHS]], %[[RHS]]) : !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[OR_INT:.*]] = cir.cast bitcast %[[OR]] : !cir.vector<64 x !cir.int<u, 1>> -> !u64i
+  // CIR: %[[CMP:.*]] = cir.cmp(eq, %[[OR_INT]], %[[ZERO]]) : !u64i, !cir.bool
+  // CIR: %[[B2I:.*]] = cir.cast bool_to_int %[[CMP]] : !cir.bool -> !s32i
+  // CIR: cir.cast integral %[[B2I]] : !s32i -> !u8i
+
+  // LLVM-LABEL: _kortestz_mask64_u8
+  // LLVM: %[[LHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // LLVM: %[[OR:.*]]  = or <64 x i1> %[[LHS]], %[[RHS]]
+  // LLVM: %[[CAST:.*]] = bitcast <64 x i1> %[[OR]] to i64
+  // LLVM: %[[CMP:.*]] = icmp eq i64 %[[CAST]], 0
+  // LLVM: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // LLVM: trunc i32 %[[ZEXT]] to i8
+
+  // OGCG-LABEL: _kortestz_mask64_u8
+  // OGCG: %[[LHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // OGCG: %[[OR:.*]]  = or <64 x i1> %[[LHS]], %[[RHS]]
+  // OGCG: %[[CAST:.*]] = bitcast <64 x i1> %[[OR]] to i64
+  // OGCG: %[[CMP:.*]] = icmp eq i64 %[[CAST]], 0
+  // OGCG: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // OGCG: trunc i32 %[[ZEXT]] to i8
+  return _kortestz_mask64_u8(__A, __B);
+}
+
+unsigned char test_ktestc_mask32_u8(__mmask32 A, __mmask32 B) {
+  // CIR-LABEL: _ktestc_mask32_u8
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u32i -> !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u32i -> !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.ktestc.d"
+  // CIR: cir.cast integral %[[RES]] : {{.*}} -> !u8i
+
+  // LLVM-LABEL: _ktestc_mask32_u8
+  // LLVM: %[[LHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // LLVM: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestc.d(<32 x i1> %[[LHS]], <32 x i1> %[[RHS]])
+  // LLVM: trunc i32 %[[RES]] to i8
+
+  // OGCG-LABEL: _ktestc_mask32_u8
+  // OGCG: %[[LHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // OGCG: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestc.d
+  // OGCG: trunc i32 %[[RES]] to i8
+  return _ktestc_mask32_u8(A, B);
+}
+
+unsigned char test_ktestz_mask32_u8(__mmask32 A, __mmask32 B) {
+  // CIR-LABEL: _ktestz_mask32_u8
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u32i -> !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u32i -> !cir.vector<32 x !cir.int<u, 1>>
+  // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.ktestz.d"
+  // CIR: cir.cast integral %[[RES]] : {{.*}} -> !u8i
+
+  // LLVM-LABEL: _ktestz_mask32_u8
+  // LLVM: %[[LHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // LLVM: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestz.d(<32 x i1> %[[LHS]], <32 x i1> %[[RHS]])
+  // LLVM: trunc i32 %[[RES]] to i8
+
+  // OGCG-LABEL: _ktestz_mask32_u8
+  // OGCG: %[[LHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i32 %{{.*}} to <32 x i1>
+  // OGCG: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestz.d
+  // OGCG: trunc i32 %[[RES]] to i8
+  return _ktestz_mask32_u8(A, B);
+}
+
+unsigned char test_ktestc_mask64_u8(__mmask64 A, __mmask64 B) {
+  // CIR-LABEL: _ktestc_mask64_u8
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u64i -> !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u64i -> !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.ktestc.q"
+  // CIR: cir.cast integral %[[RES]] : {{.*}} -> !u8i
+
+  // LLVM-LABEL: _ktestc_mask64_u8
+  // LLVM: %[[LHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // LLVM: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestc.q(<64 x i1> %[[LHS]], <64 x i1> %[[RHS]])
+  // LLVM: trunc i32 %[[RES]] to i8
+
+  // OGCG-LABEL: _ktestc_mask64_u8
+  // OGCG: %[[LHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // OGCG: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestc.q
+  // OGCG: trunc i32 %[[RES]] to i8
+  return _ktestc_mask64_u8(A, B);
+}
+
+unsigned char test_ktestz_mask64_u8(__mmask64 A, __mmask64 B) {
+  // CIR-LABEL: _ktestz_mask64_u8
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u64i -> !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u64i -> !cir.vector<64 x !cir.int<u, 1>>
+  // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.ktestz.q"
+  // CIR: cir.cast integral %[[RES]] : {{.*}} -> !u8i
+
+  // LLVM-LABEL: _ktestz_mask64_u8
+  // LLVM: %[[LHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // LLVM: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestz.q(<64 x i1> %[[LHS]], <64 x i1> %[[RHS]])
+  // LLVM: trunc i32 %[[RES]] to i8
+
+  // OGCG-LABEL: _ktestz_mask64_u8
+  // OGCG: %[[LHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i64 %{{.*}} to <64 x i1>
+  // OGCG: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestz.q
+  // OGCG: trunc i32 %[[RES]] to i8
+  return _ktestz_mask64_u8(A, B);
+}
+

--- a/clang/test/CIR/CodeGenBuiltins/X86/avx512dq-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/avx512dq-builtins.c
@@ -208,3 +208,118 @@ __mmask8 test_kmov_b(__mmask8 A) {
  // OGCG: bitcast <8 x i1> {{.*}} to i8
  return __builtin_ia32_kmovb(A);
 }
+
+unsigned char test_kortestc_mask8_u8(__mmask8 __A, __mmask8 __B) {
+  // CIR-LABEL: _kortestc_mask8_u8
+  // CIR: %[[ALL_ONES:.*]] = cir.const #cir.int<255> : !u8i
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u8i -> !cir.vector<8 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u8i -> !cir.vector<8 x !cir.int<u, 1>>
+  // CIR: %[[OR:.*]] = cir.binop(or, %[[LHS]], %[[RHS]]) : !cir.vector<8 x !cir.int<u, 1>>
+  // CIR: %[[OR_INT:.*]] = cir.cast bitcast %[[OR]] : !cir.vector<8 x !cir.int<u, 1>> -> !u8i
+  // CIR: %[[CMP:.*]] = cir.cmp(eq, %[[OR_INT]], %[[ALL_ONES]]) : !u8i, !cir.bool
+  // CIR: cir.cast bool_to_int %[[CMP]] : !cir.bool -> !s32i
+  // CIR: cir.cast integral {{.*}} : !s32i -> !u8i
+
+  // LLVM-LABEL: _kortestc_mask8_u8
+  // LLVM: %[[LHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // LLVM: %[[OR:.*]] = or <8 x i1> %[[LHS]], %[[RHS]]
+  // LLVM: %[[CAST:.*]] = bitcast <8 x i1> %[[OR]] to i8
+  // LLVM: %[[CMP:.*]] = icmp eq i8 %[[CAST]], -1
+  // LLVM: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // LLVM: trunc i32 %[[ZEXT]] to i8
+
+  // OGCG-LABEL: _kortestc_mask8_u8
+  // OGCG: %[[LHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // OGCG: %[[OR:.*]] = or <8 x i1> %[[LHS]], %[[RHS]]
+  // OGCG: %[[CAST:.*]] = bitcast <8 x i1> %[[OR]] to i8
+  // OGCG: %[[CMP:.*]] = icmp eq i8 %[[CAST]], -1
+  // OGCG: %[[ZEXT:.*]] = zext i1 %[[CMP]] to i32
+  // OGCG: trunc i32 %[[ZEXT]] to i8
+  return _kortestc_mask8_u8(__A,__B);
+}
+
+unsigned char test_ktestc_mask8_u8(__mmask8 A, __mmask8 B) {
+  // CIR-LABEL: _ktestc_mask8_u8
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u8i -> !cir.vector<8 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u8i -> !cir.vector<8 x !cir.int<u, 1>>
+  // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.ktestc.b"
+  // CIR: cir.cast integral %[[RES]] : {{.*}} -> !u8i
+
+  // LLVM-LABEL: _ktestc_mask8_u8
+  // LLVM: %[[LHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // LLVM: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestc.b(<8 x i1> %[[LHS]], <8 x i1> %[[RHS]])
+  // LLVM: trunc i32 %[[RES]] to i8
+
+  // OGCG-LABEL: _ktestc_mask8_u8
+  // OGCG: %[[LHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // OGCG: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestc.b
+  // OGCG: trunc i32 %[[RES]] to i8
+  return _ktestc_mask8_u8(A, B);
+}
+
+unsigned char test_ktestz_mask8_u8(__mmask8 A, __mmask8 B) {
+  // CIR-LABEL: _ktestz_mask8_u8
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u8i -> !cir.vector<8 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u8i -> !cir.vector<8 x !cir.int<u, 1>>
+  // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.ktestz.b"
+  // CIR: cir.cast integral %[[RES]] : {{.*}} -> !u8i
+
+  // LLVM-LABEL: _ktestz_mask8_u8
+  // LLVM: %[[LHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // LLVM: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestz.b(<8 x i1> %[[LHS]], <8 x i1> %[[RHS]])
+  // LLVM: trunc i32 %[[RES]] to i8
+
+  // OGCG-LABEL: _ktestz_mask8_u8
+  // OGCG: %[[LHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i8 %{{.*}} to <8 x i1>
+  // OGCG: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestz.b
+  // OGCG: trunc i32 %[[RES]] to i8
+  return _ktestz_mask8_u8(A, B);
+}
+
+unsigned char test_ktestc_mask16_u8(__mmask16 A, __mmask16 B) {
+  // CIR-LABEL: _ktestc_mask16_u8
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u16i -> !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u16i -> !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.ktestc.w"
+  // CIR: cir.cast integral %[[RES]] : {{.*}} -> !u8i
+
+  // LLVM-LABEL: _ktestc_mask16_u8
+  // LLVM: %[[LHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // LLVM: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestc.w(<16 x i1> %[[LHS]], <16 x i1> %[[RHS]])
+  // LLVM: trunc i32 %[[RES]] to i8
+
+  // OGCG-LABEL: _ktestc_mask16_u8
+  // OGCG: %[[LHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // OGCG: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestc.w
+  // OGCG: trunc i32 %[[RES]] to i8
+  return _ktestc_mask16_u8(A, B);
+}
+
+unsigned char test_ktestz_mask16_u8(__mmask16 A, __mmask16 B) {
+  // CIR-LABEL: _ktestz_mask16_u8
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u16i -> !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u16i -> !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.ktestz.w"
+  // CIR: cir.cast integral %[[RES]] : {{.*}} -> !u8i
+
+  // LLVM-LABEL: _ktestz_mask16_u8
+  // LLVM: %[[LHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // LLVM: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestz.w(<16 x i1> %[[LHS]], <16 x i1> %[[RHS]])
+  // LLVM: trunc i32 %[[RES]] to i8
+
+  // OGCG-LABEL: _ktestz_mask16_u8
+  // OGCG: %[[LHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // OGCG: %[[RES:.*]] = call i32 @llvm.x86.avx512.ktestz.w
+  // OGCG: trunc i32 %[[RES]] to i8
+  return _ktestz_mask16_u8(A, B);
+}

--- a/clang/test/CIR/CodeGenBuiltins/X86/avx512f-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/avx512f-builtins.c
@@ -747,3 +747,60 @@ __m512i test_mm512_mul_epu32(__m512i __A, __m512i __B) {
 
 return _mm512_mul_epu32(__A, __B);
 }
+
+int test_mm512_kortestc(__mmask16 __A, __mmask16 __B) {
+  // CIR-LABEL: _mm512_kortestc
+  // CIR: %[[ALL_ONES:.*]] = cir.const #cir.int<65535> : !u16i
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u16i -> !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u16i -> !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[OR:.*]] = cir.binop(or, %[[LHS]], %[[RHS]]) : !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[OR_INT:.*]] = cir.cast bitcast %[[OR]] : !cir.vector<16 x !cir.int<u, 1>> -> !u16i
+  // CIR: %[[CMP:.*]] = cir.cmp(eq, %[[OR_INT]], %[[ALL_ONES]]) : !u16i, !cir.bool
+  // CIR: cir.cast bool_to_int %[[CMP]] : !cir.bool -> !s32i
+
+  // LLVM-LABEL: _mm512_kortestc
+  // LLVM: %[[LHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // LLVM: %[[OR:.*]] = or <16 x i1> %[[LHS]], %[[RHS]]
+  // LLVM: %[[CAST:.*]] = bitcast <16 x i1> %[[OR]] to i16
+  // LLVM: %[[CMP:.*]] = icmp eq i16 %[[CAST]], -1
+  // LLVM: zext i1 %[[CMP]] to i32
+
+  // OGCG-LABEL: _mm512_kortestc
+  // OGCG: %[[LHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // OGCG: %[[OR:.*]] = or <16 x i1> %[[LHS]], %[[RHS]]
+  // OGCG: %[[CAST:.*]] = bitcast <16 x i1> %[[OR]] to i16
+  // OGCG: %[[CMP:.*]] = icmp eq i16 %[[CAST]], -1
+  // OGCG: zext i1 %[[CMP]] to i32
+  return _mm512_kortestc(__A,__B);
+}
+
+
+int test_mm512_kortestz(__mmask16 __A, __mmask16 __B) {
+  // CIR-LABEL: _mm512_kortestz
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !u16i
+  // CIR: %[[LHS:.*]] = cir.cast bitcast {{.*}} : !u16i -> !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[RHS:.*]] = cir.cast bitcast {{.*}} : !u16i -> !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[OR:.*]] = cir.binop(or, %[[LHS]], %[[RHS]]) : !cir.vector<16 x !cir.int<u, 1>>
+  // CIR: %[[OR_INT:.*]] = cir.cast bitcast %[[OR]] : !cir.vector<16 x !cir.int<u, 1>> -> !u16i
+  // CIR: %[[CMP:.*]] = cir.cmp(eq, %[[OR_INT]], %[[ZERO]]) : !u16i, !cir.bool
+  // CIR: cir.cast bool_to_int %[[CMP]] : !cir.bool -> !s32i
+
+  // LLVM-LABEL: _mm512_kortestz
+  // LLVM: %[[LHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // LLVM: %[[RHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // LLVM: %[[OR:.*]] = or <16 x i1> %[[LHS]], %[[RHS]]
+  // LLVM: %[[CAST:.*]] = bitcast <16 x i1> %[[OR]] to i16
+  // LLVM: %[[CMP:.*]] = icmp eq i16 %[[CAST]], 0
+  // LLVM: zext i1 %[[CMP]] to i32
+
+  // OGCG-LABEL: _mm512_kortestz
+  // OGCG: %[[LHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // OGCG: %[[RHS:.*]] = bitcast i16 %{{.*}} to <16 x i1>
+  // OGCG: %[[OR:.*]] = or <16 x i1> %[[LHS]], %[[RHS]]
+  // OGCG: %[[CAST:.*]] = bitcast <16 x i1> %[[OR]] to i16
+  // OGCG: %[[CMP:.*]] = icmp eq i16 %[[CAST]], 0
+  // OGCG: zext i1 %[[CMP]] to i32
+  return _mm512_kortestz(__A,__B);
+}


### PR DESCRIPTION
part of [#167765](https://github.com/llvm/llvm-project/issues/167765)
This is a follow-up patch to continue the work from <[#169774](https://github.com/llvm/llvm-project/pull/169774)>.
It builds on the previous lowering infrastructure and extends support to the AVX512 ktest builtins.