### PR TITLE
[clang-tidy] Fix false positive in `readability-redundant-typename`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -47,10 +47,11 @@ void RedundantTypenameCheck::check(const MatchFinder::MatchResult &Result) {
   const SourceLocation ElaboratedKeywordLoc = [&] {
     if (const auto *NonDependentTypeLoc =
             Result.Nodes.getNodeAs<TypeLoc>("nonDependentTypeLoc")) {
-      if (const auto TL = NonDependentTypeLoc->getAs<TypedefTypeLoc>()) {
-        if (!TL.getType()->isDependentType())
-          return TL.getElaboratedKeywordLoc();
-      }
+      if (NonDependentTypeLoc->getType()->isDependentType())
+        return SourceLocation();
+
+      if (const auto TL = NonDependentTypeLoc->getAs<TypedefTypeLoc>())
+        return TL.getElaboratedKeywordLoc();
 
       if (const auto TL = NonDependentTypeLoc->getAs<TagTypeLoc>())
         return TL.getElaboratedKeywordLoc();
@@ -61,8 +62,7 @@ void RedundantTypenameCheck::check(const MatchFinder::MatchResult &Result) {
 
       if (const auto TL =
               NonDependentTypeLoc->getAs<TemplateSpecializationTypeLoc>())
-        if (!TL.getType()->isDependentType())
-          return TL.getElaboratedKeywordLoc();
+        return TL.getElaboratedKeywordLoc();
     } else {
       TypeLoc InnermostTypeLoc =
           *Result.Nodes.getNodeAs<TypeLoc>("dependentTypeLoc");

--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -47,8 +47,10 @@ void RedundantTypenameCheck::check(const MatchFinder::MatchResult &Result) {
   const SourceLocation ElaboratedKeywordLoc = [&] {
     if (const auto *NonDependentTypeLoc =
             Result.Nodes.getNodeAs<TypeLoc>("nonDependentTypeLoc")) {
-      if (const auto TL = NonDependentTypeLoc->getAs<TypedefTypeLoc>())
-        return TL.getElaboratedKeywordLoc();
+      if (const auto TL = NonDependentTypeLoc->getAs<TypedefTypeLoc>()) {
+        if (!TL.getType()->isDependentType())
+          return TL.getElaboratedKeywordLoc();
+      }
 
       if (const auto TL = NonDependentTypeLoc->getAs<TagTypeLoc>())
         return TL.getElaboratedKeywordLoc();

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -547,10 +547,6 @@ Changes in existing checks
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option
   `IgnoreAliasing`, that allows not looking at underlying types of type aliases.
 
-- Improved :doc:`readability-redundant-typename
-  <clang-tidy/checks/readability/redundant-typename>` check to correctly
-  handle dependent types in type aliases.
-
 - Improved :doc:`readability-uppercase-literal-suffix
   <clang-tidy/checks/readability/uppercase-literal-suffix>` check to recognize
   literal suffixes added in C++23 and C23.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -547,6 +547,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option
   `IgnoreAliasing`, that allows not looking at underlying types of type aliases.
 
+- Improved :doc:`readability-redundant-typename
+  <clang-tidy/checks/readability/redundant-typename>` check to correctly
+  handle dependent types in type aliases.
+
 - Improved :doc:`readability-uppercase-literal-suffix
   <clang-tidy/checks/readability/uppercase-literal-suffix>` check to recognize
   literal suffixes added in C++23 and C23.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
@@ -279,3 +279,15 @@ template <typename T>
 Wrapper<typename ClassWrapper<T>::R> ClassWrapper<T>::f() {
     return {};
 }
+
+template <typename T> struct StructWrapper {};
+template <typename T>
+class ClassWithNestedStruct {
+  struct Nested {};
+  StructWrapper<Nested> f();
+};
+
+template <typename T>
+StructWrapper<typename ClassWithNestedStruct<T>::Nested> ClassWithNestedStruct<T>::f() {
+  return {};
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
@@ -268,16 +268,14 @@ WHOLE_TYPE_IN_MACRO Macro2;
 #define WHOLE_DECLARATION_IN_MACRO typename NotDependent::R Macro3
 WHOLE_DECLARATION_IN_MACRO;
 
-template<typename T> struct ListWrapper {};
-template<typename T>
-class ClassWrapper {
-public:
-    using Argument = ListWrapper<T>;
-    ListWrapper<Argument> arguments;
-    ListWrapper<Argument> getArguments() const;
+template <typename T> struct Wrapper {};
+template <typename T>
+struct ClassWrapper {
+    using R = T;
+    Wrapper<R> f();
 };
-template<typename T>
-ListWrapper<typename ClassWrapper<T>::Argument> ClassWrapper<T>::getArguments() const {
-    return arguments;
+
+template <typename T>
+Wrapper<typename ClassWrapper<T>::R> ClassWrapper<T>::f() {
+    return {};
 }
-// CHECK-NOT: warning: redundant 'typename' [readability-redundant-typename]

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
@@ -267,3 +267,17 @@ WHOLE_TYPE_IN_MACRO Macro2;
 
 #define WHOLE_DECLARATION_IN_MACRO typename NotDependent::R Macro3
 WHOLE_DECLARATION_IN_MACRO;
+
+template<typename T> struct ListWrapper {};
+template<typename T>
+class ClassWrapper {
+public:
+    using Argument = ListWrapper<T>;
+    ListWrapper<Argument> arguments;
+    ListWrapper<Argument> getArguments() const;
+};
+template<typename T>
+ListWrapper<typename ClassWrapper<T>::Argument> ClassWrapper<T>::getArguments() const {
+    return arguments;
+}
+// CHECK-NOT: warning: redundant 'typename' [readability-redundant-typename]


### PR DESCRIPTION
Closes #169166