### PR TITLE
[X86] optimize saturating (masked) pack

### DIFF
--- a/llvm/test/CodeGen/X86/masked_packss.ll
+++ b/llvm/test/CodeGen/X86/masked_packss.ll
@@ -16,11 +16,8 @@ define <16 x i8> @_mm_mask_packss_epi16_manual(<16 x i8> %src, i16 noundef %k, <
 ;
 ; AVX512-LABEL: _mm_mask_packss_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    # kill: def $xmm1 killed $xmm1 def $ymm1
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm1, %ymm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vpmovswb %ymm1, %xmm0 {%k1}
-; AVX512-NEXT:    vzeroupper
+; AVX512-NEXT:    vpacksswb %xmm2, %xmm1, %xmm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <8 x i16> %a, <8 x i16> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %minv = tail call <16 x i16> @llvm.smax.v16i16(<16 x i16> %sh, <16 x i16> splat (i16 -128))
@@ -46,11 +43,8 @@ define <32 x i8> @_mm256_mask_packss_epi16_manual(<32 x i8> %src, i32 noundef %k
 ;
 ; AVX512-LABEL: _mm256_mask_packss_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vperm2i128 {{.*#+}} ymm3 = ymm1[2,3],ymm2[2,3]
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm1, %ymm1
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm1, %zmm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vpmovswb %zmm1, %ymm0 {%k1}
+; AVX512-NEXT:    vpacksswb %ymm2, %ymm1, %ymm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <16 x i16> %a, <16 x i16> %b, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %minv = tail call <32 x i16> @llvm.smax.v32i16(<32 x i16> %sh, <32 x i16> splat (i16 -128))
@@ -81,15 +75,8 @@ define <64 x i8> @_mm512_mask_packss_epi16_manual(<64 x i8> %src, i64 noundef %k
 ;
 ; AVX512-LABEL: _mm512_mask_packss_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm3 = [4,5,12,13,6,7,14,15]
-; AVX512-NEXT:    vpermi2q %zmm2, %zmm1, %zmm3
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm4 = [0,1,8,9,2,3,10,11]
-; AVX512-NEXT:    vpermi2q %zmm2, %zmm1, %zmm4
-; AVX512-NEXT:    vpmovswb %zmm4, %ymm1
-; AVX512-NEXT:    vpmovswb %zmm3, %ymm2
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
 ; AVX512-NEXT:    kmovq %rdi, %k1
-; AVX512-NEXT:    vmovdqu8 %zmm1, %zmm0 {%k1}
+; AVX512-NEXT:    vpacksswb %zmm2, %zmm1, %zmm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <32 x i16> %a, <32 x i16> %b, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   %minv = tail call <64 x i16> @llvm.smax.v64i16(<64 x i16> %sh, <64 x i16> splat (i16 -128))
@@ -114,11 +101,8 @@ define <8 x i16> @_mm_mask_packss_epi32_manual(<8 x i16> %src, i8 noundef %k, <4
 ;
 ; AVX512-LABEL: _mm_mask_packss_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    # kill: def $xmm1 killed $xmm1 def $ymm1
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm1, %ymm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vpmovsdw %ymm1, %xmm0 {%k1}
-; AVX512-NEXT:    vzeroupper
+; AVX512-NEXT:    vpackssdw %xmm2, %xmm1, %xmm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <4 x i32> %a, <4 x i32> %b, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %minv = tail call <8 x i32> @llvm.smax.v8i32(<8 x i32> %sh, <8 x i32> splat (i32 -32768))
@@ -143,11 +127,8 @@ define <16 x i16> @_mm256_mask_packss_epi32_manual(<16 x i16> %src, i16 noundef 
 ;
 ; AVX512-LABEL: _mm256_mask_packss_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vperm2i128 {{.*#+}} ymm3 = ymm1[2,3],ymm2[2,3]
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm1, %ymm1
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm1, %zmm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vpmovsdw %zmm1, %ymm0 {%k1}
+; AVX512-NEXT:    vpackssdw %ymm2, %ymm1, %ymm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <8 x i32> %a, <8 x i32> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11, i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
   %minv = tail call <16 x i32> @llvm.smax.v16i32(<16 x i32> %sh, <16 x i32> splat (i32 -32768))
@@ -179,15 +160,8 @@ define <32 x i16> @_mm512_mask_packss_epi32_manual(<32 x i16> %src, i32 noundef 
 ;
 ; AVX512-LABEL: _mm512_mask_packss_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm3 = [4,5,12,13,6,7,14,15]
-; AVX512-NEXT:    vpermi2q %zmm2, %zmm1, %zmm3
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm4 = [0,1,8,9,2,3,10,11]
-; AVX512-NEXT:    vpermi2q %zmm2, %zmm1, %zmm4
-; AVX512-NEXT:    vpmovsdw %zmm4, %ymm1
-; AVX512-NEXT:    vpmovsdw %zmm3, %ymm2
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vmovdqu16 %zmm1, %zmm0 {%k1}
+; AVX512-NEXT:    vpackssdw %zmm2, %zmm1, %zmm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <16 x i32> %a, <16 x i32> %b, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 16, i32 17, i32 18, i32 19, i32 4, i32 5, i32 6, i32 7, i32 20, i32 21, i32 22, i32 23, i32 8, i32 9, i32 10, i32 11, i32 24, i32 25, i32 26, i32 27, i32 12, i32 13, i32 14, i32 15, i32 28, i32 29, i32 30, i32 31>
   %minv = tail call <32 x i32> @llvm.smax.v32i32(<32 x i32> %sh, <32 x i32> splat (i32 -32768))

--- a/llvm/test/CodeGen/X86/masked_packus.ll
+++ b/llvm/test/CodeGen/X86/masked_packus.ll
@@ -16,13 +16,8 @@ define <16 x i8> @_mm_mask_packus_epi16_manual(<16 x i8> %src, i16 noundef %k, <
 ;
 ; AVX512-LABEL: _mm_mask_packus_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    # kill: def $xmm1 killed $xmm1 def $ymm1
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm1, %ymm1
-; AVX512-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512-NEXT:    vpmaxsw %ymm2, %ymm1, %ymm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vpmovuswb %ymm1, %xmm0 {%k1}
-; AVX512-NEXT:    vzeroupper
+; AVX512-NEXT:    vpackuswb %xmm2, %xmm1, %xmm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <8 x i16> %a, <8 x i16> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %minv = tail call <16 x i16> @llvm.smax.v16i16(<16 x i16> %sh, <16 x i16> splat (i16 0))
@@ -48,13 +43,8 @@ define <32 x i8> @_mm256_mask_packus_epi16_manual(<32 x i8> %src, i32 noundef %k
 ;
 ; AVX512-LABEL: _mm256_mask_packus_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vperm2i128 {{.*#+}} ymm3 = ymm1[2,3],ymm2[2,3]
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm1, %ymm1
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm1, %zmm1
-; AVX512-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512-NEXT:    vpmaxsw %zmm2, %zmm1, %zmm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vpmovuswb %zmm1, %ymm0 {%k1}
+; AVX512-NEXT:    vpackuswb %ymm2, %ymm1, %ymm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <16 x i16> %a, <16 x i16> %b, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %minv = tail call <32 x i16> @llvm.smax.v32i16(<32 x i16> %sh, <32 x i16> splat (i16 0))
@@ -85,18 +75,8 @@ define <64 x i8> @_mm512_mask_packus_epi16_manual(<64 x i8> %src, i64 noundef %k
 ;
 ; AVX512-LABEL: _mm512_mask_packus_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm3 = [0,1,8,9,2,3,10,11]
-; AVX512-NEXT:    vpermi2q %zmm2, %zmm1, %zmm3
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm4 = [4,5,12,13,6,7,14,15]
-; AVX512-NEXT:    vpermi2q %zmm2, %zmm1, %zmm4
-; AVX512-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vpmaxsw %zmm1, %zmm4, %zmm2
-; AVX512-NEXT:    vpmaxsw %zmm1, %zmm3, %zmm1
-; AVX512-NEXT:    vpmovuswb %zmm1, %ymm1
-; AVX512-NEXT:    vpmovuswb %zmm2, %ymm2
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
 ; AVX512-NEXT:    kmovq %rdi, %k1
-; AVX512-NEXT:    vmovdqu8 %zmm1, %zmm0 {%k1}
+; AVX512-NEXT:    vpackuswb %zmm2, %zmm1, %zmm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <32 x i16> %a, <32 x i16> %b, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   %minv = tail call <64 x i16> @llvm.smax.v64i16(<64 x i16> %sh, <64 x i16> splat (i16 0))
@@ -121,13 +101,8 @@ define <8 x i16> @_mm_mask_packus_epi32_manual(<8 x i16> %src, i8 noundef %k, <4
 ;
 ; AVX512-LABEL: _mm_mask_packus_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    # kill: def $xmm1 killed $xmm1 def $ymm1
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm1, %ymm1
-; AVX512-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512-NEXT:    vpmaxsd %ymm2, %ymm1, %ymm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vpmovusdw %ymm1, %xmm0 {%k1}
-; AVX512-NEXT:    vzeroupper
+; AVX512-NEXT:    vpackusdw %xmm2, %xmm1, %xmm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <4 x i32> %a, <4 x i32> %b, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %minv = tail call <8 x i32> @llvm.smax.v8i32(<8 x i32> %sh, <8 x i32> splat (i32 0))
@@ -152,13 +127,8 @@ define <16 x i16> @_mm256_mask_packus_epi32_manual(<16 x i16> %src, i16 noundef 
 ;
 ; AVX512-LABEL: _mm256_mask_packus_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vperm2i128 {{.*#+}} ymm3 = ymm1[2,3],ymm2[2,3]
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm1, %ymm1
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm1, %zmm1
-; AVX512-NEXT:    vpxor %xmm2, %xmm2, %xmm2
-; AVX512-NEXT:    vpmaxsd %zmm2, %zmm1, %zmm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vpmovusdw %zmm1, %ymm0 {%k1}
+; AVX512-NEXT:    vpackusdw %ymm2, %ymm1, %ymm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <8 x i32> %a, <8 x i32> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11, i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
   %minv = tail call <16 x i32> @llvm.smax.v16i32(<16 x i32> %sh, <16 x i32> splat (i32 0))
@@ -190,18 +160,8 @@ define <32 x i16> @_mm512_mask_packus_epi32_manual(<32 x i16> %src, i32 noundef 
 ;
 ; AVX512-LABEL: _mm512_mask_packus_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm3 = [0,1,8,9,2,3,10,11]
-; AVX512-NEXT:    vpermi2q %zmm2, %zmm1, %zmm3
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm4 = [4,5,12,13,6,7,14,15]
-; AVX512-NEXT:    vpermi2q %zmm2, %zmm1, %zmm4
-; AVX512-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vpmaxsd %zmm1, %zmm4, %zmm2
-; AVX512-NEXT:    vpmaxsd %zmm1, %zmm3, %zmm1
-; AVX512-NEXT:    vpmovusdw %zmm1, %ymm1
-; AVX512-NEXT:    vpmovusdw %zmm2, %ymm2
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
 ; AVX512-NEXT:    kmovd %edi, %k1
-; AVX512-NEXT:    vmovdqu16 %zmm1, %zmm0 {%k1}
+; AVX512-NEXT:    vpackusdw %zmm2, %zmm1, %zmm0 {%k1}
 ; AVX512-NEXT:    retq
   %sh = shufflevector <16 x i32> %a, <16 x i32> %b, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 16, i32 17, i32 18, i32 19, i32 4, i32 5, i32 6, i32 7, i32 20, i32 21, i32 22, i32 23, i32 8, i32 9, i32 10, i32 11, i32 24, i32 25, i32 26, i32 27, i32 12, i32 13, i32 14, i32 15, i32 28, i32 29, i32 30, i32 31>
   %minv = tail call <32 x i32> @llvm.smax.v32i32(<32 x i32> %sh, <32 x i32> splat (i32 0))

--- a/llvm/test/CodeGen/X86/packss.ll
+++ b/llvm/test/CodeGen/X86/packss.ll
@@ -431,23 +431,10 @@ define <16 x i8> @_mm_packss_epi16_manual(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; SSE-NEXT:    packsswb %xmm1, %xmm0
 ; SSE-NEXT:    ret{{[l|q]}}
 ;
-; AVX1-LABEL: _mm_packss_epi16_manual:
-; AVX1:       # %bb.0:
-; AVX1-NEXT:    vpacksswb %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    ret{{[l|q]}}
-;
-; AVX2-LABEL: _mm_packss_epi16_manual:
-; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpacksswb %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    ret{{[l|q]}}
-;
-; AVX512-LABEL: _mm_packss_epi16_manual:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
-; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpmovswb %ymm0, %xmm0
-; AVX512-NEXT:    vzeroupper
-; AVX512-NEXT:    ret{{[l|q]}}
+; AVX-LABEL: _mm_packss_epi16_manual:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vpacksswb %xmm1, %xmm0, %xmm0
+; AVX-NEXT:    ret{{[l|q]}}
   %sh   = shufflevector <8 x i16> %a, <8 x i16> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %minv = tail call <16 x i16> @llvm.smax.v16i16(<16 x i16> %sh, <16 x i16> splat (i16 -128))
   %sat  = tail call <16 x i16> @llvm.smin.v16i16(<16 x i16> %minv, <16 x i16> splat (i16 127))
@@ -484,10 +471,7 @@ define <32 x i8> @_mm256_packss_epi16_manual(<16 x i16> %a, <16 x i16> %b) nounw
 ;
 ; AVX512-LABEL: _mm256_packss_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vperm2i128 {{.*#+}} ymm2 = ymm0[2,3],ymm1[2,3]
-; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512-NEXT:    vpmovswb %zmm0, %ymm0
+; AVX512-NEXT:    vpacksswb %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    ret{{[l|q]}}
 ;
 ; X64-SSE-LABEL: _mm256_packss_epi16_manual:
@@ -551,13 +535,7 @@ define <64 x i8> @_mm512_packss_epi16_manual(<32 x i16> %a, <32 x i16> %b) nounw
 ;
 ; AVX512-LABEL: _mm512_packss_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm2 = [4,5,12,13,6,7,14,15]
-; AVX512-NEXT:    vpermi2q %zmm1, %zmm0, %zmm2
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm3 = [0,1,8,9,2,3,10,11]
-; AVX512-NEXT:    vpermi2q %zmm1, %zmm0, %zmm3
-; AVX512-NEXT:    vpmovswb %zmm3, %ymm0
-; AVX512-NEXT:    vpmovswb %zmm2, %ymm1
-; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512-NEXT:    vpacksswb %zmm1, %zmm0, %zmm0
 ; AVX512-NEXT:    ret{{[l|q]}}
 ;
 ; X64-SSE-LABEL: _mm512_packss_epi16_manual:
@@ -600,23 +578,10 @@ define <8 x i16> @_mm_packss_epi32_manual(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; SSE-NEXT:    packssdw %xmm1, %xmm0
 ; SSE-NEXT:    ret{{[l|q]}}
 ;
-; AVX1-LABEL: _mm_packss_epi32_manual:
-; AVX1:       # %bb.0:
-; AVX1-NEXT:    vpackssdw %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    ret{{[l|q]}}
-;
-; AVX2-LABEL: _mm_packss_epi32_manual:
-; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpackssdw %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    ret{{[l|q]}}
-;
-; AVX512-LABEL: _mm_packss_epi32_manual:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
-; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpmovsdw %ymm0, %xmm0
-; AVX512-NEXT:    vzeroupper
-; AVX512-NEXT:    ret{{[l|q]}}
+; AVX-LABEL: _mm_packss_epi32_manual:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vpackssdw %xmm1, %xmm0, %xmm0
+; AVX-NEXT:    ret{{[l|q]}}
   %sh   = shufflevector <4 x i32> %a, <4 x i32> %b, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %minv = tail call <8 x i32> @llvm.smax.v8i32(<8 x i32> %sh, <8 x i32> splat (i32 -32768))
   %sat  = tail call <8 x i32> @llvm.smin.v8i32(<8 x i32> %minv, <8 x i32> splat (i32 32767))
@@ -653,10 +618,7 @@ define <16 x i16> @_mm256_packss_epi32_manual(<8 x i32> %a, <8 x i32> %b) nounwi
 ;
 ; AVX512-LABEL: _mm256_packss_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vperm2i128 {{.*#+}} ymm2 = ymm0[2,3],ymm1[2,3]
-; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512-NEXT:    vpmovsdw %zmm0, %ymm0
+; AVX512-NEXT:    vpackssdw %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    ret{{[l|q]}}
 ;
 ; X64-SSE-LABEL: _mm256_packss_epi32_manual:
@@ -720,13 +682,7 @@ define <32 x i16> @_mm512_packss_epi32_manual(<16 x i32> %a, <16 x i32> %b) noun
 ;
 ; AVX512-LABEL: _mm512_packss_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm2 = [4,5,12,13,6,7,14,15]
-; AVX512-NEXT:    vpermi2q %zmm1, %zmm0, %zmm2
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm3 = [0,1,8,9,2,3,10,11]
-; AVX512-NEXT:    vpermi2q %zmm1, %zmm0, %zmm3
-; AVX512-NEXT:    vpmovsdw %zmm3, %ymm0
-; AVX512-NEXT:    vpmovsdw %zmm2, %ymm1
-; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512-NEXT:    vpackssdw %zmm1, %zmm0, %zmm0
 ; AVX512-NEXT:    ret{{[l|q]}}
 ;
 ; X64-SSE-LABEL: _mm512_packss_epi32_manual:

--- a/llvm/test/CodeGen/X86/packus.ll
+++ b/llvm/test/CodeGen/X86/packus.ll
@@ -511,31 +511,16 @@ define <32 x i8> @packuswb_icmp_zero_trunc_256(<16 x i16> %a0) {
   ret <32 x i8> %4
 }
 
-define <16 x i8> @_mm_packus_epi16_manual(<8 x i16> %a, <8 x i16> %b) nounwind {
+define <16 x i8> @_mm_packus_epi16_manual(<8 x i16> %a, <8 x i16> %b) {
 ; SSE-LABEL: _mm_packus_epi16_manual:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    packuswb %xmm1, %xmm0
 ; SSE-NEXT:    ret{{[l|q]}}
 ;
-; AVX1-LABEL: _mm_packus_epi16_manual:
-; AVX1:       # %bb.0:
-; AVX1-NEXT:    vpackuswb %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    ret{{[l|q]}}
-;
-; AVX2-LABEL: _mm_packus_epi16_manual:
-; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpackuswb %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    ret{{[l|q]}}
-;
-; AVX512-LABEL: _mm_packus_epi16_manual:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
-; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vpmaxsw %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpmovuswb %ymm0, %xmm0
-; AVX512-NEXT:    vzeroupper
-; AVX512-NEXT:    ret{{[l|q]}}
+; AVX-LABEL: _mm_packus_epi16_manual:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vpackuswb %xmm1, %xmm0, %xmm0
+; AVX-NEXT:    ret{{[l|q]}}
   %sh  = shufflevector <8 x i16> %a, <8 x i16> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %minv = tail call <16 x i16> @llvm.smax.v16i16(<16 x i16> %sh, <16 x i16> splat (i16 0))
   %sat = tail call <16 x i16> @llvm.smin.v16i16(<16 x i16> %minv, <16 x i16> splat (i16 255))
@@ -578,12 +563,7 @@ define <32 x i8> @_mm256_packus_epi16_manual(<16 x i16> %a, <16 x i16> %b) nounw
 ;
 ; AVX512-LABEL: _mm256_packus_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vperm2i128 {{.*#+}} ymm2 = ymm0[2,3],ymm1[2,3]
-; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vpmaxsw %zmm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpmovuswb %zmm0, %ymm0
+; AVX512-NEXT:    vpackuswb %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    ret{{[l|q]}}
   %sh  = shufflevector <16 x i16> %a, <16 x i16> %b, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %minv = tail call <32 x i16> @llvm.smax.v32i16(<32 x i16> %sh, <32 x i16> splat (i16 0))
@@ -669,16 +649,7 @@ define <64 x i8> @_mm512_packus_epi16_manual(<32 x i16> %a, <32 x i16> %b) nounw
 ;
 ; AVX512-LABEL: _mm512_packus_epi16_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm2 = [0,1,8,9,2,3,10,11]
-; AVX512-NEXT:    vpermi2q %zmm1, %zmm0, %zmm2
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm3 = [4,5,12,13,6,7,14,15]
-; AVX512-NEXT:    vpermi2q %zmm1, %zmm0, %zmm3
-; AVX512-NEXT:    vpxor %xmm0, %xmm0, %xmm0
-; AVX512-NEXT:    vpmaxsw %zmm0, %zmm3, %zmm1
-; AVX512-NEXT:    vpmaxsw %zmm0, %zmm2, %zmm0
-; AVX512-NEXT:    vpmovuswb %zmm0, %ymm0
-; AVX512-NEXT:    vpmovuswb %zmm1, %ymm1
-; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512-NEXT:    vpackuswb %zmm1, %zmm0, %zmm0
 ; AVX512-NEXT:    ret{{[l|q]}}
   %sh  = shufflevector <32 x i16> %a, <32 x i16> %b, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
   %minv = tail call <64 x i16> @llvm.smax.v64i16(<64 x i16> %sh, <64 x i16> splat (i16 0))
@@ -747,25 +718,10 @@ define <8 x i16> @_mm_packus_epi32_manual(<4 x i32> %a, <4 x i32> %b) nounwind {
 ; SSE4-NEXT:    packusdw %xmm1, %xmm0
 ; SSE4-NEXT:    ret{{[l|q]}}
 ;
-; AVX1-LABEL: _mm_packus_epi32_manual:
-; AVX1:       # %bb.0:
-; AVX1-NEXT:    vpackusdw %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    ret{{[l|q]}}
-;
-; AVX2-LABEL: _mm_packus_epi32_manual:
-; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpackusdw %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    ret{{[l|q]}}
-;
-; AVX512-LABEL: _mm_packus_epi32_manual:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
-; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vpmaxsd %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpmovusdw %ymm0, %xmm0
-; AVX512-NEXT:    vzeroupper
-; AVX512-NEXT:    ret{{[l|q]}}
+; AVX-LABEL: _mm_packus_epi32_manual:
+; AVX:       # %bb.0:
+; AVX-NEXT:    vpackusdw %xmm1, %xmm0, %xmm0
+; AVX-NEXT:    ret{{[l|q]}}
   %sh  = shufflevector <4 x i32> %a, <4 x i32> %b, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %minv = tail call <8 x i32> @llvm.smax.v32i32(<8 x i32> %sh, <8 x i32> splat (i32 0))
   %sat = tail call <8 x i32> @llvm.smin.v32i32(<8 x i32> %minv, <8 x i32> splat (i32 65535))
@@ -911,12 +867,7 @@ define <16 x i16> @_mm256_packus_epi32_manual(<8 x i32> %a, <8 x i32> %b) nounwi
 ;
 ; AVX512-LABEL: _mm256_packus_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vperm2i128 {{.*#+}} ymm2 = ymm0[2,3],ymm1[2,3]
-; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512-NEXT:    vpxor %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vpmaxsd %zmm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpmovusdw %zmm0, %ymm0
+; AVX512-NEXT:    vpackusdw %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    ret{{[l|q]}}
   %sh  = shufflevector <8 x i32> %a, <8 x i32> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 8, i32 9, i32 10, i32 11, i32 4, i32 5, i32 6, i32 7, i32 12, i32 13, i32 14, i32 15>
   %minv = tail call <16 x i32> @llvm.smax.v32i32(<16 x i32> %sh, <16 x i32> splat (i32 0))
@@ -1209,16 +1160,7 @@ define <32 x i16> @_mm512_packus_epi32_manual(<16 x i32> %a, <16 x i32> %b) noun
 ;
 ; AVX512-LABEL: _mm512_packus_epi32_manual:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm2 = [0,1,8,9,2,3,10,11]
-; AVX512-NEXT:    vpermi2q %zmm1, %zmm0, %zmm2
-; AVX512-NEXT:    vpmovsxbq {{.*#+}} zmm3 = [4,5,12,13,6,7,14,15]
-; AVX512-NEXT:    vpermi2q %zmm1, %zmm0, %zmm3
-; AVX512-NEXT:    vpxor %xmm0, %xmm0, %xmm0
-; AVX512-NEXT:    vpmaxsd %zmm0, %zmm3, %zmm1
-; AVX512-NEXT:    vpmaxsd %zmm0, %zmm2, %zmm0
-; AVX512-NEXT:    vpmovusdw %zmm0, %ymm0
-; AVX512-NEXT:    vpmovusdw %zmm1, %ymm1
-; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512-NEXT:    vpackusdw %zmm1, %zmm0, %zmm0
 ; AVX512-NEXT:    ret{{[l|q]}}
   %sh  = shufflevector <16 x i32> %a, <16 x i32> %b, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 16, i32 17, i32 18, i32 19, i32 4, i32 5, i32 6, i32 7, i32 20, i32 21, i32 22, i32 23, i32 8, i32 9, i32 10, i32 11, i32 24, i32 25, i32 26, i32 27, i32 12, i32 13, i32 14, i32 15, i32 28, i32 29, i32 30, i32 31>
   %minv = tail call <32 x i32> @llvm.smax.v32i32(<32 x i32> %sh, <32 x i32> splat (i32 0))


### PR DESCRIPTION
optimize (masked) saturating packs

manual `packss` and `packus` operations like `_mm512_packss_epi32` and its masked variant don't optimize well.

https://godbolt.org/z/Gendfd1jj

```asm
src:
        vpmovsxbq       zmm2, qword ptr [rip + .LCPI0_2] # zmm2 = [4,5,12,13,6,7,14,15]
        vpermi2q        zmm2, zmm0, zmm1
        vpmovsxbq       zmm3, qword ptr [rip + .LCPI0_3] # zmm3 = [0,1,8,9,2,3,10,11]
        vpermi2q        zmm3, zmm0, zmm1
        vpmovsdw        ymm0, zmm3
        vpmovsdw        ymm1, zmm2
        vinserti64x4    zmm0, zmm0, ymm1, 1
        ret

tgt:
        vpackssdw zmm1, zmm0, zmm0
        ret
```

This requires some additional logic to recognize the shuffle mask. There are some existing functions for various masks, but not the sort of lane interleaving one that is needed here. Maybe there is some better way though?

---

When the right simd width is not available, packss optimizes much better than packus. I don't see how that is due to my code though, I suspect that is some other problem. The signed case removes the truncation fully when the packs is inserted, while the unsigned version leaves the `umin` intact.

```
Type-legalized selection DAG: %bb.0 '_mm512_packss_epi32_manual:'
SelectionDAG has 24 nodes:
  t0: ch,glue = EntryToken
  t2: v8i32,ch = CopyFromReg t0, Register:v8i32 %0
  t4: v8i32,ch = CopyFromReg t0, Register:v8i32 %1
  t6: v8i32,ch = CopyFromReg t0, Register:v8i32 %2
  t8: v8i32,ch = CopyFromReg t0, Register:v8i32 %3
        t67: v8i32 = vector_shuffle<0,1,2,3,8,9,10,11> t2, t6
        t68: v8i32 = vector_shuffle<4,5,6,7,12,13,14,15> t2, t6
      t37: v16i16 = X86ISD::PACKSS t67, t68
    t39: v16i16 = vector_shuffle<0,1,2,3,8,9,10,11,4,5,6,7,12,13,14,15> t37, undef:v16i16
  t28: ch,glue = CopyToReg t0, Register:v16i16 $ymm0, t39
        t69: v8i32 = vector_shuffle<0,1,2,3,8,9,10,11> t4, t8
        t70: v8i32 = vector_shuffle<4,5,6,7,12,13,14,15> t4, t8
      t42: v16i16 = X86ISD::PACKSS t69, t70
    t43: v16i16 = vector_shuffle<0,1,2,3,8,9,10,11,4,5,6,7,12,13,14,15> t42, undef:v16i16
  t30: ch,glue = CopyToReg t28, Register:v16i16 $ymm1, t43, t28:1
  t31: ch = X86ISD::RET_GLUE t30, TargetConstant:i32<0>, Register:v16i16 $ymm0, Register:v16i16 $ymm1, t30:1
```

```
Type-legalized selection DAG: %bb.0 '_mm512_packus_epi32_manual:'
SelectionDAG has 30 nodes:
  t0: ch,glue = EntryToken
  t2: v8i32,ch = CopyFromReg t0, Register:v8i32 %0
  t4: v8i32,ch = CopyFromReg t0, Register:v8i32 %1
  t6: v8i32,ch = CopyFromReg t0, Register:v8i32 %2
  t8: v8i32,ch = CopyFromReg t0, Register:v8i32 %3
          t43: v8i32 = vector_shuffle<0,1,2,3,8,9,10,11> t2, t6
        t45: v8i32 = umin t43, t33
          t44: v8i32 = vector_shuffle<4,5,6,7,12,13,14,15> t2, t6
        t46: v8i32 = umin t44, t33
      t50: v16i16 = X86ISD::PACKUS t45, t46
    t52: v16i16 = vector_shuffle<0,1,2,3,8,9,10,11,4,5,6,7,12,13,14,15> t50, undef:v16i16
  t25: ch,glue = CopyToReg t0, Register:v16i16 $ymm0, t52
          t53: v8i32 = vector_shuffle<0,1,2,3,8,9,10,11> t4, t8
        t55: v8i32 = umin t53, t33
          t54: v8i32 = vector_shuffle<4,5,6,7,12,13,14,15> t4, t8
        t56: v8i32 = umin t54, t33
      t59: v16i16 = X86ISD::PACKUS t55, t56
    t60: v16i16 = vector_shuffle<0,1,2,3,8,9,10,11,4,5,6,7,12,13,14,15> t59, undef:v16i16
  t27: ch,glue = CopyToReg t25, Register:v16i16 $ymm1, t60, t25:1
  t33: v8i32 = BUILD_VECTOR Constant:i32<65535>, Constant:i32<65535>, Constant:i32<65535>, Constant:i32<65535>, Constant:i32<65535>, Constant:i32<65535>, Constant:i32<65535>, Constant:i32<65535>
  t28: ch = X86ISD::RET_GLUE t27, TargetConstant:i32<0>, Register:v16i16 $ymm0, Register:v16i16 $ymm1, t27:1
```

Not that important really, but maybe it is indicative of some underlying problem?
