### PR TITLE
Fix NDEBUG Wundef warning; NFC

### DIFF
--- a/clang/include/clang/Basic/TokenKinds.h
+++ b/clang/include/clang/Basic/TokenKinds.h
@@ -98,7 +98,7 @@ inline bool isLiteral(TokenKind K) {
   const bool isInLiteralRange =
       K >= tok::numeric_constant && K <= tok::utf32_string_literal;
 
-#if !NDEBUG
+#ifndef NDEBUG
   const bool isLiteralExplicit =
       K == tok::numeric_constant || K == tok::char_constant ||
       K == tok::wide_char_constant || K == tok::utf8_char_constant ||


### PR DESCRIPTION
The `NDEBUG` macro is tested for defined-ness everywhere else. The instance here triggers a warning when compiling with `-Wundef`.