### PR TITLE
[CUDA][NFC] Fix an unused variable error when compiled with optimization

### DIFF
--- a/clang/lib/CodeGen/CGCUDARuntime.cpp
+++ b/clang/lib/CodeGen/CGCUDARuntime.cpp
@@ -62,8 +62,8 @@ static llvm::Value *emitGetParamBuf(CodeGenFunction &CGF,
 RValue CGCUDARuntime::EmitCUDADeviceKernelCallExpr(
     CodeGenFunction &CGF, const CUDAKernelCallExpr *E,
     ReturnValueSlot ReturnValue, llvm::CallBase **CallOrInvoke) {
-  ASTContext &Ctx = CGM.getContext();
-  assert(Ctx.getcudaLaunchDeviceDecl() == E->getConfig()->getDirectCallee());
+  assert(CGM.getContext().getcudaLaunchDeviceDecl() ==
+         E->getConfig()->getDirectCallee());
 
   llvm::BasicBlock *ConfigOKBlock = CGF.createBasicBlock("dkcall.configok");
   llvm::BasicBlock *ContBlock = CGF.createBasicBlock("dkcall.end");


### PR DESCRIPTION
#165519 causes some builds to fail.
[clang/lib/CodeGen/CGCUDARuntime.cpp:65]:15: error: unused variable 'Ctx' [-Werror,-Wunused-variable]
   65 |   ASTContext &Ctx = CGM.getContext();

