### PR TITLE
[mlir][Linalg] Allow more control in drop unit dims

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -564,17 +564,16 @@ struct ControlDropUnitDims {
     };
     auto indexingMap = op.getMatchingIndexingMap(opOperand);
     SmallVector<int64_t> shape = op.getStaticOperandShape(opOperand);
-    if (!hasCollapsibleType(*opOperand)) {
-      AffineMap newIndexingMap = indexingMap.replaceDimsAndSymbols(
-          dimReplacements, ArrayRef<AffineExpr>{}, oldDimsToNewDimsMap.size(),
-          0);
-      UnitExtentReplacementInfo info;
-      info.indexMap = newIndexingMap;
-      info.targetShape = llvm::to_vector(shape);
-      return info;
+    if (hasCollapsibleType(*opOperand)) {
+      return control.dropUnitExtentFromOperandMetadata(
+          context, op, opOperand, oldDimsToNewDimsMap, dimReplacements);
     }
-    return control.dropUnitExtentFromOperandMetadata(
-        context, op, opOperand, oldDimsToNewDimsMap, dimReplacements);
+    AffineMap newIndexingMap = indexingMap.replaceDimsAndSymbols(
+        dimReplacements, ArrayRef<AffineExpr>{}, oldDimsToNewDimsMap.size(), 0);
+    UnitExtentReplacementInfo info;
+    info.indexMap = newIndexingMap;
+    info.targetShape = llvm::to_vector(shape);
+    return info;
   };
 
   using CollapseValueFnTy = std::function<Value(

--- a/mlir/test/Dialect/Linalg/test-drop-unit-dims.mlir
+++ b/mlir/test/Dialect/Linalg/test-drop-unit-dims.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt -test-linalg-drop-unit-dims --split-input-file %s | FileCheck %s
+// RUN: mlir-opt -test-linalg-drop-unit-dims="preserve-encoding" --split-input-file %s | FileCheck %s --check-prefix=PRESERVE
 
 // Drop only the outermost unit dimension (controlled using a control function)
 func.func @drop_outermost_unit_dims(%arg0: tensor<1x1x42xf32>) -> tensor<1x1x42xf32> {
@@ -24,3 +25,44 @@ func.func @drop_outermost_unit_dims(%arg0: tensor<1x1x42xf32>) -> tensor<1x1x42x
 //  CHECK-SAME:       outs(%[[OUTS_RESHAPE]] :
 //       CHECK:   %[[EXPAND_SHAPE:.+]] = tensor.expand_shape %[[GENERIC]] {{\[}}[0, 1], [2]{{\]}}
 //       CHECK:   return %[[EXPAND_SHAPE]]
+
+// -----
+
+#encoding = #test.tensor_encoding<"encoding">
+
+// Test that tensor encodings are preserved when collapsing unit dimensions
+func.func @drop_outermost_unit_dims_with_encoding(%arg0: tensor<1x1x42xf32, #encoding>) -> tensor<1x1x42xf32, #encoding> {
+  %0 = tensor.empty() : tensor<1x1x42xf32, #encoding>
+  %1 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+    iterator_types = ["parallel", "parallel", "parallel"]}
+    ins(%arg0 : tensor<1x1x42xf32, #encoding>)
+    outs(%0 : tensor<1x1x42xf32, #encoding>) {
+      ^bb0(%b0: f32, %b1 : f32):
+        %2 = arith.addf %b0, %b1 : f32
+        linalg.yield %2 : f32
+    } -> tensor<1x1x42xf32, #encoding>
+  return %1 : tensor<1x1x42xf32, #encoding>
+}
+// Without preserve-encoding flag, encoded tensors are not collapsed
+// CHECK-LABEL: func @drop_outermost_unit_dims_with_encoding
+//       CHECK:   linalg.generic
+//   CHECK-NOT:   tensor.collapse_shape
+//   CHECK-NOT:   tensor.expand_shape
+
+// With preserve-encoding flag, encodings are preserved through collapse/expand
+// PRESERVE: affine_map<(d0, d1) -> (d0, d1)>
+// PRESERVE-LABEL: func @drop_outermost_unit_dims_with_encoding
+//  PRESERVE-SAME:     %[[ARG0:.+]]: tensor<1x1x42xf32, #test.tensor_encoding<"encoding">>
+//       PRESERVE:   %[[OUTS:.+]] = tensor.empty() : tensor<1x1x42xf32, #test.tensor_encoding<"encoding">>
+//       PRESERVE:   %[[ARG0_RESHAPE:.+]] = tensor.collapse_shape %[[ARG0]] {{\[}}[0, 1], [2]{{\]}}
+//  PRESERVE-SAME:       : tensor<1x1x42xf32, #test.tensor_encoding<"encoding">> into tensor<1x42xf32, #test.tensor_encoding<"encoding">>
+//       PRESERVE:   %[[OUTS_RESHAPE:.+]] = tensor.collapse_shape %[[OUTS]] {{\[}}[0, 1], [2]{{\]}}
+//  PRESERVE-SAME:       : tensor<1x1x42xf32, #test.tensor_encoding<"encoding">> into tensor<1x42xf32, #test.tensor_encoding<"encoding">>
+//       PRESERVE:   %[[GENERIC:.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]}
+//  PRESERVE-SAME:       ins(%[[ARG0_RESHAPE]] : tensor<1x42xf32, #test.tensor_encoding<"encoding">>)
+//  PRESERVE-SAME:       outs(%[[OUTS_RESHAPE]] : tensor<1x42xf32, #test.tensor_encoding<"encoding">>)
+//       PRESERVE:   %[[EXPAND_SHAPE:.+]] = tensor.expand_shape %[[GENERIC]] {{\[}}[0, 1], [2]{{\]}}
+//  PRESERVE-SAME:       : tensor<1x42xf32, #test.tensor_encoding<"encoding">> into tensor<1x1x42xf32, #test.tensor_encoding<"encoding">>
+//       PRESERVE:   return %[[EXPAND_SHAPE]]

--- a/mlir/test/Dialect/Linalg/test-drop-unit-dims.mlir
+++ b/mlir/test/Dialect/Linalg/test-drop-unit-dims.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt -test-linalg-drop-unit-dims --split-input-file %s | FileCheck %s
-// RUN: mlir-opt -test-linalg-drop-unit-dims="preserve-encoding" --split-input-file %s | FileCheck %s --check-prefix=PRESERVE
+// RUN: mlir-opt -test-linalg-drop-unit-dims="collapse-encoded" --split-input-file %s | FileCheck %s --check-prefix=PRESERVE
 
 // Drop only the outermost unit dimension (controlled using a control function)
 func.func @drop_outermost_unit_dims(%arg0: tensor<1x1x42xf32>) -> tensor<1x1x42xf32> {

--- a/mlir/test/Dialect/Linalg/test-drop-unit-dims.mlir
+++ b/mlir/test/Dialect/Linalg/test-drop-unit-dims.mlir
@@ -1,68 +1,55 @@
 // RUN: mlir-opt -test-linalg-drop-unit-dims --split-input-file %s | FileCheck %s
-// RUN: mlir-opt -test-linalg-drop-unit-dims="collapse-encoded" --split-input-file %s | FileCheck %s --check-prefix=PRESERVE
+// RUN: mlir-opt -test-linalg-drop-unit-dims="collapse-encoded" --split-input-file %s | FileCheck %s --check-prefix=ENCODED
+
+#encoding = #test.tensor_encoding<"encoding">
 
 // Drop only the outermost unit dimension (controlled using a control function)
-func.func @drop_outermost_unit_dims(%arg0: tensor<1x1x42xf32>) -> tensor<1x1x42xf32> {
+// In default mode, only the input with no encoding is collapsed.
+// With the `collape-encoded` flag, the encoded input is also collapsed.
+func.func @drop_outermost_unit_dims(%arg0: tensor<1x1x42xf32>, %arg1: tensor<1x1x42xf32, #encoding>) -> tensor<1x1x42xf32> {
   %0 = tensor.empty() : tensor<1x1x42xf32>
   %1 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
                      affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
     iterator_types = ["parallel", "parallel", "parallel"]}
-    ins(%arg0 : tensor<1x1x42xf32>) outs(%0 : tensor<1x1x42xf32>) {
-      ^bb0(%b0: f32, %b1 : f32):
+    ins(%arg0, %arg1 : tensor<1x1x42xf32>, tensor<1x1x42xf32, #encoding>)
+    outs(%0 : tensor<1x1x42xf32>) {
+      ^bb0(%b0: f32, %b1: f32, %b2: f32):
         %2 = arith.addf %b0, %b1 : f32
         linalg.yield %2 : f32
     } -> tensor<1x1x42xf32>
   return %1 : tensor<1x1x42xf32>
 }
+
+// Without the collapse-encoded flag, only the non-encoded tensor is collapsed
 // CHECK-LABEL: func @drop_outermost_unit_dims
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<1x1x42xf32>
+//  CHECK-SAME:     %[[ARG1:.+]]: tensor<1x1x42xf32, #test.tensor_encoding<"encoding">>
 //       CHECK:   %[[OUTS:.+]] = tensor.empty()
 //       CHECK:   %[[ARG0_RESHAPE:.+]] = tensor.collapse_shape %[[ARG0]] {{\[}}[0, 1], [2]{{\]}}
 //       CHECK:   %[[OUTS_RESHAPE:.+]] = tensor.collapse_shape %[[OUTS]] {{\[}}[0, 1], [2]{{\]}}
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
-//  CHECK-SAME:       ins(%[[ARG0_RESHAPE]] :
+//  CHECK-SAME:       ins(%[[ARG0_RESHAPE]], %[[ARG1]] :
 //  CHECK-SAME:       outs(%[[OUTS_RESHAPE]] :
 //       CHECK:   %[[EXPAND_SHAPE:.+]] = tensor.expand_shape %[[GENERIC]] {{\[}}[0, 1], [2]{{\]}}
 //       CHECK:   return %[[EXPAND_SHAPE]]
 
-// -----
-
-#encoding = #test.tensor_encoding<"encoding">
-
-// Test that tensor encodings are preserved when collapsing unit dimensions
-func.func @drop_outermost_unit_dims_with_encoding(%arg0: tensor<1x1x42xf32, #encoding>) -> tensor<1x1x42xf32, #encoding> {
-  %0 = tensor.empty() : tensor<1x1x42xf32, #encoding>
-  %1 = linalg.generic {
-    indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
-                     affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
-    iterator_types = ["parallel", "parallel", "parallel"]}
-    ins(%arg0 : tensor<1x1x42xf32, #encoding>)
-    outs(%0 : tensor<1x1x42xf32, #encoding>) {
-      ^bb0(%b0: f32, %b1 : f32):
-        %2 = arith.addf %b0, %b1 : f32
-        linalg.yield %2 : f32
-    } -> tensor<1x1x42xf32, #encoding>
-  return %1 : tensor<1x1x42xf32, #encoding>
-}
-// Without preserve-encoding flag, encoded tensors are not collapsed
-// CHECK-LABEL: func @drop_outermost_unit_dims_with_encoding
-//       CHECK:   linalg.generic
-//   CHECK-NOT:   tensor.collapse_shape
-//   CHECK-NOT:   tensor.expand_shape
-
-// With preserve-encoding flag, encodings are preserved through collapse/expand
-// PRESERVE: affine_map<(d0, d1) -> (d0, d1)>
-// PRESERVE-LABEL: func @drop_outermost_unit_dims_with_encoding
-//  PRESERVE-SAME:     %[[ARG0:.+]]: tensor<1x1x42xf32, #test.tensor_encoding<"encoding">>
-//       PRESERVE:   %[[OUTS:.+]] = tensor.empty() : tensor<1x1x42xf32, #test.tensor_encoding<"encoding">>
-//       PRESERVE:   %[[ARG0_RESHAPE:.+]] = tensor.collapse_shape %[[ARG0]] {{\[}}[0, 1], [2]{{\]}}
-//  PRESERVE-SAME:       : tensor<1x1x42xf32, #test.tensor_encoding<"encoding">> into tensor<1x42xf32, #test.tensor_encoding<"encoding">>
-//       PRESERVE:   %[[OUTS_RESHAPE:.+]] = tensor.collapse_shape %[[OUTS]] {{\[}}[0, 1], [2]{{\]}}
-//  PRESERVE-SAME:       : tensor<1x1x42xf32, #test.tensor_encoding<"encoding">> into tensor<1x42xf32, #test.tensor_encoding<"encoding">>
-//       PRESERVE:   %[[GENERIC:.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]}
-//  PRESERVE-SAME:       ins(%[[ARG0_RESHAPE]] : tensor<1x42xf32, #test.tensor_encoding<"encoding">>)
-//  PRESERVE-SAME:       outs(%[[OUTS_RESHAPE]] : tensor<1x42xf32, #test.tensor_encoding<"encoding">>)
-//       PRESERVE:   %[[EXPAND_SHAPE:.+]] = tensor.expand_shape %[[GENERIC]] {{\[}}[0, 1], [2]{{\]}}
-//  PRESERVE-SAME:       : tensor<1x42xf32, #test.tensor_encoding<"encoding">> into tensor<1x1x42xf32, #test.tensor_encoding<"encoding">>
-//       PRESERVE:   return %[[EXPAND_SHAPE]]
+// With the collapse-encoded flag, both tensors are collapsed and encodings are preserved
+// ENCODED: affine_map<(d0, d1) -> (d0, d1)>
+// ENCODED-LABEL: func @drop_outermost_unit_dims
+//  ENCODED-SAME:     %[[ARG0:.+]]: tensor<1x1x42xf32>
+//  ENCODED-SAME:     %[[ARG1:.+]]: tensor<1x1x42xf32, #test.tensor_encoding<"encoding">>
+//       ENCODED:   %[[OUTS:.+]] = tensor.empty() : tensor<1x1x42xf32>
+//       ENCODED:   %[[ARG0_RESHAPE:.+]] = tensor.collapse_shape %[[ARG0]] {{\[}}[0, 1], [2]{{\]}}
+//  ENCODED-SAME:       : tensor<1x1x42xf32> into tensor<1x42xf32>
+//       ENCODED:   %[[ARG1_RESHAPE:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1], [2]{{\]}}
+//  ENCODED-SAME:       : tensor<1x1x42xf32, #test.tensor_encoding<"encoding">> into tensor<1x42xf32, #test.tensor_encoding<"encoding">>
+//       ENCODED:   %[[OUTS_RESHAPE:.+]] = tensor.collapse_shape %[[OUTS]] {{\[}}[0, 1], [2]{{\]}}
+//  ENCODED-SAME:       : tensor<1x1x42xf32> into tensor<1x42xf32>
+//       ENCODED:   %[[GENERIC:.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+//  ENCODED-SAME:       ins(%[[ARG0_RESHAPE]], %[[ARG1_RESHAPE]] : tensor<1x42xf32>, tensor<1x42xf32, #test.tensor_encoding<"encoding">>)
+//  ENCODED-SAME:       outs(%[[OUTS_RESHAPE]] : tensor<1x42xf32>)
+//       ENCODED:   %[[EXPAND_SHAPE:.+]] = tensor.expand_shape %[[GENERIC]] {{\[}}[0, 1], [2]{{\]}}
+//  ENCODED-SAME:       output_shape [1, 1, 42] {test.unit_dims_expanded} : tensor<1x42xf32> into tensor<1x1x42xf32>
+//       ENCODED:   return %[[EXPAND_SHAPE]]

--- a/mlir/test/lib/Dialect/Linalg/TestLinalgDropUnitDims.cpp
+++ b/mlir/test/lib/Dialect/Linalg/TestLinalgDropUnitDims.cpp
@@ -96,9 +96,9 @@ struct TestLinalgDropUnitDims
       : PassWrapper(pass) {}
 
   Option<bool> preserveEncoding{
-      *this, "preserve-encoding",
+      *this, "collapse-encoded",
       llvm::cl::desc(
-          "Preserve tensor encodings when collapsing unit dimensions"),
+          "Collapse tensors with encodings and unit extend dimensions"),
       llvm::cl::init(false)};
 
   void getDependentDialects(DialectRegistry &registry) const override {


### PR DESCRIPTION
Extend the `ControlDropUnitDims` struct to allow users of the `linalg::dropUnitDims` function more control over the behavior of the function.

The extended struct allows users to specify functions to:
- Calculate the shape and new index map of operands, which also allows to control which operands get their unit extent dimension dropped.
- How the operands are collapsed
- How the result is expanded to the original shape

One example (and the motivation for this change) where this additional control is useful is to allow collapsing of tensors with an encoding, as demonstrated by the new test.

The default implementations preserve the previous behavior; existing users of the interface do not need to make any changes to their code.