### PR TITLE
[mlir][linalg] Re-enable linalg runtime verification test

### DIFF
--- a/mlir/test/Integration/Dialect/Linalg/CPU/runtime-verification.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/runtime-verification.mlir
@@ -80,10 +80,10 @@ func.func @main() {
   %c64x57 = arith.constant dense<0.0> : tensor<16x29xf32>
   %c3x4 = arith.constant dense<0.0> : tensor<3x4xf32>
 
-  // TODO: BROKEN CHK: ERROR: Runtime op verification failed
-  // TODO: BROKEN CHK-NEXT: linalg.generic
-  // TODO: BROKEN CHK-NEXT: unexpected negative result on dimension #0 of input/output operand #0
-  // TODO: BROKEN func.call @reverse_from_3(%d5x) : (tensor<?xf32>) -> (tensor<?xf32>)
+  // CHECK: ERROR: Runtime op verification failed
+  // CHECK-NEXT: linalg.generic
+  // CHECK-NEXT: unexpected negative result on dimension #0 of input/output operand #0
+  func.call @reverse_from_3(%d5x) : (tensor<?xf32>) -> (tensor<?xf32>)
 
   %c0x = arith.constant dense<1.0> : tensor<0xf32>
   %d0x = tensor.cast %c0x : tensor<0xf32> to tensor<?xf32>


### PR DESCRIPTION
Test seems to pass after re-enabling without any additional changes.