### PR TITLE
[CI] Add checkmark emojis for passing builds

### DIFF
--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -184,8 +184,8 @@ def generate_report(
         if return_code == 0:
             report.extend(
                 [
-                    "The build succeeded and no tests ran. This is expected in some "
-                    "build configurations."
+                    ":white_check_mark: The build succeeded and no tests ran. "
+                    "This is expected in some build configurations."
                 ]
             )
         else:
@@ -272,6 +272,8 @@ def generate_report(
                 ]
             )
             report.extend(_format_failures(ninja_failures, failure_explanations))
+    else:
+        report.extend(["", ":white_check_mark: The build succeeded and all tests passed."])
 
     if failures or return_code != 0:
         report.extend(["", UNRELATED_FAILURES_STR])

--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -273,7 +273,9 @@ def generate_report(
             )
             report.extend(_format_failures(ninja_failures, failure_explanations))
     else:
-        report.extend(["", ":white_check_mark: The build succeeded and all tests passed."])
+        report.extend(
+            ["", ":white_check_mark: The build succeeded and all tests passed."]
+        )
 
     if failures or return_code != 0:
         report.extend(["", UNRELATED_FAILURES_STR])

--- a/.ci/generate_test_report_lib_test.py
+++ b/.ci/generate_test_report_lib_test.py
@@ -194,7 +194,7 @@ class TestReports(unittest.TestCase):
                 """\
                 # Foo
 
-                The build succeeded and no tests ran. This is expected in some build configurations."""
+                :white_check_mark: The build succeeded and no tests ran. This is expected in some build configurations."""
             ),
         )
 
@@ -308,7 +308,9 @@ class TestReports(unittest.TestCase):
                     """\
               # Foo
 
-              * 1 test passed"""
+              * 1 test passed
+              
+              :white_check_mark: The build succeeded and all tests passed."""
                 )
             ),
         )


### PR DESCRIPTION
This better matches the code formatter and I personally find the visual indication valuable when I am scrolling/glancing at a comment.