### PR TITLE
[mlir][tosa] Add CastFolder for tosa.table

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -1194,6 +1194,8 @@ def Tosa_TableOp : Tosa_InferShapedTypeOp<"table"> {
   }];
 
   let hasVerifier = 1;
+  
+  let hasCanonicalizer = 1;
 
   let assemblyFormat =
       "operands attr-dict `:` functional-type(operands, results)";

--- a/mlir/test/Dialect/Tosa/canonicalize.mlir
+++ b/mlir/test/Dialect/Tosa/canonicalize.mlir
@@ -411,6 +411,17 @@ func.func @concat_fold_cast(%arg0: tensor<?x1xf32>) -> tensor<?x?xf32> {
 
 // -----
 
+// CHECK-LABEL: @fold_cast_into_table
+func.func @fold_cast_into_table(%arg0: tensor<6x256xi8>, %arg1: tensor<256xi8>) -> tensor<?x256xi8> {
+  // CHECK:           %[[VAL_0:.*]] = tosa.table %arg0, %arg1 : (tensor<6x256xi8>, tensor<256xi8>) -> tensor<6x256xi8>
+  // CHECK:           tensor.cast %[[VAL_0]] : tensor<6x256xi8> to tensor<?x256xi8>
+  %0 = tensor.cast %arg0 : tensor<6x256xi8> to tensor<?x256xi8>
+  %1 = tosa.table %0, %arg1 : (tensor<?x256xi8>, tensor<256xi8>) -> tensor<?x256xi8>
+  return %1 : tensor<?x256xi8>
+}
+
+// -----
+
 // CHECK-LABEL: @conv2d_stride_2
 func.func @conv2d_stride_2(%arg0: tensor<4x11x11x2xf32>) -> tensor<4x6x6x3xf32> {
   // CHECK: tosa.conv2d


### PR DESCRIPTION
Push tensor.cast operation past tosa.table when the cast goes from a more static type to a less static (more dynamic) type. This allows the table to operate on more refined types, enabling better optimizations and type inference in downstream operations. The pattern adds a cast back to the original result type for compatibility with existing users.

 For example:
 ```mlir
   %cast = tensor.cast %input : tensor<6x256xi8> to tensor<?x256xi8>
   %table_out = tosa.table %cast, %table_tensor
     : (tensor<?x256xi8>, tensor<256xi8>) -> tensor<?x256xi8>
 ```
 Can be folded to:
 ```mlir
   %table_out = tosa.table %input, %table_tensor
     : (tensor<6x256xi8>, tensor<256xi8>) -> tensor<6x256xi8>
   %cast = tensor.cast %table_out
     : tensor<6x256xi8> to tensor<?x256xi8>
 ```