### PR TITLE
[llvm] Issues found PVS studio static analyzer. LoopUnrollAndJam.cpp

### DIFF
--- a/llvm/lib/Transforms/Utils/LoopUnrollAndJam.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUnrollAndJam.cpp
@@ -789,7 +789,7 @@ checkDependencies(Loop &Root, const BasicBlockSet &SubLoopBlocks,
 
     size_t NumInsts = CurrentLoadsAndStores.size();
     for (size_t I = 0; I < NumInsts; ++I) {
-      for (size_t J = I; J < NumInsts; ++J) {
+      for (size_t J = I + 1; J < NumInsts; ++J) {
         if (!checkDependency(CurrentLoadsAndStores[I], CurrentLoadsAndStores[J],
                              LoopDepth, CurLoopDepth, true, DI))
           return false;


### PR DESCRIPTION
Minor misoptimization. The PVS-Studio warning: V791 The initial value of the index in the nested loop equals 'I'. Perhaps, 'I + 1' should be used instead. LoopUnrollAndJam.cpp 793