### PR TITLE
[AArch64] Optimize more floating-point round+convert combinations into fcvt instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -6852,14 +6852,16 @@ multiclass FPToIntegerPats<SDNode to_int, SDNode to_int_sat, SDNode to_int_sat_g
             (!cast<Instruction>(INST # v1i64) f64:$Rn)>;
 }
 
-defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fceil,  "FCVTPS">;
-defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fceil,  "FCVTPU">;
-defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ffloor, "FCVTMS">;
-defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ffloor, "FCVTMU">;
-defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ftrunc, "FCVTZS">;
-defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ftrunc, "FCVTZU">;
-defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fround, "FCVTAS">;
-defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fround, "FCVTAU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fceil,      "FCVTPS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fceil,      "FCVTPU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ffloor,     "FCVTMS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ffloor,     "FCVTMU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ftrunc,     "FCVTZS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ftrunc,     "FCVTZU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fround,     "FCVTAS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fround,     "FCVTAU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, froundeven, "FCVTNS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, froundeven, "FCVTNU">;
 
 // For global-isel we can use register classes to determine
 // which FCVT instruction to use.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -6804,6 +6804,21 @@ multiclass FPToIntegerPats<SDNode to_int, SDNode to_int_sat, SDNode to_int_sat_g
   def : Pat<(i64 (to_int_sat (round f64:$Rn), i64)),
             (!cast<Instruction>(INST # UXDr) f64:$Rn)>;
 
+  let Predicates = [HasFullFP16] in {
+  def : Pat<(i32 (to_int_sat_gi (round f16:$Rn))),
+            (!cast<Instruction>(INST # UWHr) f16:$Rn)>;
+  def : Pat<(i64 (to_int_sat_gi (round f16:$Rn))),
+            (!cast<Instruction>(INST # UXHr) f16:$Rn)>;
+  }
+  def : Pat<(i32 (to_int_sat_gi (round f32:$Rn))),
+            (!cast<Instruction>(INST # UWSr) f32:$Rn)>;
+  def : Pat<(i64 (to_int_sat_gi (round f32:$Rn))),
+            (!cast<Instruction>(INST # UXSr) f32:$Rn)>;
+  def : Pat<(i32 (to_int_sat_gi (round f64:$Rn))),
+            (!cast<Instruction>(INST # UWDr) f64:$Rn)>;
+  def : Pat<(i64 (to_int_sat_gi (round f64:$Rn))),
+            (!cast<Instruction>(INST # UXDr) f64:$Rn)>;
+
   // For global-isel we can use register classes to determine
   // which FCVT instruction to use.
   let Predicates = [HasFPRCVT] in {

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -5837,6 +5837,57 @@ multiclass SIMDTwoVectorFPToIntSatPats<SDNode to_int_sat, SDNode to_int_sat_gi, 
 defm : SIMDTwoVectorFPToIntSatPats<fp_to_sint_sat, fp_to_sint_sat_gi, "FCVTZS">;
 defm : SIMDTwoVectorFPToIntSatPats<fp_to_uint_sat, fp_to_uint_sat_gi, "FCVTZU">;
 
+// Fused round + convert to int patterns for vectors
+multiclass SIMDTwoVectorFPToIntRoundPats<SDNode to_int, SDNode to_int_sat, SDNode to_int_sat_gi, SDNode round, string INST> {
+  let Predicates = [HasFullFP16] in {
+    def : Pat<(v4i16 (to_int (round v4f16:$Rn))),
+              (!cast<Instruction>(INST # v4f16) v4f16:$Rn)>;
+    def : Pat<(v8i16 (to_int (round v8f16:$Rn))),
+              (!cast<Instruction>(INST # v8f16) v8f16:$Rn)>;
+
+    def : Pat<(v4i16 (to_int_sat (round v4f16:$Rn), i16)),
+              (!cast<Instruction>(INST # v4f16) v4f16:$Rn)>;
+    def : Pat<(v8i16 (to_int_sat (round v8f16:$Rn), i16)),
+              (!cast<Instruction>(INST # v8f16) v8f16:$Rn)>;
+
+    def : Pat<(v4i16 (to_int_sat_gi (round v4f16:$Rn))),
+              (!cast<Instruction>(INST # v4f16) v4f16:$Rn)>;
+    def : Pat<(v8i16 (to_int_sat_gi (round v8f16:$Rn))),
+              (!cast<Instruction>(INST # v8f16) v8f16:$Rn)>;
+  }
+  def : Pat<(v2i32 (to_int (round v2f32:$Rn))),
+            (!cast<Instruction>(INST # v2f32) v2f32:$Rn)>;
+  def : Pat<(v4i32 (to_int (round v4f32:$Rn))),
+            (!cast<Instruction>(INST # v4f32) v4f32:$Rn)>;
+  def : Pat<(v2i64 (to_int (round v2f64:$Rn))),
+            (!cast<Instruction>(INST # v2f64) v2f64:$Rn)>;
+
+  def : Pat<(v2i32 (to_int_sat (round v2f32:$Rn), i32)),
+            (!cast<Instruction>(INST # v2f32) v2f32:$Rn)>;
+  def : Pat<(v4i32 (to_int_sat (round v4f32:$Rn), i32)),
+            (!cast<Instruction>(INST # v4f32) v4f32:$Rn)>;
+  def : Pat<(v2i64 (to_int_sat (round v2f64:$Rn), i64)),
+            (!cast<Instruction>(INST # v2f64) v2f64:$Rn)>;
+
+  def : Pat<(v2i32 (to_int_sat_gi (round v2f32:$Rn))),
+            (!cast<Instruction>(INST # v2f32) v2f32:$Rn)>;
+  def : Pat<(v4i32 (to_int_sat_gi (round v4f32:$Rn))),
+            (!cast<Instruction>(INST # v4f32) v4f32:$Rn)>;
+  def : Pat<(v2i64 (to_int_sat_gi (round v2f64:$Rn))),
+            (!cast<Instruction>(INST # v2f64) v2f64:$Rn)>;
+}
+
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fceil,      "FCVTPS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fceil,      "FCVTPU">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ffloor,     "FCVTMS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ffloor,     "FCVTMU">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ftrunc,     "FCVTZS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ftrunc,     "FCVTZU">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fround,     "FCVTAS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fround,     "FCVTAU">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, froundeven, "FCVTNS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, froundeven, "FCVTNU">;
+
 def : Pat<(v4i16 (int_aarch64_neon_fcvtzs v4f16:$Rn)), (FCVTZSv4f16 $Rn)>;
 def : Pat<(v8i16 (int_aarch64_neon_fcvtzs v8f16:$Rn)), (FCVTZSv8f16 $Rn)>;
 def : Pat<(v2i32 (int_aarch64_neon_fcvtzs v2f32:$Rn)), (FCVTZSv2f32 $Rn)>;

--- a/llvm/test/CodeGen/AArch64/arm64-cvt-simd-fptoi.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-cvt-simd-fptoi.ll
@@ -546,15 +546,13 @@ define double @fcvtau_dd_round_simd(double %a) {
 define double @fcvtns_ds_roundeven_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_ds_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtns x8, s0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_ds_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs d0, s0
+; CHECK-NEXT:    fcvtns d0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = fptosi float %r to i64
@@ -565,15 +563,13 @@ define double @fcvtns_ds_roundeven_simd(float %a) {
 define float @fcvtns_sd_roundeven_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_sd_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs w8, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtns w8, d0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_sd_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs s0, d0
+; CHECK-NEXT:    fcvtns s0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = fptosi double %r to i32
@@ -584,14 +580,12 @@ define float @fcvtns_sd_roundeven_simd(double %a) {
 define float @fcvtns_ss_roundeven_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_ss_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs s0, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtns s0, s0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_ss_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs s0, s0
+; CHECK-NEXT:    fcvtns s0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = fptosi float %r to i32
@@ -602,14 +596,12 @@ define float @fcvtns_ss_roundeven_simd(float %a) {
 define double @fcvtns_dd_roundeven_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_dd_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs d0, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtns d0, d0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_dd_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs d0, d0
+; CHECK-NEXT:    fcvtns d0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = fptosi double %r to i64
@@ -621,15 +613,13 @@ define double @fcvtns_dd_roundeven_simd(double %a) {
 define double @fcvtnu_ds_roundeven_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_ds_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu x8, s0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_ds_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu d0, s0
+; CHECK-NEXT:    fcvtnu d0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = fptoui float %r to i64
@@ -640,15 +630,13 @@ define double @fcvtnu_ds_roundeven_simd(float %a) {
 define float @fcvtnu_sd_roundeven_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_sd_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu w8, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu w8, d0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_sd_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu s0, d0
+; CHECK-NEXT:    fcvtnu s0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = fptoui double %r to i32
@@ -659,14 +647,12 @@ define float @fcvtnu_sd_roundeven_simd(double %a) {
 define float @fcvtnu_ss_roundeven_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_ss_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu s0, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu s0, s0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_ss_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu s0, s0
+; CHECK-NEXT:    fcvtnu s0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = fptoui float %r to i32
@@ -677,14 +663,12 @@ define float @fcvtnu_ss_roundeven_simd(float %a) {
 define double @fcvtnu_dd_roundeven_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_dd_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu d0, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu d0, d0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_dd_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu d0, d0
+; CHECK-NEXT:    fcvtnu d0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = fptoui double %r to i64
@@ -1493,15 +1477,13 @@ define double @fcvtau_dd_simd(double %a) {
 define float @fcvtns_sh_simd(half %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_sh_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn h0, h0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs w8, h0
+; CHECK-NOFPRCVT-NEXT:    fcvtns w8, h0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_sh_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn h0, h0
-; CHECK-NEXT:    fcvtzs s0, h0
+; CHECK-NEXT:    fcvtns s0, h0
 ; CHECK-NEXT:    ret
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -1512,15 +1494,13 @@ define float @fcvtns_sh_simd(half %a) {
 define double @fcvtns_dh_simd(half %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_dh_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn h0, h0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, h0
+; CHECK-NOFPRCVT-NEXT:    fcvtns x8, h0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_dh_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn h0, h0
-; CHECK-NEXT:    fcvtzs d0, h0
+; CHECK-NEXT:    fcvtns d0, h0
 ; CHECK-NEXT:    ret
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -1531,15 +1511,13 @@ define double @fcvtns_dh_simd(half %a) {
 define double @fcvtns_ds_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_ds_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtns x8, s0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_ds_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs d0, s0
+; CHECK-NEXT:    fcvtns d0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -1550,15 +1528,13 @@ define double @fcvtns_ds_simd(float %a) {
 define float @fcvtns_sd_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_sd_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs w8, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtns w8, d0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_sd_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs s0, d0
+; CHECK-NEXT:    fcvtns s0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -1569,14 +1545,12 @@ define float @fcvtns_sd_simd(double %a) {
 define float @fcvtns_ss_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_ss_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs s0, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtns s0, s0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_ss_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs s0, s0
+; CHECK-NEXT:    fcvtns s0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -1587,14 +1561,12 @@ define float @fcvtns_ss_simd(float %a) {
 define double @fcvtns_dd_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_dd_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs d0, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtns d0, d0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_dd_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs d0, d0
+; CHECK-NEXT:    fcvtns d0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -1605,15 +1577,13 @@ define double @fcvtns_dd_simd(double %a) {
 define float @fcvtnu_sh_simd(half %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_sh_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn h0, h0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu w8, h0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu w8, h0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_sh_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn h0, h0
-; CHECK-NEXT:    fcvtzu s0, h0
+; CHECK-NEXT:    fcvtnu s0, h0
 ; CHECK-NEXT:    ret
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i32 @llvm.fptoui.sat.i32.f16(half %r)
@@ -1624,15 +1594,13 @@ define float @fcvtnu_sh_simd(half %a) {
 define double @fcvtnu_dh_simd(half %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_dh_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn h0, h0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, h0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu x8, h0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_dh_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn h0, h0
-; CHECK-NEXT:    fcvtzu d0, h0
+; CHECK-NEXT:    fcvtnu d0, h0
 ; CHECK-NEXT:    ret
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
@@ -1643,15 +1611,13 @@ define double @fcvtnu_dh_simd(half %a) {
 define double @fcvtnu_ds_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_ds_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu x8, s0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_ds_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu d0, s0
+; CHECK-NEXT:    fcvtnu d0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -1662,15 +1628,13 @@ define double @fcvtnu_ds_simd(float %a) {
 define float @fcvtnu_sd_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_sd_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu w8, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu w8, d0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_sd_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu s0, d0
+; CHECK-NEXT:    fcvtnu s0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -1681,14 +1645,12 @@ define float @fcvtnu_sd_simd(double %a) {
 define float @fcvtnu_ss_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_ss_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu s0, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu s0, s0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_ss_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu s0, s0
+; CHECK-NEXT:    fcvtnu s0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -1699,14 +1661,12 @@ define float @fcvtnu_ss_simd(float %a) {
 define double @fcvtnu_dd_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_dd_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu d0, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu d0, d0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_dd_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu d0, d0
+; CHECK-NEXT:    fcvtnu d0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)

--- a/llvm/test/CodeGen/AArch64/arm64-vcvt-fptoi.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-vcvt-fptoi.ll
@@ -15,8 +15,7 @@
 define <2 x i32> @fcvtas_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtas_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtas v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.round.v2f32(<2 x float> %A)
   %tmp2 = fptosi <2 x float> %tmp1 to <2 x i32>
@@ -26,8 +25,7 @@ define <2 x i32> @fcvtas_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtas_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtas_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtas v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.round.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -38,8 +36,7 @@ define <2 x i32> @fcvtas_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtas_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtas_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtas v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.round.v4f32(<4 x float> %A)
   %tmp2 = fptosi <4 x float> %tmp1 to <4 x i32>
@@ -49,8 +46,7 @@ define <4 x i32> @fcvtas_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtas_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtas_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtas v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.round.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptosi.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -61,8 +57,7 @@ define <4 x i32> @fcvtas_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtas_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtas_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtas v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.round.v2f64(<2 x double> %A)
   %tmp2 = fptosi <2 x double> %tmp1 to <2 x i64>
@@ -72,8 +67,7 @@ define <2 x i64> @fcvtas_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtas_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtas_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtas v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.round.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptosi.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -88,8 +82,7 @@ define <2 x i64> @fcvtas_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtau_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtau_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtau v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.round.v2f32(<2 x float> %A)
   %tmp2 = fptoui <2 x float> %tmp1 to <2 x i32>
@@ -99,8 +92,7 @@ define <2 x i32> @fcvtau_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtau_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtau_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtau v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.round.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -111,8 +103,7 @@ define <2 x i32> @fcvtau_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtau_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtau_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtau v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.round.v4f32(<4 x float> %A)
   %tmp2 = fptoui <4 x float> %tmp1 to <4 x i32>
@@ -122,8 +113,7 @@ define <4 x i32> @fcvtau_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtau_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtau_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtau v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.round.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptoui.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -134,8 +124,7 @@ define <4 x i32> @fcvtau_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtau_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtau_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtau v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.round.v2f64(<2 x double> %A)
   %tmp2 = fptoui <2 x double> %tmp1 to <2 x i64>
@@ -145,8 +134,7 @@ define <2 x i64> @fcvtau_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtau_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtau_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtau v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.round.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptoui.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -161,8 +149,7 @@ define <2 x i64> @fcvtau_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtns_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtns_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtns v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.roundeven.v2f32(<2 x float> %A)
   %tmp2 = fptosi <2 x float> %tmp1 to <2 x i32>
@@ -172,8 +159,7 @@ define <2 x i32> @fcvtns_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtns_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtns_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtns v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.roundeven.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -184,8 +170,7 @@ define <2 x i32> @fcvtns_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtns_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtns_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtns v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %A)
   %tmp2 = fptosi <4 x float> %tmp1 to <4 x i32>
@@ -195,8 +180,7 @@ define <4 x i32> @fcvtns_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtns_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtns_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtns v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptosi.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -207,8 +191,7 @@ define <4 x i32> @fcvtns_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtns_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtns_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtns v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.roundeven.v2f64(<2 x double> %A)
   %tmp2 = fptosi <2 x double> %tmp1 to <2 x i64>
@@ -218,8 +201,7 @@ define <2 x i64> @fcvtns_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtns_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtns_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtns v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.roundeven.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptosi.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -234,8 +216,7 @@ define <2 x i64> @fcvtns_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtnu_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtnu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.roundeven.v2f32(<2 x float> %A)
   %tmp2 = fptoui <2 x float> %tmp1 to <2 x i32>
@@ -245,8 +226,7 @@ define <2 x i32> @fcvtnu_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtnu_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtnu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.roundeven.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -257,8 +237,7 @@ define <2 x i32> @fcvtnu_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtnu_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtnu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %A)
   %tmp2 = fptoui <4 x float> %tmp1 to <4 x i32>
@@ -268,8 +247,7 @@ define <4 x i32> @fcvtnu_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtnu_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtnu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptoui.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -280,8 +258,7 @@ define <4 x i32> @fcvtnu_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtnu_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtnu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.roundeven.v2f64(<2 x double> %A)
   %tmp2 = fptoui <2 x double> %tmp1 to <2 x i64>
@@ -291,8 +268,7 @@ define <2 x i64> @fcvtnu_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtnu_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtnu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.roundeven.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptoui.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -307,8 +283,7 @@ define <2 x i64> @fcvtnu_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtms_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtms_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtms v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.floor.v2f32(<2 x float> %A)
   %tmp2 = fptosi <2 x float> %tmp1 to <2 x i32>
@@ -318,8 +293,7 @@ define <2 x i32> @fcvtms_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtms_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtms_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtms v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.floor.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -330,8 +304,7 @@ define <2 x i32> @fcvtms_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtms_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtms_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtms v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.floor.v4f32(<4 x float> %A)
   %tmp2 = fptosi <4 x float> %tmp1 to <4 x i32>
@@ -341,8 +314,7 @@ define <4 x i32> @fcvtms_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtms_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtms_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtms v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.floor.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptosi.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -353,8 +325,7 @@ define <4 x i32> @fcvtms_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtms_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtms_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtms v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.floor.v2f64(<2 x double> %A)
   %tmp2 = fptosi <2 x double> %tmp1 to <2 x i64>
@@ -364,8 +335,7 @@ define <2 x i64> @fcvtms_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtms_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtms_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtms v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.floor.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptosi.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -380,8 +350,7 @@ define <2 x i64> @fcvtms_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtmu_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtmu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.floor.v2f32(<2 x float> %A)
   %tmp2 = fptoui <2 x float> %tmp1 to <2 x i32>
@@ -391,8 +360,7 @@ define <2 x i32> @fcvtmu_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtmu_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtmu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.floor.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -403,8 +371,7 @@ define <2 x i32> @fcvtmu_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtmu_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtmu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.floor.v4f32(<4 x float> %A)
   %tmp2 = fptoui <4 x float> %tmp1 to <4 x i32>
@@ -414,8 +381,7 @@ define <4 x i32> @fcvtmu_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtmu_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtmu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.floor.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptoui.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -426,8 +392,7 @@ define <4 x i32> @fcvtmu_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtmu_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtmu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.floor.v2f64(<2 x double> %A)
   %tmp2 = fptoui <2 x double> %tmp1 to <2 x i64>
@@ -437,8 +402,7 @@ define <2 x i64> @fcvtmu_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtmu_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtmu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.floor.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptoui.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -453,8 +417,7 @@ define <2 x i64> @fcvtmu_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtps_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtps_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtps v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.ceil.v2f32(<2 x float> %A)
   %tmp2 = fptosi <2 x float> %tmp1 to <2 x i32>
@@ -464,8 +427,7 @@ define <2 x i32> @fcvtps_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtps_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtps_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtps v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.ceil.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -476,8 +438,7 @@ define <2 x i32> @fcvtps_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtps_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtps_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtps v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %A)
   %tmp2 = fptosi <4 x float> %tmp1 to <4 x i32>
@@ -487,8 +448,7 @@ define <4 x i32> @fcvtps_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtps_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtps_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtps v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptosi.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -499,8 +459,7 @@ define <4 x i32> @fcvtps_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtps_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtps_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtps v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.ceil.v2f64(<2 x double> %A)
   %tmp2 = fptosi <2 x double> %tmp1 to <2 x i64>
@@ -510,8 +469,7 @@ define <2 x i64> @fcvtps_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtps_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtps_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtps v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.ceil.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptosi.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -526,8 +484,7 @@ define <2 x i64> @fcvtps_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtpu_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtpu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.ceil.v2f32(<2 x float> %A)
   %tmp2 = fptoui <2 x float> %tmp1 to <2 x i32>
@@ -537,8 +494,7 @@ define <2 x i32> @fcvtpu_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtpu_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtpu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.ceil.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -549,8 +505,7 @@ define <2 x i32> @fcvtpu_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtpu_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtpu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %A)
   %tmp2 = fptoui <4 x float> %tmp1 to <4 x i32>
@@ -560,8 +515,7 @@ define <4 x i32> @fcvtpu_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtpu_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtpu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptoui.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -572,8 +526,7 @@ define <4 x i32> @fcvtpu_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtpu_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtpu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.ceil.v2f64(<2 x double> %A)
   %tmp2 = fptoui <2 x double> %tmp1 to <2 x i64>
@@ -583,8 +536,7 @@ define <2 x i64> @fcvtpu_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtpu_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtpu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.ceil.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptoui.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -599,7 +551,6 @@ define <2 x i64> @fcvtpu_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtzs_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2s, v0.2s
 ; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.trunc.v2f32(<2 x float> %A)
@@ -610,7 +561,6 @@ define <2 x i32> @fcvtzs_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtzs_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2s, v0.2s
 ; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.trunc.v2f32(<2 x float> %A)
@@ -622,7 +572,6 @@ define <2 x i32> @fcvtzs_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtzs_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.4s, v0.4s
 ; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %A)
@@ -633,7 +582,6 @@ define <4 x i32> @fcvtzs_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtzs_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.4s, v0.4s
 ; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %A)
@@ -645,7 +593,6 @@ define <4 x i32> @fcvtzs_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtzs_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2d, v0.2d
 ; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.trunc.v2f64(<2 x double> %A)
@@ -656,7 +603,6 @@ define <2 x i64> @fcvtzs_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtzs_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2d, v0.2d
 ; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.trunc.v2f64(<2 x double> %A)
@@ -672,7 +618,6 @@ define <2 x i64> @fcvtzs_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtzu_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2s, v0.2s
 ; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.trunc.v2f32(<2 x float> %A)
@@ -683,7 +628,6 @@ define <2 x i32> @fcvtzu_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtzu_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2s, v0.2s
 ; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.trunc.v2f32(<2 x float> %A)
@@ -695,7 +639,6 @@ define <2 x i32> @fcvtzu_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtzu_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.4s, v0.4s
 ; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %A)
@@ -706,7 +649,6 @@ define <4 x i32> @fcvtzu_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtzu_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.4s, v0.4s
 ; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %A)
@@ -718,7 +660,6 @@ define <4 x i32> @fcvtzu_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtzu_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2d, v0.2d
 ; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.trunc.v2f64(<2 x double> %A)
@@ -729,7 +670,6 @@ define <2 x i64> @fcvtzu_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtzu_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2d, v0.2d
 ; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.trunc.v2f64(<2 x double> %A)
@@ -755,8 +695,7 @@ define <4 x i16> @fcvtas_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtas_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtas v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtas_4h:
@@ -771,8 +710,7 @@ define <4 x i16> @fcvtas_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtas_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtas v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.round.v4f16(<4 x half> %A)
   %tmp2 = fptosi <4 x half> %tmp1 to <4 x i16>
@@ -792,8 +730,7 @@ define <4 x i16> @fcvtas_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtas_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtas v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtas_4h_sat:
@@ -808,8 +745,7 @@ define <4 x i16> @fcvtas_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtas_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtas v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.round.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptosi.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -835,8 +771,7 @@ define <8 x i16> @fcvtas_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtas_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtas v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtas_8h:
@@ -856,8 +791,7 @@ define <8 x i16> @fcvtas_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtas_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtas v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.round.v8f16(<8 x half> %A)
   %tmp2 = fptosi <8 x half> %tmp1 to <8 x i16>
@@ -883,8 +817,7 @@ define <8 x i16> @fcvtas_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtas_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtas v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtas_8h_sat:
@@ -905,8 +838,7 @@ define <8 x i16> @fcvtas_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtas_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtas v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.round.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptosi.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -927,8 +859,7 @@ define <4 x i16> @fcvtau_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtau_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtau v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtau_4h:
@@ -943,8 +874,7 @@ define <4 x i16> @fcvtau_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtau_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtau v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.round.v4f16(<4 x half> %A)
   %tmp2 = fptoui <4 x half> %tmp1 to <4 x i16>
@@ -964,8 +894,7 @@ define <4 x i16> @fcvtau_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtau_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtau v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtau_4h_sat:
@@ -980,8 +909,7 @@ define <4 x i16> @fcvtau_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtau_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtau v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.round.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptoui.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1007,8 +935,7 @@ define <8 x i16> @fcvtau_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtau_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtau v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtau_8h:
@@ -1028,8 +955,7 @@ define <8 x i16> @fcvtau_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtau_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtau v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.round.v8f16(<8 x half> %A)
   %tmp2 = fptoui <8 x half> %tmp1 to <8 x i16>
@@ -1055,8 +981,7 @@ define <8 x i16> @fcvtau_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtau_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtau v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtau_8h_sat:
@@ -1077,8 +1002,7 @@ define <8 x i16> @fcvtau_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtau_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtau v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.round.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptoui.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1099,8 +1023,7 @@ define <4 x i16> @fcvtns_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtns_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtns v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtns_4h:
@@ -1115,8 +1038,7 @@ define <4 x i16> @fcvtns_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtns_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtns v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.roundeven.v4f16(<4 x half> %A)
   %tmp2 = fptosi <4 x half> %tmp1 to <4 x i16>
@@ -1136,8 +1058,7 @@ define <4 x i16> @fcvtns_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtns_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtns v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtns_4h_sat:
@@ -1152,8 +1073,7 @@ define <4 x i16> @fcvtns_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtns_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtns v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.roundeven.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptosi.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1179,8 +1099,7 @@ define <8 x i16> @fcvtns_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtns_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtns v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtns_8h:
@@ -1200,8 +1119,7 @@ define <8 x i16> @fcvtns_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtns_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtns v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.roundeven.v8f16(<8 x half> %A)
   %tmp2 = fptosi <8 x half> %tmp1 to <8 x i16>
@@ -1227,8 +1145,7 @@ define <8 x i16> @fcvtns_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtns_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtns v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtns_8h_sat:
@@ -1249,8 +1166,7 @@ define <8 x i16> @fcvtns_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtns_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtns v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.roundeven.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptosi.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1271,8 +1187,7 @@ define <4 x i16> @fcvtnu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtnu_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtnu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtnu_4h:
@@ -1287,8 +1202,7 @@ define <4 x i16> @fcvtnu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtnu_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtnu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.roundeven.v4f16(<4 x half> %A)
   %tmp2 = fptoui <4 x half> %tmp1 to <4 x i16>
@@ -1308,8 +1222,7 @@ define <4 x i16> @fcvtnu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtnu_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtnu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtnu_4h_sat:
@@ -1324,8 +1237,7 @@ define <4 x i16> @fcvtnu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtnu_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtnu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.roundeven.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptoui.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1351,8 +1263,7 @@ define <8 x i16> @fcvtnu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtnu_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtnu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtnu_8h:
@@ -1372,8 +1283,7 @@ define <8 x i16> @fcvtnu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtnu_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtnu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.roundeven.v8f16(<8 x half> %A)
   %tmp2 = fptoui <8 x half> %tmp1 to <8 x i16>
@@ -1399,8 +1309,7 @@ define <8 x i16> @fcvtnu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtnu_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtnu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtnu_8h_sat:
@@ -1421,8 +1330,7 @@ define <8 x i16> @fcvtnu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtnu_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtnu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.roundeven.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptoui.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1443,8 +1351,7 @@ define <4 x i16> @fcvtms_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtms_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtms v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtms_4h:
@@ -1459,8 +1366,7 @@ define <4 x i16> @fcvtms_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtms_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtms v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.floor.v4f16(<4 x half> %A)
   %tmp2 = fptosi <4 x half> %tmp1 to <4 x i16>
@@ -1480,8 +1386,7 @@ define <4 x i16> @fcvtms_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtms_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtms v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtms_4h_sat:
@@ -1496,8 +1401,7 @@ define <4 x i16> @fcvtms_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtms_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtms v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.floor.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptosi.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1523,8 +1427,7 @@ define <8 x i16> @fcvtms_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtms_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtms v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtms_8h:
@@ -1544,8 +1447,7 @@ define <8 x i16> @fcvtms_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtms_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtms v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.floor.v8f16(<8 x half> %A)
   %tmp2 = fptosi <8 x half> %tmp1 to <8 x i16>
@@ -1571,8 +1473,7 @@ define <8 x i16> @fcvtms_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtms_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtms v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtms_8h_sat:
@@ -1593,8 +1494,7 @@ define <8 x i16> @fcvtms_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtms_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtms v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.floor.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptosi.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1615,8 +1515,7 @@ define <4 x i16> @fcvtmu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtmu_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtmu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtmu_4h:
@@ -1631,8 +1530,7 @@ define <4 x i16> @fcvtmu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtmu_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtmu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.floor.v4f16(<4 x half> %A)
   %tmp2 = fptoui <4 x half> %tmp1 to <4 x i16>
@@ -1652,8 +1550,7 @@ define <4 x i16> @fcvtmu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtmu_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtmu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtmu_4h_sat:
@@ -1668,8 +1565,7 @@ define <4 x i16> @fcvtmu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtmu_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtmu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.floor.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptoui.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1695,8 +1591,7 @@ define <8 x i16> @fcvtmu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtmu_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtmu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtmu_8h:
@@ -1716,8 +1611,7 @@ define <8 x i16> @fcvtmu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtmu_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtmu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.floor.v8f16(<8 x half> %A)
   %tmp2 = fptoui <8 x half> %tmp1 to <8 x i16>
@@ -1743,8 +1637,7 @@ define <8 x i16> @fcvtmu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtmu_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtmu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtmu_8h_sat:
@@ -1765,8 +1658,7 @@ define <8 x i16> @fcvtmu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtmu_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtmu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.floor.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptoui.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1787,8 +1679,7 @@ define <4 x i16> @fcvtps_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtps_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtps v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtps_4h:
@@ -1803,8 +1694,7 @@ define <4 x i16> @fcvtps_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtps_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtps v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.ceil.v4f16(<4 x half> %A)
   %tmp2 = fptosi <4 x half> %tmp1 to <4 x i16>
@@ -1824,8 +1714,7 @@ define <4 x i16> @fcvtps_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtps_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtps v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtps_4h_sat:
@@ -1840,8 +1729,7 @@ define <4 x i16> @fcvtps_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtps_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtps v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.ceil.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptosi.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1867,8 +1755,7 @@ define <8 x i16> @fcvtps_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtps_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtps v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtps_8h:
@@ -1888,8 +1775,7 @@ define <8 x i16> @fcvtps_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtps_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtps v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.ceil.v8f16(<8 x half> %A)
   %tmp2 = fptosi <8 x half> %tmp1 to <8 x i16>
@@ -1915,8 +1801,7 @@ define <8 x i16> @fcvtps_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtps_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtps v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtps_8h_sat:
@@ -1937,8 +1822,7 @@ define <8 x i16> @fcvtps_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtps_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtps v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.ceil.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptosi.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1959,8 +1843,7 @@ define <4 x i16> @fcvtpu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtpu_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtpu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtpu_4h:
@@ -1975,8 +1858,7 @@ define <4 x i16> @fcvtpu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtpu_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtpu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.ceil.v4f16(<4 x half> %A)
   %tmp2 = fptoui <4 x half> %tmp1 to <4 x i16>
@@ -1996,8 +1878,7 @@ define <4 x i16> @fcvtpu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtpu_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtpu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtpu_4h_sat:
@@ -2012,8 +1893,7 @@ define <4 x i16> @fcvtpu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtpu_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtpu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.ceil.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptoui.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -2039,8 +1919,7 @@ define <8 x i16> @fcvtpu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtpu_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtpu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtpu_8h:
@@ -2060,8 +1939,7 @@ define <8 x i16> @fcvtpu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtpu_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtpu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.ceil.v8f16(<8 x half> %A)
   %tmp2 = fptoui <8 x half> %tmp1 to <8 x i16>
@@ -2087,8 +1965,7 @@ define <8 x i16> @fcvtpu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtpu_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtpu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtpu_8h_sat:
@@ -2109,8 +1986,7 @@ define <8 x i16> @fcvtpu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtpu_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtpu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.ceil.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptoui.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -2131,7 +2007,6 @@ define <4 x i16> @fcvtzs_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzs_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2147,7 +2022,6 @@ define <4 x i16> @fcvtzs_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzs_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.trunc.v4f16(<4 x half> %A)
@@ -2168,7 +2042,6 @@ define <4 x i16> @fcvtzs_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzs_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2184,7 +2057,6 @@ define <4 x i16> @fcvtzs_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzs_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.trunc.v4f16(<4 x half> %A)
@@ -2211,7 +2083,6 @@ define <8 x i16> @fcvtzs_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzs_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2232,7 +2103,6 @@ define <8 x i16> @fcvtzs_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzs_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.trunc.v8f16(<8 x half> %A)
@@ -2259,7 +2129,6 @@ define <8 x i16> @fcvtzs_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzs_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2281,7 +2150,6 @@ define <8 x i16> @fcvtzs_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzs_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.trunc.v8f16(<8 x half> %A)
@@ -2303,7 +2171,6 @@ define <4 x i16> @fcvtzu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzu_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2319,7 +2186,6 @@ define <4 x i16> @fcvtzu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzu_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.trunc.v4f16(<4 x half> %A)
@@ -2340,7 +2206,6 @@ define <4 x i16> @fcvtzu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzu_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2356,7 +2221,6 @@ define <4 x i16> @fcvtzu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzu_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.trunc.v4f16(<4 x half> %A)
@@ -2383,7 +2247,6 @@ define <8 x i16> @fcvtzu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzu_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2404,7 +2267,6 @@ define <8 x i16> @fcvtzu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzu_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.trunc.v8f16(<8 x half> %A)
@@ -2431,7 +2293,6 @@ define <8 x i16> @fcvtzu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzu_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2453,7 +2314,6 @@ define <8 x i16> @fcvtzu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzu_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.trunc.v8f16(<8 x half> %A)

--- a/llvm/test/CodeGen/AArch64/round-conv.ll
+++ b/llvm/test/CodeGen/AArch64/round-conv.ll
@@ -280,8 +280,7 @@ entry:
 define i32 @testnsws(float %a) {
 ; CHECK-LABEL: testnsws:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs w0, s0
+; CHECK-NEXT:    fcvtns w0, s0
 ; CHECK-NEXT:    ret
 entry:
   %call = call float @llvm.roundeven.f32(float %a)
@@ -303,8 +302,7 @@ entry:
 define i64 @testnsxs(float %a) {
 ; CHECK-LABEL: testnsxs:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs x0, s0
+; CHECK-NEXT:    fcvtns x0, s0
 ; CHECK-NEXT:    ret
 entry:
   %call = call float @llvm.roundeven.f32(float %a)
@@ -326,8 +324,7 @@ entry:
 define i32 @testnswd(double %a) {
 ; CHECK-LABEL: testnswd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs w0, d0
+; CHECK-NEXT:    fcvtns w0, d0
 ; CHECK-NEXT:    ret
 entry:
   %call = call double @llvm.roundeven.f64(double %a)
@@ -349,8 +346,7 @@ entry:
 define i64 @testnsxd(double %a) {
 ; CHECK-LABEL: testnsxd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs x0, d0
+; CHECK-NEXT:    fcvtns x0, d0
 ; CHECK-NEXT:    ret
 entry:
   %call = call double @llvm.roundeven.f64(double %a)
@@ -372,8 +368,7 @@ entry:
 define i32 @testnuws(float %a) {
 ; CHECK-LABEL: testnuws:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu w0, s0
+; CHECK-NEXT:    fcvtnu w0, s0
 ; CHECK-NEXT:    ret
 entry:
   %call = call float @llvm.roundeven.f32(float %a)
@@ -395,8 +390,7 @@ entry:
 define i64 @testnuxs(float %a) {
 ; CHECK-LABEL: testnuxs:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu x0, s0
+; CHECK-NEXT:    fcvtnu x0, s0
 ; CHECK-NEXT:    ret
 entry:
   %call = call float @llvm.roundeven.f32(float %a)
@@ -418,8 +412,7 @@ entry:
 define i32 @testnuwd(double %a) {
 ; CHECK-LABEL: testnuwd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu w0, d0
+; CHECK-NEXT:    fcvtnu w0, d0
 ; CHECK-NEXT:    ret
 entry:
   %call = call double @llvm.roundeven.f64(double %a)
@@ -441,8 +434,7 @@ entry:
 define i64 @testnuxd(double %a) {
 ; CHECK-LABEL: testnuxd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu x0, d0
+; CHECK-NEXT:    fcvtnu x0, d0
 ; CHECK-NEXT:    ret
 entry:
   %call = call double @llvm.roundeven.f64(double %a)

--- a/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
@@ -87,8 +87,7 @@ define i32 @testmswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testmswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtms w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testmswh:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
@@ -130,8 +129,7 @@ define i64 @testmsxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testmsxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtms x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testmsxh:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
@@ -148,27 +146,10 @@ entry:
 }
 
 define i32 @testmsws(float %a) {
-; CHECK-CVT-LABEL: testmsws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtms w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmsws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtms w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmsws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm s0, s0
-; CHECK-GI-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmsws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmsws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtms w0, s0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testmsws:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
@@ -181,27 +162,10 @@ entry:
 }
 
 define i64 @testmsxs(float %a) {
-; CHECK-CVT-LABEL: testmsxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtms x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmsxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtms x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmsxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm s0, s0
-; CHECK-GI-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmsxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmsxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtms x0, s0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testmsxs:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
@@ -214,27 +178,10 @@ entry:
 }
 
 define i32 @testmswd(double %a) {
-; CHECK-CVT-LABEL: testmswd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtms w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmswd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtms w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmswd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm d0, d0
-; CHECK-GI-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmswd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmswd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtms w0, d0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testmswd:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintm d0, d0
@@ -247,27 +194,10 @@ entry:
 }
 
 define i64 @testmsxd(double %a) {
-; CHECK-CVT-LABEL: testmsxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtms x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmsxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtms x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmsxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm d0, d0
-; CHECK-GI-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmsxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmsxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtms x0, d0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testmsxd:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintm d0, d0
@@ -351,8 +281,7 @@ define i32 @testpswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testpswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtps w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testpswh:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
@@ -394,8 +323,7 @@ define i64 @testpsxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testpsxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtps x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testpsxh:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
@@ -412,27 +340,10 @@ entry:
 }
 
 define i32 @testpsws(float %a) {
-; CHECK-CVT-LABEL: testpsws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtps w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpsws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtps w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpsws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp s0, s0
-; CHECK-GI-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpsws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpsws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtps w0, s0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testpsws:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
@@ -445,27 +356,10 @@ entry:
 }
 
 define i64 @testpsxs(float %a) {
-; CHECK-CVT-LABEL: testpsxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtps x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpsxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtps x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpsxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp s0, s0
-; CHECK-GI-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpsxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpsxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtps x0, s0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testpsxs:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
@@ -478,27 +372,10 @@ entry:
 }
 
 define i32 @testpswd(double %a) {
-; CHECK-CVT-LABEL: testpswd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtps w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpswd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtps w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpswd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp d0, d0
-; CHECK-GI-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpswd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpswd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtps w0, d0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testpswd:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintp d0, d0
@@ -511,27 +388,10 @@ entry:
 }
 
 define i64 @testpsxd(double %a) {
-; CHECK-CVT-LABEL: testpsxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtps x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpsxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtps x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpsxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp d0, d0
-; CHECK-GI-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpsxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpsxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtps x0, d0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testpsxd:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintp d0, d0
@@ -615,7 +475,6 @@ define i32 @testzswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testzswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testzswh:
@@ -658,7 +517,6 @@ define i64 @testzsxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testzsxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testzsxh:
@@ -676,27 +534,10 @@ entry:
 }
 
 define i32 @testzsws(float %a) {
-; CHECK-CVT-LABEL: testzsws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzs w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzsws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzsws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz s0, s0
-; CHECK-GI-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzsws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzsws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzs w0, s0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testzsws:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
@@ -709,27 +550,10 @@ entry:
 }
 
 define i64 @testzsxs(float %a) {
-; CHECK-CVT-LABEL: testzsxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzs x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzsxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzsxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz s0, s0
-; CHECK-GI-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzsxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzsxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzs x0, s0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testzsxs:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
@@ -742,27 +566,10 @@ entry:
 }
 
 define i32 @testzswd(double %a) {
-; CHECK-CVT-LABEL: testzswd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzs w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzswd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzswd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz d0, d0
-; CHECK-GI-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzswd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzswd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzs w0, d0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testzswd:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintz d0, d0
@@ -775,27 +582,10 @@ entry:
 }
 
 define i64 @testzsxd(double %a) {
-; CHECK-CVT-LABEL: testzsxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzs x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzsxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzsxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz d0, d0
-; CHECK-GI-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzsxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzsxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzs x0, d0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testzsxd:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frintz d0, d0
@@ -879,8 +669,7 @@ define i32 @testaswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testaswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtas w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testaswh:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
@@ -922,8 +711,7 @@ define i64 @testasxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testasxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtas x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testasxh:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
@@ -940,27 +728,10 @@ entry:
 }
 
 define i32 @testasws(float %a) {
-; CHECK-CVT-LABEL: testasws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtas w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testasws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtas w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testasws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta s0, s0
-; CHECK-GI-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testasws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testasws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtas w0, s0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testasws:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
@@ -973,27 +744,10 @@ entry:
 }
 
 define i64 @testasxs(float %a) {
-; CHECK-CVT-LABEL: testasxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtas x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testasxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtas x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testasxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta s0, s0
-; CHECK-GI-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testasxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testasxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtas x0, s0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testasxs:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
@@ -1006,27 +760,10 @@ entry:
 }
 
 define i32 @testaswd(double %a) {
-; CHECK-CVT-LABEL: testaswd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtas w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testaswd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtas w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testaswd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta d0, d0
-; CHECK-GI-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testaswd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testaswd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtas w0, d0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testaswd:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frinta d0, d0
@@ -1039,27 +776,10 @@ entry:
 }
 
 define i64 @testasxd(double %a) {
-; CHECK-CVT-LABEL: testasxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtas x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testasxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtas x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testasxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta d0, d0
-; CHECK-GI-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testasxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testasxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtas x0, d0
+; CHECK-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testasxd:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
 ; CHECK-GI-NOFP16-NEXT:    frinta d0, d0

--- a/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
@@ -849,8 +849,7 @@ define i32 @testnswh(half %a) {
 ;
 ; CHECK-FP16-LABEL: testnswh:
 ; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    frintn h0, h0
-; CHECK-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-FP16-NEXT:    fcvtns w0, h0
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: testnswh:
@@ -864,8 +863,7 @@ define i32 @testnswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testnswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintn h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtns w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testnswh:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
@@ -893,8 +891,7 @@ define i64 @testnsxh(half %a) {
 ;
 ; CHECK-FP16-LABEL: testnsxh:
 ; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    frintn h0, h0
-; CHECK-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-FP16-NEXT:    fcvtns x0, h0
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: testnsxh:
@@ -908,8 +905,7 @@ define i64 @testnsxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testnsxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintn h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtns x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 ; CHECK-GI-NOFP16-LABEL: testnsxh:
 ; CHECK-GI-NOFP16:       // %bb.0: // %entry
@@ -928,8 +924,7 @@ entry:
 define i32 @testnsws(float %a) {
 ; CHECK-LABEL: testnsws:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs w0, s0
+; CHECK-NEXT:    fcvtns w0, s0
 ; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.roundeven.f32(float %a)
@@ -940,8 +935,7 @@ entry:
 define i64 @testnsxs(float %a) {
 ; CHECK-LABEL: testnsxs:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs x0, s0
+; CHECK-NEXT:    fcvtns x0, s0
 ; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.roundeven.f32(float %a)
@@ -952,8 +946,7 @@ entry:
 define i32 @testnswd(double %a) {
 ; CHECK-LABEL: testnswd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs w0, d0
+; CHECK-NEXT:    fcvtns w0, d0
 ; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.roundeven.f64(double %a)
@@ -964,8 +957,7 @@ entry:
 define i64 @testnsxd(double %a) {
 ; CHECK-LABEL: testnsxd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs x0, d0
+; CHECK-NEXT:    fcvtns x0, d0
 ; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.roundeven.f64(double %a)

--- a/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
@@ -89,14 +89,6 @@ define i32 @testmswh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtms w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.floor.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -131,14 +123,6 @@ define i64 @testmsxh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtms x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmsxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.floor.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -150,11 +134,6 @@ define i32 @testmsws(float %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtms w0, s0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmsws:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call float @llvm.floor.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -166,11 +145,6 @@ define i64 @testmsxs(float %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtms x0, s0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmsxs:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call float @llvm.floor.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -182,11 +156,6 @@ define i32 @testmswd(double %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtms w0, d0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmswd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintm d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call double @llvm.floor.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -198,11 +167,6 @@ define i64 @testmsxd(double %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtms x0, d0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmsxd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintm d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call double @llvm.floor.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -283,14 +247,6 @@ define i32 @testpswh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtps w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.ceil.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -325,14 +281,6 @@ define i64 @testpsxh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtps x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpsxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.ceil.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -344,11 +292,6 @@ define i32 @testpsws(float %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtps w0, s0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpsws:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -360,11 +303,6 @@ define i64 @testpsxs(float %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtps x0, s0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpsxs:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -376,11 +314,6 @@ define i32 @testpswd(double %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtps w0, d0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpswd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintp d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -392,11 +325,6 @@ define i64 @testpsxd(double %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtps x0, d0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpsxd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintp d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -477,14 +405,6 @@ define i32 @testzswh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.trunc.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -519,14 +439,6 @@ define i64 @testzsxh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzsxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.trunc.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -538,11 +450,6 @@ define i32 @testzsws(float %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtzs w0, s0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzsws:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -554,11 +461,6 @@ define i64 @testzsxs(float %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtzs x0, s0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzsxs:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -570,11 +472,6 @@ define i32 @testzswd(double %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtzs w0, d0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzswd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintz d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -586,11 +483,6 @@ define i64 @testzsxd(double %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtzs x0, d0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzsxd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintz d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -671,14 +563,6 @@ define i32 @testaswh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtas w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testaswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.round.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -713,14 +597,6 @@ define i64 @testasxh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtas x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testasxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.round.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -732,11 +608,6 @@ define i32 @testasws(float %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtas w0, s0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testasws:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call float @llvm.round.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -748,11 +619,6 @@ define i64 @testasxs(float %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtas x0, s0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testasxs:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call float @llvm.round.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -764,11 +630,6 @@ define i32 @testaswd(double %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtas w0, d0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testaswd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frinta d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call double @llvm.round.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -780,11 +641,6 @@ define i64 @testasxd(double %a) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    fcvtas x0, d0
 ; CHECK-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testasxd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frinta d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call double @llvm.round.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -865,14 +721,6 @@ define i32 @testnswh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtns w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testnswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintn s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -907,14 +755,6 @@ define i64 @testnsxh(half %a) {
 ; CHECK-GI-FP16:       // %bb.0: // %entry
 ; CHECK-GI-FP16-NEXT:    fcvtns x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testnsxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintn s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)

--- a/llvm/test/CodeGen/AArch64/round-fptoui-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/round-fptoui-sat-scalar.ll
@@ -87,8 +87,7 @@ define i32 @testmuwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testmuwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtmu w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.floor.f16(half %a)
@@ -122,8 +121,7 @@ define i64 @testmuxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testmuxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtmu x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.floor.f16(half %a)
@@ -132,27 +130,10 @@ entry:
 }
 
 define i32 @testmuws(float %a) {
-; CHECK-CVT-LABEL: testmuws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtmu w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmuws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtmu w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmuws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm s0, s0
-; CHECK-GI-NEXT:    fcvtzu w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmuws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmuws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtmu w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.floor.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -160,27 +141,10 @@ entry:
 }
 
 define i64 @testmuxs(float %a) {
-; CHECK-CVT-LABEL: testmuxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtmu x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmuxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtmu x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmuxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm s0, s0
-; CHECK-GI-NEXT:    fcvtzu x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmuxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmuxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtmu x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.floor.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -188,27 +152,10 @@ entry:
 }
 
 define i32 @testmuwd(double %a) {
-; CHECK-CVT-LABEL: testmuwd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtmu w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmuwd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtmu w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmuwd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm d0, d0
-; CHECK-GI-NEXT:    fcvtzu w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmuwd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmuwd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtmu w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.floor.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -216,27 +163,10 @@ entry:
 }
 
 define i64 @testmuxd(double %a) {
-; CHECK-CVT-LABEL: testmuxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtmu x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmuxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtmu x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmuxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm d0, d0
-; CHECK-GI-NEXT:    fcvtzu x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmuxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmuxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtmu x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.floor.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
@@ -315,8 +245,7 @@ define i32 @testpuwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testpuwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtpu w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.ceil.f16(half %a)
@@ -350,8 +279,7 @@ define i64 @testpuxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testpuxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtpu x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.ceil.f16(half %a)
@@ -360,27 +288,10 @@ entry:
 }
 
 define i32 @testpuws(float %a) {
-; CHECK-CVT-LABEL: testpuws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtpu w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpuws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtpu w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpuws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp s0, s0
-; CHECK-GI-NEXT:    fcvtzu w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpuws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpuws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtpu w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -388,27 +299,10 @@ entry:
 }
 
 define i64 @testpuxs(float %a) {
-; CHECK-CVT-LABEL: testpuxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtpu x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpuxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtpu x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpuxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp s0, s0
-; CHECK-GI-NEXT:    fcvtzu x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpuxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpuxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtpu x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -416,27 +310,10 @@ entry:
 }
 
 define i32 @testpuwd(double %a) {
-; CHECK-CVT-LABEL: testpuwd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtpu w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpuwd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtpu w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpuwd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp d0, d0
-; CHECK-GI-NEXT:    fcvtzu w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpuwd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpuwd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtpu w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -444,27 +321,10 @@ entry:
 }
 
 define i64 @testpuxd(double %a) {
-; CHECK-CVT-LABEL: testpuxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtpu x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpuxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtpu x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpuxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp d0, d0
-; CHECK-GI-NEXT:    fcvtzu x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpuxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpuxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtpu x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
@@ -543,7 +403,6 @@ define i32 @testzuwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testzuwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
@@ -578,7 +437,6 @@ define i64 @testzuxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testzuxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
@@ -588,27 +446,10 @@ entry:
 }
 
 define i32 @testzuws(float %a) {
-; CHECK-CVT-LABEL: testzuws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzu w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzuws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzuws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz s0, s0
-; CHECK-GI-NEXT:    fcvtzu w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzuws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzuws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzu w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -616,27 +457,10 @@ entry:
 }
 
 define i64 @testzuxs(float %a) {
-; CHECK-CVT-LABEL: testzuxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzu x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzuxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzuxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz s0, s0
-; CHECK-GI-NEXT:    fcvtzu x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzuxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzuxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzu x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -644,27 +468,10 @@ entry:
 }
 
 define i32 @testzuwd(double %a) {
-; CHECK-CVT-LABEL: testzuwd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzu w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzuwd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzuwd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz d0, d0
-; CHECK-GI-NEXT:    fcvtzu w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzuwd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzuwd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzu w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -672,27 +479,10 @@ entry:
 }
 
 define i64 @testzuxd(double %a) {
-; CHECK-CVT-LABEL: testzuxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzu x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzuxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzuxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz d0, d0
-; CHECK-GI-NEXT:    fcvtzu x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzuxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzuxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzu x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
@@ -771,8 +561,7 @@ define i32 @testauwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testauwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtau w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.round.f16(half %a)
@@ -806,8 +595,7 @@ define i64 @testauxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testauxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtau x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.round.f16(half %a)
@@ -816,27 +604,10 @@ entry:
 }
 
 define i32 @testauws(float %a) {
-; CHECK-CVT-LABEL: testauws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtau w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testauws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtau w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testauws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta s0, s0
-; CHECK-GI-NEXT:    fcvtzu w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testauws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testauws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtau w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.round.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -844,27 +615,10 @@ entry:
 }
 
 define i64 @testauxs(float %a) {
-; CHECK-CVT-LABEL: testauxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtau x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testauxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtau x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testauxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta s0, s0
-; CHECK-GI-NEXT:    fcvtzu x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testauxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testauxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtau x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.round.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -872,27 +626,10 @@ entry:
 }
 
 define i32 @testauwd(double %a) {
-; CHECK-CVT-LABEL: testauwd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtau w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testauwd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtau w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testauwd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta d0, d0
-; CHECK-GI-NEXT:    fcvtzu w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testauwd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testauwd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtau w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.round.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -900,27 +637,10 @@ entry:
 }
 
 define i64 @testauxd(double %a) {
-; CHECK-CVT-LABEL: testauxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtau x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testauxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtau x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testauxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta d0, d0
-; CHECK-GI-NEXT:    fcvtzu x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testauxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testauxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtau x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.round.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)

--- a/llvm/test/CodeGen/AArch64/round-fptoui-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/round-fptoui-sat-scalar.ll
@@ -705,8 +705,7 @@ define i32 @testnuwh(half %a) {
 ;
 ; CHECK-FP16-LABEL: testnuwh:
 ; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    frintn h0, h0
-; CHECK-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-FP16-NEXT:    fcvtnu w0, h0
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: testnuwh:
@@ -720,8 +719,7 @@ define i32 @testnuwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testnuwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintn h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtnu w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
@@ -741,8 +739,7 @@ define i64 @testnuxh(half %a) {
 ;
 ; CHECK-FP16-LABEL: testnuxh:
 ; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    frintn h0, h0
-; CHECK-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-FP16-NEXT:    fcvtnu x0, h0
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: testnuxh:
@@ -756,8 +753,7 @@ define i64 @testnuxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testnuxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintn h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtnu x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
@@ -768,8 +764,7 @@ entry:
 define i32 @testnuws(float %a) {
 ; CHECK-LABEL: testnuws:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu w0, s0
+; CHECK-NEXT:    fcvtnu w0, s0
 ; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.roundeven.f32(float %a)
@@ -780,8 +775,7 @@ entry:
 define i64 @testnuxs(float %a) {
 ; CHECK-LABEL: testnuxs:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu x0, s0
+; CHECK-NEXT:    fcvtnu x0, s0
 ; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.roundeven.f32(float %a)
@@ -792,8 +786,7 @@ entry:
 define i32 @testnuwd(double %a) {
 ; CHECK-LABEL: testnuwd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu w0, d0
+; CHECK-NEXT:    fcvtnu w0, d0
 ; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.roundeven.f64(double %a)
@@ -804,8 +797,7 @@ entry:
 define i64 @testnuxd(double %a) {
 ; CHECK-LABEL: testnuxd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu x0, d0
+; CHECK-NEXT:    fcvtnu x0, d0
 ; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.roundeven.f64(double %a)

--- a/llvm/test/CodeGen/AArch64/shuffle-tbl34.ll
+++ b/llvm/test/CodeGen/AArch64/shuffle-tbl34.ll
@@ -700,23 +700,15 @@ define <16 x i8> @insert4_v16i8(<8 x i8> %a, <16 x i8> %b, <8 x i8> %c, <16 x i8
 define <16 x i16> @test(<2 x double> %l213, <2 x double> %l231, <2 x double> %l249, <2 x double> %l267, <2 x double> %l285, <2 x double> %l303, <2 x double> %l321, <2 x double> %l339) {
 ; CHECK-LABEL: test:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    frintm v4.2d, v4.2d
+; CHECK-NEXT:    fcvtms v0.2d, v0.2d
+; CHECK-NEXT:    fcvtms v4.2d, v4.2d
 ; CHECK-NEXT:    adrp x8, .LCPI16_0
-; CHECK-NEXT:    frintm v1.2d, v1.2d
-; CHECK-NEXT:    frintm v5.2d, v5.2d
-; CHECK-NEXT:    frintm v2.2d, v2.2d
-; CHECK-NEXT:    frintm v6.2d, v6.2d
-; CHECK-NEXT:    frintm v3.2d, v3.2d
-; CHECK-NEXT:    frintm v7.2d, v7.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v4.2d, v4.2d
-; CHECK-NEXT:    fcvtzs v1.2d, v1.2d
-; CHECK-NEXT:    fcvtzs v5.2d, v5.2d
-; CHECK-NEXT:    fcvtzs v2.2d, v2.2d
-; CHECK-NEXT:    fcvtzs v6.2d, v6.2d
-; CHECK-NEXT:    fcvtzs v3.2d, v3.2d
-; CHECK-NEXT:    fcvtzs v7.2d, v7.2d
+; CHECK-NEXT:    fcvtms v1.2d, v1.2d
+; CHECK-NEXT:    fcvtms v5.2d, v5.2d
+; CHECK-NEXT:    fcvtms v2.2d, v2.2d
+; CHECK-NEXT:    fcvtms v6.2d, v6.2d
+; CHECK-NEXT:    fcvtms v3.2d, v3.2d
+; CHECK-NEXT:    fcvtms v7.2d, v7.2d
 ; CHECK-NEXT:    xtn v16.2s, v0.2d
 ; CHECK-NEXT:    xtn v20.2s, v4.2d
 ; CHECK-NEXT:    ldr q0, [x8, :lo12:.LCPI16_0]


### PR DESCRIPTION
Resolves https://github.com/llvm/llvm-project/issues/170010.

This PR adds more instruction selection patterns for lowering floating-point rounding operations (ceil, floor, trunc, round, etc.) to `FCVT[AMNPZ][SU]` instructions. There are two optimizations added here, which are somewhat related:

- A `roundeven` operation followed by a float-to-int conversion can be lowered to a `FCVTNS`/`FCVTNU`.

- These optimizations, which were previously only performed on *single* floats, are now done on vectors as well.

An open question is whether it's legal to optimize a `rint` or `nearbyint` + conversion into a `FCVTNS`/`FCVTNU`; https://github.com/llvm/llvm-project/issues/77561 will need to be resolved first, so I've not implemented those optimizations now.