### PR TITLE
[mlir] Fold memref.cast static-to-dynamic to memref.expand_shape

### DIFF
--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -2544,12 +2544,11 @@ public:
     SmallVector<ReassociationIndices> reassociationIndices =
         op.getReassociationIndices();
     for (auto [idx, group] : llvm::enumerate(reassociationIndices)) {
-      int64_t castSourceDynCount = castSourceType.isDynamicDim(idx) ? 1 : 0;
       auto newOutputShapeSizesSlice =
           ArrayRef(newOutputShapeSizes).slice(group.front(), group.size());
-      int64_t newOutputDynCount =
-          llvm::count_if(newOutputShapeSizesSlice, ShapedType::isDynamic);
-      if (castSourceDynCount != newOutputDynCount)
+      bool newOutputDynamic =
+          llvm::is_contained(newOutputShapeSizesSlice, ShapedType::kDynamic);
+      if (castSourceType.isDynamicDim(idx) != newOutputDynamic)
         return rewriter.notifyMatchFailure(
             op, "folding cast will result in changing dynamicity in "
                 "reassociation group");

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -2524,7 +2524,7 @@ public:
 
     // Convert output shape dims from dynamic to static where possible.
     for (auto [dimIdx, dimSize] : enumerate(originalOutputShape)) {
-      auto sizeOpt = getConstantIntValue(dimSize);
+      std::optional<int64_t> sizeOpt = getConstantIntValue(dimSize);
       if (sizeOpt.has_value()) {
         newOutputShapeSizes.push_back(sizeOpt.value());
         newOutputShape[dimIdx] = rewriter.getIndexAttr(sizeOpt.value());

--- a/mlir/test/Dialect/MemRef/canonicalize.mlir
+++ b/mlir/test/Dialect/MemRef/canonicalize.mlir
@@ -670,6 +670,21 @@ func.func @not_fold_memref_expand_static_to_dynamic_cast_if_really_dynamic(%arg0
 
 // -----
 
+// CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_layout(
+// CHECK-SAME:      %[[ARG0:.*]]: memref<8x4xf32>) -> memref<8x1x4xf32> {
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2]] output_shape [8, 1, 4] : memref<8x4xf32> into memref<8x1x4xf32>
+// CHECK:           return %[[EXPAND_SHAPE_0]] : memref<8x1x4xf32>
+// CHECK:         }
+func.func @fold_memref_expand_static_to_dynamic_layout(%arg0 : memref<8x4xf32>) -> memref<8x1x4xf32> {
+  %0 = memref.cast %arg0 : memref<8x4xf32> to memref<8x4xf32, strided<[?, ?], offset: ?>>
+  %1 = memref.expand_shape %0 [[0, 1], [2]] output_shape [8, 1, 4]
+      : memref<8x4xf32, strided<[?, ?], offset: ?>> into memref<8x1x4xf32, strided<[?,?,?], offset: ?>>
+  %2 = memref.cast %1 : memref<8x1x4xf32, strided<[?,?,?], offset: ?>> to memref<8x1x4xf32>
+  return %2 : memref<8x1x4xf32>
+}
+
+// -----
+
 // CHECK-LABEL:   func @collapse_after_memref_cast_type_change(
 // CHECK-SAME:      %[[INPUT:.*]]: memref<?x512x1x1xf32>) -> memref<?x?xf32> {
 // CHECK:           %[[COLLAPSED:.*]] = memref.collapse_shape %[[INPUT]]

--- a/mlir/test/Dialect/MemRef/canonicalize.mlir
+++ b/mlir/test/Dialect/MemRef/canonicalize.mlir
@@ -551,11 +551,11 @@ func.func @fold_memref_expand_cast(%arg0 : memref<?x?xf32>) -> memref<2x4x4xf32>
 
 // -----
 
-// CHECK-LABEL: @fold_memref_expand_with_static_to_dynamic_cast
-// CHECK-NOT:     memref.cast
-// CHECK:         memref.expand_shape {{.*}} output_shape [2, 1, 4, 4] : memref<8x4xf32> into memref<2x1x4x4xf32>
-// CHECK-NOT:     memref.cast
-// CHECK:         return
+// CHECK-LABEL:   func.func @fold_memref_expand_with_static_to_dynamic_cast(
+// CHECK-SAME:      %[[ARG0:.*]]: memref<8x4xf32>) -> memref<2x1x4x4xf32> {
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1, 2], [3]] output_shape [2, 1, 4, 4] : memref<8x4xf32> into memref<2x1x4x4xf32>
+// CHECK:           return %[[EXPAND_SHAPE_0]] : memref<2x1x4x4xf32>
+// CHECK:         }
 func.func @fold_memref_expand_with_static_to_dynamic_cast(%arg0 : memref<8x4xf32>) -> memref<2x1x4x4xf32> {
   %0 = memref.cast %arg0 : memref<8x4xf32> to memref<?x4xf32>
   %c0 = arith.constant 0 : index
@@ -571,10 +571,12 @@ func.func @fold_memref_expand_with_static_to_dynamic_cast(%arg0 : memref<8x4xf32
 // -----
 
 // CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_partial(
-// CHECK-NOT:     memref.cast
-// CHECK:         memref.expand_shape {{.*}} {{\[\[}}0, 1], [2, 3]] output_shape [1, 8, 1, %{{.*}}] : memref<8x?xf32> into memref<1x8x1x?xf32>
-// CHECK-NOT:     memref.cast
-// CHECK:         return
+// CHECK-SAME:      %[[ARG0:.*]]: memref<8x?xf32>) -> memref<1x8x1x?xf32> {
+// CHECK:           %[[C1:.*]] = arith.constant 1 : index
+// CHECK:           %[[DIM1:.*]] = memref.dim %[[ARG0]], %[[C1]] : memref<8x?xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2, 3]] output_shape [1, 8, 1, %[[DIM1]]] : memref<8x?xf32> into memref<1x8x1x?xf32>
+// CHECK:           return %[[EXPAND_SHAPE_0]] : memref<1x8x1x?xf32>
+// CHECK:         }
 func.func @fold_memref_expand_static_to_dynamic_partial(%arg0 : memref<8x?xf32>) -> memref<1x8x1x?xf32> {
   %0 = memref.cast %arg0 : memref<8x?xf32> to memref<?x?xf32>
   %c0 = arith.constant 0 : index
@@ -590,10 +592,12 @@ func.func @fold_memref_expand_static_to_dynamic_partial(%arg0 : memref<8x?xf32>)
 // -----
 
 // CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_partial1(
-// CHECK-NOT:     memref.cast
-// CHECK:         memref.expand_shape {{.*}} {{\[\[}}0, 1], [2, 3]] output_shape [1, 8, 1, %{{.*}}] : memref<8x?xf32> into memref<1x8x1x?xf32>
-// CHECK-NOT:     memref.cast
-// CHECK:         return
+// CHECK-SAME:      %[[ARG0:.*]]: memref<8x?xf32>) -> memref<1x8x1x?xf32> {
+// CHECK:           %[[C1:.*]] = arith.constant 1 : index
+// CHECK:           %[[DIM1:.*]] = memref.dim %[[ARG0]], %[[C1]] : memref<8x?xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2, 3]] output_shape [1, 8, 1, %[[DIM1]]] : memref<8x?xf32> into memref<1x8x1x?xf32>
+// CHECK:           return %[[EXPAND_SHAPE_0]] : memref<1x8x1x?xf32>
+// CHECK:         }
 func.func @fold_memref_expand_static_to_dynamic_partial1(%arg0 : memref<8x?xf32>) -> memref<1x8x1x?xf32> {
   %0 = memref.cast %arg0 : memref<8x?xf32> to memref<?x?xf32>
   %c0 = arith.constant 0 : index
@@ -646,9 +650,9 @@ func.func @not_fold_memref_expand_with_dynamic_to_static_cast(%arg0 : memref<?x4
 // CHECK-LABEL:   func.func @not_fold_memref_expand_static_to_dynamic_cast_if_really_dynamic(
 // CHECK-SAME:      %[[ARG0:.*]]: memref<8x4xf32>,
 // CHECK-SAME:      %[[ARG1:.*]]: index) -> memref<2x1x4x4xf32> {
-// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 8 : index
+// CHECK:           %[[C8:.*]] = arith.constant 8 : index
 // CHECK:           %[[CAST_0:.*]] = memref.cast %[[ARG0]] : memref<8x4xf32> to memref<?x4xf32>
-// CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[CONSTANT_0]], %[[ARG1]] : index
+// CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[C8]], %[[ARG1]] : index
 // CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[CAST_0]] {{\[\[}}0, 1, 2], [3]] output_shape {{\[}}%[[DIVUI_0]], 1, 4, 4] : memref<?x4xf32> into memref<?x1x4x4xf32>
 // CHECK:           %[[CAST_1:.*]] = memref.cast %[[EXPAND_SHAPE_0]] : memref<?x1x4x4xf32> to memref<2x1x4x4xf32>
 // CHECK:           return %[[CAST_1]] : memref<2x1x4x4xf32>

--- a/mlir/test/Dialect/MemRef/canonicalize.mlir
+++ b/mlir/test/Dialect/MemRef/canonicalize.mlir
@@ -553,19 +553,17 @@ func.func @fold_memref_expand_cast(%arg0 : memref<?x?xf32>) -> memref<2x4x4xf32>
 
 // CHECK-LABEL:   func.func @fold_memref_expand_with_static_to_dynamic_cast(
 // CHECK-SAME:      %[[ARG0:.*]]: memref<8x4xf32>) -> memref<2x1x4x4xf32> {
-// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1, 2], [3]] output_shape [2, 1, 4, 4] : memref<8x4xf32> into memref<2x1x4x4xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1, 2], [3]]
+// CHECK-SAME:                  output_shape [2, 1, 4, 4] : memref<8x4xf32> into memref<2x1x4x4xf32>
 // CHECK:           return %[[EXPAND_SHAPE_0]] : memref<2x1x4x4xf32>
 // CHECK:         }
-func.func @fold_memref_expand_with_static_to_dynamic_cast(%arg0 : memref<8x4xf32>) -> memref<2x1x4x4xf32> {
-  %0 = memref.cast %arg0 : memref<8x4xf32> to memref<?x4xf32>
-  %c0 = arith.constant 0 : index
-  %dim0 = memref.dim %0, %c0 : memref<?x4xf32>
-  %c4 = arith.constant 4 : index
-  %dim_ext = arith.divui %dim0 , %c4: index
-  %1 = memref.expand_shape %0 [[0, 1, 2], [3]] output_shape [%dim_ext, 1, 4, 4]
+func.func @fold_memref_expand_with_static_to_dynamic_cast(%arg0: memref<8x4xf32>) -> memref<2x1x4x4xf32> {
+  %c2 = arith.constant 2 : index
+  %cast = memref.cast %arg0 : memref<8x4xf32> to memref<?x4xf32>
+  %expand_shape = memref.expand_shape %cast [[0, 1, 2], [3]] output_shape [%c2, 1, 4, 4]
       : memref<?x4xf32> into memref<?x1x4x4xf32>
-  %2 = memref.cast %1 : memref<?x1x4x4xf32> to memref<2x1x4x4xf32>
-  return %2 : memref<2x1x4x4xf32>
+  %cast_0 = memref.cast %expand_shape : memref<?x1x4x4xf32> to memref<2x1x4x4xf32>
+  return %cast_0 : memref<2x1x4x4xf32>
 }
 
 // -----
@@ -574,7 +572,8 @@ func.func @fold_memref_expand_with_static_to_dynamic_cast(%arg0 : memref<8x4xf32
 // CHECK-SAME:      %[[ARG0:.*]]: memref<8x?xf32>) -> memref<1x8x1x?xf32> {
 // CHECK:           %[[C1:.*]] = arith.constant 1 : index
 // CHECK:           %[[DIM1:.*]] = memref.dim %[[ARG0]], %[[C1]] : memref<8x?xf32>
-// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2, 3]] output_shape [1, 8, 1, %[[DIM1]]] : memref<8x?xf32> into memref<1x8x1x?xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2, 3]]
+// CHECK-SAME:              output_shape [1, 8, 1, %[[DIM1]]] : memref<8x?xf32> into memref<1x8x1x?xf32>
 // CHECK:           return %[[EXPAND_SHAPE_0]] : memref<1x8x1x?xf32>
 // CHECK:         }
 func.func @fold_memref_expand_static_to_dynamic_partial(%arg0 : memref<8x?xf32>) -> memref<1x8x1x?xf32> {
@@ -591,14 +590,15 @@ func.func @fold_memref_expand_static_to_dynamic_partial(%arg0 : memref<8x?xf32>)
 
 // -----
 
-// CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_partial1(
+// CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_partial_with_arith_const_as_dim(
 // CHECK-SAME:      %[[ARG0:.*]]: memref<8x?xf32>) -> memref<1x8x1x?xf32> {
 // CHECK:           %[[C1:.*]] = arith.constant 1 : index
 // CHECK:           %[[DIM1:.*]] = memref.dim %[[ARG0]], %[[C1]] : memref<8x?xf32>
-// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2, 3]] output_shape [1, 8, 1, %[[DIM1]]] : memref<8x?xf32> into memref<1x8x1x?xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2, 3]]
+// CHECK-SAME:               output_shape [1, 8, 1, %[[DIM1]]] : memref<8x?xf32> into memref<1x8x1x?xf32>
 // CHECK:           return %[[EXPAND_SHAPE_0]] : memref<1x8x1x?xf32>
 // CHECK:         }
-func.func @fold_memref_expand_static_to_dynamic_partial1(%arg0 : memref<8x?xf32>) -> memref<1x8x1x?xf32> {
+func.func @fold_memref_expand_static_to_dynamic_partial_with_arith_const_as_dim(%arg0 : memref<8x?xf32>) -> memref<1x8x1x?xf32> {
   %0 = memref.cast %arg0 : memref<8x?xf32> to memref<?x?xf32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -616,7 +616,8 @@ func.func @fold_memref_expand_static_to_dynamic_partial1(%arg0 : memref<8x?xf32>
 // CHECK-SAME:      %[[ARG0:.*]]: memref<8x?xf32>,
 // CHECK-SAME:      %[[ARG1:.*]]: index, %[[ARG2:.*]]: index) -> memref<8x1x?x?xf32> {
 // CHECK-NOT:     memref.cast
-// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2, 3]] output_shape [8, 1, %[[ARG1]], %[[ARG2]]] : memref<8x?xf32> into memref<8x1x?x?xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2, 3]]
+// CHECK-SAME:        output_shape [8, 1, %[[ARG1]], %[[ARG2]]] : memref<8x?xf32> into memref<8x1x?x?xf32>
 // CHECK-NOT:     memref.cast
 // CHECK:           return %[[EXPAND_SHAPE_0]] : memref<8x1x?x?xf32>
 // CHECK:         }
@@ -635,7 +636,8 @@ func.func @fold_memref_expand_static_to_dynamic_multiple(%arg0 : memref<8x?xf32>
 // CHECK-LABEL:   func.func @not_fold_memref_expand_with_dynamic_to_static_cast(
 // CHECK-SAME:      %[[ARG0:.*]]: memref<?x4xf32>) -> memref<2x1x4x4xf32> {
 // CHECK:           %[[CAST_0:.*]] = memref.cast %[[ARG0]] : memref<?x4xf32> to memref<8x4xf32>
-// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[CAST_0]] {{\[\[}}0, 1, 2], [3]] output_shape [2, 1, 4, 4] : memref<8x4xf32> into memref<2x1x4x4xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[CAST_0]] {{\[\[}}0, 1, 2], [3]]
+// CHECK-SAME:          output_shape [2, 1, 4, 4] : memref<8x4xf32> into memref<2x1x4x4xf32>
 // CHECK:           return %[[EXPAND_SHAPE_0]] : memref<2x1x4x4xf32>
 // CHECK:         }
 func.func @not_fold_memref_expand_with_dynamic_to_static_cast(%arg0 : memref<?x4xf32>) -> memref<2x1x4x4xf32> {
@@ -653,7 +655,8 @@ func.func @not_fold_memref_expand_with_dynamic_to_static_cast(%arg0 : memref<?x4
 // CHECK:           %[[C8:.*]] = arith.constant 8 : index
 // CHECK:           %[[CAST_0:.*]] = memref.cast %[[ARG0]] : memref<8x4xf32> to memref<?x4xf32>
 // CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[C8]], %[[ARG1]] : index
-// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[CAST_0]] {{\[\[}}0, 1, 2], [3]] output_shape {{\[}}%[[DIVUI_0]], 1, 4, 4] : memref<?x4xf32> into memref<?x1x4x4xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[CAST_0]] {{\[\[}}0, 1, 2], [3]]
+// CHECK-SAME:          output_shape {{\[}}%[[DIVUI_0]], 1, 4, 4] : memref<?x4xf32> into memref<?x1x4x4xf32>
 // CHECK:           %[[CAST_1:.*]] = memref.cast %[[EXPAND_SHAPE_0]] : memref<?x1x4x4xf32> to memref<2x1x4x4xf32>
 // CHECK:           return %[[CAST_1]] : memref<2x1x4x4xf32>
 // CHECK:         }
@@ -672,7 +675,8 @@ func.func @not_fold_memref_expand_static_to_dynamic_cast_if_really_dynamic(%arg0
 
 // CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_layout(
 // CHECK-SAME:      %[[ARG0:.*]]: memref<8x4xf32>) -> memref<8x1x4xf32> {
-// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2]] output_shape [8, 1, 4] : memref<8x4xf32> into memref<8x1x4xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[ARG0]] {{\[\[}}0, 1], [2]]
+// CHECK-SAME:          output_shape [8, 1, 4] : memref<8x4xf32> into memref<8x1x4xf32>
 // CHECK:           return %[[EXPAND_SHAPE_0]] : memref<8x1x4xf32>
 // CHECK:         }
 func.func @fold_memref_expand_static_to_dynamic_layout(%arg0 : memref<8x4xf32>) -> memref<8x1x4xf32> {

--- a/mlir/test/Dialect/MemRef/canonicalize.mlir
+++ b/mlir/test/Dialect/MemRef/canonicalize.mlir
@@ -553,6 +553,8 @@ func.func @fold_memref_expand_cast(%arg0 : memref<?x?xf32>) -> memref<2x4x4xf32>
 
 // CHECK-LABEL: @fold_memref_expand_with_static_to_dynamic_cast
 // CHECK-NOT:     memref.cast
+// CHECK:         memref.expand_shape {{.*}} output_shape [2, 1, 4, 4] : memref<8x4xf32> into memref<2x1x4x4xf32>
+// CHECK-NOT:     memref.cast
 // CHECK:         return
 func.func @fold_memref_expand_with_static_to_dynamic_cast(%arg0 : memref<8x4xf32>) -> memref<2x1x4x4xf32> {
   %0 = memref.cast %arg0 : memref<8x4xf32> to memref<?x4xf32>
@@ -569,6 +571,8 @@ func.func @fold_memref_expand_with_static_to_dynamic_cast(%arg0 : memref<8x4xf32
 // -----
 
 // CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_partial(
+// CHECK-NOT:     memref.cast
+// CHECK:         memref.expand_shape {{.*}} {{\[\[}}0, 1], [2, 3]] output_shape [1, 8, 1, %{{.*}}] : memref<8x?xf32> into memref<1x8x1x?xf32>
 // CHECK-NOT:     memref.cast
 // CHECK:         return
 func.func @fold_memref_expand_static_to_dynamic_partial(%arg0 : memref<8x?xf32>) -> memref<1x8x1x?xf32> {
@@ -587,6 +591,8 @@ func.func @fold_memref_expand_static_to_dynamic_partial(%arg0 : memref<8x?xf32>)
 
 // CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_partial1(
 // CHECK-NOT:     memref.cast
+// CHECK:         memref.expand_shape {{.*}} {{\[\[}}0, 1], [2, 3]] output_shape [1, 8, 1, %{{.*}}] : memref<8x?xf32> into memref<1x8x1x?xf32>
+// CHECK-NOT:     memref.cast
 // CHECK:         return
 func.func @fold_memref_expand_static_to_dynamic_partial1(%arg0 : memref<8x?xf32>) -> memref<1x8x1x?xf32> {
   %0 = memref.cast %arg0 : memref<8x?xf32> to memref<?x?xf32>
@@ -603,9 +609,10 @@ func.func @fold_memref_expand_static_to_dynamic_partial1(%arg0 : memref<8x?xf32>
 // -----
 
 // CHECK-LABEL:   func.func @not_fold_memref_expand_with_dynamic_to_static_cast(
-// CHECK:           memref.cast
-// CHECK:           memref.expand_shape
-// CHECK:           return
+// CHECK-SAME:      %[[ARG0:.*]]: memref<?x4xf32>) -> memref<2x1x4x4xf32> {
+// CHECK:           %[[CAST_0:.*]] = memref.cast %[[ARG0]] : memref<?x4xf32> to memref<8x4xf32>
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[CAST_0]] {{\[\[}}0, 1, 2], [3]] output_shape [2, 1, 4, 4] : memref<8x4xf32> into memref<2x1x4x4xf32>
+// CHECK:           return %[[EXPAND_SHAPE_0]] : memref<2x1x4x4xf32>
 // CHECK:         }
 func.func @not_fold_memref_expand_with_dynamic_to_static_cast(%arg0 : memref<?x4xf32>) -> memref<2x1x4x4xf32> {
   %0 = memref.cast %arg0 : memref<?x4xf32> to memref<8x4xf32>
@@ -617,10 +624,14 @@ func.func @not_fold_memref_expand_with_dynamic_to_static_cast(%arg0 : memref<?x4
 // -----
 
 // CHECK-LABEL:   func.func @not_fold_memref_expand_static_to_dynamic_cast_if_really_dynamic(
-// CHECK:           memref.cast
-// CHECK:           memref.expand_shape
-// CHECK:           memref.cast
-// CHECK:           return
+// CHECK-SAME:      %[[ARG0:.*]]: memref<8x4xf32>,
+// CHECK-SAME:      %[[ARG1:.*]]: index) -> memref<2x1x4x4xf32> {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 8 : index
+// CHECK:           %[[CAST_0:.*]] = memref.cast %[[ARG0]] : memref<8x4xf32> to memref<?x4xf32>
+// CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[CONSTANT_0]], %[[ARG1]] : index
+// CHECK:           %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[CAST_0]] {{\[\[}}0, 1, 2], [3]] output_shape {{\[}}%[[DIVUI_0]], 1, 4, 4] : memref<?x4xf32> into memref<?x1x4x4xf32>
+// CHECK:           %[[CAST_1:.*]] = memref.cast %[[EXPAND_SHAPE_0]] : memref<?x1x4x4xf32> to memref<2x1x4x4xf32>
+// CHECK:           return %[[CAST_1]] : memref<2x1x4x4xf32>
 // CHECK:         }
 func.func @not_fold_memref_expand_static_to_dynamic_cast_if_really_dynamic(%arg0 : memref<8x4xf32>, %arg1 : index) -> memref<2x1x4x4xf32> {
   %0 = memref.cast %arg0 : memref<8x4xf32> to memref<?x4xf32>

--- a/mlir/test/Dialect/MemRef/canonicalize.mlir
+++ b/mlir/test/Dialect/MemRef/canonicalize.mlir
@@ -551,6 +551,90 @@ func.func @fold_memref_expand_cast(%arg0 : memref<?x?xf32>) -> memref<2x4x4xf32>
 
 // -----
 
+// CHECK-LABEL: @fold_memref_expand_with_static_to_dynamic_cast
+// CHECK-NOT:     memref.cast
+// CHECK:         return
+func.func @fold_memref_expand_with_static_to_dynamic_cast(%arg0 : memref<8x4xf32>) -> memref<2x1x4x4xf32> {
+  %0 = memref.cast %arg0 : memref<8x4xf32> to memref<?x4xf32>
+  %c0 = arith.constant 0 : index
+  %dim0 = memref.dim %0, %c0 : memref<?x4xf32>
+  %c4 = arith.constant 4 : index
+  %dim_ext = arith.divui %dim0 , %c4: index
+  %1 = memref.expand_shape %0 [[0, 1, 2], [3]] output_shape [%dim_ext, 1, 4, 4]
+      : memref<?x4xf32> into memref<?x1x4x4xf32>
+  %2 = memref.cast %1 : memref<?x1x4x4xf32> to memref<2x1x4x4xf32>
+  return %2 : memref<2x1x4x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_partial(
+// CHECK-NOT:     memref.cast
+// CHECK:         return
+func.func @fold_memref_expand_static_to_dynamic_partial(%arg0 : memref<8x?xf32>) -> memref<1x8x1x?xf32> {
+  %0 = memref.cast %arg0 : memref<8x?xf32> to memref<?x?xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %dim0 = memref.dim %0, %c0 : memref<?x?xf32>
+  %dim1 = memref.dim %0, %c1 : memref<?x?xf32>
+  %1 = memref.expand_shape %0 [[0, 1], [2, 3]] output_shape [1, %dim0, 1, %dim1]
+      : memref<?x?xf32> into memref<1x?x1x?xf32>
+  %2 = memref.cast %1 : memref<1x?x1x?xf32> to memref<1x8x1x?xf32>
+  return %2 : memref<1x8x1x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @fold_memref_expand_static_to_dynamic_partial1(
+// CHECK-NOT:     memref.cast
+// CHECK:         return
+func.func @fold_memref_expand_static_to_dynamic_partial1(%arg0 : memref<8x?xf32>) -> memref<1x8x1x?xf32> {
+  %0 = memref.cast %arg0 : memref<8x?xf32> to memref<?x?xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %dim0 = memref.dim %0, %c0 : memref<?x?xf32>
+  %dim1 = memref.dim %0, %c1 : memref<?x?xf32>
+  %1 = memref.expand_shape %0 [[0, 1], [2, 3]] output_shape [%c1, %dim0, %c1, %dim1]
+      : memref<?x?xf32> into memref<?x?x?x?xf32>
+  %2 = memref.cast %1 : memref<?x?x?x?xf32> to memref<1x8x1x?xf32>
+  return %2 : memref<1x8x1x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @not_fold_memref_expand_with_dynamic_to_static_cast(
+// CHECK:           memref.cast
+// CHECK:           memref.expand_shape
+// CHECK:           return
+// CHECK:         }
+func.func @not_fold_memref_expand_with_dynamic_to_static_cast(%arg0 : memref<?x4xf32>) -> memref<2x1x4x4xf32> {
+  %0 = memref.cast %arg0 : memref<?x4xf32> to memref<8x4xf32>
+  %1 = memref.expand_shape %0 [[0, 1, 2], [3]] output_shape [2, 1, 4, 4]
+      : memref<8x4xf32> into memref<2x1x4x4xf32>
+  return %1 : memref<2x1x4x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   func.func @not_fold_memref_expand_static_to_dynamic_cast_if_really_dynamic(
+// CHECK:           memref.cast
+// CHECK:           memref.expand_shape
+// CHECK:           memref.cast
+// CHECK:           return
+// CHECK:         }
+func.func @not_fold_memref_expand_static_to_dynamic_cast_if_really_dynamic(%arg0 : memref<8x4xf32>, %arg1 : index) -> memref<2x1x4x4xf32> {
+  %0 = memref.cast %arg0 : memref<8x4xf32> to memref<?x4xf32>
+  %c0 = arith.constant 0 : index
+  %dim0 = memref.dim %0, %c0 : memref<?x4xf32>
+  %dim_ext = arith.divui %dim0 , %arg1: index
+  %1 = memref.expand_shape %0 [[0, 1, 2], [3]] output_shape [%dim_ext, 1, 4, 4]
+      : memref<?x4xf32> into memref<?x1x4x4xf32>
+  %2 = memref.cast %1 : memref<?x1x4x4xf32> to memref<2x1x4x4xf32>
+  return %2 : memref<2x1x4x4xf32>
+}
+
+// -----
+
 // CHECK-LABEL:   func @collapse_after_memref_cast_type_change(
 // CHECK-SAME:      %[[INPUT:.*]]: memref<?x512x1x1xf32>) -> memref<?x?xf32> {
 // CHECK:           %[[COLLAPSED:.*]] = memref.collapse_shape %[[INPUT]]


### PR DESCRIPTION
memref.expand_shape didn't have memref.cast op folder. Added canonicalization pattern to allow folding of memref.cast from static to dynamic.

Example:

```mlir
  %0 = memref.cast %arg0 : memref<8x4xf32> to memref<?x4xf32>
  %c0 = arith.constant 0 : index
  %dim0 = memref.dim %0, %c0 : memref<?x4xf32>
  %1 = memref.expand_shape %0 [[0, 1], [2]] output_shape [%dim0, 1, 4]  : memref<?x4xf32> into memref<?x1x4xf32>
```

is converted to:

```mlir
  %expand_shape = memref.expand_shape %arg0 [[0, 1], [2]] output_shape [8, 1, 4] : memref<8x4xf32> into memref<8x1x4xf32>
  %cast = memref.cast %expand_shape : memref<8x1x4xf32> to memref<?x1x4xf32>

```

