### PR TITLE
[flang][cuda] Use the option to populate conversion patterns

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUFOpConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CUFOpConversion.cpp
@@ -557,8 +557,9 @@ public:
     target.addLegalOp<cuf::StreamCastOp>();
     cuf::populateCUFToFIRConversionPatterns(typeConverter, *dl, symtab,
                                             patterns);
-    cuf::populateCUFAllocationConversionPatterns(typeConverter, *dl, symtab,
-                                                 patterns);
+    if (allocationConversion)
+      cuf::populateCUFAllocationConversionPatterns(typeConverter, *dl, symtab,
+                                                   patterns);
     if (mlir::failed(mlir::applyPartialConversion(getOperation(), target,
                                                   std::move(patterns)))) {
       mlir::emitError(mlir::UnknownLoc::get(ctx),


### PR DESCRIPTION
#169740 split the conversion patterns but the option was not use when populating them. 