### PR TITLE
[libc++] Update the Docker image hash in run-buildbot-container

### DIFF
--- a/libcxx/docs/Contributing.rst
+++ b/libcxx/docs/Contributing.rst
@@ -311,6 +311,9 @@ To do so, you will need to create a PR in the llvm-zorg repository and wait for 
 merged. Once that change has been merged, an LLVM premerge maintainer (a Google employee)
 must use terraform to apply the change to the running GKE cluster.
 
+.. note:: When you update the ``libcxx_runner_image``, also make sure to update the
+          ``libcxx/utils/ci/run-buildbot-container`` script to contain the new image.
+
 
 Monitoring premerge testing performance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/libcxx/utils/ci/run-buildbot-container
+++ b/libcxx/utils/ci/run-buildbot-container
@@ -26,6 +26,6 @@ if [[ ! -d "${MONOREPO_ROOT}/libcxx/utils/ci" ]]; then
     echo "Was unable to find the root of the LLVM monorepo; are you running from within the monorepo?"
     exit 1
 fi
-docker pull ghcr.io/llvm/libcxx-linux-builder:b060022103f551d8ca1dad84122ef73927c86512
-docker run -it --volume "${MONOREPO_ROOT}:/llvm" --workdir "/llvm" --cap-add=SYS_PTRACE ghcr.io/llvm/libcxx-linux-builder:b060022103f551d8ca1dad84122ef73927c86512 \
+docker pull ghcr.io/llvm/libcxx-linux-builder:d6b22a347f813cf4a9832627323a43074f57bbcf
+docker run -it --volume "${MONOREPO_ROOT}:/llvm" --workdir "/llvm" --cap-add=SYS_PTRACE ghcr.io/llvm/libcxx-linux-builder:d6b22a347f813cf4a9832627323a43074f57bbcf \
     bash -c 'git config --global --add safe.directory /llvm ; exec bash'


### PR DESCRIPTION
The current Docker image used by our CI is d6b22a347f813cf4a983, but we forgot to synchronize the value in run-buildbot-container.