### PR TITLE
[mlir][gpu] Fix gpu.host_register lowering and runtime support

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
@@ -1566,7 +1566,7 @@ def GPU_BinaryOp : GPU_Op<"binary", [Symbol]>, Arguments<(ins
 }
 
 def GPU_HostRegisterOp : GPU_Op<"host_register">,
-    Arguments<(ins AnyUnrankedMemRef:$value)> {
+    Arguments<(ins AnyMemRef:$value)> {
   let summary = "Registers a memref for access from device.";
   let description = [{
     This op maps the provided host buffer into the device address space.
@@ -1583,7 +1583,7 @@ def GPU_HostRegisterOp : GPU_Op<"host_register">,
 }
 
 def GPU_HostUnregisterOp : GPU_Op<"host_unregister">,
-    Arguments<(ins AnyUnrankedMemRef:$value)> {
+    Arguments<(ins AnyMemRef:$value)> {
   let summary = "Unregisters a memref for access from device.";
   let description = [{
       This op unmaps the provided host buffer from the device address space.

--- a/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
+++ b/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
@@ -721,8 +721,8 @@ static LogicalResult prepareHostRegisterUnregisterArguments(
     elementTypes.push_back(elementType);
     Type llvmIntPtrType = IntegerType::get(
         rewriter.getContext(), typeConverter->getPointerBitwidth(0));
-    Value rank = rewriter.create<LLVM::ConstantOp>(
-        loc, llvmIntPtrType,
+    Value rank = LLVM::ConstantOp::create(
+        rewriter, loc, llvmIntPtrType,
         rewriter.getIntegerAttr(llvmIntPtrType, memRefType.getRank()));
     Value descriptor = adaptorValue;
     Value descriptorPtr;

--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseGPUCodegen.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseGPUCodegen.cpp
@@ -109,21 +109,17 @@ static Value genLaunchGPUFunc(OpBuilder &builder, gpu::GPUFuncOp gpuFunc,
 /// Writes from the host are guaranteed to be visible to device kernels
 /// that are launched afterwards. Writes from the device are guaranteed
 /// to be visible on the host after synchronizing with the device kernel
-/// completion. Needs to cast the buffer to a unranked buffer.
+/// completion.
 static Value genHostRegisterMemref(OpBuilder &builder, Location loc,
                                    Value mem) {
-  MemRefType memTp = cast<MemRefType>(mem.getType());
-  UnrankedMemRefType resTp =
-      UnrankedMemRefType::get(memTp.getElementType(), /*memorySpace=*/0);
-  Value cast = memref::CastOp::create(builder, loc, resTp, mem);
-  gpu::HostRegisterOp::create(builder, loc, cast);
-  return cast;
+  gpu::HostRegisterOp::create(builder, loc, mem);
+  return mem;
 }
 
-/// Unmaps the provided buffer, expecting the casted buffer.
+/// Unmaps the provided buffer.
 static void genHostUnregisterMemref(OpBuilder &builder, Location loc,
-                                    Value cast) {
-  gpu::HostUnregisterOp::create(builder, loc, cast);
+                                    Value mem) {
+  gpu::HostUnregisterOp::create(builder, loc, mem);
 }
 
 /// Generates first wait in an asynchronous chain.

--- a/mlir/test/Conversion/GPUCommon/host-register-bare-ptr-func.mlir
+++ b/mlir/test/Conversion/GPUCommon/host-register-bare-ptr-func.mlir
@@ -1,0 +1,9 @@
+// RUN: mlir-opt %s --gpu-to-llvm="use-bare-pointers-for-host=1" -split-input-file -verify-diagnostics
+
+module attributes {gpu.container_module} {
+  func.func @dynamic(%buf : memref<?xf32>) {
+    // expected-error @+1 {{cannot lower memref with bare pointer calling convention}}
+    gpu.host_register %buf : memref<?xf32>
+    return
+  }
+}

--- a/mlir/test/Conversion/GPUCommon/host-register-bare-ptr.mlir
+++ b/mlir/test/Conversion/GPUCommon/host-register-bare-ptr.mlir
@@ -1,0 +1,54 @@
+// RUN: mlir-opt %s --gpu-to-llvm="use-bare-pointers-for-host=1" -split-input-file -verify-diagnostics | FileCheck %s --check-prefix=BARE
+
+module attributes {gpu.container_module} {
+  func.func @host_register(%arg0: memref<4x6xf16>) {
+    gpu.host_register %arg0 : memref<4x6xf16>
+    gpu.host_unregister %arg0 : memref<4x6xf16>
+    return
+  }
+}
+
+// BARE-LABEL: llvm.func @host_register
+// BARE-SAME: ({{.*}}: !llvm.ptr) {
+// BARE: %[[DESC0:.+]] = llvm.mlir.poison : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
+// BARE: %[[DESC1:.+]] = llvm.insertvalue %arg0, %[[DESC0]][0]
+// BARE: %[[DESC2:.+]] = llvm.insertvalue %arg0, %[[DESC1]][1]
+// BARE: %[[OFF:.+]] = llvm.mlir.constant(0 : {{.*}}) : i64
+// BARE: %[[DESC3:.+]] = llvm.insertvalue %[[OFF]], %[[DESC2]][2]
+// BARE: %[[SIZE0:.+]] = llvm.mlir.constant(4 : {{.*}}) : i64
+// BARE: %[[DESC4:.+]] = llvm.insertvalue %[[SIZE0]], %[[DESC3]][3, 0]
+// BARE: %[[STRIDE0:.+]] = llvm.mlir.constant(6 : {{.*}}) : i64
+// BARE: %[[DESC5:.+]] = llvm.insertvalue %[[STRIDE0]], %[[DESC4]][4, 0]
+// BARE: %[[SIZE1:.+]] = llvm.mlir.constant(6 : {{.*}}) : i64
+// BARE: %[[DESC6:.+]] = llvm.insertvalue %[[SIZE1]], %[[DESC5]][3, 1]
+// BARE: %[[STRIDE1:.+]] = llvm.mlir.constant(1 : {{.*}}) : i64
+// BARE: %[[DESC7:.+]] = llvm.insertvalue %[[STRIDE1]], %[[DESC6]][4, 1]
+// BARE: %[[RANK:.+]] = llvm.mlir.constant(2 : {{.*}}) : i64
+// BARE: %[[ALLOCA:.+]] = llvm.alloca %{{.*}} x !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
+// BARE: llvm.store %[[DESC7]], %[[ALLOCA]] : !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>, !llvm.ptr
+// BARE: %[[NULL:.+]] = llvm.mlir.zero : !llvm.ptr
+// BARE: %[[GEP:.+]] = llvm.getelementptr %[[NULL]][1] : (!llvm.ptr) -> !llvm.ptr, f16
+// BARE: %[[ELTSZ:.+]] = llvm.ptrtoint %[[GEP]] : !llvm.ptr to i64
+// BARE: llvm.call @mgpuMemHostRegisterMemRef(%[[RANK]], %[[ALLOCA]], %[[ELTSZ]])
+// BARE: llvm.call @mgpuMemHostUnregisterMemRef(%{{.*}}, %{{.*}}, %{{.*}})
+
+// -----
+
+module attributes {gpu.container_module} {
+  func.func @dynamic(%n: index) {
+    %buf = memref.alloc(%n) : memref<?xf32>
+    // expected-error @+1 {{cannot lower memref with bare pointer calling convention}}
+    gpu.host_register %buf : memref<?xf32>
+    return
+  }
+}
+
+// -----
+
+module attributes {gpu.container_module} {
+  func.func @unranked(%arg0: memref<*xf32>) {
+    // expected-error @+1 {{custom op 'gpu.host_register' invalid kind of type specified: expected builtin.memref, but found 'memref<*xf32>'}}
+    gpu.host_register %arg0 : memref<*xf32>
+    return
+  }
+}

--- a/mlir/test/Integration/GPU/CUDA/host-register-ranked-memref.mlir
+++ b/mlir/test/Integration/GPU/CUDA/host-register-ranked-memref.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-opt %s -gpu-lower-to-nvvm-pipeline="cubin-format=%gpu_compilation_format" \
+// RUN: | mlir-runner \
+// RUN:   --shared-libs=%mlir_cuda_runtime \
+// RUN:   --shared-libs=%mlir_runner_utils \
+// RUN:   --shared-libs=%mlir_c_runner_utils \
+// RUN:   --entry-point-result=void
+
+module attributes {gpu.container_module} {
+  func.func @main() {
+    %0 = memref.alloc() : memref<64x64xf32>
+
+    // Call host_register with a rank-2 memref.
+    gpu.host_register %0 : memref<64x64xf32>
+
+    memref.dealloc %0 : memref<64x64xf32>
+    return
+  }
+}


### PR DESCRIPTION
This PR fixes related issues with `gpu.host_register` to ensure correct behavior with bare pointers and multi-rank memrefs, and updates the op definition.

## 1. Fix bare pointer lowering
When `gpu-to-llvm` is configured with `use-bare-pointers-for-host=1`, `gpu.host_register` previously lowered to a runtime call passing the raw bare pointer. However, the runtime entry point `mgpuMemHostRegisterMemRef` expects a pointer to a memref descriptor struct. This PR updates the lowering in `GPUToLLVMConversion.cpp` to reconstruct a `MemRefDescriptor` from the bare pointer (using static shape information) before passing it to the runtime. This prevents crashes and ensures the runtime receives the expected descriptor format.

## 2. Fix runtime for multi-rank memrefs
Updates the CUDA and ROCm runtime wrappers (`CudaRuntimeWrappers.cpp`, `RocmRuntimeWrappers.cpp`) to correctly handle multi-rank memrefs in `mgpuMemHostRegisterMemRef`. This ensures that host registration works reliably for memrefs with `rank > 1`.

Fixes: https://github.com/llvm/llvm-project/issues/56366

## 3. Update `gpu.host_register` signature
Updates `gpu.host_register` and `gpu.host_unregister` to accept `AnyMemRef` instead of `AnyUnrankedMemRef`. This removes the requirement to cast ranked memrefs to unranked before registration. SparseGPUCodegen.cpp is updated to remove these unnecessary casts.