### PR TITLE
[libc++] Optimize vector<bool>::reserve

### DIFF
--- a/libcxx/docs/ReleaseNotes/22.rst
+++ b/libcxx/docs/ReleaseNotes/22.rst
@@ -84,6 +84,7 @@ Improvements and New Features
   ``std::join_view<vector<vector<short>>>`` iterators.
 - ``std::atomic::wait`` has been refactored to accept more types to use platform native wait functions directly.
   This is guarded behind the ABI Macro ``_LIBCPP_ABI_ATOMIC_WAIT_NATIVE_BY_SIZE``.
+- The performance of ``vector<bool>::reserve()`` has been improved by up to 2x.
 
 - The ``num_get::do_get`` integral overloads have been optimized, resulting in a performance improvement of up to 2.8x.
 

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -761,7 +761,8 @@ vector<bool, _Allocator>::vector(vector&& __v, const __type_identity_t<allocator
     __v.__cap_ = __v.__size_ = 0;
   } else if (__v.size() > 0) {
     __vallocate(__v.size());
-    __construct_at_end(__v.begin(), __v.end(), __v.size());
+    __size_ = __v.__size_;
+    std::copy_n(__v.__begin_, __external_cap_to_internal(__v.size()), __begin_);
   }
 }
 
@@ -856,7 +857,8 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::reserve(size_type _
       this->__throw_length_error();
     vector __v(this->get_allocator());
     __v.__vallocate(__n);
-    __v.__construct_at_end(this->begin(), this->end(), this->size());
+    __v.__size_ = __size_;
+    std::copy_n(__begin_, __external_cap_to_internal(__size_), __v.__begin_);
     swap(__v);
   }
 }

--- a/libcxx/test/benchmarks/containers/sequence/vector_bool.bench.cpp
+++ b/libcxx/test/benchmarks/containers/sequence/vector_bool.bench.cpp
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include <benchmark/benchmark.h>
+#include <memory_resource>
 #include <vector>
+
+#include "test_macros.h"
 
 static void BM_vector_bool_copy_ctor(benchmark::State& state) {
   std::vector<bool> vec(100, true);
@@ -18,7 +21,35 @@ static void BM_vector_bool_copy_ctor(benchmark::State& state) {
     benchmark::DoNotOptimize(vec2);
   }
 }
-BENCHMARK(BM_vector_bool_copy_ctor);
+BENCHMARK(BM_vector_bool_copy_ctor)->Name("vector<bool>(const vector<bool>&)");
+
+static void BM_vector_bool_move_ctor_alloc_equal(benchmark::State& state) {
+  std::vector<bool> vec(100, true);
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(vec);
+    std::vector<bool> vec2(std::move(vec), std::allocator<bool>());
+    benchmark::DoNotOptimize(vec2);
+    swap(vec, vec2);
+  }
+}
+BENCHMARK(BM_vector_bool_move_ctor_alloc_equal)
+    ->Name("vector<bool>(vector<bool>&&, const allocator_type&) (equal allocators)");
+
+#if TEST_STD_VER >= 17
+static void BM_vector_bool_move_ctor_alloc_different(benchmark::State& state) {
+  std::pmr::monotonic_buffer_resource resource;
+  std::pmr::vector<bool> vec(100, true, &resource);
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(vec);
+    std::pmr::vector<bool> vec2(std::move(vec), std::pmr::new_delete_resource());
+    benchmark::DoNotOptimize(vec2);
+  }
+}
+BENCHMARK(BM_vector_bool_move_ctor_alloc_different)
+    ->Name("vector<bool>(vector<bool>&&, const allocator_type&) (different allocators)");
+#endif
 
 static void BM_vector_bool_size_ctor(benchmark::State& state) {
   for (auto _ : state) {
@@ -26,6 +57,15 @@ static void BM_vector_bool_size_ctor(benchmark::State& state) {
     benchmark::DoNotOptimize(vec);
   }
 }
-BENCHMARK(BM_vector_bool_size_ctor);
+BENCHMARK(BM_vector_bool_size_ctor)->Name("vector<bool>(size_type, const value_type&)");
+
+static void BM_vector_bool_reserve(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<bool> vec;
+    vec.reserve(100);
+    benchmark::DoNotOptimize(vec);
+  }
+}
+BENCHMARK(BM_vector_bool_reserve)->Name("vector<bool>::reserve()");
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Apple M4:
```
Benchmark                                                                      old        new    Difference    % Difference
--------------------------------------------------------------------------  ------  ----------  ------------  --------------
vector<bool>(const_vector<bool>&)                                            12.73       12.87          0.14           1.07%
vector<bool>(size_type,_const_value_type&)                                    9.39        9.41          0.02           0.22%
vector<bool>(vector<bool>&&,_const_allocator_type&)_(different_allocators)   16.87       15.22         -1.65          -9.80%
vector<bool>(vector<bool>&&,_const_allocator_type&)_(equal_allocators)        2.68        2.73          0.05           1.90%
vector<bool>::reserve()                                                      11.81        9.43         -2.38         -20.14%
Geomean                                                                       9.14        8.62         -0.53          -5.76%
```