### PR TITLE
[MLIR][linalg] Erase effectful producer after fusion if it's no longer used

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp
@@ -493,6 +493,12 @@ public:
         });
       }
       rewriter.eraseOp(genericOp);
+      // If after fusion, the producer no longer has uses, erase it. Usually the
+      // greedy pattern driver takes care of this, however if the producer
+      // contains ops with memory effects it won't be considered trivially dead.
+      if (producer->use_empty())
+        rewriter.eraseOp(producer);
+
       return success();
     }
     return failure();


### PR DESCRIPTION
This PR fixes a subtle bug in the `linalg-fuse-elementwise-ops` pass where some producers are not being erased after fusion.

The pass relies on the DCE done by the greedy pattern rewriter in order to erase any trivially dead producer ops that no longer have uses after fusion.
However if the producer's region contains ops with memory effects, the producer itself cannot be erased because `linalg.generic` ops have the `RecursiveMemoryEffects` trait. This makes the producer not trivially dead even when it has no uses. This causes miscompiles as the body of the 'old' producer is essentially "duplicated", as opposed to "moved", in the IR after fusion.

The fix is to erase the producer within the pattern if it no longer has uses instead of solely relying on DCE.