### PR TITLE
[lldb][NFC] Change ObjectFile's DataExtractor to a shared ptr

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -419,7 +419,7 @@ public:
   /// Attempts to parse the object header.
   ///
   /// This function is used as a test to see if a given plug-in instance can
-  /// parse the header data already contained in ObjectFile::m_data_sp. If an
+  /// parse the header data already contained in ObjectFile::m_data_nsp. If an
   /// object file parser does not recognize that magic bytes in a header,
   /// false should be returned and the next plug-in can attempt to parse an
   /// object file.
@@ -789,10 +789,10 @@ protected:
   lldb::addr_t m_length; ///< The length of this object file if it is known (can
                          ///be zero if length is unknown or can't be
                          ///determined).
-  DataExtractorNSP m_data_sp; ///< The data for this object file so things
-                              ///< can be parsed lazily.  This shared pointer
-                              ///< will always have a DataExtractor object,
-                              ///< although it may only be default-constructed.
+  DataExtractorNSP m_data_nsp; ///< The data for this object file so things
+                               ///< can be parsed lazily.  This shared pointer
+                               ///< will always have a DataExtractor object,
+                               ///< although it may only be default-constructed.
   lldb::ProcessWP m_process_wp;
   /// Set if the object file only exists in memory.
   const lldb::addr_t m_memory_addr;

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -418,7 +418,7 @@ public:
   /// Attempts to parse the object header.
   ///
   /// This function is used as a test to see if a given plug-in instance can
-  /// parse the header data already contained in ObjectFile::m_data. If an
+  /// parse the header data already contained in ObjectFile::m_data_up. If an
   /// object file parser does not recognize that magic bytes in a header,
   /// false should be returned and the next plug-in can attempt to parse an
   /// object file.
@@ -786,8 +786,11 @@ protected:
   lldb::addr_t m_length; ///< The length of this object file if it is known (can
                          ///be zero if length is unknown or can't be
                          ///determined).
-  DataExtractor
-      m_data; ///< The data for this object file so things can be parsed lazily.
+  lldb::DataExtractorUP
+      m_data_up; ///< The data for this object file so things
+                 ///< can be parsed lazily.  This unique pointer
+                 ///< will always have a DataExtractor object,
+                 ///< although it may only be default-constructed.
   lldb::ProcessWP m_process_wp;
   /// Set if the object file only exists in memory.
   const lldb::addr_t m_memory_addr;

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -418,7 +418,7 @@ public:
   /// Attempts to parse the object header.
   ///
   /// This function is used as a test to see if a given plug-in instance can
-  /// parse the header data already contained in ObjectFile::m_data_up. If an
+  /// parse the header data already contained in ObjectFile::m_data_sp. If an
   /// object file parser does not recognize that magic bytes in a header,
   /// false should be returned and the next plug-in can attempt to parse an
   /// object file.
@@ -786,9 +786,9 @@ protected:
   lldb::addr_t m_length; ///< The length of this object file if it is known (can
                          ///be zero if length is unknown or can't be
                          ///determined).
-  lldb::DataExtractorUP
-      m_data_up; ///< The data for this object file so things
-                 ///< can be parsed lazily.  This unique pointer
+  lldb::DataExtractorSP
+      m_data_sp; ///< The data for this object file so things
+                 ///< can be parsed lazily.  This shared pointer
                  ///< will always have a DataExtractor object,
                  ///< although it may only be default-constructed.
   lldb::ProcessWP m_process_wp;

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -18,6 +18,7 @@
 #include "lldb/Utility/Endian.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/FileSpecList.h"
+#include "lldb/Utility/NonNullSharedPtr.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/UUID.h"
 #include "lldb/lldb-private.h"
@@ -777,6 +778,8 @@ public:
   std::string GetObjectName() const;
 
 protected:
+  typedef NonNullSharedPtr<lldb_private::DataExtractor> DataExtractorNSP;
+
   // Member variables.
   FileSpec m_file;
   Type m_type;
@@ -786,11 +789,10 @@ protected:
   lldb::addr_t m_length; ///< The length of this object file if it is known (can
                          ///be zero if length is unknown or can't be
                          ///determined).
-  lldb::DataExtractorSP
-      m_data_sp; ///< The data for this object file so things
-                 ///< can be parsed lazily.  This shared pointer
-                 ///< will always have a DataExtractor object,
-                 ///< although it may only be default-constructed.
+  DataExtractorNSP m_data_sp; ///< The data for this object file so things
+                              ///< can be parsed lazily.  This shared pointer
+                              ///< will always have a DataExtractor object,
+                              ///< although it may only be default-constructed.
   lldb::ProcessWP m_process_wp;
   /// Set if the object file only exists in memory.
   const lldb::addr_t m_memory_addr;

--- a/lldb/include/lldb/lldb-forward.h
+++ b/lldb/include/lldb/lldb-forward.h
@@ -342,6 +342,7 @@ typedef std::shared_ptr<lldb_private::CompileUnit> CompUnitSP;
 typedef std::shared_ptr<lldb_private::DataBuffer> DataBufferSP;
 typedef std::shared_ptr<lldb_private::WritableDataBuffer> WritableDataBufferSP;
 typedef std::shared_ptr<lldb_private::DataExtractor> DataExtractorSP;
+typedef std::unique_ptr<lldb_private::DataExtractor> DataExtractorUP;
 typedef std::shared_ptr<lldb_private::Debugger> DebuggerSP;
 typedef std::weak_ptr<lldb_private::Debugger> DebuggerWP;
 typedef std::shared_ptr<lldb_private::Disassembler> DisassemblerSP;

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -73,8 +73,8 @@ ObjectFileJIT::ObjectFileJIT(const lldb::ModuleSP &module_sp,
     : ObjectFile(module_sp, nullptr, 0, 0, DataBufferSP(), 0), m_delegate_wp() {
   if (delegate_sp) {
     m_delegate_wp = delegate_sp;
-    m_data.SetByteOrder(delegate_sp->GetByteOrder());
-    m_data.SetAddressByteSize(delegate_sp->GetAddressByteSize());
+    m_data_up->SetByteOrder(delegate_sp->GetByteOrder());
+    m_data_up->SetAddressByteSize(delegate_sp->GetAddressByteSize());
   }
 }
 
@@ -85,12 +85,14 @@ bool ObjectFileJIT::ParseHeader() {
   return false;
 }
 
-ByteOrder ObjectFileJIT::GetByteOrder() const { return m_data.GetByteOrder(); }
+ByteOrder ObjectFileJIT::GetByteOrder() const {
+  return m_data_up->GetByteOrder();
+}
 
 bool ObjectFileJIT::IsExecutable() const { return false; }
 
 uint32_t ObjectFileJIT::GetAddressByteSize() const {
-  return m_data.GetAddressByteSize();
+  return m_data_up->GetAddressByteSize();
 }
 
 void ObjectFileJIT::ParseSymtab(Symtab &symtab) {

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -73,8 +73,8 @@ ObjectFileJIT::ObjectFileJIT(const lldb::ModuleSP &module_sp,
     : ObjectFile(module_sp, nullptr, 0, 0, DataBufferSP(), 0), m_delegate_wp() {
   if (delegate_sp) {
     m_delegate_wp = delegate_sp;
-    m_data_sp->SetByteOrder(delegate_sp->GetByteOrder());
-    m_data_sp->SetAddressByteSize(delegate_sp->GetAddressByteSize());
+    m_data_nsp->SetByteOrder(delegate_sp->GetByteOrder());
+    m_data_nsp->SetAddressByteSize(delegate_sp->GetAddressByteSize());
   }
 }
 
@@ -86,13 +86,13 @@ bool ObjectFileJIT::ParseHeader() {
 }
 
 ByteOrder ObjectFileJIT::GetByteOrder() const {
-  return m_data_sp->GetByteOrder();
+  return m_data_nsp->GetByteOrder();
 }
 
 bool ObjectFileJIT::IsExecutable() const { return false; }
 
 uint32_t ObjectFileJIT::GetAddressByteSize() const {
-  return m_data_sp->GetAddressByteSize();
+  return m_data_nsp->GetAddressByteSize();
 }
 
 void ObjectFileJIT::ParseSymtab(Symtab &symtab) {

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -73,8 +73,8 @@ ObjectFileJIT::ObjectFileJIT(const lldb::ModuleSP &module_sp,
     : ObjectFile(module_sp, nullptr, 0, 0, DataBufferSP(), 0), m_delegate_wp() {
   if (delegate_sp) {
     m_delegate_wp = delegate_sp;
-    m_data_up->SetByteOrder(delegate_sp->GetByteOrder());
-    m_data_up->SetAddressByteSize(delegate_sp->GetAddressByteSize());
+    m_data_sp->SetByteOrder(delegate_sp->GetByteOrder());
+    m_data_sp->SetAddressByteSize(delegate_sp->GetAddressByteSize());
   }
 }
 
@@ -86,13 +86,13 @@ bool ObjectFileJIT::ParseHeader() {
 }
 
 ByteOrder ObjectFileJIT::GetByteOrder() const {
-  return m_data_up->GetByteOrder();
+  return m_data_sp->GetByteOrder();
 }
 
 bool ObjectFileJIT::IsExecutable() const { return false; }
 
 uint32_t ObjectFileJIT::GetAddressByteSize() const {
-  return m_data_up->GetAddressByteSize();
+  return m_data_sp->GetAddressByteSize();
 }
 
 void ObjectFileJIT::ParseSymtab(Symtab &symtab) {

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
@@ -130,13 +130,13 @@ void ObjectFileBreakpad::CreateSections(SectionList &unified_section_list) {
 
   std::optional<Record::Kind> current_section;
   offset_t section_start;
-  llvm::StringRef text = toStringRef(m_data.GetData());
+  llvm::StringRef text = toStringRef(m_data_up->GetData());
   uint32_t next_section_id = 1;
   auto maybe_add_section = [&](const uint8_t *end_ptr) {
     if (!current_section)
       return; // We have been called before parsing the first line.
 
-    offset_t end_offset = end_ptr - m_data.GetDataStart();
+    offset_t end_offset = end_ptr - m_data_up->GetDataStart();
     auto section_sp = std::make_shared<Section>(
         GetModule(), this, next_section_id++,
         ConstString(toString(*current_section)), eSectionTypeOther,
@@ -162,8 +162,8 @@ void ObjectFileBreakpad::CreateSections(SectionList &unified_section_list) {
     maybe_add_section(line.bytes_begin());
     // And start a new one.
     current_section = next_section;
-    section_start = line.bytes_begin() - m_data.GetDataStart();
+    section_start = line.bytes_begin() - m_data_up->GetDataStart();
   }
   // Finally, add the last section.
-  maybe_add_section(m_data.GetDataEnd());
+  maybe_add_section(m_data_up->GetDataEnd());
 }

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
@@ -130,13 +130,13 @@ void ObjectFileBreakpad::CreateSections(SectionList &unified_section_list) {
 
   std::optional<Record::Kind> current_section;
   offset_t section_start;
-  llvm::StringRef text = toStringRef(m_data_up->GetData());
+  llvm::StringRef text = toStringRef(m_data_sp->GetData());
   uint32_t next_section_id = 1;
   auto maybe_add_section = [&](const uint8_t *end_ptr) {
     if (!current_section)
       return; // We have been called before parsing the first line.
 
-    offset_t end_offset = end_ptr - m_data_up->GetDataStart();
+    offset_t end_offset = end_ptr - m_data_sp->GetDataStart();
     auto section_sp = std::make_shared<Section>(
         GetModule(), this, next_section_id++,
         ConstString(toString(*current_section)), eSectionTypeOther,
@@ -162,8 +162,8 @@ void ObjectFileBreakpad::CreateSections(SectionList &unified_section_list) {
     maybe_add_section(line.bytes_begin());
     // And start a new one.
     current_section = next_section;
-    section_start = line.bytes_begin() - m_data_up->GetDataStart();
+    section_start = line.bytes_begin() - m_data_sp->GetDataStart();
   }
   // Finally, add the last section.
-  maybe_add_section(m_data_up->GetDataEnd());
+  maybe_add_section(m_data_sp->GetDataEnd());
 }

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
@@ -130,13 +130,13 @@ void ObjectFileBreakpad::CreateSections(SectionList &unified_section_list) {
 
   std::optional<Record::Kind> current_section;
   offset_t section_start;
-  llvm::StringRef text = toStringRef(m_data_sp->GetData());
+  llvm::StringRef text = toStringRef(m_data_nsp->GetData());
   uint32_t next_section_id = 1;
   auto maybe_add_section = [&](const uint8_t *end_ptr) {
     if (!current_section)
       return; // We have been called before parsing the first line.
 
-    offset_t end_offset = end_ptr - m_data_sp->GetDataStart();
+    offset_t end_offset = end_ptr - m_data_nsp->GetDataStart();
     auto section_sp = std::make_shared<Section>(
         GetModule(), this, next_section_id++,
         ConstString(toString(*current_section)), eSectionTypeOther,
@@ -162,8 +162,8 @@ void ObjectFileBreakpad::CreateSections(SectionList &unified_section_list) {
     maybe_add_section(line.bytes_begin());
     // And start a new one.
     current_section = next_section;
-    section_start = line.bytes_begin() - m_data_sp->GetDataStart();
+    section_start = line.bytes_begin() - m_data_nsp->GetDataStart();
   }
   // Finally, add the last section.
-  maybe_add_section(m_data_sp->GetDataEnd());
+  maybe_add_section(m_data_nsp->GetDataEnd());
 }

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -300,8 +300,8 @@ bool ObjectFileCOFF::ParseHeader() {
 
   std::lock_guard<std::recursive_mutex> guard(module->GetMutex());
 
-  m_data.SetByteOrder(eByteOrderLittle);
-  m_data.SetAddressByteSize(GetAddressByteSize());
+  m_data_up->SetByteOrder(eByteOrderLittle);
+  m_data_up->SetAddressByteSize(GetAddressByteSize());
 
   return true;
 }

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -300,8 +300,8 @@ bool ObjectFileCOFF::ParseHeader() {
 
   std::lock_guard<std::recursive_mutex> guard(module->GetMutex());
 
-  m_data_up->SetByteOrder(eByteOrderLittle);
-  m_data_up->SetAddressByteSize(GetAddressByteSize());
+  m_data_sp->SetByteOrder(eByteOrderLittle);
+  m_data_sp->SetAddressByteSize(GetAddressByteSize());
 
   return true;
 }

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -300,8 +300,8 @@ bool ObjectFileCOFF::ParseHeader() {
 
   std::lock_guard<std::recursive_mutex> guard(module->GetMutex());
 
-  m_data_sp->SetByteOrder(eByteOrderLittle);
-  m_data_sp->SetAddressByteSize(GetAddressByteSize());
+  m_data_nsp->SetByteOrder(eByteOrderLittle);
+  m_data_nsp->SetAddressByteSize(GetAddressByteSize());
 
   return true;
 }

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -804,7 +804,7 @@ ByteOrder ObjectFileELF::GetByteOrder() const {
 }
 
 uint32_t ObjectFileELF::GetAddressByteSize() const {
-  return m_data.GetAddressByteSize();
+  return m_data_up->GetAddressByteSize();
 }
 
 AddressClass ObjectFileELF::GetAddressClass(addr_t file_addr) {
@@ -845,7 +845,7 @@ size_t ObjectFileELF::SectionIndex(const SectionHeaderCollConstIter &I) const {
 
 bool ObjectFileELF::ParseHeader() {
   lldb::offset_t offset = 0;
-  return m_header.Parse(m_data, &offset);
+  return m_header.Parse(*m_data_up.get(), &offset);
 }
 
 UUID ObjectFileELF::GetUUID() {
@@ -881,7 +881,7 @@ UUID ObjectFileELF::GetUUID() {
         return UUID();
 
       core_notes_crc =
-          CalculateELFNotesSegmentsCRC32(m_program_headers, m_data);
+          CalculateELFNotesSegmentsCRC32(m_program_headers, *m_data_up.get());
 
       if (core_notes_crc) {
         // Use 8 bytes - first 4 bytes for *magic* prefix, mainly to make it
@@ -892,7 +892,7 @@ UUID ObjectFileELF::GetUUID() {
       }
     } else {
       if (!m_gnu_debuglink_crc)
-        m_gnu_debuglink_crc = calc_crc32(0, m_data);
+        m_gnu_debuglink_crc = calc_crc32(0, *m_data_up.get());
       if (m_gnu_debuglink_crc) {
         // Use 4 bytes of crc from the .gnu_debuglink section.
         u32le data(m_gnu_debuglink_crc);
@@ -1078,7 +1078,8 @@ size_t ObjectFileELF::GetProgramHeaderInfo(ProgramHeaderColl &program_headers,
 
 // ParseProgramHeaders
 bool ObjectFileELF::ParseProgramHeaders() {
-  return GetProgramHeaderInfo(m_program_headers, m_data, m_header) != 0;
+  return GetProgramHeaderInfo(m_program_headers, *m_data_up.get(), m_header) !=
+         0;
 }
 
 lldb_private::Status
@@ -1668,8 +1669,8 @@ ObjectFileELF::StripLinkerSymbolAnnotations(llvm::StringRef symbol_name) const {
 
 // ParseSectionHeaders
 size_t ObjectFileELF::ParseSectionHeaders() {
-  return GetSectionHeaderInfo(m_section_headers, m_data, m_header, m_uuid,
-                              m_gnu_debuglink_file, m_gnu_debuglink_crc,
+  return GetSectionHeaderInfo(m_section_headers, *m_data_up.get(), m_header,
+                              m_uuid, m_gnu_debuglink_file, m_gnu_debuglink_crc,
                               m_arch_spec);
 }
 
@@ -3678,7 +3679,8 @@ ArchSpec ObjectFileELF::GetArchitecture() {
       if (H.p_type != PT_NOTE || H.p_offset == 0 || H.p_filesz == 0)
         continue;
       DataExtractor data;
-      if (data.SetData(m_data, H.p_offset, H.p_filesz) == H.p_filesz) {
+      if (data.SetData(*m_data_up.get(), H.p_offset, H.p_filesz) ==
+          H.p_filesz) {
         UUID uuid;
         RefineModuleDetailsFromNote(data, m_arch_spec, uuid);
       }
@@ -3833,10 +3835,10 @@ llvm::ArrayRef<ELFProgramHeader> ObjectFileELF::ProgramHeaders() {
 }
 
 DataExtractor ObjectFileELF::GetSegmentData(const ELFProgramHeader &H) {
-  // Try and read the program header from our cached m_data which can come from
-  // the file on disk being mmap'ed or from the initial part of the ELF file we
-  // read from memory and cached.
-  DataExtractor data = DataExtractor(m_data, H.p_offset, H.p_filesz);
+  // Try and read the program header from our cached m_data_up which can come
+  // from the file on disk being mmap'ed or from the initial part of the ELF
+  // file we read from memory and cached.
+  DataExtractor data = DataExtractor(*m_data_up.get(), H.p_offset, H.p_filesz);
   if (data.GetByteSize() == H.p_filesz)
     return data;
   if (IsInMemory()) {

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -804,7 +804,7 @@ ByteOrder ObjectFileELF::GetByteOrder() const {
 }
 
 uint32_t ObjectFileELF::GetAddressByteSize() const {
-  return m_data_up->GetAddressByteSize();
+  return m_data_sp->GetAddressByteSize();
 }
 
 AddressClass ObjectFileELF::GetAddressClass(addr_t file_addr) {
@@ -845,7 +845,7 @@ size_t ObjectFileELF::SectionIndex(const SectionHeaderCollConstIter &I) const {
 
 bool ObjectFileELF::ParseHeader() {
   lldb::offset_t offset = 0;
-  return m_header.Parse(*m_data_up.get(), &offset);
+  return m_header.Parse(*m_data_sp.get(), &offset);
 }
 
 UUID ObjectFileELF::GetUUID() {
@@ -881,7 +881,7 @@ UUID ObjectFileELF::GetUUID() {
         return UUID();
 
       core_notes_crc =
-          CalculateELFNotesSegmentsCRC32(m_program_headers, *m_data_up.get());
+          CalculateELFNotesSegmentsCRC32(m_program_headers, *m_data_sp.get());
 
       if (core_notes_crc) {
         // Use 8 bytes - first 4 bytes for *magic* prefix, mainly to make it
@@ -892,7 +892,7 @@ UUID ObjectFileELF::GetUUID() {
       }
     } else {
       if (!m_gnu_debuglink_crc)
-        m_gnu_debuglink_crc = calc_crc32(0, *m_data_up.get());
+        m_gnu_debuglink_crc = calc_crc32(0, *m_data_sp.get());
       if (m_gnu_debuglink_crc) {
         // Use 4 bytes of crc from the .gnu_debuglink section.
         u32le data(m_gnu_debuglink_crc);
@@ -1078,7 +1078,7 @@ size_t ObjectFileELF::GetProgramHeaderInfo(ProgramHeaderColl &program_headers,
 
 // ParseProgramHeaders
 bool ObjectFileELF::ParseProgramHeaders() {
-  return GetProgramHeaderInfo(m_program_headers, *m_data_up.get(), m_header) !=
+  return GetProgramHeaderInfo(m_program_headers, *m_data_sp.get(), m_header) !=
          0;
 }
 
@@ -1669,7 +1669,7 @@ ObjectFileELF::StripLinkerSymbolAnnotations(llvm::StringRef symbol_name) const {
 
 // ParseSectionHeaders
 size_t ObjectFileELF::ParseSectionHeaders() {
-  return GetSectionHeaderInfo(m_section_headers, *m_data_up.get(), m_header,
+  return GetSectionHeaderInfo(m_section_headers, *m_data_sp.get(), m_header,
                               m_uuid, m_gnu_debuglink_file, m_gnu_debuglink_crc,
                               m_arch_spec);
 }
@@ -3679,7 +3679,7 @@ ArchSpec ObjectFileELF::GetArchitecture() {
       if (H.p_type != PT_NOTE || H.p_offset == 0 || H.p_filesz == 0)
         continue;
       DataExtractor data;
-      if (data.SetData(*m_data_up.get(), H.p_offset, H.p_filesz) ==
+      if (data.SetData(*m_data_sp.get(), H.p_offset, H.p_filesz) ==
           H.p_filesz) {
         UUID uuid;
         RefineModuleDetailsFromNote(data, m_arch_spec, uuid);
@@ -3835,10 +3835,10 @@ llvm::ArrayRef<ELFProgramHeader> ObjectFileELF::ProgramHeaders() {
 }
 
 DataExtractor ObjectFileELF::GetSegmentData(const ELFProgramHeader &H) {
-  // Try and read the program header from our cached m_data_up which can come
+  // Try and read the program header from our cached m_data_sp which can come
   // from the file on disk being mmap'ed or from the initial part of the ELF
   // file we read from memory and cached.
-  DataExtractor data = DataExtractor(*m_data_up.get(), H.p_offset, H.p_filesz);
+  DataExtractor data = DataExtractor(*m_data_sp.get(), H.p_offset, H.p_filesz);
   if (data.GetByteSize() == H.p_filesz)
     return data;
   if (IsInMemory()) {

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -804,7 +804,7 @@ ByteOrder ObjectFileELF::GetByteOrder() const {
 }
 
 uint32_t ObjectFileELF::GetAddressByteSize() const {
-  return m_data_sp->GetAddressByteSize();
+  return m_data_nsp->GetAddressByteSize();
 }
 
 AddressClass ObjectFileELF::GetAddressClass(addr_t file_addr) {
@@ -845,7 +845,7 @@ size_t ObjectFileELF::SectionIndex(const SectionHeaderCollConstIter &I) const {
 
 bool ObjectFileELF::ParseHeader() {
   lldb::offset_t offset = 0;
-  return m_header.Parse(*m_data_sp.get(), &offset);
+  return m_header.Parse(*m_data_nsp.get(), &offset);
 }
 
 UUID ObjectFileELF::GetUUID() {
@@ -881,7 +881,7 @@ UUID ObjectFileELF::GetUUID() {
         return UUID();
 
       core_notes_crc =
-          CalculateELFNotesSegmentsCRC32(m_program_headers, *m_data_sp.get());
+          CalculateELFNotesSegmentsCRC32(m_program_headers, *m_data_nsp.get());
 
       if (core_notes_crc) {
         // Use 8 bytes - first 4 bytes for *magic* prefix, mainly to make it
@@ -892,7 +892,7 @@ UUID ObjectFileELF::GetUUID() {
       }
     } else {
       if (!m_gnu_debuglink_crc)
-        m_gnu_debuglink_crc = calc_crc32(0, *m_data_sp.get());
+        m_gnu_debuglink_crc = calc_crc32(0, *m_data_nsp.get());
       if (m_gnu_debuglink_crc) {
         // Use 4 bytes of crc from the .gnu_debuglink section.
         u32le data(m_gnu_debuglink_crc);
@@ -1078,7 +1078,7 @@ size_t ObjectFileELF::GetProgramHeaderInfo(ProgramHeaderColl &program_headers,
 
 // ParseProgramHeaders
 bool ObjectFileELF::ParseProgramHeaders() {
-  return GetProgramHeaderInfo(m_program_headers, *m_data_sp.get(), m_header) !=
+  return GetProgramHeaderInfo(m_program_headers, *m_data_nsp.get(), m_header) !=
          0;
 }
 
@@ -1669,7 +1669,7 @@ ObjectFileELF::StripLinkerSymbolAnnotations(llvm::StringRef symbol_name) const {
 
 // ParseSectionHeaders
 size_t ObjectFileELF::ParseSectionHeaders() {
-  return GetSectionHeaderInfo(m_section_headers, *m_data_sp.get(), m_header,
+  return GetSectionHeaderInfo(m_section_headers, *m_data_nsp.get(), m_header,
                               m_uuid, m_gnu_debuglink_file, m_gnu_debuglink_crc,
                               m_arch_spec);
 }
@@ -3679,7 +3679,7 @@ ArchSpec ObjectFileELF::GetArchitecture() {
       if (H.p_type != PT_NOTE || H.p_offset == 0 || H.p_filesz == 0)
         continue;
       DataExtractor data;
-      if (data.SetData(*m_data_sp.get(), H.p_offset, H.p_filesz) ==
+      if (data.SetData(*m_data_nsp.get(), H.p_offset, H.p_filesz) ==
           H.p_filesz) {
         UUID uuid;
         RefineModuleDetailsFromNote(data, m_arch_spec, uuid);
@@ -3835,10 +3835,10 @@ llvm::ArrayRef<ELFProgramHeader> ObjectFileELF::ProgramHeaders() {
 }
 
 DataExtractor ObjectFileELF::GetSegmentData(const ELFProgramHeader &H) {
-  // Try and read the program header from our cached m_data_sp which can come
+  // Try and read the program header from our cached m_data_nsp which can come
   // from the file on disk being mmap'ed or from the initial part of the ELF
   // file we read from memory and cached.
-  DataExtractor data = DataExtractor(*m_data_sp.get(), H.p_offset, H.p_filesz);
+  DataExtractor data = DataExtractor(*m_data_nsp.get(), H.p_offset, H.p_filesz);
   if (data.GetByteSize() == H.p_filesz)
     return data;
   if (IsInMemory()) {

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -1012,35 +1012,35 @@ bool ObjectFileMachO::ParseHeader() {
   std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
   bool can_parse = false;
   lldb::offset_t offset = 0;
-  m_data.SetByteOrder(endian::InlHostByteOrder());
+  m_data_up->SetByteOrder(endian::InlHostByteOrder());
   // Leave magic in the original byte order
-  m_header.magic = m_data.GetU32(&offset);
+  m_header.magic = m_data_up->GetU32(&offset);
   switch (m_header.magic) {
   case MH_MAGIC:
-    m_data.SetByteOrder(endian::InlHostByteOrder());
-    m_data.SetAddressByteSize(4);
+    m_data_up->SetByteOrder(endian::InlHostByteOrder());
+    m_data_up->SetAddressByteSize(4);
     can_parse = true;
     break;
 
   case MH_MAGIC_64:
-    m_data.SetByteOrder(endian::InlHostByteOrder());
-    m_data.SetAddressByteSize(8);
+    m_data_up->SetByteOrder(endian::InlHostByteOrder());
+    m_data_up->SetAddressByteSize(8);
     can_parse = true;
     break;
 
   case MH_CIGAM:
-    m_data.SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
-                            ? eByteOrderLittle
-                            : eByteOrderBig);
-    m_data.SetAddressByteSize(4);
+    m_data_up->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+                                ? eByteOrderLittle
+                                : eByteOrderBig);
+    m_data_up->SetAddressByteSize(4);
     can_parse = true;
     break;
 
   case MH_CIGAM_64:
-    m_data.SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
-                            ? eByteOrderLittle
-                            : eByteOrderBig);
-    m_data.SetAddressByteSize(8);
+    m_data_up->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+                                ? eByteOrderLittle
+                                : eByteOrderBig);
+    m_data_up->SetAddressByteSize(8);
     can_parse = true;
     break;
 
@@ -1049,12 +1049,13 @@ bool ObjectFileMachO::ParseHeader() {
   }
 
   if (can_parse) {
-    m_data.GetU32(&offset, &m_header.cputype, 6);
+    m_data_up->GetU32(&offset, &m_header.cputype, 6);
 
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, m_data, MachHeaderSizeFromMagic(m_header.magic),
-                    base_spec, all_specs);
+    GetAllArchSpecs(m_header, *m_data_up.get(),
+                    MachHeaderSizeFromMagic(m_header.magic), base_spec,
+                    all_specs);
 
     for (unsigned i = 0, e = all_specs.GetSize(); i != e; ++i) {
       ArchSpec mach_arch =
@@ -1068,7 +1069,7 @@ bool ObjectFileMachO::ParseHeader() {
       if (SetModulesArchitecture(mach_arch)) {
         const size_t header_and_lc_size =
             m_header.sizeofcmds + MachHeaderSizeFromMagic(m_header.magic);
-        if (m_data.GetByteSize() < header_and_lc_size) {
+        if (m_data_up->GetByteSize() < header_and_lc_size) {
           DataBufferSP data_sp;
           ProcessSP process_sp(m_process_wp.lock());
           if (process_sp) {
@@ -1080,7 +1081,7 @@ bool ObjectFileMachO::ParseHeader() {
               continue;
           }
           if (data_sp)
-            m_data.SetData(data_sp);
+            m_data_up->SetData(data_sp);
         }
       }
       return true;
@@ -1094,7 +1095,7 @@ bool ObjectFileMachO::ParseHeader() {
 }
 
 ByteOrder ObjectFileMachO::GetByteOrder() const {
-  return m_data.GetByteOrder();
+  return m_data_up->GetByteOrder();
 }
 
 bool ObjectFileMachO::IsExecutable() const {
@@ -1114,7 +1115,7 @@ bool ObjectFileMachO::IsKext() const {
 }
 
 uint32_t ObjectFileMachO::GetAddressByteSize() const {
-  return m_data.GetAddressByteSize();
+  return m_data_up->GetAddressByteSize();
 }
 
 AddressClass ObjectFileMachO::GetAddressClass(lldb::addr_t file_addr) {
@@ -1297,13 +1298,13 @@ bool ObjectFileMachO::IsStripped() {
         const lldb::offset_t load_cmd_offset = offset;
 
         llvm::MachO::load_command lc = {};
-        if (m_data.GetU32(&offset, &lc.cmd, 2) == nullptr)
+        if (m_data_up->GetU32(&offset, &lc.cmd, 2) == nullptr)
           break;
         if (lc.cmd == LC_DYSYMTAB) {
           m_dysymtab.cmd = lc.cmd;
           m_dysymtab.cmdsize = lc.cmdsize;
-          if (m_data.GetU32(&offset, &m_dysymtab.ilocalsym,
-                            (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2) ==
+          if (m_data_up->GetU32(&offset, &m_dysymtab.ilocalsym,
+                                (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2) ==
               nullptr) {
             // Clear m_dysymtab if we were unable to read all items from the
             // load command
@@ -1326,14 +1327,14 @@ ObjectFileMachO::EncryptedFileRanges ObjectFileMachO::GetEncryptedFileRanges() {
   llvm::MachO::encryption_info_command encryption_cmd;
   for (uint32_t i = 0; i < m_header.ncmds; ++i) {
     const lldb::offset_t load_cmd_offset = offset;
-    if (m_data.GetU32(&offset, &encryption_cmd, 2) == nullptr)
+    if (m_data_up->GetU32(&offset, &encryption_cmd, 2) == nullptr)
       break;
 
     // LC_ENCRYPTION_INFO and LC_ENCRYPTION_INFO_64 have the same sizes for the
     // 3 fields we care about, so treat them the same.
     if (encryption_cmd.cmd == LC_ENCRYPTION_INFO ||
         encryption_cmd.cmd == LC_ENCRYPTION_INFO_64) {
-      if (m_data.GetU32(&offset, &encryption_cmd.cryptoff, 3)) {
+      if (m_data_up->GetU32(&offset, &encryption_cmd.cryptoff, 3)) {
         if (encryption_cmd.cryptid != 0) {
           EncryptedFileRanges::Entry entry;
           entry.SetRangeBase(encryption_cmd.cryptoff);
@@ -1562,7 +1563,7 @@ void ObjectFileMachO::ProcessSegmentCommand(
   llvm::MachO::segment_command_64 load_cmd;
   memcpy(&load_cmd, &load_cmd_, sizeof(load_cmd_));
 
-  if (!m_data.GetU8(&offset, (uint8_t *)load_cmd.segname, 16))
+  if (!m_data_up->GetU8(&offset, (uint8_t *)load_cmd.segname, 16))
     return;
 
   ModuleSP module_sp = GetModule();
@@ -1586,11 +1587,11 @@ void ObjectFileMachO::ProcessSegmentCommand(
       add_section = false;
     }
   }
-  load_cmd.vmaddr = m_data.GetAddress(&offset);
-  load_cmd.vmsize = m_data.GetAddress(&offset);
-  load_cmd.fileoff = m_data.GetAddress(&offset);
-  load_cmd.filesize = m_data.GetAddress(&offset);
-  if (!m_data.GetU32(&offset, &load_cmd.maxprot, 4))
+  load_cmd.vmaddr = m_data_up->GetAddress(&offset);
+  load_cmd.vmsize = m_data_up->GetAddress(&offset);
+  load_cmd.fileoff = m_data_up->GetAddress(&offset);
+  load_cmd.filesize = m_data_up->GetAddress(&offset);
+  if (!m_data_up->GetU32(&offset, &load_cmd.maxprot, 4))
     return;
 
   SanitizeSegmentCommand(load_cmd, cmd_idx);
@@ -1681,16 +1682,16 @@ void ObjectFileMachO::ProcessSegmentCommand(
   const uint32_t num_u32s = load_cmd.cmd == LC_SEGMENT ? 7 : 8;
   for (segment_sect_idx = 0; segment_sect_idx < load_cmd.nsects;
        ++segment_sect_idx) {
-    if (m_data.GetU8(&offset, (uint8_t *)sect64.sectname,
-                     sizeof(sect64.sectname)) == nullptr)
+    if (m_data_up->GetU8(&offset, (uint8_t *)sect64.sectname,
+                         sizeof(sect64.sectname)) == nullptr)
       break;
-    if (m_data.GetU8(&offset, (uint8_t *)sect64.segname,
-                     sizeof(sect64.segname)) == nullptr)
+    if (m_data_up->GetU8(&offset, (uint8_t *)sect64.segname,
+                         sizeof(sect64.segname)) == nullptr)
       break;
-    sect64.addr = m_data.GetAddress(&offset);
-    sect64.size = m_data.GetAddress(&offset);
+    sect64.addr = m_data_up->GetAddress(&offset);
+    sect64.size = m_data_up->GetAddress(&offset);
 
-    if (m_data.GetU32(&offset, &sect64.offset, num_u32s) == nullptr)
+    if (m_data_up->GetU32(&offset, &sect64.offset, num_u32s) == nullptr)
       break;
 
     if (IsSharedCacheBinary() && !IsInMemory()) {
@@ -1855,8 +1856,8 @@ void ObjectFileMachO::ProcessDysymtabCommand(
     const llvm::MachO::load_command &load_cmd, lldb::offset_t offset) {
   m_dysymtab.cmd = load_cmd.cmd;
   m_dysymtab.cmdsize = load_cmd.cmdsize;
-  m_data.GetU32(&offset, &m_dysymtab.ilocalsym,
-                (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2);
+  m_data_up->GetU32(&offset, &m_dysymtab.ilocalsym,
+                    (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2);
 }
 
 void ObjectFileMachO::CreateSections(SectionList &unified_section_list) {
@@ -1875,7 +1876,7 @@ void ObjectFileMachO::CreateSections(SectionList &unified_section_list) {
   llvm::MachO::load_command load_cmd;
   for (uint32_t i = 0; i < m_header.ncmds; ++i) {
     const lldb::offset_t load_cmd_offset = offset;
-    if (m_data.GetU32(&offset, &load_cmd, 2) == nullptr)
+    if (m_data_up->GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     if (load_cmd.cmd == LC_SEGMENT || load_cmd.cmd == LC_SEGMENT_64)
@@ -2240,13 +2241,13 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     const lldb::offset_t cmd_offset = offset;
     // Read in the load command and load command size
     llvm::MachO::load_command lc;
-    if (m_data.GetU32(&offset, &lc, 2) == nullptr)
+    if (m_data_up->GetU32(&offset, &lc, 2) == nullptr)
       break;
     // Watch for the symbol table load command
     switch (lc.cmd) {
     case LC_SYMTAB: {
       llvm::MachO::symtab_command lc_obj;
-      if (m_data.GetU32(&offset, &lc_obj.symoff, 4)) {
+      if (m_data_up->GetU32(&offset, &lc_obj.symoff, 4)) {
         lc_obj.cmd = lc.cmd;
         lc_obj.cmdsize = lc.cmdsize;
         symtab_load_command = lc_obj;
@@ -2256,7 +2257,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     case LC_DYLD_INFO:
     case LC_DYLD_INFO_ONLY: {
       llvm::MachO::dyld_info_command lc_obj;
-      if (m_data.GetU32(&offset, &lc_obj.rebase_off, 10)) {
+      if (m_data_up->GetU32(&offset, &lc_obj.rebase_off, 10)) {
         lc_obj.cmd = lc.cmd;
         lc_obj.cmdsize = lc.cmdsize;
         dyld_info = lc_obj;
@@ -2268,8 +2269,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     case LC_REEXPORT_DYLIB:
     case LC_LOADFVMLIB:
     case LC_LOAD_UPWARD_DYLIB: {
-      uint32_t name_offset = cmd_offset + m_data.GetU32(&offset);
-      const char *path = m_data.PeekCStr(name_offset);
+      uint32_t name_offset = cmd_offset + m_data_up->GetU32(&offset);
+      const char *path = m_data_up->PeekCStr(name_offset);
       if (path) {
         FileSpec file_spec(path);
         // Strip the path if there is @rpath, @executable, etc so we just use
@@ -2289,19 +2290,19 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       llvm::MachO::linkedit_data_command lc_obj;
       lc_obj.cmd = lc.cmd;
       lc_obj.cmdsize = lc.cmdsize;
-      if (m_data.GetU32(&offset, &lc_obj.dataoff, 2))
+      if (m_data_up->GetU32(&offset, &lc_obj.dataoff, 2))
         exports_trie_load_command = lc_obj;
     } break;
     case LC_FUNCTION_STARTS: {
       llvm::MachO::linkedit_data_command lc_obj;
       lc_obj.cmd = lc.cmd;
       lc_obj.cmdsize = lc.cmdsize;
-      if (m_data.GetU32(&offset, &lc_obj.dataoff, 2))
+      if (m_data_up->GetU32(&offset, &lc_obj.dataoff, 2))
         function_starts_load_command = lc_obj;
     } break;
 
     case LC_UUID: {
-      const uint8_t *uuid_bytes = m_data.PeekData(offset, 16);
+      const uint8_t *uuid_bytes = m_data_up->PeekData(offset, 16);
 
       if (uuid_bytes)
         image_uuid = UUID(uuid_bytes, 16);
@@ -2321,8 +2322,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
   if (section_list == nullptr)
     return;
 
-  const uint32_t addr_byte_size = m_data.GetAddressByteSize();
-  const ByteOrder byte_order = m_data.GetByteOrder();
+  const uint32_t addr_byte_size = m_data_up->GetAddressByteSize();
+  const ByteOrder byte_order = m_data_up->GetByteOrder();
   bool bit_width_32 = addr_byte_size == 4;
   const size_t nlist_byte_size =
       bit_width_32 ? sizeof(struct nlist) : sizeof(struct nlist_64);
@@ -2487,9 +2488,9 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       exports_trie_load_command.dataoff += linkedit_slide;
     }
 
-    nlist_data.SetData(m_data, symtab_load_command.symoff,
+    nlist_data.SetData(*m_data_up.get(), symtab_load_command.symoff,
                        nlist_data_byte_size);
-    strtab_data.SetData(m_data, symtab_load_command.stroff,
+    strtab_data.SetData(*m_data_up.get(), symtab_load_command.stroff,
                         strtab_data_byte_size);
 
     // We shouldn't have exports data from both the LC_DYLD_INFO command
@@ -2497,19 +2498,22 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     lldbassert(!((dyld_info.export_size > 0)
                  && (exports_trie_load_command.datasize > 0)));
     if (dyld_info.export_size > 0) {
-      dyld_trie_data.SetData(m_data, dyld_info.export_off,
+      dyld_trie_data.SetData(*m_data_up.get(), dyld_info.export_off,
                              dyld_info.export_size);
     } else if (exports_trie_load_command.datasize > 0) {
-      dyld_trie_data.SetData(m_data, exports_trie_load_command.dataoff,
+      dyld_trie_data.SetData(*m_data_up.get(),
+                             exports_trie_load_command.dataoff,
                              exports_trie_load_command.datasize);
     }
 
     if (dysymtab.nindirectsyms != 0) {
-      indirect_symbol_index_data.SetData(m_data, dysymtab.indirectsymoff,
+      indirect_symbol_index_data.SetData(*m_data_up.get(),
+                                         dysymtab.indirectsymoff,
                                          dysymtab.nindirectsyms * 4);
     }
     if (function_starts_load_command.cmd) {
-      function_starts_data.SetData(m_data, function_starts_load_command.dataoff,
+      function_starts_data.SetData(*m_data_up.get(),
+                                   function_starts_load_command.dataoff,
                                    function_starts_load_command.datasize);
     }
   }
@@ -4561,8 +4565,9 @@ void ObjectFileMachO::Dump(Stream *s) {
     *s << ", file = '" << m_file;
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, m_data, MachHeaderSizeFromMagic(m_header.magic),
-                    base_spec, all_specs);
+    GetAllArchSpecs(m_header, *m_data_up.get(),
+                    MachHeaderSizeFromMagic(m_header.magic), base_spec,
+                    all_specs);
     for (unsigned i = 0, e = all_specs.GetSize(); i != e; ++i) {
       *s << "', triple";
       if (e)
@@ -4868,7 +4873,7 @@ UUID ObjectFileMachO::GetUUID() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     lldb::offset_t offset = MachHeaderSizeFromMagic(m_header.magic);
-    return GetUUID(m_header, m_data, offset);
+    return GetUUID(m_header, *m_data_up.get(), offset);
   }
   return UUID();
 }
@@ -4888,7 +4893,7 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
   uint32_t i;
   for (i = 0; i < m_header.ncmds; ++i) {
     const uint32_t cmd_offset = offset;
-    if (m_data.GetU32(&offset, &load_cmd, 2) == nullptr)
+    if (m_data_up->GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     switch (load_cmd.cmd) {
@@ -4899,17 +4904,17 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
     case LC_LOAD_DYLINKER:
     case LC_LOADFVMLIB:
     case LC_LOAD_UPWARD_DYLIB: {
-      uint32_t name_offset = cmd_offset + m_data.GetU32(&offset);
+      uint32_t name_offset = cmd_offset + m_data_up->GetU32(&offset);
       // For LC_LOAD_DYLIB there is an alternate encoding
       // which adds a uint32_t `flags` field for `DYLD_USE_*`
       // flags.  This can be detected by a timestamp field with
       // the `DYLIB_USE_MARKER` constant value.
       bool is_delayed_init = false;
-      uint32_t use_command_marker = m_data.GetU32(&offset);
+      uint32_t use_command_marker = m_data_up->GetU32(&offset);
       if (use_command_marker == 0x1a741800 /* DYLIB_USE_MARKER */) {
         offset += 4; /* uint32_t current_version */
         offset += 4; /* uint32_t compat_version */
-        uint32_t flags = m_data.GetU32(&offset);
+        uint32_t flags = m_data_up->GetU32(&offset);
         // If this LC_LOAD_DYLIB is marked delay-init,
         // don't report it as a dependent library -- it
         // may be loaded in the process at some point,
@@ -4917,7 +4922,7 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
         if (flags & 0x08 /* DYLIB_USE_DELAYED_INIT */)
           is_delayed_init = true;
       }
-      const char *path = m_data.PeekCStr(name_offset);
+      const char *path = m_data_up->PeekCStr(name_offset);
       if (path && !is_delayed_init) {
         if (load_cmd.cmd == LC_RPATH)
           rpath_paths.push_back(path);
@@ -5037,15 +5042,15 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
 
     for (i = 0; i < m_header.ncmds; ++i) {
       const lldb::offset_t cmd_offset = offset;
-      if (m_data.GetU32(&offset, &load_cmd, 2) == nullptr)
+      if (m_data_up->GetU32(&offset, &load_cmd, 2) == nullptr)
         break;
 
       switch (load_cmd.cmd) {
       case LC_UNIXTHREAD:
       case LC_THREAD: {
         while (offset < cmd_offset + load_cmd.cmdsize) {
-          uint32_t flavor = m_data.GetU32(&offset);
-          uint32_t count = m_data.GetU32(&offset);
+          uint32_t flavor = m_data_up->GetU32(&offset);
+          uint32_t count = m_data_up->GetU32(&offset);
           if (count == 0) {
             // We've gotten off somehow, log and exit;
             return m_entry_point_address;
@@ -5059,7 +5064,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 60; // This is the offset of pc in the GPR thread state
                             // data structure.
-              start_address = m_data.GetU32(&offset);
+              start_address = m_data_up->GetU32(&offset);
               done = true;
             }
             break;
@@ -5069,7 +5074,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 256; // This is the offset of pc in the GPR thread state
                              // data structure.
-              start_address = m_data.GetU64(&offset);
+              start_address = m_data_up->GetU64(&offset);
               done = true;
             }
             break;
@@ -5079,7 +5084,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 16 * 8; // This is the offset of rip in the GPR thread
                                 // state data structure.
-              start_address = m_data.GetU64(&offset);
+              start_address = m_data_up->GetU64(&offset);
               done = true;
             }
             break;
@@ -5094,7 +5099,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
         }
       } break;
       case LC_MAIN: {
-        uint64_t entryoffset = m_data.GetU64(&offset);
+        uint64_t entryoffset = m_data_up->GetU64(&offset);
         SectionSP text_segment_sp =
             GetSectionList()->FindSectionByName(GetSegmentNameTEXT());
         if (text_segment_sp) {
@@ -5178,7 +5183,7 @@ uint32_t ObjectFileMachO::GetNumThreadContexts() {
       llvm::MachO::thread_command thread_cmd;
       for (uint32_t i = 0; i < m_header.ncmds; ++i) {
         const uint32_t cmd_offset = offset;
-        if (m_data.GetU32(&offset, &thread_cmd, 2) == nullptr)
+        if (m_data_up->GetU32(&offset, &thread_cmd, 2) == nullptr)
           break;
 
         if (thread_cmd.cmd == LC_THREAD) {
@@ -5204,17 +5209,17 @@ ObjectFileMachO::FindLC_NOTEByName(std::string name) {
     for (uint32_t i = 0; i < m_header.ncmds; ++i) {
       const uint32_t cmd_offset = offset;
       llvm::MachO::load_command lc = {};
-      if (m_data.GetU32(&offset, &lc.cmd, 2) == nullptr)
+      if (m_data_up->GetU32(&offset, &lc.cmd, 2) == nullptr)
         break;
       if (lc.cmd == LC_NOTE) {
         char data_owner[17];
-        m_data.CopyData(offset, 16, data_owner);
+        m_data_up->CopyData(offset, 16, data_owner);
         data_owner[16] = '\0';
         offset += 16;
 
         if (name == data_owner) {
-          offset_t payload_offset = m_data.GetU64_unchecked(&offset);
-          offset_t payload_size = m_data.GetU64_unchecked(&offset);
+          offset_t payload_offset = m_data_up->GetU64_unchecked(&offset);
+          offset_t payload_size = m_data_up->GetU64_unchecked(&offset);
           results.push_back({payload_offset, payload_size});
         }
       }
@@ -5236,11 +5241,11 @@ std::string ObjectFileMachO::GetIdentifierString() {
       offset_t payload_offset = std::get<0>(lc_note);
       offset_t payload_size = std::get<1>(lc_note);
       uint32_t version;
-      if (m_data.GetU32(&payload_offset, &version, 1) != nullptr) {
+      if (m_data_up->GetU32(&payload_offset, &version, 1) != nullptr) {
         if (version == 1) {
           uint32_t strsize = payload_size - sizeof(uint32_t);
           std::string result(strsize, '\0');
-          m_data.CopyData(payload_offset, strsize, result.data());
+          m_data_up->CopyData(payload_offset, strsize, result.data());
           LLDB_LOGF(log, "LC_NOTE 'kern ver str' found with text '%s'",
                     result.c_str());
           return result;
@@ -5254,11 +5259,11 @@ std::string ObjectFileMachO::GetIdentifierString() {
     for (uint32_t i = 0; i < m_header.ncmds; ++i) {
       const uint32_t cmd_offset = offset;
       llvm::MachO::ident_command ident_command;
-      if (m_data.GetU32(&offset, &ident_command, 2) == nullptr)
+      if (m_data_up->GetU32(&offset, &ident_command, 2) == nullptr)
         break;
       if (ident_command.cmd == LC_IDENT && ident_command.cmdsize != 0) {
         std::string result(ident_command.cmdsize, '\0');
-        if (m_data.CopyData(offset, ident_command.cmdsize, result.data()) ==
+        if (m_data_up->CopyData(offset, ident_command.cmdsize, result.data()) ==
             ident_command.cmdsize) {
           LLDB_LOGF(log, "LC_IDENT found with text '%s'", result.c_str());
           return result;
@@ -5281,9 +5286,9 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
     for (auto lc_note : lc_notes) {
       offset_t payload_offset = std::get<0>(lc_note);
       uint32_t version;
-      if (m_data.GetU32(&payload_offset, &version, 1) != nullptr) {
+      if (m_data_up->GetU32(&payload_offset, &version, 1) != nullptr) {
         if (version == 3) {
-          uint32_t num_addr_bits = m_data.GetU32_unchecked(&payload_offset);
+          uint32_t num_addr_bits = m_data_up->GetU32_unchecked(&payload_offset);
           addressable_bits.SetAddressableBits(num_addr_bits);
           LLDB_LOGF(log,
                     "LC_NOTE 'addrable bits' v3 found, value %d "
@@ -5291,8 +5296,8 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
                     num_addr_bits);
         }
         if (version == 4) {
-          uint32_t lo_addr_bits = m_data.GetU32_unchecked(&payload_offset);
-          uint32_t hi_addr_bits = m_data.GetU32_unchecked(&payload_offset);
+          uint32_t lo_addr_bits = m_data_up->GetU32_unchecked(&payload_offset);
+          uint32_t hi_addr_bits = m_data_up->GetU32_unchecked(&payload_offset);
 
           if (lo_addr_bits == hi_addr_bits)
             addressable_bits.SetAddressableBits(lo_addr_bits);
@@ -5363,25 +5368,26 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
       //    uint32_t unused        [ for alignment ]
 
       uint32_t version;
-      if (m_data.GetU32(&payload_offset, &version, 1) != nullptr &&
+      if (m_data_up->GetU32(&payload_offset, &version, 1) != nullptr &&
           version <= 2) {
         uint32_t binspec_type = 0;
         uuid_t raw_uuid;
         memset(raw_uuid, 0, sizeof(uuid_t));
 
-        if (!m_data.GetU32(&payload_offset, &binspec_type, 1))
+        if (!m_data_up->GetU32(&payload_offset, &binspec_type, 1))
           return false;
-        if (!m_data.GetU64(&payload_offset, &value, 1))
+        if (!m_data_up->GetU64(&payload_offset, &value, 1))
           return false;
         uint64_t slide = LLDB_INVALID_ADDRESS;
-        if (version > 1 && !m_data.GetU64(&payload_offset, &slide, 1))
+        if (version > 1 && !m_data_up->GetU64(&payload_offset, &slide, 1))
           return false;
         if (value == LLDB_INVALID_ADDRESS && slide != LLDB_INVALID_ADDRESS) {
           value = slide;
           value_is_offset = true;
         }
 
-        if (m_data.CopyData(payload_offset, sizeof(uuid_t), raw_uuid) != 0) {
+        if (m_data_up->CopyData(payload_offset, sizeof(uuid_t), raw_uuid) !=
+            0) {
           uuid = UUID(raw_uuid, sizeof(uuid_t));
           // convert the "main bin spec" type into our
           // ObjectFile::BinaryType enum
@@ -5415,9 +5421,9 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
                     version, type, typestr, value,
                     value_is_offset ? "true" : "false",
                     uuid.GetAsString().c_str());
-          if (!m_data.GetU32(&payload_offset, &log2_pagesize, 1))
+          if (!m_data_up->GetU32(&payload_offset, &log2_pagesize, 1))
             return false;
-          if (version > 1 && !m_data.GetU32(&payload_offset, &platform, 1))
+          if (version > 1 && !m_data_up->GetU32(&payload_offset, &platform, 1))
             return false;
           return true;
         }
@@ -5497,7 +5503,7 @@ StructuredData::ObjectSP ObjectFileMachO::GetCorefileProcessMetadata() {
 
   auto [payload_offset, strsize] = lc_notes[0];
   std::string buf(strsize, '\0');
-  if (m_data.CopyData(payload_offset, strsize, buf.data()) != strsize) {
+  if (m_data_up->CopyData(payload_offset, strsize, buf.data()) != strsize) {
     LLDB_LOGF(log,
               "Unable to read %" PRIu64
               " bytes of 'process metadata' LC_NOTE JSON contents",
@@ -5537,7 +5543,8 @@ ObjectFileMachO::GetThreadContextAtIndex(uint32_t idx,
         m_thread_context_offsets.GetEntryAtIndex(idx);
     if (thread_context_file_range) {
 
-      DataExtractor data(m_data, thread_context_file_range->GetRangeBase(),
+      DataExtractor data(*m_data_up.get(),
+                         thread_context_file_range->GetRangeBase(),
                          thread_context_file_range->GetByteSize());
 
       switch (m_header.cputype) {
@@ -5677,13 +5684,13 @@ llvm::VersionTuple ObjectFileMachO::GetVersion() {
     uint32_t i;
     for (i = 0; i < m_header.ncmds; ++i) {
       const lldb::offset_t cmd_offset = offset;
-      if (m_data.GetU32(&offset, &load_cmd, 2) == nullptr)
+      if (m_data_up->GetU32(&offset, &load_cmd, 2) == nullptr)
         break;
 
       if (load_cmd.cmd == LC_ID_DYLIB) {
         if (version_cmd == 0) {
           version_cmd = load_cmd.cmd;
-          if (m_data.GetU32(&offset, &load_cmd.dylib, 4) == nullptr)
+          if (m_data_up->GetU32(&offset, &load_cmd.dylib, 4) == nullptr)
             break;
           version = load_cmd.dylib.current_version;
         }
@@ -5709,7 +5716,7 @@ ArchSpec ObjectFileMachO::GetArchitecture() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
 
-    return GetArchitecture(module_sp, m_header, m_data,
+    return GetArchitecture(module_sp, m_header, *m_data_up.get(),
                            MachHeaderSizeFromMagic(m_header.magic));
   }
   return arch;
@@ -5880,14 +5887,16 @@ static llvm::VersionTuple FindMinimumVersionInfo(DataExtractor &data,
 llvm::VersionTuple ObjectFileMachO::GetMinimumOSVersion() {
   if (!m_min_os_version)
     m_min_os_version = FindMinimumVersionInfo(
-        m_data, MachHeaderSizeFromMagic(m_header.magic), m_header.ncmds);
+        *m_data_up.get(), MachHeaderSizeFromMagic(m_header.magic),
+        m_header.ncmds);
   return *m_min_os_version;
 }
 
 llvm::VersionTuple ObjectFileMachO::GetSDKVersion() {
   if (!m_sdk_versions)
     m_sdk_versions = FindMinimumVersionInfo(
-        m_data, MachHeaderSizeFromMagic(m_header.magic), m_header.ncmds);
+        *m_data_up.get(), MachHeaderSizeFromMagic(m_header.magic),
+        m_header.ncmds);
   return *m_sdk_versions;
 }
 
@@ -6702,12 +6711,12 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
   for (auto lc_note : lc_notes) {
     offset_t payload_offset = std::get<0>(lc_note);
     // Read the struct all_image_infos_header.
-    uint32_t version = m_data.GetU32(&payload_offset);
+    uint32_t version = m_data_up->GetU32(&payload_offset);
     if (version != 1) {
       return image_infos;
     }
-    uint32_t imgcount = m_data.GetU32(&payload_offset);
-    uint64_t entries_fileoff = m_data.GetU64(&payload_offset);
+    uint32_t imgcount = m_data_up->GetU32(&payload_offset);
+    uint64_t entries_fileoff = m_data_up->GetU64(&payload_offset);
     // 'entries_size' is not used, nor is the 'unused' entry.
     //  offset += 4; // uint32_t entries_size;
     //  offset += 4; // uint32_t unused;
@@ -6717,17 +6726,17 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
     payload_offset = entries_fileoff;
     for (uint32_t i = 0; i < imgcount; i++) {
       // Read the struct image_entry.
-      offset_t filepath_offset = m_data.GetU64(&payload_offset);
+      offset_t filepath_offset = m_data_up->GetU64(&payload_offset);
       uuid_t uuid;
-      memcpy(&uuid, m_data.GetData(&payload_offset, sizeof(uuid_t)),
+      memcpy(&uuid, m_data_up->GetData(&payload_offset, sizeof(uuid_t)),
              sizeof(uuid_t));
-      uint64_t load_address = m_data.GetU64(&payload_offset);
-      offset_t seg_addrs_offset = m_data.GetU64(&payload_offset);
-      uint32_t segment_count = m_data.GetU32(&payload_offset);
-      uint32_t currently_executing = m_data.GetU32(&payload_offset);
+      uint64_t load_address = m_data_up->GetU64(&payload_offset);
+      offset_t seg_addrs_offset = m_data_up->GetU64(&payload_offset);
+      uint32_t segment_count = m_data_up->GetU32(&payload_offset);
+      uint32_t currently_executing = m_data_up->GetU32(&payload_offset);
 
       MachOCorefileImageEntry image_entry;
-      image_entry.filename = (const char *)m_data.GetCStr(&filepath_offset);
+      image_entry.filename = (const char *)m_data_up->GetCStr(&filepath_offset);
       image_entry.uuid = UUID(uuid, sizeof(uuid_t));
       image_entry.load_address = load_address;
       image_entry.currently_executing = currently_executing;
@@ -6735,10 +6744,10 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
       offset_t seg_vmaddrs_offset = seg_addrs_offset;
       for (uint32_t j = 0; j < segment_count; j++) {
         char segname[17];
-        m_data.CopyData(seg_vmaddrs_offset, 16, segname);
+        m_data_up->CopyData(seg_vmaddrs_offset, 16, segname);
         segname[16] = '\0';
         seg_vmaddrs_offset += 16;
-        uint64_t vmaddr = m_data.GetU64(&seg_vmaddrs_offset);
+        uint64_t vmaddr = m_data_up->GetU64(&seg_vmaddrs_offset);
         seg_vmaddrs_offset += 8; /* unused */
 
         std::tuple<ConstString, addr_t> new_seg{ConstString(segname), vmaddr};
@@ -6757,14 +6766,14 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
   lc_notes = FindLC_NOTEByName("load binary");
   for (auto lc_note : lc_notes) {
     offset_t payload_offset = std::get<0>(lc_note);
-    uint32_t version = m_data.GetU32(&payload_offset);
+    uint32_t version = m_data_up->GetU32(&payload_offset);
     if (version == 1) {
       uuid_t uuid;
-      memcpy(&uuid, m_data.GetData(&payload_offset, sizeof(uuid_t)),
+      memcpy(&uuid, m_data_up->GetData(&payload_offset, sizeof(uuid_t)),
              sizeof(uuid_t));
-      uint64_t load_address = m_data.GetU64(&payload_offset);
-      uint64_t slide = m_data.GetU64(&payload_offset);
-      std::string filename = m_data.GetCStr(&payload_offset);
+      uint64_t load_address = m_data_up->GetU64(&payload_offset);
+      uint64_t slide = m_data_up->GetU64(&payload_offset);
+      std::string filename = m_data_up->GetCStr(&payload_offset);
 
       MachOCorefileImageEntry image_entry;
       image_entry.filename = filename;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -1012,35 +1012,35 @@ bool ObjectFileMachO::ParseHeader() {
   std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
   bool can_parse = false;
   lldb::offset_t offset = 0;
-  m_data_sp->SetByteOrder(endian::InlHostByteOrder());
+  m_data_nsp->SetByteOrder(endian::InlHostByteOrder());
   // Leave magic in the original byte order
-  m_header.magic = m_data_sp->GetU32(&offset);
+  m_header.magic = m_data_nsp->GetU32(&offset);
   switch (m_header.magic) {
   case MH_MAGIC:
-    m_data_sp->SetByteOrder(endian::InlHostByteOrder());
-    m_data_sp->SetAddressByteSize(4);
+    m_data_nsp->SetByteOrder(endian::InlHostByteOrder());
+    m_data_nsp->SetAddressByteSize(4);
     can_parse = true;
     break;
 
   case MH_MAGIC_64:
-    m_data_sp->SetByteOrder(endian::InlHostByteOrder());
-    m_data_sp->SetAddressByteSize(8);
+    m_data_nsp->SetByteOrder(endian::InlHostByteOrder());
+    m_data_nsp->SetAddressByteSize(8);
     can_parse = true;
     break;
 
   case MH_CIGAM:
-    m_data_sp->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
-                                ? eByteOrderLittle
-                                : eByteOrderBig);
-    m_data_sp->SetAddressByteSize(4);
+    m_data_nsp->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+                                 ? eByteOrderLittle
+                                 : eByteOrderBig);
+    m_data_nsp->SetAddressByteSize(4);
     can_parse = true;
     break;
 
   case MH_CIGAM_64:
-    m_data_sp->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
-                                ? eByteOrderLittle
-                                : eByteOrderBig);
-    m_data_sp->SetAddressByteSize(8);
+    m_data_nsp->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+                                 ? eByteOrderLittle
+                                 : eByteOrderBig);
+    m_data_nsp->SetAddressByteSize(8);
     can_parse = true;
     break;
 
@@ -1049,11 +1049,11 @@ bool ObjectFileMachO::ParseHeader() {
   }
 
   if (can_parse) {
-    m_data_sp->GetU32(&offset, &m_header.cputype, 6);
+    m_data_nsp->GetU32(&offset, &m_header.cputype, 6);
 
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, *m_data_sp.get(),
+    GetAllArchSpecs(m_header, *m_data_nsp.get(),
                     MachHeaderSizeFromMagic(m_header.magic), base_spec,
                     all_specs);
 
@@ -1069,7 +1069,7 @@ bool ObjectFileMachO::ParseHeader() {
       if (SetModulesArchitecture(mach_arch)) {
         const size_t header_and_lc_size =
             m_header.sizeofcmds + MachHeaderSizeFromMagic(m_header.magic);
-        if (m_data_sp->GetByteSize() < header_and_lc_size) {
+        if (m_data_nsp->GetByteSize() < header_and_lc_size) {
           DataBufferSP data_sp;
           ProcessSP process_sp(m_process_wp.lock());
           if (process_sp) {
@@ -1081,7 +1081,7 @@ bool ObjectFileMachO::ParseHeader() {
               continue;
           }
           if (data_sp)
-            m_data_sp->SetData(data_sp);
+            m_data_nsp->SetData(data_sp);
         }
       }
       return true;
@@ -1095,7 +1095,7 @@ bool ObjectFileMachO::ParseHeader() {
 }
 
 ByteOrder ObjectFileMachO::GetByteOrder() const {
-  return m_data_sp->GetByteOrder();
+  return m_data_nsp->GetByteOrder();
 }
 
 bool ObjectFileMachO::IsExecutable() const {
@@ -1115,7 +1115,7 @@ bool ObjectFileMachO::IsKext() const {
 }
 
 uint32_t ObjectFileMachO::GetAddressByteSize() const {
-  return m_data_sp->GetAddressByteSize();
+  return m_data_nsp->GetAddressByteSize();
 }
 
 AddressClass ObjectFileMachO::GetAddressClass(lldb::addr_t file_addr) {
@@ -1298,13 +1298,13 @@ bool ObjectFileMachO::IsStripped() {
         const lldb::offset_t load_cmd_offset = offset;
 
         llvm::MachO::load_command lc = {};
-        if (m_data_sp->GetU32(&offset, &lc.cmd, 2) == nullptr)
+        if (m_data_nsp->GetU32(&offset, &lc.cmd, 2) == nullptr)
           break;
         if (lc.cmd == LC_DYSYMTAB) {
           m_dysymtab.cmd = lc.cmd;
           m_dysymtab.cmdsize = lc.cmdsize;
-          if (m_data_sp->GetU32(&offset, &m_dysymtab.ilocalsym,
-                                (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2) ==
+          if (m_data_nsp->GetU32(&offset, &m_dysymtab.ilocalsym,
+                                 (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2) ==
               nullptr) {
             // Clear m_dysymtab if we were unable to read all items from the
             // load command
@@ -1327,14 +1327,14 @@ ObjectFileMachO::EncryptedFileRanges ObjectFileMachO::GetEncryptedFileRanges() {
   llvm::MachO::encryption_info_command encryption_cmd;
   for (uint32_t i = 0; i < m_header.ncmds; ++i) {
     const lldb::offset_t load_cmd_offset = offset;
-    if (m_data_sp->GetU32(&offset, &encryption_cmd, 2) == nullptr)
+    if (m_data_nsp->GetU32(&offset, &encryption_cmd, 2) == nullptr)
       break;
 
     // LC_ENCRYPTION_INFO and LC_ENCRYPTION_INFO_64 have the same sizes for the
     // 3 fields we care about, so treat them the same.
     if (encryption_cmd.cmd == LC_ENCRYPTION_INFO ||
         encryption_cmd.cmd == LC_ENCRYPTION_INFO_64) {
-      if (m_data_sp->GetU32(&offset, &encryption_cmd.cryptoff, 3)) {
+      if (m_data_nsp->GetU32(&offset, &encryption_cmd.cryptoff, 3)) {
         if (encryption_cmd.cryptid != 0) {
           EncryptedFileRanges::Entry entry;
           entry.SetRangeBase(encryption_cmd.cryptoff);
@@ -1563,7 +1563,7 @@ void ObjectFileMachO::ProcessSegmentCommand(
   llvm::MachO::segment_command_64 load_cmd;
   memcpy(&load_cmd, &load_cmd_, sizeof(load_cmd_));
 
-  if (!m_data_sp->GetU8(&offset, (uint8_t *)load_cmd.segname, 16))
+  if (!m_data_nsp->GetU8(&offset, (uint8_t *)load_cmd.segname, 16))
     return;
 
   ModuleSP module_sp = GetModule();
@@ -1587,11 +1587,11 @@ void ObjectFileMachO::ProcessSegmentCommand(
       add_section = false;
     }
   }
-  load_cmd.vmaddr = m_data_sp->GetAddress(&offset);
-  load_cmd.vmsize = m_data_sp->GetAddress(&offset);
-  load_cmd.fileoff = m_data_sp->GetAddress(&offset);
-  load_cmd.filesize = m_data_sp->GetAddress(&offset);
-  if (!m_data_sp->GetU32(&offset, &load_cmd.maxprot, 4))
+  load_cmd.vmaddr = m_data_nsp->GetAddress(&offset);
+  load_cmd.vmsize = m_data_nsp->GetAddress(&offset);
+  load_cmd.fileoff = m_data_nsp->GetAddress(&offset);
+  load_cmd.filesize = m_data_nsp->GetAddress(&offset);
+  if (!m_data_nsp->GetU32(&offset, &load_cmd.maxprot, 4))
     return;
 
   SanitizeSegmentCommand(load_cmd, cmd_idx);
@@ -1682,16 +1682,16 @@ void ObjectFileMachO::ProcessSegmentCommand(
   const uint32_t num_u32s = load_cmd.cmd == LC_SEGMENT ? 7 : 8;
   for (segment_sect_idx = 0; segment_sect_idx < load_cmd.nsects;
        ++segment_sect_idx) {
-    if (m_data_sp->GetU8(&offset, (uint8_t *)sect64.sectname,
-                         sizeof(sect64.sectname)) == nullptr)
+    if (m_data_nsp->GetU8(&offset, (uint8_t *)sect64.sectname,
+                          sizeof(sect64.sectname)) == nullptr)
       break;
-    if (m_data_sp->GetU8(&offset, (uint8_t *)sect64.segname,
-                         sizeof(sect64.segname)) == nullptr)
+    if (m_data_nsp->GetU8(&offset, (uint8_t *)sect64.segname,
+                          sizeof(sect64.segname)) == nullptr)
       break;
-    sect64.addr = m_data_sp->GetAddress(&offset);
-    sect64.size = m_data_sp->GetAddress(&offset);
+    sect64.addr = m_data_nsp->GetAddress(&offset);
+    sect64.size = m_data_nsp->GetAddress(&offset);
 
-    if (m_data_sp->GetU32(&offset, &sect64.offset, num_u32s) == nullptr)
+    if (m_data_nsp->GetU32(&offset, &sect64.offset, num_u32s) == nullptr)
       break;
 
     if (IsSharedCacheBinary() && !IsInMemory()) {
@@ -1856,8 +1856,8 @@ void ObjectFileMachO::ProcessDysymtabCommand(
     const llvm::MachO::load_command &load_cmd, lldb::offset_t offset) {
   m_dysymtab.cmd = load_cmd.cmd;
   m_dysymtab.cmdsize = load_cmd.cmdsize;
-  m_data_sp->GetU32(&offset, &m_dysymtab.ilocalsym,
-                    (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2);
+  m_data_nsp->GetU32(&offset, &m_dysymtab.ilocalsym,
+                     (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2);
 }
 
 void ObjectFileMachO::CreateSections(SectionList &unified_section_list) {
@@ -1876,7 +1876,7 @@ void ObjectFileMachO::CreateSections(SectionList &unified_section_list) {
   llvm::MachO::load_command load_cmd;
   for (uint32_t i = 0; i < m_header.ncmds; ++i) {
     const lldb::offset_t load_cmd_offset = offset;
-    if (m_data_sp->GetU32(&offset, &load_cmd, 2) == nullptr)
+    if (m_data_nsp->GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     if (load_cmd.cmd == LC_SEGMENT || load_cmd.cmd == LC_SEGMENT_64)
@@ -2241,13 +2241,13 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     const lldb::offset_t cmd_offset = offset;
     // Read in the load command and load command size
     llvm::MachO::load_command lc;
-    if (m_data_sp->GetU32(&offset, &lc, 2) == nullptr)
+    if (m_data_nsp->GetU32(&offset, &lc, 2) == nullptr)
       break;
     // Watch for the symbol table load command
     switch (lc.cmd) {
     case LC_SYMTAB: {
       llvm::MachO::symtab_command lc_obj;
-      if (m_data_sp->GetU32(&offset, &lc_obj.symoff, 4)) {
+      if (m_data_nsp->GetU32(&offset, &lc_obj.symoff, 4)) {
         lc_obj.cmd = lc.cmd;
         lc_obj.cmdsize = lc.cmdsize;
         symtab_load_command = lc_obj;
@@ -2257,7 +2257,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     case LC_DYLD_INFO:
     case LC_DYLD_INFO_ONLY: {
       llvm::MachO::dyld_info_command lc_obj;
-      if (m_data_sp->GetU32(&offset, &lc_obj.rebase_off, 10)) {
+      if (m_data_nsp->GetU32(&offset, &lc_obj.rebase_off, 10)) {
         lc_obj.cmd = lc.cmd;
         lc_obj.cmdsize = lc.cmdsize;
         dyld_info = lc_obj;
@@ -2269,8 +2269,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     case LC_REEXPORT_DYLIB:
     case LC_LOADFVMLIB:
     case LC_LOAD_UPWARD_DYLIB: {
-      uint32_t name_offset = cmd_offset + m_data_sp->GetU32(&offset);
-      const char *path = m_data_sp->PeekCStr(name_offset);
+      uint32_t name_offset = cmd_offset + m_data_nsp->GetU32(&offset);
+      const char *path = m_data_nsp->PeekCStr(name_offset);
       if (path) {
         FileSpec file_spec(path);
         // Strip the path if there is @rpath, @executable, etc so we just use
@@ -2290,19 +2290,19 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       llvm::MachO::linkedit_data_command lc_obj;
       lc_obj.cmd = lc.cmd;
       lc_obj.cmdsize = lc.cmdsize;
-      if (m_data_sp->GetU32(&offset, &lc_obj.dataoff, 2))
+      if (m_data_nsp->GetU32(&offset, &lc_obj.dataoff, 2))
         exports_trie_load_command = lc_obj;
     } break;
     case LC_FUNCTION_STARTS: {
       llvm::MachO::linkedit_data_command lc_obj;
       lc_obj.cmd = lc.cmd;
       lc_obj.cmdsize = lc.cmdsize;
-      if (m_data_sp->GetU32(&offset, &lc_obj.dataoff, 2))
+      if (m_data_nsp->GetU32(&offset, &lc_obj.dataoff, 2))
         function_starts_load_command = lc_obj;
     } break;
 
     case LC_UUID: {
-      const uint8_t *uuid_bytes = m_data_sp->PeekData(offset, 16);
+      const uint8_t *uuid_bytes = m_data_nsp->PeekData(offset, 16);
 
       if (uuid_bytes)
         image_uuid = UUID(uuid_bytes, 16);
@@ -2322,8 +2322,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
   if (section_list == nullptr)
     return;
 
-  const uint32_t addr_byte_size = m_data_sp->GetAddressByteSize();
-  const ByteOrder byte_order = m_data_sp->GetByteOrder();
+  const uint32_t addr_byte_size = m_data_nsp->GetAddressByteSize();
+  const ByteOrder byte_order = m_data_nsp->GetByteOrder();
   bool bit_width_32 = addr_byte_size == 4;
   const size_t nlist_byte_size =
       bit_width_32 ? sizeof(struct nlist) : sizeof(struct nlist_64);
@@ -2488,9 +2488,9 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       exports_trie_load_command.dataoff += linkedit_slide;
     }
 
-    nlist_data.SetData(*m_data_sp.get(), symtab_load_command.symoff,
+    nlist_data.SetData(*m_data_nsp.get(), symtab_load_command.symoff,
                        nlist_data_byte_size);
-    strtab_data.SetData(*m_data_sp.get(), symtab_load_command.stroff,
+    strtab_data.SetData(*m_data_nsp.get(), symtab_load_command.stroff,
                         strtab_data_byte_size);
 
     // We shouldn't have exports data from both the LC_DYLD_INFO command
@@ -2498,21 +2498,21 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     lldbassert(!((dyld_info.export_size > 0)
                  && (exports_trie_load_command.datasize > 0)));
     if (dyld_info.export_size > 0) {
-      dyld_trie_data.SetData(*m_data_sp.get(), dyld_info.export_off,
+      dyld_trie_data.SetData(*m_data_nsp.get(), dyld_info.export_off,
                              dyld_info.export_size);
     } else if (exports_trie_load_command.datasize > 0) {
-      dyld_trie_data.SetData(*m_data_sp.get(),
+      dyld_trie_data.SetData(*m_data_nsp.get(),
                              exports_trie_load_command.dataoff,
                              exports_trie_load_command.datasize);
     }
 
     if (dysymtab.nindirectsyms != 0) {
-      indirect_symbol_index_data.SetData(*m_data_sp.get(),
+      indirect_symbol_index_data.SetData(*m_data_nsp.get(),
                                          dysymtab.indirectsymoff,
                                          dysymtab.nindirectsyms * 4);
     }
     if (function_starts_load_command.cmd) {
-      function_starts_data.SetData(*m_data_sp.get(),
+      function_starts_data.SetData(*m_data_nsp.get(),
                                    function_starts_load_command.dataoff,
                                    function_starts_load_command.datasize);
     }
@@ -4565,7 +4565,7 @@ void ObjectFileMachO::Dump(Stream *s) {
     *s << ", file = '" << m_file;
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, *m_data_sp.get(),
+    GetAllArchSpecs(m_header, *m_data_nsp.get(),
                     MachHeaderSizeFromMagic(m_header.magic), base_spec,
                     all_specs);
     for (unsigned i = 0, e = all_specs.GetSize(); i != e; ++i) {
@@ -4873,7 +4873,7 @@ UUID ObjectFileMachO::GetUUID() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     lldb::offset_t offset = MachHeaderSizeFromMagic(m_header.magic);
-    return GetUUID(m_header, *m_data_sp.get(), offset);
+    return GetUUID(m_header, *m_data_nsp.get(), offset);
   }
   return UUID();
 }
@@ -4893,7 +4893,7 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
   uint32_t i;
   for (i = 0; i < m_header.ncmds; ++i) {
     const uint32_t cmd_offset = offset;
-    if (m_data_sp->GetU32(&offset, &load_cmd, 2) == nullptr)
+    if (m_data_nsp->GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     switch (load_cmd.cmd) {
@@ -4904,17 +4904,17 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
     case LC_LOAD_DYLINKER:
     case LC_LOADFVMLIB:
     case LC_LOAD_UPWARD_DYLIB: {
-      uint32_t name_offset = cmd_offset + m_data_sp->GetU32(&offset);
+      uint32_t name_offset = cmd_offset + m_data_nsp->GetU32(&offset);
       // For LC_LOAD_DYLIB there is an alternate encoding
       // which adds a uint32_t `flags` field for `DYLD_USE_*`
       // flags.  This can be detected by a timestamp field with
       // the `DYLIB_USE_MARKER` constant value.
       bool is_delayed_init = false;
-      uint32_t use_command_marker = m_data_sp->GetU32(&offset);
+      uint32_t use_command_marker = m_data_nsp->GetU32(&offset);
       if (use_command_marker == 0x1a741800 /* DYLIB_USE_MARKER */) {
         offset += 4; /* uint32_t current_version */
         offset += 4; /* uint32_t compat_version */
-        uint32_t flags = m_data_sp->GetU32(&offset);
+        uint32_t flags = m_data_nsp->GetU32(&offset);
         // If this LC_LOAD_DYLIB is marked delay-init,
         // don't report it as a dependent library -- it
         // may be loaded in the process at some point,
@@ -4922,7 +4922,7 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
         if (flags & 0x08 /* DYLIB_USE_DELAYED_INIT */)
           is_delayed_init = true;
       }
-      const char *path = m_data_sp->PeekCStr(name_offset);
+      const char *path = m_data_nsp->PeekCStr(name_offset);
       if (path && !is_delayed_init) {
         if (load_cmd.cmd == LC_RPATH)
           rpath_paths.push_back(path);
@@ -5042,15 +5042,15 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
 
     for (i = 0; i < m_header.ncmds; ++i) {
       const lldb::offset_t cmd_offset = offset;
-      if (m_data_sp->GetU32(&offset, &load_cmd, 2) == nullptr)
+      if (m_data_nsp->GetU32(&offset, &load_cmd, 2) == nullptr)
         break;
 
       switch (load_cmd.cmd) {
       case LC_UNIXTHREAD:
       case LC_THREAD: {
         while (offset < cmd_offset + load_cmd.cmdsize) {
-          uint32_t flavor = m_data_sp->GetU32(&offset);
-          uint32_t count = m_data_sp->GetU32(&offset);
+          uint32_t flavor = m_data_nsp->GetU32(&offset);
+          uint32_t count = m_data_nsp->GetU32(&offset);
           if (count == 0) {
             // We've gotten off somehow, log and exit;
             return m_entry_point_address;
@@ -5064,7 +5064,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 60; // This is the offset of pc in the GPR thread state
                             // data structure.
-              start_address = m_data_sp->GetU32(&offset);
+              start_address = m_data_nsp->GetU32(&offset);
               done = true;
             }
             break;
@@ -5074,7 +5074,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 256; // This is the offset of pc in the GPR thread state
                              // data structure.
-              start_address = m_data_sp->GetU64(&offset);
+              start_address = m_data_nsp->GetU64(&offset);
               done = true;
             }
             break;
@@ -5084,7 +5084,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 16 * 8; // This is the offset of rip in the GPR thread
                                 // state data structure.
-              start_address = m_data_sp->GetU64(&offset);
+              start_address = m_data_nsp->GetU64(&offset);
               done = true;
             }
             break;
@@ -5099,7 +5099,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
         }
       } break;
       case LC_MAIN: {
-        uint64_t entryoffset = m_data_sp->GetU64(&offset);
+        uint64_t entryoffset = m_data_nsp->GetU64(&offset);
         SectionSP text_segment_sp =
             GetSectionList()->FindSectionByName(GetSegmentNameTEXT());
         if (text_segment_sp) {
@@ -5183,7 +5183,7 @@ uint32_t ObjectFileMachO::GetNumThreadContexts() {
       llvm::MachO::thread_command thread_cmd;
       for (uint32_t i = 0; i < m_header.ncmds; ++i) {
         const uint32_t cmd_offset = offset;
-        if (m_data_sp->GetU32(&offset, &thread_cmd, 2) == nullptr)
+        if (m_data_nsp->GetU32(&offset, &thread_cmd, 2) == nullptr)
           break;
 
         if (thread_cmd.cmd == LC_THREAD) {
@@ -5209,17 +5209,17 @@ ObjectFileMachO::FindLC_NOTEByName(std::string name) {
     for (uint32_t i = 0; i < m_header.ncmds; ++i) {
       const uint32_t cmd_offset = offset;
       llvm::MachO::load_command lc = {};
-      if (m_data_sp->GetU32(&offset, &lc.cmd, 2) == nullptr)
+      if (m_data_nsp->GetU32(&offset, &lc.cmd, 2) == nullptr)
         break;
       if (lc.cmd == LC_NOTE) {
         char data_owner[17];
-        m_data_sp->CopyData(offset, 16, data_owner);
+        m_data_nsp->CopyData(offset, 16, data_owner);
         data_owner[16] = '\0';
         offset += 16;
 
         if (name == data_owner) {
-          offset_t payload_offset = m_data_sp->GetU64_unchecked(&offset);
-          offset_t payload_size = m_data_sp->GetU64_unchecked(&offset);
+          offset_t payload_offset = m_data_nsp->GetU64_unchecked(&offset);
+          offset_t payload_size = m_data_nsp->GetU64_unchecked(&offset);
           results.push_back({payload_offset, payload_size});
         }
       }
@@ -5241,11 +5241,11 @@ std::string ObjectFileMachO::GetIdentifierString() {
       offset_t payload_offset = std::get<0>(lc_note);
       offset_t payload_size = std::get<1>(lc_note);
       uint32_t version;
-      if (m_data_sp->GetU32(&payload_offset, &version, 1) != nullptr) {
+      if (m_data_nsp->GetU32(&payload_offset, &version, 1) != nullptr) {
         if (version == 1) {
           uint32_t strsize = payload_size - sizeof(uint32_t);
           std::string result(strsize, '\0');
-          m_data_sp->CopyData(payload_offset, strsize, result.data());
+          m_data_nsp->CopyData(payload_offset, strsize, result.data());
           LLDB_LOGF(log, "LC_NOTE 'kern ver str' found with text '%s'",
                     result.c_str());
           return result;
@@ -5259,12 +5259,12 @@ std::string ObjectFileMachO::GetIdentifierString() {
     for (uint32_t i = 0; i < m_header.ncmds; ++i) {
       const uint32_t cmd_offset = offset;
       llvm::MachO::ident_command ident_command;
-      if (m_data_sp->GetU32(&offset, &ident_command, 2) == nullptr)
+      if (m_data_nsp->GetU32(&offset, &ident_command, 2) == nullptr)
         break;
       if (ident_command.cmd == LC_IDENT && ident_command.cmdsize != 0) {
         std::string result(ident_command.cmdsize, '\0');
-        if (m_data_sp->CopyData(offset, ident_command.cmdsize, result.data()) ==
-            ident_command.cmdsize) {
+        if (m_data_nsp->CopyData(offset, ident_command.cmdsize,
+                                 result.data()) == ident_command.cmdsize) {
           LLDB_LOGF(log, "LC_IDENT found with text '%s'", result.c_str());
           return result;
         }
@@ -5286,9 +5286,10 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
     for (auto lc_note : lc_notes) {
       offset_t payload_offset = std::get<0>(lc_note);
       uint32_t version;
-      if (m_data_sp->GetU32(&payload_offset, &version, 1) != nullptr) {
+      if (m_data_nsp->GetU32(&payload_offset, &version, 1) != nullptr) {
         if (version == 3) {
-          uint32_t num_addr_bits = m_data_sp->GetU32_unchecked(&payload_offset);
+          uint32_t num_addr_bits =
+              m_data_nsp->GetU32_unchecked(&payload_offset);
           addressable_bits.SetAddressableBits(num_addr_bits);
           LLDB_LOGF(log,
                     "LC_NOTE 'addrable bits' v3 found, value %d "
@@ -5296,8 +5297,8 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
                     num_addr_bits);
         }
         if (version == 4) {
-          uint32_t lo_addr_bits = m_data_sp->GetU32_unchecked(&payload_offset);
-          uint32_t hi_addr_bits = m_data_sp->GetU32_unchecked(&payload_offset);
+          uint32_t lo_addr_bits = m_data_nsp->GetU32_unchecked(&payload_offset);
+          uint32_t hi_addr_bits = m_data_nsp->GetU32_unchecked(&payload_offset);
 
           if (lo_addr_bits == hi_addr_bits)
             addressable_bits.SetAddressableBits(lo_addr_bits);
@@ -5368,25 +5369,25 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
       //    uint32_t unused        [ for alignment ]
 
       uint32_t version;
-      if (m_data_sp->GetU32(&payload_offset, &version, 1) != nullptr &&
+      if (m_data_nsp->GetU32(&payload_offset, &version, 1) != nullptr &&
           version <= 2) {
         uint32_t binspec_type = 0;
         uuid_t raw_uuid;
         memset(raw_uuid, 0, sizeof(uuid_t));
 
-        if (!m_data_sp->GetU32(&payload_offset, &binspec_type, 1))
+        if (!m_data_nsp->GetU32(&payload_offset, &binspec_type, 1))
           return false;
-        if (!m_data_sp->GetU64(&payload_offset, &value, 1))
+        if (!m_data_nsp->GetU64(&payload_offset, &value, 1))
           return false;
         uint64_t slide = LLDB_INVALID_ADDRESS;
-        if (version > 1 && !m_data_sp->GetU64(&payload_offset, &slide, 1))
+        if (version > 1 && !m_data_nsp->GetU64(&payload_offset, &slide, 1))
           return false;
         if (value == LLDB_INVALID_ADDRESS && slide != LLDB_INVALID_ADDRESS) {
           value = slide;
           value_is_offset = true;
         }
 
-        if (m_data_sp->CopyData(payload_offset, sizeof(uuid_t), raw_uuid) !=
+        if (m_data_nsp->CopyData(payload_offset, sizeof(uuid_t), raw_uuid) !=
             0) {
           uuid = UUID(raw_uuid, sizeof(uuid_t));
           // convert the "main bin spec" type into our
@@ -5421,9 +5422,9 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
                     version, type, typestr, value,
                     value_is_offset ? "true" : "false",
                     uuid.GetAsString().c_str());
-          if (!m_data_sp->GetU32(&payload_offset, &log2_pagesize, 1))
+          if (!m_data_nsp->GetU32(&payload_offset, &log2_pagesize, 1))
             return false;
-          if (version > 1 && !m_data_sp->GetU32(&payload_offset, &platform, 1))
+          if (version > 1 && !m_data_nsp->GetU32(&payload_offset, &platform, 1))
             return false;
           return true;
         }
@@ -5503,7 +5504,7 @@ StructuredData::ObjectSP ObjectFileMachO::GetCorefileProcessMetadata() {
 
   auto [payload_offset, strsize] = lc_notes[0];
   std::string buf(strsize, '\0');
-  if (m_data_sp->CopyData(payload_offset, strsize, buf.data()) != strsize) {
+  if (m_data_nsp->CopyData(payload_offset, strsize, buf.data()) != strsize) {
     LLDB_LOGF(log,
               "Unable to read %" PRIu64
               " bytes of 'process metadata' LC_NOTE JSON contents",
@@ -5543,7 +5544,7 @@ ObjectFileMachO::GetThreadContextAtIndex(uint32_t idx,
         m_thread_context_offsets.GetEntryAtIndex(idx);
     if (thread_context_file_range) {
 
-      DataExtractor data(*m_data_sp.get(),
+      DataExtractor data(*m_data_nsp.get(),
                          thread_context_file_range->GetRangeBase(),
                          thread_context_file_range->GetByteSize());
 
@@ -5684,13 +5685,13 @@ llvm::VersionTuple ObjectFileMachO::GetVersion() {
     uint32_t i;
     for (i = 0; i < m_header.ncmds; ++i) {
       const lldb::offset_t cmd_offset = offset;
-      if (m_data_sp->GetU32(&offset, &load_cmd, 2) == nullptr)
+      if (m_data_nsp->GetU32(&offset, &load_cmd, 2) == nullptr)
         break;
 
       if (load_cmd.cmd == LC_ID_DYLIB) {
         if (version_cmd == 0) {
           version_cmd = load_cmd.cmd;
-          if (m_data_sp->GetU32(&offset, &load_cmd.dylib, 4) == nullptr)
+          if (m_data_nsp->GetU32(&offset, &load_cmd.dylib, 4) == nullptr)
             break;
           version = load_cmd.dylib.current_version;
         }
@@ -5716,7 +5717,7 @@ ArchSpec ObjectFileMachO::GetArchitecture() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
 
-    return GetArchitecture(module_sp, m_header, *m_data_sp.get(),
+    return GetArchitecture(module_sp, m_header, *m_data_nsp.get(),
                            MachHeaderSizeFromMagic(m_header.magic));
   }
   return arch;
@@ -5887,7 +5888,7 @@ static llvm::VersionTuple FindMinimumVersionInfo(DataExtractor &data,
 llvm::VersionTuple ObjectFileMachO::GetMinimumOSVersion() {
   if (!m_min_os_version)
     m_min_os_version = FindMinimumVersionInfo(
-        *m_data_sp.get(), MachHeaderSizeFromMagic(m_header.magic),
+        *m_data_nsp.get(), MachHeaderSizeFromMagic(m_header.magic),
         m_header.ncmds);
   return *m_min_os_version;
 }
@@ -5895,7 +5896,7 @@ llvm::VersionTuple ObjectFileMachO::GetMinimumOSVersion() {
 llvm::VersionTuple ObjectFileMachO::GetSDKVersion() {
   if (!m_sdk_versions)
     m_sdk_versions = FindMinimumVersionInfo(
-        *m_data_sp.get(), MachHeaderSizeFromMagic(m_header.magic),
+        *m_data_nsp.get(), MachHeaderSizeFromMagic(m_header.magic),
         m_header.ncmds);
   return *m_sdk_versions;
 }
@@ -6711,12 +6712,12 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
   for (auto lc_note : lc_notes) {
     offset_t payload_offset = std::get<0>(lc_note);
     // Read the struct all_image_infos_header.
-    uint32_t version = m_data_sp->GetU32(&payload_offset);
+    uint32_t version = m_data_nsp->GetU32(&payload_offset);
     if (version != 1) {
       return image_infos;
     }
-    uint32_t imgcount = m_data_sp->GetU32(&payload_offset);
-    uint64_t entries_fileoff = m_data_sp->GetU64(&payload_offset);
+    uint32_t imgcount = m_data_nsp->GetU32(&payload_offset);
+    uint64_t entries_fileoff = m_data_nsp->GetU64(&payload_offset);
     // 'entries_size' is not used, nor is the 'unused' entry.
     //  offset += 4; // uint32_t entries_size;
     //  offset += 4; // uint32_t unused;
@@ -6726,17 +6727,18 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
     payload_offset = entries_fileoff;
     for (uint32_t i = 0; i < imgcount; i++) {
       // Read the struct image_entry.
-      offset_t filepath_offset = m_data_sp->GetU64(&payload_offset);
+      offset_t filepath_offset = m_data_nsp->GetU64(&payload_offset);
       uuid_t uuid;
-      memcpy(&uuid, m_data_sp->GetData(&payload_offset, sizeof(uuid_t)),
+      memcpy(&uuid, m_data_nsp->GetData(&payload_offset, sizeof(uuid_t)),
              sizeof(uuid_t));
-      uint64_t load_address = m_data_sp->GetU64(&payload_offset);
-      offset_t seg_addrs_offset = m_data_sp->GetU64(&payload_offset);
-      uint32_t segment_count = m_data_sp->GetU32(&payload_offset);
-      uint32_t currently_executing = m_data_sp->GetU32(&payload_offset);
+      uint64_t load_address = m_data_nsp->GetU64(&payload_offset);
+      offset_t seg_addrs_offset = m_data_nsp->GetU64(&payload_offset);
+      uint32_t segment_count = m_data_nsp->GetU32(&payload_offset);
+      uint32_t currently_executing = m_data_nsp->GetU32(&payload_offset);
 
       MachOCorefileImageEntry image_entry;
-      image_entry.filename = (const char *)m_data_sp->GetCStr(&filepath_offset);
+      image_entry.filename =
+          (const char *)m_data_nsp->GetCStr(&filepath_offset);
       image_entry.uuid = UUID(uuid, sizeof(uuid_t));
       image_entry.load_address = load_address;
       image_entry.currently_executing = currently_executing;
@@ -6744,10 +6746,10 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
       offset_t seg_vmaddrs_offset = seg_addrs_offset;
       for (uint32_t j = 0; j < segment_count; j++) {
         char segname[17];
-        m_data_sp->CopyData(seg_vmaddrs_offset, 16, segname);
+        m_data_nsp->CopyData(seg_vmaddrs_offset, 16, segname);
         segname[16] = '\0';
         seg_vmaddrs_offset += 16;
-        uint64_t vmaddr = m_data_sp->GetU64(&seg_vmaddrs_offset);
+        uint64_t vmaddr = m_data_nsp->GetU64(&seg_vmaddrs_offset);
         seg_vmaddrs_offset += 8; /* unused */
 
         std::tuple<ConstString, addr_t> new_seg{ConstString(segname), vmaddr};
@@ -6766,14 +6768,14 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
   lc_notes = FindLC_NOTEByName("load binary");
   for (auto lc_note : lc_notes) {
     offset_t payload_offset = std::get<0>(lc_note);
-    uint32_t version = m_data_sp->GetU32(&payload_offset);
+    uint32_t version = m_data_nsp->GetU32(&payload_offset);
     if (version == 1) {
       uuid_t uuid;
-      memcpy(&uuid, m_data_sp->GetData(&payload_offset, sizeof(uuid_t)),
+      memcpy(&uuid, m_data_nsp->GetData(&payload_offset, sizeof(uuid_t)),
              sizeof(uuid_t));
-      uint64_t load_address = m_data_sp->GetU64(&payload_offset);
-      uint64_t slide = m_data_sp->GetU64(&payload_offset);
-      std::string filename = m_data_sp->GetCStr(&payload_offset);
+      uint64_t load_address = m_data_nsp->GetU64(&payload_offset);
+      uint64_t slide = m_data_nsp->GetU64(&payload_offset);
+      std::string filename = m_data_nsp->GetCStr(&payload_offset);
 
       MachOCorefileImageEntry image_entry;
       image_entry.filename = filename;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -1012,35 +1012,35 @@ bool ObjectFileMachO::ParseHeader() {
   std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
   bool can_parse = false;
   lldb::offset_t offset = 0;
-  m_data_up->SetByteOrder(endian::InlHostByteOrder());
+  m_data_sp->SetByteOrder(endian::InlHostByteOrder());
   // Leave magic in the original byte order
-  m_header.magic = m_data_up->GetU32(&offset);
+  m_header.magic = m_data_sp->GetU32(&offset);
   switch (m_header.magic) {
   case MH_MAGIC:
-    m_data_up->SetByteOrder(endian::InlHostByteOrder());
-    m_data_up->SetAddressByteSize(4);
+    m_data_sp->SetByteOrder(endian::InlHostByteOrder());
+    m_data_sp->SetAddressByteSize(4);
     can_parse = true;
     break;
 
   case MH_MAGIC_64:
-    m_data_up->SetByteOrder(endian::InlHostByteOrder());
-    m_data_up->SetAddressByteSize(8);
+    m_data_sp->SetByteOrder(endian::InlHostByteOrder());
+    m_data_sp->SetAddressByteSize(8);
     can_parse = true;
     break;
 
   case MH_CIGAM:
-    m_data_up->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+    m_data_sp->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
                                 ? eByteOrderLittle
                                 : eByteOrderBig);
-    m_data_up->SetAddressByteSize(4);
+    m_data_sp->SetAddressByteSize(4);
     can_parse = true;
     break;
 
   case MH_CIGAM_64:
-    m_data_up->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+    m_data_sp->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
                                 ? eByteOrderLittle
                                 : eByteOrderBig);
-    m_data_up->SetAddressByteSize(8);
+    m_data_sp->SetAddressByteSize(8);
     can_parse = true;
     break;
 
@@ -1049,11 +1049,11 @@ bool ObjectFileMachO::ParseHeader() {
   }
 
   if (can_parse) {
-    m_data_up->GetU32(&offset, &m_header.cputype, 6);
+    m_data_sp->GetU32(&offset, &m_header.cputype, 6);
 
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, *m_data_up.get(),
+    GetAllArchSpecs(m_header, *m_data_sp.get(),
                     MachHeaderSizeFromMagic(m_header.magic), base_spec,
                     all_specs);
 
@@ -1069,7 +1069,7 @@ bool ObjectFileMachO::ParseHeader() {
       if (SetModulesArchitecture(mach_arch)) {
         const size_t header_and_lc_size =
             m_header.sizeofcmds + MachHeaderSizeFromMagic(m_header.magic);
-        if (m_data_up->GetByteSize() < header_and_lc_size) {
+        if (m_data_sp->GetByteSize() < header_and_lc_size) {
           DataBufferSP data_sp;
           ProcessSP process_sp(m_process_wp.lock());
           if (process_sp) {
@@ -1081,7 +1081,7 @@ bool ObjectFileMachO::ParseHeader() {
               continue;
           }
           if (data_sp)
-            m_data_up->SetData(data_sp);
+            m_data_sp->SetData(data_sp);
         }
       }
       return true;
@@ -1095,7 +1095,7 @@ bool ObjectFileMachO::ParseHeader() {
 }
 
 ByteOrder ObjectFileMachO::GetByteOrder() const {
-  return m_data_up->GetByteOrder();
+  return m_data_sp->GetByteOrder();
 }
 
 bool ObjectFileMachO::IsExecutable() const {
@@ -1115,7 +1115,7 @@ bool ObjectFileMachO::IsKext() const {
 }
 
 uint32_t ObjectFileMachO::GetAddressByteSize() const {
-  return m_data_up->GetAddressByteSize();
+  return m_data_sp->GetAddressByteSize();
 }
 
 AddressClass ObjectFileMachO::GetAddressClass(lldb::addr_t file_addr) {
@@ -1298,12 +1298,12 @@ bool ObjectFileMachO::IsStripped() {
         const lldb::offset_t load_cmd_offset = offset;
 
         llvm::MachO::load_command lc = {};
-        if (m_data_up->GetU32(&offset, &lc.cmd, 2) == nullptr)
+        if (m_data_sp->GetU32(&offset, &lc.cmd, 2) == nullptr)
           break;
         if (lc.cmd == LC_DYSYMTAB) {
           m_dysymtab.cmd = lc.cmd;
           m_dysymtab.cmdsize = lc.cmdsize;
-          if (m_data_up->GetU32(&offset, &m_dysymtab.ilocalsym,
+          if (m_data_sp->GetU32(&offset, &m_dysymtab.ilocalsym,
                                 (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2) ==
               nullptr) {
             // Clear m_dysymtab if we were unable to read all items from the
@@ -1327,14 +1327,14 @@ ObjectFileMachO::EncryptedFileRanges ObjectFileMachO::GetEncryptedFileRanges() {
   llvm::MachO::encryption_info_command encryption_cmd;
   for (uint32_t i = 0; i < m_header.ncmds; ++i) {
     const lldb::offset_t load_cmd_offset = offset;
-    if (m_data_up->GetU32(&offset, &encryption_cmd, 2) == nullptr)
+    if (m_data_sp->GetU32(&offset, &encryption_cmd, 2) == nullptr)
       break;
 
     // LC_ENCRYPTION_INFO and LC_ENCRYPTION_INFO_64 have the same sizes for the
     // 3 fields we care about, so treat them the same.
     if (encryption_cmd.cmd == LC_ENCRYPTION_INFO ||
         encryption_cmd.cmd == LC_ENCRYPTION_INFO_64) {
-      if (m_data_up->GetU32(&offset, &encryption_cmd.cryptoff, 3)) {
+      if (m_data_sp->GetU32(&offset, &encryption_cmd.cryptoff, 3)) {
         if (encryption_cmd.cryptid != 0) {
           EncryptedFileRanges::Entry entry;
           entry.SetRangeBase(encryption_cmd.cryptoff);
@@ -1563,7 +1563,7 @@ void ObjectFileMachO::ProcessSegmentCommand(
   llvm::MachO::segment_command_64 load_cmd;
   memcpy(&load_cmd, &load_cmd_, sizeof(load_cmd_));
 
-  if (!m_data_up->GetU8(&offset, (uint8_t *)load_cmd.segname, 16))
+  if (!m_data_sp->GetU8(&offset, (uint8_t *)load_cmd.segname, 16))
     return;
 
   ModuleSP module_sp = GetModule();
@@ -1587,11 +1587,11 @@ void ObjectFileMachO::ProcessSegmentCommand(
       add_section = false;
     }
   }
-  load_cmd.vmaddr = m_data_up->GetAddress(&offset);
-  load_cmd.vmsize = m_data_up->GetAddress(&offset);
-  load_cmd.fileoff = m_data_up->GetAddress(&offset);
-  load_cmd.filesize = m_data_up->GetAddress(&offset);
-  if (!m_data_up->GetU32(&offset, &load_cmd.maxprot, 4))
+  load_cmd.vmaddr = m_data_sp->GetAddress(&offset);
+  load_cmd.vmsize = m_data_sp->GetAddress(&offset);
+  load_cmd.fileoff = m_data_sp->GetAddress(&offset);
+  load_cmd.filesize = m_data_sp->GetAddress(&offset);
+  if (!m_data_sp->GetU32(&offset, &load_cmd.maxprot, 4))
     return;
 
   SanitizeSegmentCommand(load_cmd, cmd_idx);
@@ -1682,16 +1682,16 @@ void ObjectFileMachO::ProcessSegmentCommand(
   const uint32_t num_u32s = load_cmd.cmd == LC_SEGMENT ? 7 : 8;
   for (segment_sect_idx = 0; segment_sect_idx < load_cmd.nsects;
        ++segment_sect_idx) {
-    if (m_data_up->GetU8(&offset, (uint8_t *)sect64.sectname,
+    if (m_data_sp->GetU8(&offset, (uint8_t *)sect64.sectname,
                          sizeof(sect64.sectname)) == nullptr)
       break;
-    if (m_data_up->GetU8(&offset, (uint8_t *)sect64.segname,
+    if (m_data_sp->GetU8(&offset, (uint8_t *)sect64.segname,
                          sizeof(sect64.segname)) == nullptr)
       break;
-    sect64.addr = m_data_up->GetAddress(&offset);
-    sect64.size = m_data_up->GetAddress(&offset);
+    sect64.addr = m_data_sp->GetAddress(&offset);
+    sect64.size = m_data_sp->GetAddress(&offset);
 
-    if (m_data_up->GetU32(&offset, &sect64.offset, num_u32s) == nullptr)
+    if (m_data_sp->GetU32(&offset, &sect64.offset, num_u32s) == nullptr)
       break;
 
     if (IsSharedCacheBinary() && !IsInMemory()) {
@@ -1856,7 +1856,7 @@ void ObjectFileMachO::ProcessDysymtabCommand(
     const llvm::MachO::load_command &load_cmd, lldb::offset_t offset) {
   m_dysymtab.cmd = load_cmd.cmd;
   m_dysymtab.cmdsize = load_cmd.cmdsize;
-  m_data_up->GetU32(&offset, &m_dysymtab.ilocalsym,
+  m_data_sp->GetU32(&offset, &m_dysymtab.ilocalsym,
                     (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2);
 }
 
@@ -1876,7 +1876,7 @@ void ObjectFileMachO::CreateSections(SectionList &unified_section_list) {
   llvm::MachO::load_command load_cmd;
   for (uint32_t i = 0; i < m_header.ncmds; ++i) {
     const lldb::offset_t load_cmd_offset = offset;
-    if (m_data_up->GetU32(&offset, &load_cmd, 2) == nullptr)
+    if (m_data_sp->GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     if (load_cmd.cmd == LC_SEGMENT || load_cmd.cmd == LC_SEGMENT_64)
@@ -2241,13 +2241,13 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     const lldb::offset_t cmd_offset = offset;
     // Read in the load command and load command size
     llvm::MachO::load_command lc;
-    if (m_data_up->GetU32(&offset, &lc, 2) == nullptr)
+    if (m_data_sp->GetU32(&offset, &lc, 2) == nullptr)
       break;
     // Watch for the symbol table load command
     switch (lc.cmd) {
     case LC_SYMTAB: {
       llvm::MachO::symtab_command lc_obj;
-      if (m_data_up->GetU32(&offset, &lc_obj.symoff, 4)) {
+      if (m_data_sp->GetU32(&offset, &lc_obj.symoff, 4)) {
         lc_obj.cmd = lc.cmd;
         lc_obj.cmdsize = lc.cmdsize;
         symtab_load_command = lc_obj;
@@ -2257,7 +2257,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     case LC_DYLD_INFO:
     case LC_DYLD_INFO_ONLY: {
       llvm::MachO::dyld_info_command lc_obj;
-      if (m_data_up->GetU32(&offset, &lc_obj.rebase_off, 10)) {
+      if (m_data_sp->GetU32(&offset, &lc_obj.rebase_off, 10)) {
         lc_obj.cmd = lc.cmd;
         lc_obj.cmdsize = lc.cmdsize;
         dyld_info = lc_obj;
@@ -2269,8 +2269,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     case LC_REEXPORT_DYLIB:
     case LC_LOADFVMLIB:
     case LC_LOAD_UPWARD_DYLIB: {
-      uint32_t name_offset = cmd_offset + m_data_up->GetU32(&offset);
-      const char *path = m_data_up->PeekCStr(name_offset);
+      uint32_t name_offset = cmd_offset + m_data_sp->GetU32(&offset);
+      const char *path = m_data_sp->PeekCStr(name_offset);
       if (path) {
         FileSpec file_spec(path);
         // Strip the path if there is @rpath, @executable, etc so we just use
@@ -2290,19 +2290,19 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       llvm::MachO::linkedit_data_command lc_obj;
       lc_obj.cmd = lc.cmd;
       lc_obj.cmdsize = lc.cmdsize;
-      if (m_data_up->GetU32(&offset, &lc_obj.dataoff, 2))
+      if (m_data_sp->GetU32(&offset, &lc_obj.dataoff, 2))
         exports_trie_load_command = lc_obj;
     } break;
     case LC_FUNCTION_STARTS: {
       llvm::MachO::linkedit_data_command lc_obj;
       lc_obj.cmd = lc.cmd;
       lc_obj.cmdsize = lc.cmdsize;
-      if (m_data_up->GetU32(&offset, &lc_obj.dataoff, 2))
+      if (m_data_sp->GetU32(&offset, &lc_obj.dataoff, 2))
         function_starts_load_command = lc_obj;
     } break;
 
     case LC_UUID: {
-      const uint8_t *uuid_bytes = m_data_up->PeekData(offset, 16);
+      const uint8_t *uuid_bytes = m_data_sp->PeekData(offset, 16);
 
       if (uuid_bytes)
         image_uuid = UUID(uuid_bytes, 16);
@@ -2322,8 +2322,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
   if (section_list == nullptr)
     return;
 
-  const uint32_t addr_byte_size = m_data_up->GetAddressByteSize();
-  const ByteOrder byte_order = m_data_up->GetByteOrder();
+  const uint32_t addr_byte_size = m_data_sp->GetAddressByteSize();
+  const ByteOrder byte_order = m_data_sp->GetByteOrder();
   bool bit_width_32 = addr_byte_size == 4;
   const size_t nlist_byte_size =
       bit_width_32 ? sizeof(struct nlist) : sizeof(struct nlist_64);
@@ -2488,9 +2488,9 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       exports_trie_load_command.dataoff += linkedit_slide;
     }
 
-    nlist_data.SetData(*m_data_up.get(), symtab_load_command.symoff,
+    nlist_data.SetData(*m_data_sp.get(), symtab_load_command.symoff,
                        nlist_data_byte_size);
-    strtab_data.SetData(*m_data_up.get(), symtab_load_command.stroff,
+    strtab_data.SetData(*m_data_sp.get(), symtab_load_command.stroff,
                         strtab_data_byte_size);
 
     // We shouldn't have exports data from both the LC_DYLD_INFO command
@@ -2498,21 +2498,21 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     lldbassert(!((dyld_info.export_size > 0)
                  && (exports_trie_load_command.datasize > 0)));
     if (dyld_info.export_size > 0) {
-      dyld_trie_data.SetData(*m_data_up.get(), dyld_info.export_off,
+      dyld_trie_data.SetData(*m_data_sp.get(), dyld_info.export_off,
                              dyld_info.export_size);
     } else if (exports_trie_load_command.datasize > 0) {
-      dyld_trie_data.SetData(*m_data_up.get(),
+      dyld_trie_data.SetData(*m_data_sp.get(),
                              exports_trie_load_command.dataoff,
                              exports_trie_load_command.datasize);
     }
 
     if (dysymtab.nindirectsyms != 0) {
-      indirect_symbol_index_data.SetData(*m_data_up.get(),
+      indirect_symbol_index_data.SetData(*m_data_sp.get(),
                                          dysymtab.indirectsymoff,
                                          dysymtab.nindirectsyms * 4);
     }
     if (function_starts_load_command.cmd) {
-      function_starts_data.SetData(*m_data_up.get(),
+      function_starts_data.SetData(*m_data_sp.get(),
                                    function_starts_load_command.dataoff,
                                    function_starts_load_command.datasize);
     }
@@ -4565,7 +4565,7 @@ void ObjectFileMachO::Dump(Stream *s) {
     *s << ", file = '" << m_file;
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, *m_data_up.get(),
+    GetAllArchSpecs(m_header, *m_data_sp.get(),
                     MachHeaderSizeFromMagic(m_header.magic), base_spec,
                     all_specs);
     for (unsigned i = 0, e = all_specs.GetSize(); i != e; ++i) {
@@ -4873,7 +4873,7 @@ UUID ObjectFileMachO::GetUUID() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     lldb::offset_t offset = MachHeaderSizeFromMagic(m_header.magic);
-    return GetUUID(m_header, *m_data_up.get(), offset);
+    return GetUUID(m_header, *m_data_sp.get(), offset);
   }
   return UUID();
 }
@@ -4893,7 +4893,7 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
   uint32_t i;
   for (i = 0; i < m_header.ncmds; ++i) {
     const uint32_t cmd_offset = offset;
-    if (m_data_up->GetU32(&offset, &load_cmd, 2) == nullptr)
+    if (m_data_sp->GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     switch (load_cmd.cmd) {
@@ -4904,17 +4904,17 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
     case LC_LOAD_DYLINKER:
     case LC_LOADFVMLIB:
     case LC_LOAD_UPWARD_DYLIB: {
-      uint32_t name_offset = cmd_offset + m_data_up->GetU32(&offset);
+      uint32_t name_offset = cmd_offset + m_data_sp->GetU32(&offset);
       // For LC_LOAD_DYLIB there is an alternate encoding
       // which adds a uint32_t `flags` field for `DYLD_USE_*`
       // flags.  This can be detected by a timestamp field with
       // the `DYLIB_USE_MARKER` constant value.
       bool is_delayed_init = false;
-      uint32_t use_command_marker = m_data_up->GetU32(&offset);
+      uint32_t use_command_marker = m_data_sp->GetU32(&offset);
       if (use_command_marker == 0x1a741800 /* DYLIB_USE_MARKER */) {
         offset += 4; /* uint32_t current_version */
         offset += 4; /* uint32_t compat_version */
-        uint32_t flags = m_data_up->GetU32(&offset);
+        uint32_t flags = m_data_sp->GetU32(&offset);
         // If this LC_LOAD_DYLIB is marked delay-init,
         // don't report it as a dependent library -- it
         // may be loaded in the process at some point,
@@ -4922,7 +4922,7 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
         if (flags & 0x08 /* DYLIB_USE_DELAYED_INIT */)
           is_delayed_init = true;
       }
-      const char *path = m_data_up->PeekCStr(name_offset);
+      const char *path = m_data_sp->PeekCStr(name_offset);
       if (path && !is_delayed_init) {
         if (load_cmd.cmd == LC_RPATH)
           rpath_paths.push_back(path);
@@ -5042,15 +5042,15 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
 
     for (i = 0; i < m_header.ncmds; ++i) {
       const lldb::offset_t cmd_offset = offset;
-      if (m_data_up->GetU32(&offset, &load_cmd, 2) == nullptr)
+      if (m_data_sp->GetU32(&offset, &load_cmd, 2) == nullptr)
         break;
 
       switch (load_cmd.cmd) {
       case LC_UNIXTHREAD:
       case LC_THREAD: {
         while (offset < cmd_offset + load_cmd.cmdsize) {
-          uint32_t flavor = m_data_up->GetU32(&offset);
-          uint32_t count = m_data_up->GetU32(&offset);
+          uint32_t flavor = m_data_sp->GetU32(&offset);
+          uint32_t count = m_data_sp->GetU32(&offset);
           if (count == 0) {
             // We've gotten off somehow, log and exit;
             return m_entry_point_address;
@@ -5064,7 +5064,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 60; // This is the offset of pc in the GPR thread state
                             // data structure.
-              start_address = m_data_up->GetU32(&offset);
+              start_address = m_data_sp->GetU32(&offset);
               done = true;
             }
             break;
@@ -5074,7 +5074,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 256; // This is the offset of pc in the GPR thread state
                              // data structure.
-              start_address = m_data_up->GetU64(&offset);
+              start_address = m_data_sp->GetU64(&offset);
               done = true;
             }
             break;
@@ -5084,7 +5084,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 16 * 8; // This is the offset of rip in the GPR thread
                                 // state data structure.
-              start_address = m_data_up->GetU64(&offset);
+              start_address = m_data_sp->GetU64(&offset);
               done = true;
             }
             break;
@@ -5099,7 +5099,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
         }
       } break;
       case LC_MAIN: {
-        uint64_t entryoffset = m_data_up->GetU64(&offset);
+        uint64_t entryoffset = m_data_sp->GetU64(&offset);
         SectionSP text_segment_sp =
             GetSectionList()->FindSectionByName(GetSegmentNameTEXT());
         if (text_segment_sp) {
@@ -5183,7 +5183,7 @@ uint32_t ObjectFileMachO::GetNumThreadContexts() {
       llvm::MachO::thread_command thread_cmd;
       for (uint32_t i = 0; i < m_header.ncmds; ++i) {
         const uint32_t cmd_offset = offset;
-        if (m_data_up->GetU32(&offset, &thread_cmd, 2) == nullptr)
+        if (m_data_sp->GetU32(&offset, &thread_cmd, 2) == nullptr)
           break;
 
         if (thread_cmd.cmd == LC_THREAD) {
@@ -5209,17 +5209,17 @@ ObjectFileMachO::FindLC_NOTEByName(std::string name) {
     for (uint32_t i = 0; i < m_header.ncmds; ++i) {
       const uint32_t cmd_offset = offset;
       llvm::MachO::load_command lc = {};
-      if (m_data_up->GetU32(&offset, &lc.cmd, 2) == nullptr)
+      if (m_data_sp->GetU32(&offset, &lc.cmd, 2) == nullptr)
         break;
       if (lc.cmd == LC_NOTE) {
         char data_owner[17];
-        m_data_up->CopyData(offset, 16, data_owner);
+        m_data_sp->CopyData(offset, 16, data_owner);
         data_owner[16] = '\0';
         offset += 16;
 
         if (name == data_owner) {
-          offset_t payload_offset = m_data_up->GetU64_unchecked(&offset);
-          offset_t payload_size = m_data_up->GetU64_unchecked(&offset);
+          offset_t payload_offset = m_data_sp->GetU64_unchecked(&offset);
+          offset_t payload_size = m_data_sp->GetU64_unchecked(&offset);
           results.push_back({payload_offset, payload_size});
         }
       }
@@ -5241,11 +5241,11 @@ std::string ObjectFileMachO::GetIdentifierString() {
       offset_t payload_offset = std::get<0>(lc_note);
       offset_t payload_size = std::get<1>(lc_note);
       uint32_t version;
-      if (m_data_up->GetU32(&payload_offset, &version, 1) != nullptr) {
+      if (m_data_sp->GetU32(&payload_offset, &version, 1) != nullptr) {
         if (version == 1) {
           uint32_t strsize = payload_size - sizeof(uint32_t);
           std::string result(strsize, '\0');
-          m_data_up->CopyData(payload_offset, strsize, result.data());
+          m_data_sp->CopyData(payload_offset, strsize, result.data());
           LLDB_LOGF(log, "LC_NOTE 'kern ver str' found with text '%s'",
                     result.c_str());
           return result;
@@ -5259,11 +5259,11 @@ std::string ObjectFileMachO::GetIdentifierString() {
     for (uint32_t i = 0; i < m_header.ncmds; ++i) {
       const uint32_t cmd_offset = offset;
       llvm::MachO::ident_command ident_command;
-      if (m_data_up->GetU32(&offset, &ident_command, 2) == nullptr)
+      if (m_data_sp->GetU32(&offset, &ident_command, 2) == nullptr)
         break;
       if (ident_command.cmd == LC_IDENT && ident_command.cmdsize != 0) {
         std::string result(ident_command.cmdsize, '\0');
-        if (m_data_up->CopyData(offset, ident_command.cmdsize, result.data()) ==
+        if (m_data_sp->CopyData(offset, ident_command.cmdsize, result.data()) ==
             ident_command.cmdsize) {
           LLDB_LOGF(log, "LC_IDENT found with text '%s'", result.c_str());
           return result;
@@ -5286,9 +5286,9 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
     for (auto lc_note : lc_notes) {
       offset_t payload_offset = std::get<0>(lc_note);
       uint32_t version;
-      if (m_data_up->GetU32(&payload_offset, &version, 1) != nullptr) {
+      if (m_data_sp->GetU32(&payload_offset, &version, 1) != nullptr) {
         if (version == 3) {
-          uint32_t num_addr_bits = m_data_up->GetU32_unchecked(&payload_offset);
+          uint32_t num_addr_bits = m_data_sp->GetU32_unchecked(&payload_offset);
           addressable_bits.SetAddressableBits(num_addr_bits);
           LLDB_LOGF(log,
                     "LC_NOTE 'addrable bits' v3 found, value %d "
@@ -5296,8 +5296,8 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
                     num_addr_bits);
         }
         if (version == 4) {
-          uint32_t lo_addr_bits = m_data_up->GetU32_unchecked(&payload_offset);
-          uint32_t hi_addr_bits = m_data_up->GetU32_unchecked(&payload_offset);
+          uint32_t lo_addr_bits = m_data_sp->GetU32_unchecked(&payload_offset);
+          uint32_t hi_addr_bits = m_data_sp->GetU32_unchecked(&payload_offset);
 
           if (lo_addr_bits == hi_addr_bits)
             addressable_bits.SetAddressableBits(lo_addr_bits);
@@ -5368,25 +5368,25 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
       //    uint32_t unused        [ for alignment ]
 
       uint32_t version;
-      if (m_data_up->GetU32(&payload_offset, &version, 1) != nullptr &&
+      if (m_data_sp->GetU32(&payload_offset, &version, 1) != nullptr &&
           version <= 2) {
         uint32_t binspec_type = 0;
         uuid_t raw_uuid;
         memset(raw_uuid, 0, sizeof(uuid_t));
 
-        if (!m_data_up->GetU32(&payload_offset, &binspec_type, 1))
+        if (!m_data_sp->GetU32(&payload_offset, &binspec_type, 1))
           return false;
-        if (!m_data_up->GetU64(&payload_offset, &value, 1))
+        if (!m_data_sp->GetU64(&payload_offset, &value, 1))
           return false;
         uint64_t slide = LLDB_INVALID_ADDRESS;
-        if (version > 1 && !m_data_up->GetU64(&payload_offset, &slide, 1))
+        if (version > 1 && !m_data_sp->GetU64(&payload_offset, &slide, 1))
           return false;
         if (value == LLDB_INVALID_ADDRESS && slide != LLDB_INVALID_ADDRESS) {
           value = slide;
           value_is_offset = true;
         }
 
-        if (m_data_up->CopyData(payload_offset, sizeof(uuid_t), raw_uuid) !=
+        if (m_data_sp->CopyData(payload_offset, sizeof(uuid_t), raw_uuid) !=
             0) {
           uuid = UUID(raw_uuid, sizeof(uuid_t));
           // convert the "main bin spec" type into our
@@ -5421,9 +5421,9 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
                     version, type, typestr, value,
                     value_is_offset ? "true" : "false",
                     uuid.GetAsString().c_str());
-          if (!m_data_up->GetU32(&payload_offset, &log2_pagesize, 1))
+          if (!m_data_sp->GetU32(&payload_offset, &log2_pagesize, 1))
             return false;
-          if (version > 1 && !m_data_up->GetU32(&payload_offset, &platform, 1))
+          if (version > 1 && !m_data_sp->GetU32(&payload_offset, &platform, 1))
             return false;
           return true;
         }
@@ -5503,7 +5503,7 @@ StructuredData::ObjectSP ObjectFileMachO::GetCorefileProcessMetadata() {
 
   auto [payload_offset, strsize] = lc_notes[0];
   std::string buf(strsize, '\0');
-  if (m_data_up->CopyData(payload_offset, strsize, buf.data()) != strsize) {
+  if (m_data_sp->CopyData(payload_offset, strsize, buf.data()) != strsize) {
     LLDB_LOGF(log,
               "Unable to read %" PRIu64
               " bytes of 'process metadata' LC_NOTE JSON contents",
@@ -5543,7 +5543,7 @@ ObjectFileMachO::GetThreadContextAtIndex(uint32_t idx,
         m_thread_context_offsets.GetEntryAtIndex(idx);
     if (thread_context_file_range) {
 
-      DataExtractor data(*m_data_up.get(),
+      DataExtractor data(*m_data_sp.get(),
                          thread_context_file_range->GetRangeBase(),
                          thread_context_file_range->GetByteSize());
 
@@ -5684,13 +5684,13 @@ llvm::VersionTuple ObjectFileMachO::GetVersion() {
     uint32_t i;
     for (i = 0; i < m_header.ncmds; ++i) {
       const lldb::offset_t cmd_offset = offset;
-      if (m_data_up->GetU32(&offset, &load_cmd, 2) == nullptr)
+      if (m_data_sp->GetU32(&offset, &load_cmd, 2) == nullptr)
         break;
 
       if (load_cmd.cmd == LC_ID_DYLIB) {
         if (version_cmd == 0) {
           version_cmd = load_cmd.cmd;
-          if (m_data_up->GetU32(&offset, &load_cmd.dylib, 4) == nullptr)
+          if (m_data_sp->GetU32(&offset, &load_cmd.dylib, 4) == nullptr)
             break;
           version = load_cmd.dylib.current_version;
         }
@@ -5716,7 +5716,7 @@ ArchSpec ObjectFileMachO::GetArchitecture() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
 
-    return GetArchitecture(module_sp, m_header, *m_data_up.get(),
+    return GetArchitecture(module_sp, m_header, *m_data_sp.get(),
                            MachHeaderSizeFromMagic(m_header.magic));
   }
   return arch;
@@ -5887,7 +5887,7 @@ static llvm::VersionTuple FindMinimumVersionInfo(DataExtractor &data,
 llvm::VersionTuple ObjectFileMachO::GetMinimumOSVersion() {
   if (!m_min_os_version)
     m_min_os_version = FindMinimumVersionInfo(
-        *m_data_up.get(), MachHeaderSizeFromMagic(m_header.magic),
+        *m_data_sp.get(), MachHeaderSizeFromMagic(m_header.magic),
         m_header.ncmds);
   return *m_min_os_version;
 }
@@ -5895,7 +5895,7 @@ llvm::VersionTuple ObjectFileMachO::GetMinimumOSVersion() {
 llvm::VersionTuple ObjectFileMachO::GetSDKVersion() {
   if (!m_sdk_versions)
     m_sdk_versions = FindMinimumVersionInfo(
-        *m_data_up.get(), MachHeaderSizeFromMagic(m_header.magic),
+        *m_data_sp.get(), MachHeaderSizeFromMagic(m_header.magic),
         m_header.ncmds);
   return *m_sdk_versions;
 }
@@ -6711,12 +6711,12 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
   for (auto lc_note : lc_notes) {
     offset_t payload_offset = std::get<0>(lc_note);
     // Read the struct all_image_infos_header.
-    uint32_t version = m_data_up->GetU32(&payload_offset);
+    uint32_t version = m_data_sp->GetU32(&payload_offset);
     if (version != 1) {
       return image_infos;
     }
-    uint32_t imgcount = m_data_up->GetU32(&payload_offset);
-    uint64_t entries_fileoff = m_data_up->GetU64(&payload_offset);
+    uint32_t imgcount = m_data_sp->GetU32(&payload_offset);
+    uint64_t entries_fileoff = m_data_sp->GetU64(&payload_offset);
     // 'entries_size' is not used, nor is the 'unused' entry.
     //  offset += 4; // uint32_t entries_size;
     //  offset += 4; // uint32_t unused;
@@ -6726,17 +6726,17 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
     payload_offset = entries_fileoff;
     for (uint32_t i = 0; i < imgcount; i++) {
       // Read the struct image_entry.
-      offset_t filepath_offset = m_data_up->GetU64(&payload_offset);
+      offset_t filepath_offset = m_data_sp->GetU64(&payload_offset);
       uuid_t uuid;
-      memcpy(&uuid, m_data_up->GetData(&payload_offset, sizeof(uuid_t)),
+      memcpy(&uuid, m_data_sp->GetData(&payload_offset, sizeof(uuid_t)),
              sizeof(uuid_t));
-      uint64_t load_address = m_data_up->GetU64(&payload_offset);
-      offset_t seg_addrs_offset = m_data_up->GetU64(&payload_offset);
-      uint32_t segment_count = m_data_up->GetU32(&payload_offset);
-      uint32_t currently_executing = m_data_up->GetU32(&payload_offset);
+      uint64_t load_address = m_data_sp->GetU64(&payload_offset);
+      offset_t seg_addrs_offset = m_data_sp->GetU64(&payload_offset);
+      uint32_t segment_count = m_data_sp->GetU32(&payload_offset);
+      uint32_t currently_executing = m_data_sp->GetU32(&payload_offset);
 
       MachOCorefileImageEntry image_entry;
-      image_entry.filename = (const char *)m_data_up->GetCStr(&filepath_offset);
+      image_entry.filename = (const char *)m_data_sp->GetCStr(&filepath_offset);
       image_entry.uuid = UUID(uuid, sizeof(uuid_t));
       image_entry.load_address = load_address;
       image_entry.currently_executing = currently_executing;
@@ -6744,10 +6744,10 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
       offset_t seg_vmaddrs_offset = seg_addrs_offset;
       for (uint32_t j = 0; j < segment_count; j++) {
         char segname[17];
-        m_data_up->CopyData(seg_vmaddrs_offset, 16, segname);
+        m_data_sp->CopyData(seg_vmaddrs_offset, 16, segname);
         segname[16] = '\0';
         seg_vmaddrs_offset += 16;
-        uint64_t vmaddr = m_data_up->GetU64(&seg_vmaddrs_offset);
+        uint64_t vmaddr = m_data_sp->GetU64(&seg_vmaddrs_offset);
         seg_vmaddrs_offset += 8; /* unused */
 
         std::tuple<ConstString, addr_t> new_seg{ConstString(segname), vmaddr};
@@ -6766,14 +6766,14 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
   lc_notes = FindLC_NOTEByName("load binary");
   for (auto lc_note : lc_notes) {
     offset_t payload_offset = std::get<0>(lc_note);
-    uint32_t version = m_data_up->GetU32(&payload_offset);
+    uint32_t version = m_data_sp->GetU32(&payload_offset);
     if (version == 1) {
       uuid_t uuid;
-      memcpy(&uuid, m_data_up->GetData(&payload_offset, sizeof(uuid_t)),
+      memcpy(&uuid, m_data_sp->GetData(&payload_offset, sizeof(uuid_t)),
              sizeof(uuid_t));
-      uint64_t load_address = m_data_up->GetU64(&payload_offset);
-      uint64_t slide = m_data_up->GetU64(&payload_offset);
-      std::string filename = m_data_up->GetCStr(&payload_offset);
+      uint64_t load_address = m_data_sp->GetU64(&payload_offset);
+      uint64_t slide = m_data_sp->GetU64(&payload_offset);
+      std::string filename = m_data_sp->GetCStr(&payload_offset);
 
       MachOCorefileImageEntry image_entry;
       image_entry.filename = filename;

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -396,7 +396,7 @@ bool ObjectFilePECOFF::CreateBinary() {
   Log *log = GetLog(LLDBLog::Object);
 
   auto binary = llvm::object::createBinary(llvm::MemoryBufferRef(
-      toStringRef(m_data_sp->GetData()), m_file.GetFilename().GetStringRef()));
+      toStringRef(m_data_nsp->GetData()), m_file.GetFilename().GetStringRef()));
   if (!binary) {
     LLDB_LOG_ERROR(log, binary.takeError(),
                    "Failed to create binary for file ({1}): {0}", m_file);
@@ -442,20 +442,20 @@ bool ObjectFilePECOFF::ParseHeader() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     m_sect_headers.clear();
-    m_data_sp->SetByteOrder(eByteOrderLittle);
+    m_data_nsp->SetByteOrder(eByteOrderLittle);
     lldb::offset_t offset = 0;
 
-    if (ParseDOSHeader(*m_data_sp.get(), m_dos_header)) {
+    if (ParseDOSHeader(*m_data_nsp.get(), m_dos_header)) {
       offset = m_dos_header.e_lfanew;
-      uint32_t pe_signature = m_data_sp->GetU32(&offset);
+      uint32_t pe_signature = m_data_nsp->GetU32(&offset);
       if (pe_signature != IMAGE_NT_SIGNATURE)
         return false;
-      if (ParseCOFFHeader(*m_data_sp.get(), &offset, m_coff_header)) {
+      if (ParseCOFFHeader(*m_data_nsp.get(), &offset, m_coff_header)) {
         if (m_coff_header.hdrsize > 0)
           ParseCOFFOptionalHeader(&offset);
         ParseSectionHeaders(offset);
       }
-      m_data_sp->SetAddressByteSize(GetAddressByteSize());
+      m_data_nsp->SetAddressByteSize(GetAddressByteSize());
       return true;
     }
   }
@@ -602,61 +602,63 @@ bool ObjectFilePECOFF::ParseCOFFOptionalHeader(lldb::offset_t *offset_ptr) {
   const lldb::offset_t end_offset = *offset_ptr + m_coff_header.hdrsize;
   if (*offset_ptr < end_offset) {
     success = true;
-    m_coff_header_opt.magic = m_data_sp->GetU16(offset_ptr);
-    m_coff_header_opt.major_linker_version = m_data_sp->GetU8(offset_ptr);
-    m_coff_header_opt.minor_linker_version = m_data_sp->GetU8(offset_ptr);
-    m_coff_header_opt.code_size = m_data_sp->GetU32(offset_ptr);
-    m_coff_header_opt.data_size = m_data_sp->GetU32(offset_ptr);
-    m_coff_header_opt.bss_size = m_data_sp->GetU32(offset_ptr);
-    m_coff_header_opt.entry = m_data_sp->GetU32(offset_ptr);
-    m_coff_header_opt.code_offset = m_data_sp->GetU32(offset_ptr);
+    m_coff_header_opt.magic = m_data_nsp->GetU16(offset_ptr);
+    m_coff_header_opt.major_linker_version = m_data_nsp->GetU8(offset_ptr);
+    m_coff_header_opt.minor_linker_version = m_data_nsp->GetU8(offset_ptr);
+    m_coff_header_opt.code_size = m_data_nsp->GetU32(offset_ptr);
+    m_coff_header_opt.data_size = m_data_nsp->GetU32(offset_ptr);
+    m_coff_header_opt.bss_size = m_data_nsp->GetU32(offset_ptr);
+    m_coff_header_opt.entry = m_data_nsp->GetU32(offset_ptr);
+    m_coff_header_opt.code_offset = m_data_nsp->GetU32(offset_ptr);
 
     const uint32_t addr_byte_size = GetAddressByteSize();
 
     if (*offset_ptr < end_offset) {
       if (m_coff_header_opt.magic == OPT_HEADER_MAGIC_PE32) {
         // PE32 only
-        m_coff_header_opt.data_offset = m_data_sp->GetU32(offset_ptr);
+        m_coff_header_opt.data_offset = m_data_nsp->GetU32(offset_ptr);
       } else
         m_coff_header_opt.data_offset = 0;
 
       if (*offset_ptr < end_offset) {
         m_coff_header_opt.image_base =
-            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
-        m_coff_header_opt.sect_alignment = m_data_sp->GetU32(offset_ptr);
-        m_coff_header_opt.file_alignment = m_data_sp->GetU32(offset_ptr);
+            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
+        m_coff_header_opt.sect_alignment = m_data_nsp->GetU32(offset_ptr);
+        m_coff_header_opt.file_alignment = m_data_nsp->GetU32(offset_ptr);
         m_coff_header_opt.major_os_system_version =
-            m_data_sp->GetU16(offset_ptr);
+            m_data_nsp->GetU16(offset_ptr);
         m_coff_header_opt.minor_os_system_version =
-            m_data_sp->GetU16(offset_ptr);
-        m_coff_header_opt.major_image_version = m_data_sp->GetU16(offset_ptr);
-        m_coff_header_opt.minor_image_version = m_data_sp->GetU16(offset_ptr);
+            m_data_nsp->GetU16(offset_ptr);
+        m_coff_header_opt.major_image_version = m_data_nsp->GetU16(offset_ptr);
+        m_coff_header_opt.minor_image_version = m_data_nsp->GetU16(offset_ptr);
         m_coff_header_opt.major_subsystem_version =
-            m_data_sp->GetU16(offset_ptr);
+            m_data_nsp->GetU16(offset_ptr);
         m_coff_header_opt.minor_subsystem_version =
-            m_data_sp->GetU16(offset_ptr);
-        m_coff_header_opt.reserved1 = m_data_sp->GetU32(offset_ptr);
-        m_coff_header_opt.image_size = m_data_sp->GetU32(offset_ptr);
-        m_coff_header_opt.header_size = m_data_sp->GetU32(offset_ptr);
-        m_coff_header_opt.checksum = m_data_sp->GetU32(offset_ptr);
-        m_coff_header_opt.subsystem = m_data_sp->GetU16(offset_ptr);
-        m_coff_header_opt.dll_flags = m_data_sp->GetU16(offset_ptr);
+            m_data_nsp->GetU16(offset_ptr);
+        m_coff_header_opt.reserved1 = m_data_nsp->GetU32(offset_ptr);
+        m_coff_header_opt.image_size = m_data_nsp->GetU32(offset_ptr);
+        m_coff_header_opt.header_size = m_data_nsp->GetU32(offset_ptr);
+        m_coff_header_opt.checksum = m_data_nsp->GetU32(offset_ptr);
+        m_coff_header_opt.subsystem = m_data_nsp->GetU16(offset_ptr);
+        m_coff_header_opt.dll_flags = m_data_nsp->GetU16(offset_ptr);
         m_coff_header_opt.stack_reserve_size =
-            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
+            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.stack_commit_size =
-            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
+            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.heap_reserve_size =
-            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
+            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.heap_commit_size =
-            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
-        m_coff_header_opt.loader_flags = m_data_sp->GetU32(offset_ptr);
-        uint32_t num_data_dir_entries = m_data_sp->GetU32(offset_ptr);
+            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
+        m_coff_header_opt.loader_flags = m_data_nsp->GetU32(offset_ptr);
+        uint32_t num_data_dir_entries = m_data_nsp->GetU32(offset_ptr);
         m_coff_header_opt.data_dirs.clear();
         m_coff_header_opt.data_dirs.resize(num_data_dir_entries);
         uint32_t i;
         for (i = 0; i < num_data_dir_entries; i++) {
-          m_coff_header_opt.data_dirs[i].vmaddr = m_data_sp->GetU32(offset_ptr);
-          m_coff_header_opt.data_dirs[i].vmsize = m_data_sp->GetU32(offset_ptr);
+          m_coff_header_opt.data_dirs[i].vmaddr =
+              m_data_nsp->GetU32(offset_ptr);
+          m_coff_header_opt.data_dirs[i].vmsize =
+              m_data_nsp->GetU32(offset_ptr);
         }
 
         m_image_base = m_coff_header_opt.image_base;
@@ -688,8 +690,8 @@ DataExtractor ObjectFilePECOFF::ReadImageData(uint32_t offset, size_t size) {
   if (!size)
     return {};
 
-  if (m_data_sp->ValidOffsetForDataOfSize(offset, size))
-    return DataExtractor(*m_data_sp.get(), offset, size);
+  if (m_data_nsp->ValidOffsetForDataOfSize(offset, size))
+    return DataExtractor(*m_data_nsp.get(), offset, size);
 
   ProcessSP process_sp(m_process_wp.lock());
   DataExtractor data;
@@ -763,7 +765,7 @@ llvm::StringRef ObjectFilePECOFF::GetSectionName(const section_header_t &sect) {
       return "";
     lldb::offset_t string_file_offset =
         m_coff_header.symoff + (m_coff_header.nsyms * 18) + stroff;
-    if (const char *name = m_data_sp->GetCStr(&string_file_offset))
+    if (const char *name = m_data_nsp->GetCStr(&string_file_offset))
       return name;
     return "";
   }

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -396,7 +396,7 @@ bool ObjectFilePECOFF::CreateBinary() {
   Log *log = GetLog(LLDBLog::Object);
 
   auto binary = llvm::object::createBinary(llvm::MemoryBufferRef(
-      toStringRef(m_data_up->GetData()), m_file.GetFilename().GetStringRef()));
+      toStringRef(m_data_sp->GetData()), m_file.GetFilename().GetStringRef()));
   if (!binary) {
     LLDB_LOG_ERROR(log, binary.takeError(),
                    "Failed to create binary for file ({1}): {0}", m_file);
@@ -442,20 +442,20 @@ bool ObjectFilePECOFF::ParseHeader() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     m_sect_headers.clear();
-    m_data_up->SetByteOrder(eByteOrderLittle);
+    m_data_sp->SetByteOrder(eByteOrderLittle);
     lldb::offset_t offset = 0;
 
-    if (ParseDOSHeader(*m_data_up.get(), m_dos_header)) {
+    if (ParseDOSHeader(*m_data_sp.get(), m_dos_header)) {
       offset = m_dos_header.e_lfanew;
-      uint32_t pe_signature = m_data_up->GetU32(&offset);
+      uint32_t pe_signature = m_data_sp->GetU32(&offset);
       if (pe_signature != IMAGE_NT_SIGNATURE)
         return false;
-      if (ParseCOFFHeader(*m_data_up.get(), &offset, m_coff_header)) {
+      if (ParseCOFFHeader(*m_data_sp.get(), &offset, m_coff_header)) {
         if (m_coff_header.hdrsize > 0)
           ParseCOFFOptionalHeader(&offset);
         ParseSectionHeaders(offset);
       }
-      m_data_up->SetAddressByteSize(GetAddressByteSize());
+      m_data_sp->SetAddressByteSize(GetAddressByteSize());
       return true;
     }
   }
@@ -602,61 +602,61 @@ bool ObjectFilePECOFF::ParseCOFFOptionalHeader(lldb::offset_t *offset_ptr) {
   const lldb::offset_t end_offset = *offset_ptr + m_coff_header.hdrsize;
   if (*offset_ptr < end_offset) {
     success = true;
-    m_coff_header_opt.magic = m_data_up->GetU16(offset_ptr);
-    m_coff_header_opt.major_linker_version = m_data_up->GetU8(offset_ptr);
-    m_coff_header_opt.minor_linker_version = m_data_up->GetU8(offset_ptr);
-    m_coff_header_opt.code_size = m_data_up->GetU32(offset_ptr);
-    m_coff_header_opt.data_size = m_data_up->GetU32(offset_ptr);
-    m_coff_header_opt.bss_size = m_data_up->GetU32(offset_ptr);
-    m_coff_header_opt.entry = m_data_up->GetU32(offset_ptr);
-    m_coff_header_opt.code_offset = m_data_up->GetU32(offset_ptr);
+    m_coff_header_opt.magic = m_data_sp->GetU16(offset_ptr);
+    m_coff_header_opt.major_linker_version = m_data_sp->GetU8(offset_ptr);
+    m_coff_header_opt.minor_linker_version = m_data_sp->GetU8(offset_ptr);
+    m_coff_header_opt.code_size = m_data_sp->GetU32(offset_ptr);
+    m_coff_header_opt.data_size = m_data_sp->GetU32(offset_ptr);
+    m_coff_header_opt.bss_size = m_data_sp->GetU32(offset_ptr);
+    m_coff_header_opt.entry = m_data_sp->GetU32(offset_ptr);
+    m_coff_header_opt.code_offset = m_data_sp->GetU32(offset_ptr);
 
     const uint32_t addr_byte_size = GetAddressByteSize();
 
     if (*offset_ptr < end_offset) {
       if (m_coff_header_opt.magic == OPT_HEADER_MAGIC_PE32) {
         // PE32 only
-        m_coff_header_opt.data_offset = m_data_up->GetU32(offset_ptr);
+        m_coff_header_opt.data_offset = m_data_sp->GetU32(offset_ptr);
       } else
         m_coff_header_opt.data_offset = 0;
 
       if (*offset_ptr < end_offset) {
         m_coff_header_opt.image_base =
-            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
-        m_coff_header_opt.sect_alignment = m_data_up->GetU32(offset_ptr);
-        m_coff_header_opt.file_alignment = m_data_up->GetU32(offset_ptr);
+            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
+        m_coff_header_opt.sect_alignment = m_data_sp->GetU32(offset_ptr);
+        m_coff_header_opt.file_alignment = m_data_sp->GetU32(offset_ptr);
         m_coff_header_opt.major_os_system_version =
-            m_data_up->GetU16(offset_ptr);
+            m_data_sp->GetU16(offset_ptr);
         m_coff_header_opt.minor_os_system_version =
-            m_data_up->GetU16(offset_ptr);
-        m_coff_header_opt.major_image_version = m_data_up->GetU16(offset_ptr);
-        m_coff_header_opt.minor_image_version = m_data_up->GetU16(offset_ptr);
+            m_data_sp->GetU16(offset_ptr);
+        m_coff_header_opt.major_image_version = m_data_sp->GetU16(offset_ptr);
+        m_coff_header_opt.minor_image_version = m_data_sp->GetU16(offset_ptr);
         m_coff_header_opt.major_subsystem_version =
-            m_data_up->GetU16(offset_ptr);
+            m_data_sp->GetU16(offset_ptr);
         m_coff_header_opt.minor_subsystem_version =
-            m_data_up->GetU16(offset_ptr);
-        m_coff_header_opt.reserved1 = m_data_up->GetU32(offset_ptr);
-        m_coff_header_opt.image_size = m_data_up->GetU32(offset_ptr);
-        m_coff_header_opt.header_size = m_data_up->GetU32(offset_ptr);
-        m_coff_header_opt.checksum = m_data_up->GetU32(offset_ptr);
-        m_coff_header_opt.subsystem = m_data_up->GetU16(offset_ptr);
-        m_coff_header_opt.dll_flags = m_data_up->GetU16(offset_ptr);
+            m_data_sp->GetU16(offset_ptr);
+        m_coff_header_opt.reserved1 = m_data_sp->GetU32(offset_ptr);
+        m_coff_header_opt.image_size = m_data_sp->GetU32(offset_ptr);
+        m_coff_header_opt.header_size = m_data_sp->GetU32(offset_ptr);
+        m_coff_header_opt.checksum = m_data_sp->GetU32(offset_ptr);
+        m_coff_header_opt.subsystem = m_data_sp->GetU16(offset_ptr);
+        m_coff_header_opt.dll_flags = m_data_sp->GetU16(offset_ptr);
         m_coff_header_opt.stack_reserve_size =
-            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
+            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.stack_commit_size =
-            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
+            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.heap_reserve_size =
-            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
+            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.heap_commit_size =
-            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
-        m_coff_header_opt.loader_flags = m_data_up->GetU32(offset_ptr);
-        uint32_t num_data_dir_entries = m_data_up->GetU32(offset_ptr);
+            m_data_sp->GetMaxU64(offset_ptr, addr_byte_size);
+        m_coff_header_opt.loader_flags = m_data_sp->GetU32(offset_ptr);
+        uint32_t num_data_dir_entries = m_data_sp->GetU32(offset_ptr);
         m_coff_header_opt.data_dirs.clear();
         m_coff_header_opt.data_dirs.resize(num_data_dir_entries);
         uint32_t i;
         for (i = 0; i < num_data_dir_entries; i++) {
-          m_coff_header_opt.data_dirs[i].vmaddr = m_data_up->GetU32(offset_ptr);
-          m_coff_header_opt.data_dirs[i].vmsize = m_data_up->GetU32(offset_ptr);
+          m_coff_header_opt.data_dirs[i].vmaddr = m_data_sp->GetU32(offset_ptr);
+          m_coff_header_opt.data_dirs[i].vmsize = m_data_sp->GetU32(offset_ptr);
         }
 
         m_image_base = m_coff_header_opt.image_base;
@@ -688,8 +688,8 @@ DataExtractor ObjectFilePECOFF::ReadImageData(uint32_t offset, size_t size) {
   if (!size)
     return {};
 
-  if (m_data_up->ValidOffsetForDataOfSize(offset, size))
-    return DataExtractor(*m_data_up.get(), offset, size);
+  if (m_data_sp->ValidOffsetForDataOfSize(offset, size))
+    return DataExtractor(*m_data_sp.get(), offset, size);
 
   ProcessSP process_sp(m_process_wp.lock());
   DataExtractor data;
@@ -763,7 +763,7 @@ llvm::StringRef ObjectFilePECOFF::GetSectionName(const section_header_t &sect) {
       return "";
     lldb::offset_t string_file_offset =
         m_coff_header.symoff + (m_coff_header.nsyms * 18) + stroff;
-    if (const char *name = m_data_up->GetCStr(&string_file_offset))
+    if (const char *name = m_data_sp->GetCStr(&string_file_offset))
       return name;
     return "";
   }

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -396,7 +396,7 @@ bool ObjectFilePECOFF::CreateBinary() {
   Log *log = GetLog(LLDBLog::Object);
 
   auto binary = llvm::object::createBinary(llvm::MemoryBufferRef(
-      toStringRef(m_data.GetData()), m_file.GetFilename().GetStringRef()));
+      toStringRef(m_data_up->GetData()), m_file.GetFilename().GetStringRef()));
   if (!binary) {
     LLDB_LOG_ERROR(log, binary.takeError(),
                    "Failed to create binary for file ({1}): {0}", m_file);
@@ -442,20 +442,20 @@ bool ObjectFilePECOFF::ParseHeader() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     m_sect_headers.clear();
-    m_data.SetByteOrder(eByteOrderLittle);
+    m_data_up->SetByteOrder(eByteOrderLittle);
     lldb::offset_t offset = 0;
 
-    if (ParseDOSHeader(m_data, m_dos_header)) {
+    if (ParseDOSHeader(*m_data_up.get(), m_dos_header)) {
       offset = m_dos_header.e_lfanew;
-      uint32_t pe_signature = m_data.GetU32(&offset);
+      uint32_t pe_signature = m_data_up->GetU32(&offset);
       if (pe_signature != IMAGE_NT_SIGNATURE)
         return false;
-      if (ParseCOFFHeader(m_data, &offset, m_coff_header)) {
+      if (ParseCOFFHeader(*m_data_up.get(), &offset, m_coff_header)) {
         if (m_coff_header.hdrsize > 0)
           ParseCOFFOptionalHeader(&offset);
         ParseSectionHeaders(offset);
       }
-      m_data.SetAddressByteSize(GetAddressByteSize());
+      m_data_up->SetAddressByteSize(GetAddressByteSize());
       return true;
     }
   }
@@ -602,57 +602,61 @@ bool ObjectFilePECOFF::ParseCOFFOptionalHeader(lldb::offset_t *offset_ptr) {
   const lldb::offset_t end_offset = *offset_ptr + m_coff_header.hdrsize;
   if (*offset_ptr < end_offset) {
     success = true;
-    m_coff_header_opt.magic = m_data.GetU16(offset_ptr);
-    m_coff_header_opt.major_linker_version = m_data.GetU8(offset_ptr);
-    m_coff_header_opt.minor_linker_version = m_data.GetU8(offset_ptr);
-    m_coff_header_opt.code_size = m_data.GetU32(offset_ptr);
-    m_coff_header_opt.data_size = m_data.GetU32(offset_ptr);
-    m_coff_header_opt.bss_size = m_data.GetU32(offset_ptr);
-    m_coff_header_opt.entry = m_data.GetU32(offset_ptr);
-    m_coff_header_opt.code_offset = m_data.GetU32(offset_ptr);
+    m_coff_header_opt.magic = m_data_up->GetU16(offset_ptr);
+    m_coff_header_opt.major_linker_version = m_data_up->GetU8(offset_ptr);
+    m_coff_header_opt.minor_linker_version = m_data_up->GetU8(offset_ptr);
+    m_coff_header_opt.code_size = m_data_up->GetU32(offset_ptr);
+    m_coff_header_opt.data_size = m_data_up->GetU32(offset_ptr);
+    m_coff_header_opt.bss_size = m_data_up->GetU32(offset_ptr);
+    m_coff_header_opt.entry = m_data_up->GetU32(offset_ptr);
+    m_coff_header_opt.code_offset = m_data_up->GetU32(offset_ptr);
 
     const uint32_t addr_byte_size = GetAddressByteSize();
 
     if (*offset_ptr < end_offset) {
       if (m_coff_header_opt.magic == OPT_HEADER_MAGIC_PE32) {
         // PE32 only
-        m_coff_header_opt.data_offset = m_data.GetU32(offset_ptr);
+        m_coff_header_opt.data_offset = m_data_up->GetU32(offset_ptr);
       } else
         m_coff_header_opt.data_offset = 0;
 
       if (*offset_ptr < end_offset) {
         m_coff_header_opt.image_base =
-            m_data.GetMaxU64(offset_ptr, addr_byte_size);
-        m_coff_header_opt.sect_alignment = m_data.GetU32(offset_ptr);
-        m_coff_header_opt.file_alignment = m_data.GetU32(offset_ptr);
-        m_coff_header_opt.major_os_system_version = m_data.GetU16(offset_ptr);
-        m_coff_header_opt.minor_os_system_version = m_data.GetU16(offset_ptr);
-        m_coff_header_opt.major_image_version = m_data.GetU16(offset_ptr);
-        m_coff_header_opt.minor_image_version = m_data.GetU16(offset_ptr);
-        m_coff_header_opt.major_subsystem_version = m_data.GetU16(offset_ptr);
-        m_coff_header_opt.minor_subsystem_version = m_data.GetU16(offset_ptr);
-        m_coff_header_opt.reserved1 = m_data.GetU32(offset_ptr);
-        m_coff_header_opt.image_size = m_data.GetU32(offset_ptr);
-        m_coff_header_opt.header_size = m_data.GetU32(offset_ptr);
-        m_coff_header_opt.checksum = m_data.GetU32(offset_ptr);
-        m_coff_header_opt.subsystem = m_data.GetU16(offset_ptr);
-        m_coff_header_opt.dll_flags = m_data.GetU16(offset_ptr);
+            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
+        m_coff_header_opt.sect_alignment = m_data_up->GetU32(offset_ptr);
+        m_coff_header_opt.file_alignment = m_data_up->GetU32(offset_ptr);
+        m_coff_header_opt.major_os_system_version =
+            m_data_up->GetU16(offset_ptr);
+        m_coff_header_opt.minor_os_system_version =
+            m_data_up->GetU16(offset_ptr);
+        m_coff_header_opt.major_image_version = m_data_up->GetU16(offset_ptr);
+        m_coff_header_opt.minor_image_version = m_data_up->GetU16(offset_ptr);
+        m_coff_header_opt.major_subsystem_version =
+            m_data_up->GetU16(offset_ptr);
+        m_coff_header_opt.minor_subsystem_version =
+            m_data_up->GetU16(offset_ptr);
+        m_coff_header_opt.reserved1 = m_data_up->GetU32(offset_ptr);
+        m_coff_header_opt.image_size = m_data_up->GetU32(offset_ptr);
+        m_coff_header_opt.header_size = m_data_up->GetU32(offset_ptr);
+        m_coff_header_opt.checksum = m_data_up->GetU32(offset_ptr);
+        m_coff_header_opt.subsystem = m_data_up->GetU16(offset_ptr);
+        m_coff_header_opt.dll_flags = m_data_up->GetU16(offset_ptr);
         m_coff_header_opt.stack_reserve_size =
-            m_data.GetMaxU64(offset_ptr, addr_byte_size);
+            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.stack_commit_size =
-            m_data.GetMaxU64(offset_ptr, addr_byte_size);
+            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.heap_reserve_size =
-            m_data.GetMaxU64(offset_ptr, addr_byte_size);
+            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.heap_commit_size =
-            m_data.GetMaxU64(offset_ptr, addr_byte_size);
-        m_coff_header_opt.loader_flags = m_data.GetU32(offset_ptr);
-        uint32_t num_data_dir_entries = m_data.GetU32(offset_ptr);
+            m_data_up->GetMaxU64(offset_ptr, addr_byte_size);
+        m_coff_header_opt.loader_flags = m_data_up->GetU32(offset_ptr);
+        uint32_t num_data_dir_entries = m_data_up->GetU32(offset_ptr);
         m_coff_header_opt.data_dirs.clear();
         m_coff_header_opt.data_dirs.resize(num_data_dir_entries);
         uint32_t i;
         for (i = 0; i < num_data_dir_entries; i++) {
-          m_coff_header_opt.data_dirs[i].vmaddr = m_data.GetU32(offset_ptr);
-          m_coff_header_opt.data_dirs[i].vmsize = m_data.GetU32(offset_ptr);
+          m_coff_header_opt.data_dirs[i].vmaddr = m_data_up->GetU32(offset_ptr);
+          m_coff_header_opt.data_dirs[i].vmsize = m_data_up->GetU32(offset_ptr);
         }
 
         m_image_base = m_coff_header_opt.image_base;
@@ -684,8 +688,8 @@ DataExtractor ObjectFilePECOFF::ReadImageData(uint32_t offset, size_t size) {
   if (!size)
     return {};
 
-  if (m_data.ValidOffsetForDataOfSize(offset, size))
-    return DataExtractor(m_data, offset, size);
+  if (m_data_up->ValidOffsetForDataOfSize(offset, size))
+    return DataExtractor(*m_data_up.get(), offset, size);
 
   ProcessSP process_sp(m_process_wp.lock());
   DataExtractor data;
@@ -759,7 +763,7 @@ llvm::StringRef ObjectFilePECOFF::GetSectionName(const section_header_t &sect) {
       return "";
     lldb::offset_t string_file_offset =
         m_coff_header.symoff + (m_coff_header.nsyms * 18) + stroff;
-    if (const char *name = m_data.GetCStr(&string_file_offset))
+    if (const char *name = m_data_up->GetCStr(&string_file_offset))
       return name;
     return "";
   }

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -94,7 +94,7 @@ bool ObjectFileXCOFF::CreateBinary() {
 
   Log *log = GetLog(LLDBLog::Object);
 
-  auto memory_ref = llvm::MemoryBufferRef(toStringRef(m_data_sp->GetData()),
+  auto memory_ref = llvm::MemoryBufferRef(toStringRef(m_data_nsp->GetData()),
                                           m_file.GetFilename().GetStringRef());
   llvm::file_magic magic = llvm::identify_magic(memory_ref.getBuffer());
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -94,7 +94,7 @@ bool ObjectFileXCOFF::CreateBinary() {
 
   Log *log = GetLog(LLDBLog::Object);
 
-  auto memory_ref = llvm::MemoryBufferRef(toStringRef(m_data.GetData()),
+  auto memory_ref = llvm::MemoryBufferRef(toStringRef(m_data_up->GetData()),
                                           m_file.GetFilename().GetStringRef());
   llvm::file_magic magic = llvm::identify_magic(memory_ref.getBuffer());
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -94,7 +94,7 @@ bool ObjectFileXCOFF::CreateBinary() {
 
   Log *log = GetLog(LLDBLog::Object);
 
-  auto memory_ref = llvm::MemoryBufferRef(toStringRef(m_data_up->GetData()),
+  auto memory_ref = llvm::MemoryBufferRef(toStringRef(m_data_sp->GetData()),
                                           m_file.GetFilename().GetStringRef());
   llvm::file_magic magic = llvm::identify_magic(memory_ref.getBuffer());
 

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -287,7 +287,7 @@ ObjectFileWasm::ObjectFileWasm(const ModuleSP &module_sp, DataBufferSP data_sp,
                                offset_t offset, offset_t length)
     : ObjectFile(module_sp, file, offset, length, data_sp, data_offset),
       m_arch("wasm32-unknown-unknown-wasm") {
-  m_data_up->SetAddressByteSize(4);
+  m_data_sp->SetAddressByteSize(4);
 }
 
 ObjectFileWasm::ObjectFileWasm(const lldb::ModuleSP &module_sp,
@@ -719,10 +719,10 @@ DataExtractor ObjectFileWasm::ReadImageData(offset_t offset, uint32_t size) {
         DataBufferSP buffer_sp(data_up.release());
         data.SetData(buffer_sp, 0, buffer_sp->GetByteSize());
       }
-    } else if (offset < m_data_up->GetByteSize()) {
+    } else if (offset < m_data_sp->GetByteSize()) {
       size = std::min(static_cast<uint64_t>(size),
-                      m_data_up->GetByteSize() - offset);
-      return DataExtractor(m_data_up->GetDataStart() + offset, size,
+                      m_data_sp->GetByteSize() - offset);
+      return DataExtractor(m_data_sp->GetDataStart() + offset, size,
                            GetByteOrder(), GetAddressByteSize());
     }
   }

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -287,7 +287,7 @@ ObjectFileWasm::ObjectFileWasm(const ModuleSP &module_sp, DataBufferSP data_sp,
                                offset_t offset, offset_t length)
     : ObjectFile(module_sp, file, offset, length, data_sp, data_offset),
       m_arch("wasm32-unknown-unknown-wasm") {
-  m_data.SetAddressByteSize(4);
+  m_data_up->SetAddressByteSize(4);
 }
 
 ObjectFileWasm::ObjectFileWasm(const lldb::ModuleSP &module_sp,
@@ -719,11 +719,11 @@ DataExtractor ObjectFileWasm::ReadImageData(offset_t offset, uint32_t size) {
         DataBufferSP buffer_sp(data_up.release());
         data.SetData(buffer_sp, 0, buffer_sp->GetByteSize());
       }
-    } else if (offset < m_data.GetByteSize()) {
-      size =
-          std::min(static_cast<uint64_t>(size), m_data.GetByteSize() - offset);
-      return DataExtractor(m_data.GetDataStart() + offset, size, GetByteOrder(),
-                           GetAddressByteSize());
+    } else if (offset < m_data_up->GetByteSize()) {
+      size = std::min(static_cast<uint64_t>(size),
+                      m_data_up->GetByteSize() - offset);
+      return DataExtractor(m_data_up->GetDataStart() + offset, size,
+                           GetByteOrder(), GetAddressByteSize());
     }
   }
   data.SetByteOrder(GetByteOrder());

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -287,7 +287,7 @@ ObjectFileWasm::ObjectFileWasm(const ModuleSP &module_sp, DataBufferSP data_sp,
                                offset_t offset, offset_t length)
     : ObjectFile(module_sp, file, offset, length, data_sp, data_offset),
       m_arch("wasm32-unknown-unknown-wasm") {
-  m_data_sp->SetAddressByteSize(4);
+  m_data_nsp->SetAddressByteSize(4);
 }
 
 ObjectFileWasm::ObjectFileWasm(const lldb::ModuleSP &module_sp,
@@ -719,10 +719,10 @@ DataExtractor ObjectFileWasm::ReadImageData(offset_t offset, uint32_t size) {
         DataBufferSP buffer_sp(data_up.release());
         data.SetData(buffer_sp, 0, buffer_sp->GetByteSize());
       }
-    } else if (offset < m_data_sp->GetByteSize()) {
+    } else if (offset < m_data_nsp->GetByteSize()) {
       size = std::min(static_cast<uint64_t>(size),
-                      m_data_sp->GetByteSize() - offset);
-      return DataExtractor(m_data_sp->GetDataStart() + offset, size,
+                      m_data_nsp->GetByteSize() - offset);
+      return DataExtractor(m_data_nsp->GetDataStart() + offset, size,
                            GetByteOrder(), GetAddressByteSize());
     }
   }

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -254,13 +254,14 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
     : ModuleChild(module_sp),
       m_file(), // This file could be different from the original module's file
       m_type(eTypeInvalid), m_strata(eStrataInvalid),
-      m_file_offset(file_offset), m_length(length), m_data(), m_process_wp(),
+      m_file_offset(file_offset), m_length(length),
+      m_data_up(std::make_unique<DataExtractor>()), m_process_wp(),
       m_memory_addr(LLDB_INVALID_ADDRESS), m_sections_up(), m_symtab_up(),
       m_symtab_once_up(new llvm::once_flag()) {
   if (file_spec_ptr)
     m_file = *file_spec_ptr;
   if (data_sp)
-    m_data.SetData(data_sp, data_offset, length);
+    m_data_up->SetData(data_sp, data_offset, length);
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), file = %s, "
@@ -275,11 +276,12 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
                        const ProcessSP &process_sp, lldb::addr_t header_addr,
                        DataBufferSP header_data_sp)
     : ModuleChild(module_sp), m_file(), m_type(eTypeInvalid),
-      m_strata(eStrataInvalid), m_file_offset(0), m_length(0), m_data(),
-      m_process_wp(process_sp), m_memory_addr(header_addr), m_sections_up(),
-      m_symtab_up(), m_symtab_once_up(new llvm::once_flag()) {
+      m_strata(eStrataInvalid), m_file_offset(0), m_length(0),
+      m_data_up(std::make_unique<DataExtractor>()), m_process_wp(process_sp),
+      m_memory_addr(header_addr), m_sections_up(), m_symtab_up(),
+      m_symtab_once_up(new llvm::once_flag()) {
   if (header_data_sp)
-    m_data.SetData(header_data_sp, 0, header_data_sp->GetByteSize());
+    m_data_up->SetData(header_data_sp, 0, header_data_sp->GetByteSize());
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), process = %p, "
@@ -474,16 +476,16 @@ WritableDataBufferSP ObjectFile::ReadMemory(const ProcessSP &process_sp,
 
 size_t ObjectFile::GetData(lldb::offset_t offset, size_t length,
                            DataExtractor &data) const {
-  // The entire file has already been mmap'ed into m_data, so just copy from
+  // The entire file has already been mmap'ed into m_data_up, so just copy from
   // there as the back mmap buffer will be shared with shared pointers.
-  return data.SetData(m_data, offset, length);
+  return data.SetData(*m_data_up.get(), offset, length);
 }
 
 size_t ObjectFile::CopyData(lldb::offset_t offset, size_t length,
                             void *dst) const {
-  // The entire file has already been mmap'ed into m_data, so just copy from
+  // The entire file has already been mmap'ed into m_data_up, so just copy from
   // there Note that the data remains in target byte order.
-  return m_data.CopyData(offset, length, dst);
+  return m_data_up->CopyData(offset, length, dst);
 }
 
 size_t ObjectFile::ReadSectionData(Section *section,

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -255,13 +255,13 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
       m_file(), // This file could be different from the original module's file
       m_type(eTypeInvalid), m_strata(eStrataInvalid),
       m_file_offset(file_offset), m_length(length),
-      m_data_up(std::make_unique<DataExtractor>()), m_process_wp(),
+      m_data_sp(std::make_shared<DataExtractor>()), m_process_wp(),
       m_memory_addr(LLDB_INVALID_ADDRESS), m_sections_up(), m_symtab_up(),
       m_symtab_once_up(new llvm::once_flag()) {
   if (file_spec_ptr)
     m_file = *file_spec_ptr;
   if (data_sp)
-    m_data_up->SetData(data_sp, data_offset, length);
+    m_data_sp->SetData(data_sp, data_offset, length);
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), file = %s, "
@@ -277,11 +277,11 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
                        DataBufferSP header_data_sp)
     : ModuleChild(module_sp), m_file(), m_type(eTypeInvalid),
       m_strata(eStrataInvalid), m_file_offset(0), m_length(0),
-      m_data_up(std::make_unique<DataExtractor>()), m_process_wp(process_sp),
+      m_data_sp(std::make_shared<DataExtractor>()), m_process_wp(process_sp),
       m_memory_addr(header_addr), m_sections_up(), m_symtab_up(),
       m_symtab_once_up(new llvm::once_flag()) {
   if (header_data_sp)
-    m_data_up->SetData(header_data_sp, 0, header_data_sp->GetByteSize());
+    m_data_sp->SetData(header_data_sp, 0, header_data_sp->GetByteSize());
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), process = %p, "
@@ -476,16 +476,16 @@ WritableDataBufferSP ObjectFile::ReadMemory(const ProcessSP &process_sp,
 
 size_t ObjectFile::GetData(lldb::offset_t offset, size_t length,
                            DataExtractor &data) const {
-  // The entire file has already been mmap'ed into m_data_up, so just copy from
+  // The entire file has already been mmap'ed into m_data_sp, so just copy from
   // there as the back mmap buffer will be shared with shared pointers.
-  return data.SetData(*m_data_up.get(), offset, length);
+  return data.SetData(*m_data_sp.get(), offset, length);
 }
 
 size_t ObjectFile::CopyData(lldb::offset_t offset, size_t length,
                             void *dst) const {
-  // The entire file has already been mmap'ed into m_data_up, so just copy from
+  // The entire file has already been mmap'ed into m_data_sp, so just copy from
   // there Note that the data remains in target byte order.
-  return m_data_up->CopyData(offset, length, dst);
+  return m_data_sp->CopyData(offset, length, dst);
 }
 
 size_t ObjectFile::ReadSectionData(Section *section,

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -255,13 +255,13 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
       m_file(), // This file could be different from the original module's file
       m_type(eTypeInvalid), m_strata(eStrataInvalid),
       m_file_offset(file_offset), m_length(length),
-      m_data_sp(std::make_shared<DataExtractor>()), m_process_wp(),
+      m_data_nsp(std::make_shared<DataExtractor>()), m_process_wp(),
       m_memory_addr(LLDB_INVALID_ADDRESS), m_sections_up(), m_symtab_up(),
       m_symtab_once_up(new llvm::once_flag()) {
   if (file_spec_ptr)
     m_file = *file_spec_ptr;
   if (data_sp)
-    m_data_sp->SetData(data_sp, data_offset, length);
+    m_data_nsp->SetData(data_sp, data_offset, length);
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), file = %s, "
@@ -277,11 +277,11 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
                        DataBufferSP header_data_sp)
     : ModuleChild(module_sp), m_file(), m_type(eTypeInvalid),
       m_strata(eStrataInvalid), m_file_offset(0), m_length(0),
-      m_data_sp(std::make_shared<DataExtractor>()), m_process_wp(process_sp),
+      m_data_nsp(std::make_shared<DataExtractor>()), m_process_wp(process_sp),
       m_memory_addr(header_addr), m_sections_up(), m_symtab_up(),
       m_symtab_once_up(new llvm::once_flag()) {
   if (header_data_sp)
-    m_data_sp->SetData(header_data_sp, 0, header_data_sp->GetByteSize());
+    m_data_nsp->SetData(header_data_sp, 0, header_data_sp->GetByteSize());
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), process = %p, "
@@ -476,16 +476,16 @@ WritableDataBufferSP ObjectFile::ReadMemory(const ProcessSP &process_sp,
 
 size_t ObjectFile::GetData(lldb::offset_t offset, size_t length,
                            DataExtractor &data) const {
-  // The entire file has already been mmap'ed into m_data_sp, so just copy from
+  // The entire file has already been mmap'ed into m_data_nsp, so just copy from
   // there as the back mmap buffer will be shared with shared pointers.
-  return data.SetData(*m_data_sp.get(), offset, length);
+  return data.SetData(*m_data_nsp.get(), offset, length);
 }
 
 size_t ObjectFile::CopyData(lldb::offset_t offset, size_t length,
                             void *dst) const {
-  // The entire file has already been mmap'ed into m_data_sp, so just copy from
+  // The entire file has already been mmap'ed into m_data_nsp, so just copy from
   // there Note that the data remains in target byte order.
-  return m_data_sp->CopyData(offset, length, dst);
+  return m_data_nsp->CopyData(offset, length, dst);
 }
 
 size_t ObjectFile::ReadSectionData(Section *section,


### PR DESCRIPTION
ObjectFile has an m_data DataExtractor ivar which may be default constructed initially, or initialized with a DataBuffer passed in to its ctor.  If the DataExtractor does not get a DataBuffer source passed in, the subclass will initialize it with access to the object file's data.  When a DataBuffer is passed in to the base class ctor, the DataExtractor only has its buffer initialized; ObjectFile doesn't yet know the address size and endianness to fully initialize the DataExtractor.

This patch changes ObjectFile to instead have a DataExtractorSP ivar which is always initialized with at least a default-constructed DataExtractor object in the base class ctor.  The next patch I will be writing is to change the ObjectFile ctor to take an optional DataExtractorSP, so the caller can pass a DataExtractor subclass -- the VirtualizeDataExtractor being added via
https://github.com/llvm/llvm-project/pull/168802
instead of a DataBuffer which is trivially saved into the DataExtractor.

The change is otherwise mechanical; all `m_data.` changed to `m_data_sp->` and all the places where `m_data` was passed in for a by-ref call were changed to `*m_data_sp.get()`.  The shared pointer is always initialized to contain an object.

I built & ran the testsuite on macOS and on aarch64-Ubuntu (thanks for getting the Linux testsuite to run on SME-only systems David). All of the ObjectFile subclasses I modifed compile cleanly, but I haven't tested them beyond any unit tests they may have (prob breakpad).

rdar://148939795