### PR TITLE
[clang-doc] Add Mustache case to assets test

### DIFF
--- a/clang-tools-extra/clang-doc/support/Utils.cpp
+++ b/clang-tools-extra/clang-doc/support/Utils.cpp
@@ -33,8 +33,20 @@ void getMustacheHtmlFiles(StringRef AssetsPath,
   assert(!AssetsPath.empty());
   assert(sys::fs::is_directory(AssetsPath));
 
-  SmallString<128> DefaultStylesheet =
-      appendPathPosix(AssetsPath, "clang-doc-mustache.css");
+  // TODO: Allow users to override default templates with their own. We would
+  // similarly have to check if a template file already exists in CDCtx.
+  if (CDCtx.UserStylesheets.empty()) {
+    SmallString<128> DefaultStylesheet =
+        appendPathPosix(AssetsPath, "clang-doc-mustache.css");
+    CDCtx.UserStylesheets.insert(CDCtx.UserStylesheets.begin(),
+                                 DefaultStylesheet.c_str());
+  }
+
+  if (CDCtx.JsScripts.empty()) {
+    SmallString<128> IndexJS = appendPathPosix(AssetsPath, "mustache-index.js");
+    CDCtx.JsScripts.insert(CDCtx.JsScripts.begin(), IndexJS.c_str());
+  }
+
   SmallString<128> NamespaceTemplate =
       appendPathPosix(AssetsPath, "namespace-template.mustache");
   SmallString<128> ClassTemplate =
@@ -45,11 +57,7 @@ void getMustacheHtmlFiles(StringRef AssetsPath,
       appendPathPosix(AssetsPath, "function-template.mustache");
   SmallString<128> CommentTemplate =
       appendPathPosix(AssetsPath, "comment-template.mustache");
-  SmallString<128> IndexJS = appendPathPosix(AssetsPath, "mustache-index.js");
 
-  CDCtx.JsScripts.insert(CDCtx.JsScripts.begin(), IndexJS.c_str());
-  CDCtx.UserStylesheets.insert(CDCtx.UserStylesheets.begin(),
-                               DefaultStylesheet.c_str());
   CDCtx.MustacheTemplates.insert(
       {"namespace-template", NamespaceTemplate.c_str()});
   CDCtx.MustacheTemplates.insert({"class-template", ClassTemplate.c_str()});

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -151,6 +151,7 @@ static std::string getExecutablePath(const char *Argv0, void *MainAddr) {
   return llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
 }
 
+// TODO: Rename this, since it only gets custom CSS/JS
 static llvm::Error getAssetFiles(clang::doc::ClangDocContext &CDCtx) {
   using DirIt = llvm::sys::fs::directory_iterator;
   std::error_code FileErr;
@@ -221,8 +222,8 @@ static llvm::Error getMustacheHtmlFiles(const char *Argv0,
     llvm::outs() << "Asset path supply is not a directory: " << UserAssetPath
                  << " falling back to default\n";
   if (IsDir) {
-    getMustacheHtmlFiles(UserAssetPath, CDCtx);
-    return llvm::Error::success();
+    if (auto Err = getAssetFiles(CDCtx))
+      return Err;
   }
   void *MainAddr = (void *)(intptr_t)getExecutablePath;
   std::string ClangDocPath = getExecutablePath(Argv0, MainAddr);

--- a/clang-tools-extra/test/clang-doc/assets.cpp
+++ b/clang-tools-extra/test/clang-doc/assets.cpp
@@ -1,8 +1,12 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: clang-doc --format=html --output=%t --asset=%S/Inputs/test-assets --executor=standalone %s --base base_dir
+// RUN: clang-doc --format=mustache --output=%t --asset=%S/Inputs/test-assets --executor=standalone %s --base base_dir
 // RUN: FileCheck %s -input-file=%t/index.html -check-prefix=INDEX
 // RUN: FileCheck %s -input-file=%t/test.css -check-prefix=CSS
 // RUN: FileCheck %s -input-file=%t/test.js -check-prefix=JS
+
+// RUN: FileCheck %s -input-file=%t/html/test.css -check-prefix=CSS
+// RUN: FileCheck %s -input-file=%t/html/test.js -check-prefix=JS
 
 // INDEX: <!DOCTYPE html>
 // INDEX-NEXT: <meta charset="utf-8"/>


### PR DESCRIPTION
Mustache wasn't tested in the assets lit test, which tests if
user-supplied assets are copied correctly. The Mustache HTML backend
initialy failed this test because it expected every asset, which
included Mustache templates, to be supplied. For now, we just expect
either CSS or JS to be supplied and use the default if one of them isn't
given.

We can allow custom templates in the future using the same checks.