### PR TITLE
[Clang] Fix handling of zero-length arrays in sfinae context.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -554,6 +554,7 @@ Bug Fixes to C++ Support
 - Fix for clang incorrectly rejecting the default construction of a union with
   nontrivial member when another member has an initializer. (#GH81774)
 - Fixed a template depth issue when parsing lambdas inside a type constraint. (#GH162092)
+- Fix the support of zero-length arrays in SFINAE context. (#GH170040)
 - Diagnose unresolved overload sets in non-dependent compound requirements. (#GH51246) (#GH97753)
 - Fix a crash when extracting unavailable member type from alias in template deduction. (#GH165560)
 - Fix incorrect diagnostics for lambdas with init-captures inside braced initializers. (#GH163498)

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -2259,6 +2259,8 @@ QualType Sema::BuildArrayType(QualType T, ArraySizeModifier ASM,
              isSFINAEContext() ? diag::err_typecheck_zero_array_size
                                : diag::ext_typecheck_zero_array_size)
             << 0 << ArraySize->getSourceRange();
+        if (isSFINAEContext())
+          return QualType();
       }
 
       // Is the array too large?

--- a/clang/test/SemaCXX/zero-length-arrays.cpp
+++ b/clang/test/SemaCXX/zero-length-arrays.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++98 %s
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 %s
 
 class Foo {
   ~Foo();
@@ -19,7 +20,7 @@ class Bar {
   Foo foos3[2][0];
 
 public:
-  Bar(): foo_count(0) { }    
+  Bar(): foo_count(0) { }
   ~Bar() { }
 };
 
@@ -32,4 +33,18 @@ void testBar() {
 // expected-no-diagnostics
 #endif
   b = b2;
+}
+
+namespace GH170040 {
+#if __cplusplus >= 202002L
+template <int N> struct Foo {
+    operator int() const requires(N == 2);
+    template <int I = 0, char (*)[(I)] = nullptr> operator long() const;
+};
+
+void test () {
+    Foo<2> foo;
+    long bar = foo;
+}
+#endif
 }


### PR DESCRIPTION
We were producing a diagnostic for zero-length arrays in Sfinae context, without invalidating the overload.

This causes the diagnostic to be emitted
if and when that undiagnosed overload is selected.

Fixes #170040