### PR TITLE
[lldb] Make sure SBError is valid when SBDebugger::InitializeWithErrorHandling succeeds

### DIFF
--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -179,7 +179,7 @@ void SBDebugger::Initialize() {
 lldb::SBError SBDebugger::InitializeWithErrorHandling() {
   LLDB_INSTRUMENT();
 
-  SBError error;
+  SBError error((Status()));
   if (auto e = g_debugger_lifetime->Initialize(
           std::make_unique<SystemInitializerFull>())) {
     error.SetError(Status::FromError(std::move(e)));

--- a/lldb/unittests/DAP/TestBase.cpp
+++ b/lldb/unittests/DAP/TestBase.cpp
@@ -72,6 +72,7 @@ void DAPTestBase::TearDown() {
 
 void DAPTestBase::SetUpTestSuite() {
   lldb::SBError error = SBDebugger::InitializeWithErrorHandling();
+  EXPECT_TRUE(error.IsValid());
   EXPECT_TRUE(error.Success());
 }
 void DAPTestBase::TeatUpTestSuite() { SBDebugger::Terminate(); }


### PR DESCRIPTION
Fixes #169788

When this function fails to initialise the debugger, it sets the SBError using the returned error from the initialise function. This results in Success being false and isVaid being true. This is expected behaviour.

When it does not fail to initialise, it was returning the default constructed SBError which has Success() == true but IsValid == false. IsValid should be true, to show that the success can be trusted.

To fix this, construct the SBError using a default constructed Status, which results in Success and IsValid being true.