### PR TITLE
[libclc] Fix bitfield_insert implementation

### DIFF
--- a/libclc/opencl/lib/generic/integer/bitfield_insert.cl
+++ b/libclc/opencl/lib/generic/integer/bitfield_insert.cl
@@ -12,7 +12,7 @@
 #include <clc/opencl/integer/bitfield_insert.h>
 
 #define __CLC_FUNCTION bitfield_insert
-#define __CLC_BODY <clc/integer/clc_bitfield_insert.inc>
+#define __CLC_BODY <bitfield_insert.inc>
 #include <clc/integer/gentype.inc>
 
 #endif // cl_khr_extended_bit_ops


### PR DESCRIPTION
The `bitfield_insert` function in the OpenCL C library had an incorrect
`__CLC_BODY` definition, that included the `.inc` file for the
`__clc_bitfield_insert` declaration instead of the correct
implementation. So, the function was not defined at all, leading to
linker errors when trying to use it.