### PR TITLE
[LifetimeSafety] Track moved declarations to prevent false positives

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
@@ -106,6 +106,15 @@ private:
   // corresponding to the left-hand side is updated to be a "write", thereby
   // exempting it from the check.
   llvm::DenseMap<const DeclRefExpr *, UseFact *> UseFacts;
+
+  // This is a flow-insensitive approximation: once a declaration is moved
+  // anywhere in the function, it's treated as moved everywhere. This can lead
+  // to false negatives on control flow paths where the value is not actually
+  // moved, but these are considered lower priority than the false positives
+  // this tracking prevents.
+  // TODO: The ideal solution would be flow-sensitive ownership tracking that
+  // records where values are moved from and to, but this is more complex.
+  llvm::DenseSet<const ValueDecl *> MovedDecls;
 };
 
 } // namespace clang::lifetimes::internal

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -30,6 +30,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, LoanID ID) {
 /// variable.
 /// TODO: Model access paths of other types, e.g., s.field, heap and globals.
 struct AccessPath {
+private:
   // An access path can be:
   // - ValueDecl * , to represent the storage location corresponding to the
   //   variable declared in ValueDecl.
@@ -39,6 +40,7 @@ struct AccessPath {
                            const clang::MaterializeTemporaryExpr *>
       P;
 
+public:
   AccessPath(const clang::ValueDecl *D) : P(D) {}
   AccessPath(const clang::MaterializeTemporaryExpr *MTE) : P(MTE) {}
 


### PR DESCRIPTION
Prevent false positives in lifetime safety analysis when variables are moved using `std::move`.

When a value is moved using `std::move`, ownership is transferred from the original variable to another. The lifetime safety analysis was previously generating false positives by warning about use-after-lifetime when the original variable was destroyed after being moved. This change prevents those false positives by tracking moved declarations and exempting them from loan expiration checks.

- Added tracking for declarations that have been moved via `std::move` in the `FactsGenerator` class
- Added a `MovedDecls` set to track moved declarations in a flow-insensitive manner
- Implemented detection of `std::move` calls in `VisitCallExpr`
- Modified `handleLifetimeEnds` to skip loans for declarations that have been moved
- Added a test case demonstrating that warnings are suppressed for moved variables

```cpp
void silenced() {
  MyObj b;
  View v;
  {
    MyObj a;
    v = a;
    b = std::move(a); // No warning for 'a' being moved.
  }
  (void)v;
}
```

Fixes https://github.com/llvm/llvm-project/issues/167290
Fixes https://github.com/llvm/llvm-project/issues/175273