### PR TITLE
[mlir][bytecode] Avoid crash when test dialect version is missing

### DIFF
--- a/mlir/test/Bytecode/roundtrip-missing-dialect.mlir
+++ b/mlir/test/Bytecode/roundtrip-missing-dialect.mlir
@@ -1,0 +1,6 @@
+// RUN: mlir-opt %s --test-bytecode-roundtrip=test-dialect-version=2.0 | FileCheck %s
+
+// CHECK-LABEL: func.func @main
+func.func @main() {
+  return
+}

--- a/mlir/test/lib/IR/TestBytecodeRoundtrip.cpp
+++ b/mlir/test/lib/IR/TestBytecodeRoundtrip.cpp
@@ -141,8 +141,8 @@ private:
             DialectBytecodeWriter &writer) -> LogicalResult {
           // Do not override anything if version greater than 2.0.
           auto versionOr = writer.getDialectVersion<test::TestDialect>();
-          assert(succeeded(versionOr) && "expected reader to be able to access "
-                                         "the version for test dialect");
+          if (failed(versionOr))
+            return failure();
           const auto *version =
               reinterpret_cast<const test::TestDialectVersion *>(*versionOr);
           if (version->major_ >= 2)
@@ -166,8 +166,8 @@ private:
             Type &entry) -> LogicalResult {
           // Get test dialect version from the version map.
           auto versionOr = reader.getDialectVersion<test::TestDialect>();
-          assert(succeeded(versionOr) && "expected reader to be able to access "
-                                         "the version for test dialect");
+          if (failed(versionOr))
+            return success();
           const auto *version =
               reinterpret_cast<const test::TestDialectVersion *>(*versionOr);
           if (version->major_ >= 2)

--- a/mlir/test/lib/IR/TestBytecodeRoundtrip.cpp
+++ b/mlir/test/lib/IR/TestBytecodeRoundtrip.cpp
@@ -166,6 +166,8 @@ private:
             Type &entry) -> LogicalResult {
           // Get test dialect version from the version map.
           auto versionOr = reader.getDialectVersion<test::TestDialect>();
+          // Missing version is non-fatal (consistent with other test-dialect
+          // readers); return success() and fall through to default parsing.
           if (failed(versionOr))
             return success();
           const auto *version =
@@ -191,7 +193,8 @@ private:
                     widthAndSignedness & 0x3)),
                true))
             entry = IntegerType::get(reader.getContext(), width, signedness);
-          // Return nullopt to fall through the rest of the parsing code path.
+          // Return success() and fall through to default parsing when this
+          // callback does not override the entry.
           return success();
         });
     doRoundtripWithConfigs(op, writeConfig, parseConfig);


### PR DESCRIPTION
Guard the test bytecode roundtrip writer/reader in `mlir/test/lib/IR/TestBytecodeRoundtrip.cpp` so `--test-bytecode-roundtrip=test-dialect-version=2.0` no longer asserts when the test dialect version isn’t present.
The custom reader callback is only needed for legacy (<2.0) encodings; when version metadata is missing, parsing should fall through to the default decoder rather than abort.

Add regression coverage in `mlir/test/Bytecode/roundtrip-missing-dialect.mlir`.

Fixes: https://github.com/llvm/llvm-project/issues/128325
Fixes: https://github.com/llvm/llvm-project/issues/128321
