### PR TITLE
[mlir][SPIRV] Improve ub.unreachable lowering test case

### DIFF
--- a/mlir/test/Conversion/UBToSPIRV/ub-to-spirv.mlir
+++ b/mlir/test/Conversion/UBToSPIRV/ub-to-spirv.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -split-input-file -convert-ub-to-spirv -verify-diagnostics %s | FileCheck %s
+// RUN: mlir-opt -split-input-file -convert-ub-to-spirv %s | FileCheck %s
 
 module attributes {
   spirv.target_env = #spirv.target_env<
@@ -22,15 +22,17 @@ func.func @check_poison() {
 
 // -----
 
-// No successful test because the dialect conversion framework does not convert
-// unreachable blocks.
-
 module attributes {
   spirv.target_env = #spirv.target_env<
     #spirv.vce<v1.0, [Int8, Int16, Int64, Float16, Float64, Shader], []>, #spirv.resource_limits<>>
 } {
-func.func @check_unrechable() {
-// expected-error@+1{{cannot be used in reachable block}}
-  spirv.Unreachable
+// CHECK-LABEL: @check_unrechable
+func.func @check_unrechable(%c: i1) {
+  cf.cond_br %c, ^bb1, ^bb2
+^bb1:
+// CHECK: spirv.Unreachable
+  ub.unreachable
+^bb2:
+  return
 }
 }


### PR DESCRIPTION
Addresses a comment on the PR that introduces the ub.reachable -> spriv.Unreachable lowering (https://github.com/llvm/llvm-project/pull/169872#discussion_r2573670611).