### PR TITLE
[clang-doc] Add Mustache case to test for DR 131697

### DIFF
--- a/clang-tools-extra/clang-doc/Generators.cpp
+++ b/clang-tools-extra/clang-doc/Generators.cpp
@@ -84,27 +84,33 @@ Error MustacheGenerator::generateDocumentation(
       return JSONGenerator.takeError();
   }
 
-  SmallString<128> JSONPath;
-  sys::path::native(RootDir.str() + "/json", JSONPath);
+  SmallString<128> JSONDirPath(RootDir);
+  SmallString<128> DocsDirPath(RootDir);
+  {
+    TimeTraceScope TS("Create Output Directories");
+    sys::path::append(JSONDirPath, "json");
+    if (auto EC = sys::fs::create_directories(JSONDirPath))
+      return createFileError(JSONDirPath, EC);
+    sys::path::append(DocsDirPath, DirName);
+    if (auto EC = sys::fs::create_directories(DocsDirPath))
+      return createFileError(DocsDirPath, EC);
+  }
 
   {
     llvm::TimeTraceScope TS("Iterate JSON files");
     std::error_code EC;
-    sys::fs::recursive_directory_iterator JSONIter(JSONPath, EC);
+    sys::fs::recursive_directory_iterator JSONIter(JSONDirPath, EC);
     std::vector<json::Value> JSONFiles;
     JSONFiles.reserve(Infos.size());
     if (EC)
       return createStringError("Failed to create directory iterator.");
 
-    SmallString<128> DocsDirPath(RootDir.str() + '/' + DirName);
-    sys::path::native(DocsDirPath);
-    if (auto EC = sys::fs::create_directories(DocsDirPath))
-      return createFileError(DocsDirPath, EC);
     while (JSONIter != sys::fs::recursive_directory_iterator()) {
       // create the same directory structure in the docs format dir
       if (JSONIter->type() == sys::fs::file_type::directory_file) {
         SmallString<128> DocsClonedPath(JSONIter->path());
-        sys::path::replace_path_prefix(DocsClonedPath, JSONPath, DocsDirPath);
+        sys::path::replace_path_prefix(DocsClonedPath, JSONDirPath,
+                                       DocsDirPath);
         if (auto EC = sys::fs::create_directories(DocsClonedPath)) {
           return createFileError(DocsClonedPath, EC);
         }
@@ -134,7 +140,7 @@ Error MustacheGenerator::generateDocumentation(
 
       std::error_code FileErr;
       SmallString<128> DocsFilePath(JSONIter->path());
-      sys::path::replace_path_prefix(DocsFilePath, JSONPath, DocsDirPath);
+      sys::path::replace_path_prefix(DocsFilePath, JSONDirPath, DocsDirPath);
       sys::path::replace_extension(DocsFilePath, DirName);
       raw_fd_ostream InfoOS(DocsFilePath, FileErr, sys::fs::OF_None);
       if (FileErr)

--- a/clang-tools-extra/test/clang-doc/DR-131697.cpp
+++ b/clang-tools-extra/test/clang-doc/DR-131697.cpp
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: split-file %s %t
 // RUN: clang-doc -format=html %t/compile_commands.json %t/main.cpp
+// RUN: clang-doc -format=mustache %t/compile_commands.json %t/main.cpp
 
 //--- main.cpp
 


### PR DESCRIPTION
The test for DR 131697 only requires that clang-doc doesn't crash. There
is no documentation created. However, when using Mustache, clang-doc still expects certain
paths to exist, like the directory where assets are placed. In legacy
HTML, the `docs` directory is still created and assets are placed there
regardless of there being any Infos to document. Mustache didn't do
this, so now we create `docs/json` and `docs/html` even if there is
nothing to document.