### PR TITLE
[LifetimeSafety] Add implicit tracking for STL functions

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -14,6 +14,13 @@
 
 namespace clang ::lifetimes {
 
+// This function is needed because Decl::isInStdNamespace will return false for
+// iterators in some STL implementations due to them being defined in a
+// namespace outside of the std namespace.
+bool isInStlNamespace(const Decl *D);
+
+bool isPointerLikeType(QualType QT);
+
 /// Returns the most recent declaration of the method to ensure all
 /// lifetime-bound attributes from redeclarations are considered.
 const FunctionDecl *getDeclWithMergedLifetimeBoundAttrs(const FunctionDecl *FD);
@@ -37,6 +44,20 @@ bool isAssignmentOperatorLifetimeBound(const CXXMethodDecl *CMD);
 /// lifetimebound, either due to an explicit lifetimebound attribute on the
 /// method or because it's a normal assignment operator.
 bool implicitObjectParamIsLifetimeBound(const FunctionDecl *FD);
+
+// Returns true if the implicit object argument (this) of a method call should
+// be tracked for GSL lifetime analysis. This applies to STL methods that return
+// pointers or references that depend on the lifetime of the object, such as
+// container iterators (begin, end), data accessors (c_str, data, get), or
+// element accessors (operator[], operator*, front, back, at).
+bool shouldTrackImplicitObjectArg(const CXXMethodDecl *Callee);
+
+// Returns true if the first argument of a free function should be tracked for
+// GSL lifetime analysis. This applies to STL free functions that take a pointer
+// to a GSL Owner or Pointer and return a pointer or reference that depends on
+// the lifetime of the argument, such as std::begin, std::data, std::get, or
+// std::any_cast.
+bool shouldTrackFirstArgument(const FunctionDecl *FD);
 
 // Tells whether the type is annotated with [[gsl::Pointer]].
 bool isGslPointerType(QualType QT);

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -410,11 +410,14 @@ void FactsGenerator::handleFunctionCall(const Expr *Call,
         Method && Method->isInstance()) {
       if (I == 0)
         // For the 'this' argument, the attribute is on the method itself.
-        return implicitObjectParamIsLifetimeBound(Method);
+        return implicitObjectParamIsLifetimeBound(Method) ||
+               shouldTrackImplicitObjectArg(Method);
       if ((I - 1) < Method->getNumParams())
         // For explicit arguments, find the corresponding parameter
         // declaration.
         PVD = Method->getParamDecl(I - 1);
+    } else if (I == 0 && shouldTrackFirstArgument(FD)) {
+      return true;
     } else if (I < FD->getNumParams()) {
       // For free functions or static methods.
       PVD = FD->getParamDecl(I);

--- a/clang/lib/Analysis/LifetimeSafety/Origins.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Origins.cpp
@@ -12,6 +12,7 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/TypeBase.h"
 #include "clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h"
@@ -124,6 +125,9 @@ OriginList *OriginManager::getOrCreateList(const ValueDecl *D) {
 OriginList *OriginManager::getOrCreateList(const Expr *E) {
   if (auto *ParenIgnored = E->IgnoreParens(); ParenIgnored != E)
     return getOrCreateList(ParenIgnored);
+  // We do not see CFG stmts for ExprWithCleanups. Simply peel them.
+  if (auto *EC = dyn_cast<ExprWithCleanups>(E))
+    return getOrCreateList(EC->getSubExpr());
 
   if (!hasOrigins(E))
     return nullptr;


### PR DESCRIPTION
Add support for tracking STL container methods and free functions in the lifetime safety analysis.

- Added `VisitExprWithCleanups` to the `FactsGenerator` to properly handle expressions with cleanup code
- Moved `shouldTrackImplicitObjectArg` and `shouldTrackFirstArgument` from `CheckExprLifetime.cpp` to `LifetimeAnnotations.h/cpp` to make them available to the lifetime safety analysis
- Enhanced the lifetime analysis to track STL container methods that return pointers or references dependent on the container's lifetime (e.g., `begin()`, `data()`, `c_str()`)
- Added support for tracking free functions like `std::begin`, `std::data`, and `std::any_cast` that return pointers or references dependent on their arguments

Fixes https://github.com/llvm/llvm-project/issues/162622