### PR TITLE
[AMDGPU][NPM] Preserve analyses in AMDGPURewriteAGPRCopyMFMA for NPM

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -659,7 +659,10 @@ AMDGPURewriteAGPRCopyMFMAPass::run(MachineFunction &MF,
   if (!Impl.run(MF))
     return PreservedAnalyses::all();
   auto PA = getMachineFunctionPassPreservedAnalyses();
-  PA.preserveSet<CFGAnalyses>();
-  PA.preserve<LiveStacksAnalysis>();
+  PA.preserveSet<CFGAnalyses>()
+    .preserve<LiveStacksAnalysis>()
+    .preserve<VirtRegMapAnalysis>()
+    .preserve<LiveIntervalsAnalysis>()
+    .preserve<LiveRegMatrixAnalysis>();
   return PA;
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -32,6 +32,7 @@
 #include "llvm/CodeGen/LiveStacks.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/SlotIndexes.h"
 #include "llvm/CodeGen/VirtRegMap.h"
 #include "llvm/InitializePasses.h"
 
@@ -662,6 +663,7 @@ AMDGPURewriteAGPRCopyMFMAPass::run(MachineFunction &MF,
   PA.preserveSet<CFGAnalyses>()
     .preserve<LiveStacksAnalysis>()
     .preserve<VirtRegMapAnalysis>()
+    .preserve<SlotIndexesAnalysis>()
     .preserve<LiveIntervalsAnalysis>()
     .preserve<LiveRegMatrixAnalysis>();
   return PA;

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -661,10 +661,10 @@ AMDGPURewriteAGPRCopyMFMAPass::run(MachineFunction &MF,
     return PreservedAnalyses::all();
   auto PA = getMachineFunctionPassPreservedAnalyses();
   PA.preserveSet<CFGAnalyses>()
-    .preserve<LiveStacksAnalysis>()
-    .preserve<VirtRegMapAnalysis>()
-    .preserve<SlotIndexesAnalysis>()
-    .preserve<LiveIntervalsAnalysis>()
-    .preserve<LiveRegMatrixAnalysis>();
+      .preserve<LiveStacksAnalysis>()
+      .preserve<VirtRegMapAnalysis>()
+      .preserve<SlotIndexesAnalysis>()
+      .preserve<LiveIntervalsAnalysis>()
+      .preserve<LiveRegMatrixAnalysis>();
   return PA;
 }


### PR DESCRIPTION
The pass preserved LiveStacksAnalysis but failed to preserve LiveIntervalsAnalysis, LiveRegMatrixAnalysis, VirtRegMapAnalysis, and SlotIndexesAnalysis under NPM. This caused these analyses to be invalidated and recomputed, leading to incorrect behavior in subsequent passes like VirtRegRewriter.

Fix by explicitly preserving all required analyses in the NPM version, matching the legacy pass manager behavior.