### PR TITLE
[LifetimeSafety] Add origin tracking for pointer dereference

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -232,13 +232,23 @@ void FactsGenerator::VisitImplicitCastExpr(const ImplicitCastExpr *ICE) {
 }
 
 void FactsGenerator::VisitUnaryOperator(const UnaryOperator *UO) {
-  if (UO->getOpcode() == UO_AddrOf) {
+  switch (UO->getOpcode()) {
+  case UO_AddrOf: {
     const Expr *SubExpr = UO->getSubExpr();
     // The origin of an address-of expression (e.g., &x) is the origin of
     // its sub-expression (x). This fact will cause the dataflow analysis
     // to propagate any loans held by the sub-expression's origin to the
     // origin of this UnaryOperator expression.
     killAndFlowOrigin(*UO, *SubExpr);
+    return;
+  }
+  case UO_Deref: {
+    const Expr *SubExpr = UO->getSubExpr();
+    killAndFlowOrigin(*UO, *SubExpr);
+    return;
+  }
+  default:
+    return;
   }
 }
 

--- a/clang/test/Sema/warn-lifetime-safety-dataflow.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-dataflow.cpp
@@ -152,6 +152,12 @@ void pointer_indirection() {
 // CHECK-NEXT:       Dest: {{[0-9]+}} (Expr: ImplicitCastExpr, Type : int *)
 // CHECK-NEXT:       Src:  [[O_PP_INNER]] (Decl: pp, Type : int *)
 // CHECK:   OriginFlow:
+// CHECK-NEXT:       Dest: {{[0-9]+}} (Expr: UnaryOperator, Type : int *&)
+// CHECK-NEXT:       Src:  {{[0-9]+}} (Expr: ImplicitCastExpr, Type : int **)
+// CHECK:   OriginFlow:
+// CHECK-NEXT:       Dest: {{[0-9]+}} (Expr: UnaryOperator, Type : int *)
+// CHECK-NEXT:       Src:  {{[0-9]+}} (Expr: ImplicitCastExpr, Type : int *)
+// CHECK:   OriginFlow:
 // CHECK-NEXT:       Dest: {{[0-9]+}} (Expr: ImplicitCastExpr, Type : int *)
 // CHECK-NEXT:       Src:  {{[0-9]+}} (Expr: UnaryOperator, Type : int *)
 // CHECK:   OriginFlow:

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -94,9 +94,12 @@ MyObj* return_ptr_to_ref(MyObj& a) { // expected-warning {{parameter in intra-TU
   return &a; // expected-note {{param returned here}}
 }
 
-// FIXME: Dereference does not propagate loans.
-MyObj& return_ref_to_ptr(MyObj* a) {
-  return *a;
+MyObj& return_ref_to_ptr(MyObj* a) {  // expected-warning {{parameter in intra-TU function should be marked [[clang::lifetimebound]]}}
+  return *a;  // expected-note {{param returned here}}
+}
+
+View return_ref_to_ptr_multiple(MyObj* a) {  // expected-warning {{parameter in intra-TU function should be marked [[clang::lifetimebound]]}}
+  return *(&(*(&(*a))));  // expected-note {{param returned here}}
 }
 
 View return_view_from_reference(MyObj& p) {  // expected-warning {{parameter in intra-TU function should be marked [[clang::lifetimebound]]}}


### PR DESCRIPTION
Fix lifetime safety analysis for pointer dereference operations by properly tracking origin flow.

Added support in `FactsGenerator::VisitUnaryOperator()` to handle the dereference operator (`UO_Deref`). This change ensures that when a pointer is dereferenced, the origin of the pointer is properly propagated to the dereference expression.