### PR TITLE
[SPARC] Remove CCIfConsecutiveRegs for f128 returns

### DIFF
--- a/llvm/lib/Target/Sparc/SparcCallingConv.td
+++ b/llvm/lib/Target/Sparc/SparcCallingConv.td
@@ -37,7 +37,7 @@ def RetCC_Sparc32 : CallingConv<[
   CCIfType<[f32], CCAssignToReg<[F0, F1, F2, F3]>>,
   CCIfType<[f64], CCAssignToReg<[D0, D1]>>,
   // FIXME GCC in soft-float mode passes f128 as if 2xi64 values.
-  CCIfType<[f128], CCIfInReg<CCIfConsecutiveRegs<CCAssignToReg<[Q0, Q1]>>>>,
+  CCIfType<[f128], CCIfInReg<CCAssignToReg<[Q0, Q1]>>>,
   CCIfType<[v2i32], CCCustom<"CC_Sparc_Assign_Ret_Split_64">>
 ]>;
 

--- a/llvm/test/CodeGen/SPARC/fp128-abi.ll
+++ b/llvm/test/CodeGen/SPARC/fp128-abi.ll
@@ -87,3 +87,78 @@ define fp128 @f128_direct_spill(i32 %o0, i32 %o1, i32 %o2, i32 %o3, i32 %o4, i32
     ret fp128 %ret
 }
 declare fp128 @f128_callee_spill(i32 %o0, i32 %o1, i32 %o2, i32 %o3, i32 %o4, i32 %o5, fp128 %a)
+
+define inreg { fp128, fp128 } @f128_complex(fp128 %num) nounwind {
+; SPARC32-LABEL: f128_complex:
+; SPARC32:       ! %bb.0:
+; SPARC32-NEXT:    save %sp, -192, %sp
+; SPARC32-NEXT:    ldd [%i0], %f0
+; SPARC32-NEXT:    ldd [%i0+8], %f4
+; SPARC32-NEXT:    std %f4, [%fp+-24]
+; SPARC32-NEXT:    std %f0, [%fp+-32]
+; SPARC32-NEXT:    std %f4, [%fp+-8]
+; SPARC32-NEXT:    add %fp, -16, %o0
+; SPARC32-NEXT:    add %fp, -32, %o1
+; SPARC32-NEXT:    call f128_complex_callee
+; SPARC32-NEXT:    std %f0, [%fp+-16]
+; SPARC32-NEXT:    sethi %hi(.LCPI2_0), %i0
+; SPARC32-NEXT:    ldd [%i0+%lo(.LCPI2_0)], %f8
+; SPARC32-NEXT:    add %i0, %lo(.LCPI2_0), %i0
+; SPARC32-NEXT:    ldd [%i0+8], %f12
+; SPARC32-NEXT:    std %f4, [%fp+-96]
+; SPARC32-NEXT:    std %f6, [%fp+-88] ! 16-byte Folded Spill
+; SPARC32-NEXT:    std %f8, [%fp+-80]
+; SPARC32-NEXT:    std %f12, [%fp+-72]
+; SPARC32-NEXT:    std %f2, [%fp+-56]
+; SPARC32-NEXT:    std %f0, [%fp+-64]
+; SPARC32-NEXT:    add %fp, -48, %i0
+; SPARC32-NEXT:    add %fp, -64, %o0
+; SPARC32-NEXT:    add %fp, -80, %o1
+; SPARC32-NEXT:    call _Q_add
+; SPARC32-NEXT:    st %i0, [%sp+64]
+; SPARC32-NEXT:    unimp 16
+; SPARC32-NEXT:    ldd [%fp+-48], %f0
+; SPARC32-NEXT:    ldd [%fp+-40], %f2
+; SPARC32-NEXT:    ldd [%fp+-96], %f4
+; SPARC32-NEXT:    ldd [%fp+-88], %f6 ! 16-byte Folded Reload
+; SPARC32-NEXT:    ret
+; SPARC32-NEXT:    restore
+;
+; SPARC64-LABEL: f128_complex:
+; SPARC64:       ! %bb.0:
+; SPARC64-NEXT:    save %sp, -240, %sp
+; SPARC64-NEXT:    fmovd %f0, %f4
+; SPARC64-NEXT:    fmovd %f2, %f6
+; SPARC64-NEXT:    call f128_complex_callee
+; SPARC64-NEXT:    nop
+; SPARC64-NEXT:    std %f4, [%fp+1983]
+; SPARC64-NEXT:    std %f6, [%fp+1991] ! 16-byte Folded Spill
+; SPARC64-NEXT:    sethi %h44(.LCPI2_0), %i0
+; SPARC64-NEXT:    add %i0, %m44(.LCPI2_0), %i0
+; SPARC64-NEXT:    sllx %i0, 12, %i0
+; SPARC64-NEXT:    ldd [%i0+%l44(.LCPI2_0)], %f4
+; SPARC64-NEXT:    add %i0, %l44(.LCPI2_0), %i0
+; SPARC64-NEXT:    ldd [%i0+8], %f8
+; SPARC64-NEXT:    std %f2, [%fp+2023]
+; SPARC64-NEXT:    std %f0, [%fp+2015]
+; SPARC64-NEXT:    std %f4, [%fp+1999]
+; SPARC64-NEXT:    std %f8, [%fp+2007]
+; SPARC64-NEXT:    add %fp, 2031, %o0
+; SPARC64-NEXT:    add %fp, 2015, %o1
+; SPARC64-NEXT:    call _Qp_add
+; SPARC64-NEXT:    add %fp, 1999, %o2
+; SPARC64-NEXT:    ldd [%fp+2031], %f0
+; SPARC64-NEXT:    ldd [%fp+2039], %f2
+; SPARC64-NEXT:    ldd [%fp+1983], %f4
+; SPARC64-NEXT:    ldd [%fp+1991], %f6 ! 16-byte Folded Reload
+; SPARC64-NEXT:    ret
+; SPARC64-NEXT:    restore
+    %call = call inreg { fp128, fp128 } @f128_complex_callee(fp128 %num, fp128 %num)
+    %real = extractvalue { fp128, fp128 } %call, 0
+    %imag = extractvalue { fp128, fp128 } %call, 1
+    %add  = fadd fp128 %real, 0xL00000000000000003FFF000000000000
+    %tmp = insertvalue { fp128, fp128 } poison, fp128 %add, 0
+    %ret = insertvalue { fp128, fp128 } %tmp, fp128 %imag, 1
+    ret { fp128, fp128 } %ret
+}
+declare inreg { fp128, fp128 } @f128_complex_callee(fp128 %a, fp128 %b)


### PR DESCRIPTION
It appears that using it will result in callers mistakenly thinking that complex f128 returns is done the sret-way, when it should be returned in registers.