### PR TITLE
[llvm-exegesis] Add CLI Option to set Fixed RNG seed

### DIFF
--- a/llvm/test/tools/llvm-exegesis/X86/snippet-generator-seed.test
+++ b/llvm/test/tools/llvm-exegesis/X86/snippet-generator-seed.test
@@ -1,0 +1,16 @@
+# REQUIRES: exegesis-can-measure-latency, x86_64-linux
+
+# Check that the snippet we generate is exactly the same between runs when we
+# use a fixed RNG seed.
+
+# RUN: llvm-exegesis -mtriple=x86_64-unknown-unknown -mode=latency -opcode-name=ADD64rr --benchmark-phase=prepare-snippet -random-generator-seed=5 | FileCheck %s
+
+# CHECK: ---
+# CHECK: mode:            latency
+# CHECK: key:
+# CHECK:   instructions:
+# CHECK:     - 'ADD64rr RCX RCX RAX'
+# CHECK:   config:          ''
+# CHECK:   register_initial_values:
+# CHECK:     - 'RCX=0x0'
+# CHECK:     - 'RAX=0x0'

--- a/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
@@ -21,8 +21,16 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Program.h"
 
+#define DEBUG_TYPE "snippet-generator"
+
 namespace llvm {
 namespace exegesis {
+
+static cl::opt<unsigned>
+    RandomGeneratorSeed("random-generator-seed",
+                        cl::desc("The seed value to use for the random number "
+                                 "generator when generating snippets."),
+                        cl::init(0));
 
 std::vector<CodeTemplate> getSingleton(CodeTemplate &&CT) {
   std::vector<CodeTemplate> Result;
@@ -187,8 +195,13 @@ generateUnconstrainedCodeTemplates(const InstructionTemplate &Variant,
 }
 
 std::mt19937 &randomGenerator() {
+  unsigned RandomSeed = RandomGeneratorSeed;
   static std::random_device RandomDevice;
-  static std::mt19937 RandomGenerator(RandomDevice());
+  if (RandomSeed == 0) {
+    RandomSeed = RandomDevice();
+  }
+  LLVM_DEBUG(dbgs() << "Using random seed " << RandomSeed << ".\n");
+  static std::mt19937 RandomGenerator(RandomSeed);
   return RandomGenerator;
 }
 

--- a/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
@@ -195,11 +195,10 @@ generateUnconstrainedCodeTemplates(const InstructionTemplate &Variant,
 }
 
 std::mt19937 &randomGenerator() {
-  unsigned RandomSeed = RandomGeneratorSeed;
   static std::random_device RandomDevice;
-  if (RandomSeed == 0) {
-    RandomSeed = RandomDevice();
-  }
+  unsigned RandomSeed = RandomGeneratorSeed.getNumOccurrences()
+                            ? RandomGeneratorSeed
+                            : RandomDevice();
   LLVM_DEBUG(dbgs() << "Using random seed " << RandomSeed << ".\n");
   static std::mt19937 RandomGenerator(RandomSeed);
   return RandomGenerator;


### PR DESCRIPTION
The primary motivation for this is to set a fixed RNG seed for flaky
tests. This also has the bonus of adding debug logging for what seed
gets used which can make it much easier to reproduce issues that only
happen occasionally and are seed-dependent.
