### PR TITLE
[CMake] Don't explicitly set folder for InstrumentationTests

### DIFF
--- a/llvm/unittests/Transforms/Instrumentation/CMakeLists.txt
+++ b/llvm/unittests/Transforms/Instrumentation/CMakeLists.txt
@@ -14,5 +14,3 @@ add_llvm_unittest(InstrumentationTests
   )
 
 target_link_libraries(InstrumentationTests PRIVATE LLVMTestingSupport)
-
-set_property(TARGET InstrumentationTests PROPERTY FOLDER "Tests/UnitTests/TransformTests")


### PR DESCRIPTION
Use the default of `LLVM/Tests/Unit` to group these tests with other LLVM unit test targets in the IDE.