### PR TITLE
[clang-doc] Use DiagnosticsEngine to handle diagnostic output

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.h
+++ b/clang-tools-extra/clang-doc/BitcodeReader.h
@@ -27,7 +27,8 @@ namespace doc {
 // Class to read bitstream into an InfoSet collection
 class ClangDocBitcodeReader {
 public:
-  ClangDocBitcodeReader(llvm::BitstreamCursor &Stream) : Stream(Stream) {}
+  ClangDocBitcodeReader(llvm::BitstreamCursor &Stream, DiagnosticsEngine &Diags)
+      : Stream(Stream), Diags(Diags) {}
 
   // Main entry point, calls readBlock to read each block in the given stream.
   llvm::Expected<std::vector<std::unique_ptr<Info>>> readBitcode();
@@ -72,6 +73,7 @@ private:
   llvm::BitstreamCursor &Stream;
   std::optional<llvm::BitstreamBlockInfo> BlockInfo;
   FieldId CurrentReferenceField;
+  DiagnosticsEngine &Diags;
 };
 
 } // namespace doc

--- a/clang-tools-extra/clang-doc/BitcodeWriter.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeWriter.cpp
@@ -769,7 +769,9 @@ bool ClangDocBitcodeWriter::dispatchInfoForWrite(Info *I) {
     emitBlock(*static_cast<FriendInfo *>(I));
     break;
   case InfoType::IT_default:
-    llvm::errs() << "Unexpected info, unable to write.\n";
+    unsigned ID = Diags.getCustomDiagID(DiagnosticsEngine::Error,
+                                        "Unexpected info, unable to write.");
+    Diags.Report(ID);
     return true;
   }
   return false;

--- a/clang-tools-extra/clang-doc/BitcodeWriter.h
+++ b/clang-tools-extra/clang-doc/BitcodeWriter.h
@@ -16,6 +16,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_BITCODEWRITER_H
 
 #include "Representation.h"
+#include "clang/Basic/Diagnostic.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Bitstream/BitstreamWriter.h"
 #include <vector>
@@ -175,7 +176,8 @@ enum class FieldId {
 
 class ClangDocBitcodeWriter {
 public:
-  ClangDocBitcodeWriter(llvm::BitstreamWriter &Stream) : Stream(Stream) {
+  ClangDocBitcodeWriter(llvm::BitstreamWriter &Stream, DiagnosticsEngine &Diags)
+      : Stream(Stream), Diags(Diags) {
     emitHeader();
     emitBlockInfoBlock();
     emitVersionBlock();
@@ -260,6 +262,7 @@ private:
   SmallVector<uint32_t, BitCodeConstants::RecordSize> Record;
   llvm::BitstreamWriter &Stream;
   AbbreviationMap Abbrevs;
+  DiagnosticsEngine &Diags;
 };
 
 } // namespace doc

--- a/clang-tools-extra/clang-doc/Generators.cpp
+++ b/clang-tools-extra/clang-doc/Generators.cpp
@@ -121,10 +121,11 @@ Error MustacheGenerator::generateDocumentation(
 
       auto File = MemoryBuffer::getFile(Path);
       if (EC = File.getError(); EC) {
-        // TODO: Buffer errors to report later, look into using Clang
-        // diagnostics.
-        llvm::errs() << "Failed to open file: " << Path << " " << EC.message()
-                     << '\n';
+        unsigned ID = CDCtx.Diags.getCustomDiagID(DiagnosticsEngine::Warning,
+                                                  "Failed to open file: %0 %1");
+        CDCtx.Diags.Report(ID) << Path << EC.message();
+        JSONIter.increment(EC);
+        continue;
       }
 
       auto Parsed = json::parse((*File)->getBuffer());

--- a/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
@@ -15,6 +15,7 @@
 #include "Generators.h"
 #include "Representation.h"
 #include "support/File.h"
+#include "clang/Basic/Diagnostic.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Path.h"
 

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -95,10 +95,10 @@ bool MapASTVisitor::mapDecl(const T *D, bool IsDefinition) {
     // this decl for some reason (e.g. we're only reporting public decls).
     if (Child)
       CDCtx.ECtx->reportResult(llvm::toHex(llvm::toStringRef(Child->USR)),
-                               serialize::serialize(Child));
+                               serialize::serialize(Child, CDCtx.Diags));
     if (Parent)
       CDCtx.ECtx->reportResult(llvm::toHex(llvm::toStringRef(Parent->USR)),
-                               serialize::serialize(Parent));
+                               serialize::serialize(Parent, CDCtx.Diags));
   }
   return true;
 }

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -481,10 +481,11 @@ ClangDocContext::ClangDocContext(tooling::ExecutionContext *ECtx,
                                  StringRef RepositoryUrl,
                                  StringRef RepositoryLinePrefix, StringRef Base,
                                  std::vector<std::string> UserStylesheets,
+                                 clang::DiagnosticsEngine &Diags,
                                  bool FTimeTrace)
-    : ECtx(ECtx), ProjectName(ProjectName), PublicOnly(PublicOnly),
-      FTimeTrace(FTimeTrace), OutDirectory(OutDirectory),
-      UserStylesheets(UserStylesheets), Base(Base) {
+    : ECtx(ECtx), ProjectName(ProjectName), OutDirectory(OutDirectory),
+      SourceRoot(std::string(SourceRoot)), UserStylesheets(UserStylesheets),
+      Base(Base), Diags(Diags), PublicOnly(PublicOnly), FTimeTrace(FTimeTrace) {
   llvm::SmallString<128> SourceRootDir(SourceRoot);
   if (SourceRoot.empty())
     // If no SourceRoot was provided the current path is used as the default

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -15,6 +15,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_REPRESENTATION_H
 
 #include "clang/AST/Type.h"
+#include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Tooling/Execution.h"
 #include "llvm/ADT/SmallVector.h"
@@ -598,17 +599,13 @@ llvm::Expected<std::unique_ptr<Info>>
 mergeInfos(std::vector<std::unique_ptr<Info>> &Values);
 
 struct ClangDocContext {
-  ClangDocContext() = default;
   ClangDocContext(tooling::ExecutionContext *ECtx, StringRef ProjectName,
                   bool PublicOnly, StringRef OutDirectory, StringRef SourceRoot,
                   StringRef RepositoryUrl, StringRef RepositoryCodeLinePrefix,
                   StringRef Base, std::vector<std::string> UserStylesheets,
-                  bool FTimeTrace = false);
+                  clang::DiagnosticsEngine &Diags, bool FTimeTrace = false);
   tooling::ExecutionContext *ECtx;
-  std::string ProjectName; // Name of project clang-doc is documenting.
-  bool PublicOnly; // Indicates if only public declarations are documented.
-  bool FTimeTrace; // Indicates if ftime trace is turned on
-  int Granularity; // Granularity of ftime trace
+  std::string ProjectName;  // Name of project clang-doc is documenting.
   std::string OutDirectory; // Directory for outputting generated files.
   std::string SourceRoot;   // Directory where processed files are stored. Links
                             // to definition locations will only be generated if
@@ -627,7 +624,12 @@ struct ClangDocContext {
   // Maps mustache template types to specific mustache template files.
   // Ex.    comment-template -> /path/to/comment-template.mustache
   llvm::StringMap<std::string> MustacheTemplates;
+  // A pointer to a DiagnosticsEngine for error reporting.
+  clang::DiagnosticsEngine &Diags;
   Index Idx;
+  int Granularity; // Granularity of ftime trace
+  bool PublicOnly; // Indicates if only public declarations are documented.
+  bool FTimeTrace; // Indicates if ftime trace is turned on
 };
 
 } // namespace doc

--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -337,28 +337,29 @@ static std::string getSourceCode(const Decl *D, const SourceRange &R) {
       .str();
 }
 
-template <typename T> static std::string serialize(T &I) {
+template <typename T>
+static std::string serialize(T &I, DiagnosticsEngine &Diags) {
   SmallString<2048> Buffer;
   llvm::BitstreamWriter Stream(Buffer);
-  ClangDocBitcodeWriter Writer(Stream);
+  ClangDocBitcodeWriter Writer(Stream, Diags);
   Writer.emitBlock(I);
   return Buffer.str().str();
 }
 
-std::string serialize(std::unique_ptr<Info> &I) {
+std::string serialize(std::unique_ptr<Info> &I, DiagnosticsEngine &Diags) {
   switch (I->IT) {
   case InfoType::IT_namespace:
-    return serialize(*static_cast<NamespaceInfo *>(I.get()));
+    return serialize(*static_cast<NamespaceInfo *>(I.get()), Diags);
   case InfoType::IT_record:
-    return serialize(*static_cast<RecordInfo *>(I.get()));
+    return serialize(*static_cast<RecordInfo *>(I.get()), Diags);
   case InfoType::IT_enum:
-    return serialize(*static_cast<EnumInfo *>(I.get()));
+    return serialize(*static_cast<EnumInfo *>(I.get()), Diags);
   case InfoType::IT_function:
-    return serialize(*static_cast<FunctionInfo *>(I.get()));
+    return serialize(*static_cast<FunctionInfo *>(I.get()), Diags);
   case InfoType::IT_concept:
-    return serialize(*static_cast<ConceptInfo *>(I.get()));
+    return serialize(*static_cast<ConceptInfo *>(I.get()), Diags);
   case InfoType::IT_variable:
-    return serialize(*static_cast<VarInfo *>(I.get()));
+    return serialize(*static_cast<VarInfo *>(I.get()), Diags);
   case InfoType::IT_friend:
   case InfoType::IT_typedef:
   case InfoType::IT_default:

--- a/clang-tools-extra/clang-doc/Serialize.h
+++ b/clang-tools-extra/clang-doc/Serialize.h
@@ -80,7 +80,7 @@ emitInfo(const VarDecl *D, const FullComment *FC, const Location &Loc,
 // memory (vs storing USRs directly).
 SymbolID hashUSR(llvm::StringRef USR);
 
-std::string serialize(std::unique_ptr<Info> &I);
+std::string serialize(std::unique_ptr<Info> &I, DiagnosticsEngine &Diags);
 
 } // namespace serialize
 } // namespace doc

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -22,6 +22,9 @@
 #include "Generators.h"
 #include "Representation.h"
 #include "support/Utils.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticOptions.h"
+#include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Tooling/AllTUsExecution.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Execution.h"
@@ -206,9 +209,12 @@ static llvm::Error getDefaultAssetFiles(const char *Argv0,
 static llvm::Error getHtmlAssetFiles(const char *Argv0,
                                      clang::doc::ClangDocContext &CDCtx) {
   if (!UserAssetPath.empty() &&
-      !llvm::sys::fs::is_directory(std::string(UserAssetPath)))
-    llvm::outs() << "Asset path supply is not a directory: " << UserAssetPath
-                 << " falling back to default\n";
+      !llvm::sys::fs::is_directory(std::string(UserAssetPath))) {
+    unsigned ID = CDCtx.Diags.getCustomDiagID(
+        DiagnosticsEngine::Warning,
+        "Asset path supply is not a directory: %0 falling back to default");
+    CDCtx.Diags.Report(ID) << UserAssetPath;
+  }
   if (llvm::sys::fs::is_directory(std::string(UserAssetPath)))
     return getAssetFiles(CDCtx);
   return getDefaultAssetFiles(Argv0, CDCtx);
@@ -217,9 +223,12 @@ static llvm::Error getHtmlAssetFiles(const char *Argv0,
 static llvm::Error getMustacheHtmlFiles(const char *Argv0,
                                         clang::doc::ClangDocContext &CDCtx) {
   bool IsDir = llvm::sys::fs::is_directory(UserAssetPath);
-  if (!UserAssetPath.empty() && !IsDir)
-    llvm::outs() << "Asset path supply is not a directory: " << UserAssetPath
-                 << " falling back to default\n";
+  if (!UserAssetPath.empty() && !IsDir) {
+    unsigned ID = CDCtx.Diags.getCustomDiagID(
+        DiagnosticsEngine::Note,
+        "Asset path supply is not a directory: %0 falling back to default");
+    CDCtx.Diags.Report(ID) << UserAssetPath;
+  }
   if (IsDir) {
     getMustacheHtmlFiles(UserAssetPath, CDCtx);
     return llvm::Error::success();
@@ -255,13 +264,16 @@ sortUsrToInfo(llvm::StringMap<std::unique_ptr<doc::Info>> &USRToInfo) {
   }
 }
 
-static llvm::Error handleMappingFailures(llvm::Error Err) {
+static llvm::Error handleMappingFailures(DiagnosticsEngine &Diags,
+                                         llvm::Error Err) {
   if (!Err)
     return llvm::Error::success();
   if (IgnoreMappingFailures) {
-    llvm::errs() << "Error mapping decls in files. Clang-doc will ignore these "
-                    "files and continue:\n"
-                 << toString(std::move(Err)) << "\n";
+    unsigned ID = Diags.getCustomDiagID(
+        DiagnosticsEngine::Warning,
+        "Error mapping decls in files. Clang-doc will ignore these files and "
+        "continue:\n%0");
+    Diags.Report(ID) << toString(std::move(Err));
     return llvm::Error::success();
   }
   return Err;
@@ -313,17 +325,16 @@ Example usage for a project using a compile commands database:
                                     tooling::ArgumentInsertPosition::END),
           ArgAdjuster);
 
-    clang::doc::ClangDocContext CDCtx = {
-        Executor->getExecutionContext(),
-        ProjectName,
-        PublicOnly,
-        OutDirectory,
-        SourceRoot,
-        RepositoryUrl,
-        RepositoryCodeLinePrefix,
-        BaseDirectory,
-        {UserStylesheets.begin(), UserStylesheets.end()},
-        FTimeTrace};
+    auto DiagOpts = std::make_unique<DiagnosticOptions>();
+    TextDiagnosticPrinter *DiagClient =
+        new TextDiagnosticPrinter(llvm::errs(), *DiagOpts);
+    IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
+    DiagnosticsEngine Diags(DiagID, *DiagOpts, DiagClient);
+
+    clang::doc::ClangDocContext CDCtx(
+        Executor->getExecutionContext(), ProjectName, PublicOnly, OutDirectory,
+        SourceRoot, RepositoryUrl, RepositoryCodeLinePrefix, BaseDirectory,
+        {UserStylesheets.begin(), UserStylesheets.end()}, Diags, FTimeTrace);
 
     if (Format == "html") {
       ExitOnErr(getHtmlAssetFiles(argv[0], CDCtx));
@@ -335,6 +346,7 @@ Example usage for a project using a compile commands database:
     // Mapping phase
     llvm::outs() << "Mapping decls...\n";
     ExitOnErr(handleMappingFailures(
+        Diags,
         Executor->execute(doc::newMapperActionFactory(CDCtx), ArgAdjuster)));
     llvm::timeTraceProfilerEnd();
 
@@ -360,13 +372,18 @@ Example usage for a project using a compile commands database:
     std::atomic<bool> Error;
     Error = false;
     llvm::sys::Mutex IndexMutex;
+    llvm::sys::Mutex DiagMutex;
+    unsigned DiagIDBitcodeReading = Diags.getCustomDiagID(
+        DiagnosticsEngine::Error, "error reading bitcode: %0");
+    unsigned DiagIDBitcodeMerging = Diags.getCustomDiagID(
+        DiagnosticsEngine::Error, "error merging bitcode: %0");
     // ExecutorConcurrency is a flag exposed by AllTUsExecution.h
     llvm::DefaultThreadPool Pool(
         llvm::hardware_concurrency(ExecutorConcurrency));
     {
       llvm::TimeTraceScope TS("Reduce");
       for (auto &Group : USRToBitcode) {
-        Pool.async([&]() { // time trace decoding bitcode
+        Pool.async([&, &Diags = Diags]() { // time trace decoding bitcode
           if (FTimeTrace)
             llvm::timeTraceProfilerInitialize(200, "clang-doc");
 
@@ -375,10 +392,13 @@ Example usage for a project using a compile commands database:
             llvm::TimeTraceScope Red("decoding bitcode");
             for (auto &Bitcode : Group.getValue()) {
               llvm::BitstreamCursor Stream(Bitcode);
-              doc::ClangDocBitcodeReader Reader(Stream);
+              doc::ClangDocBitcodeReader Reader(Stream, Diags);
               auto ReadInfos = Reader.readBitcode();
               if (!ReadInfos) {
-                llvm::errs() << toString(ReadInfos.takeError()) << "\n";
+                std::lock_guard<llvm::sys::Mutex> Guard(DiagMutex);
+
+                Diags.Report(DiagIDBitcodeReading)
+                    << toString(ReadInfos.takeError());
                 Error = true;
                 return;
               }
@@ -394,7 +414,9 @@ Example usage for a project using a compile commands database:
             auto ExpReduced = doc::mergeInfos(Infos);
 
             if (!ExpReduced) {
-              llvm::errs() << llvm::toString(ExpReduced.takeError());
+              std::lock_guard<llvm::sys::Mutex> Guard(DiagMutex);
+              Diags.Report(DiagIDBitcodeMerging)
+                  << toString(ExpReduced.takeError());
               return;
             }
             Reduced = std::move(*ExpReduced);

--- a/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/ClangDocTest.cpp
@@ -9,10 +9,25 @@
 #include "ClangDocTest.h"
 #include "Representation.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Basic/DiagnosticOptions.h"
 #include "gtest/gtest.h"
 
 namespace clang {
 namespace doc {
+
+ClangDocContextTest::ClangDocContextTest()
+    : DiagID(new DiagnosticIDs()),
+      Diags(DiagID, DiagOpts, new IgnoringDiagConsumer()) {}
+
+ClangDocContextTest::~ClangDocContextTest() = default;
+
+ClangDocContext ClangDocContextTest::getClangDocContext(
+    std::vector<std::string> UserStylesheets, StringRef RepositoryUrl,
+    StringRef RepositoryLinePrefix, StringRef Base) {
+  return ClangDocContext(nullptr, "test-project", false, "", "", RepositoryUrl,
+                         RepositoryLinePrefix, Base, UserStylesheets, Diags,
+                         false);
+}
 
 NamespaceInfo *InfoAsNamespace(Info *I) {
   assert(I->IT == InfoType::IT_namespace);

--- a/clang-tools-extra/unittests/clang-doc/ClangDocTest.h
+++ b/clang-tools-extra/unittests/clang-doc/ClangDocTest.h
@@ -12,6 +12,8 @@
 #include "ClangDocTest.h"
 #include "Representation.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticOptions.h"
 #include "gtest/gtest.h"
 
 namespace clang {
@@ -48,6 +50,21 @@ void CheckRecordInfo(RecordInfo *Expected, RecordInfo *Actual);
 void CheckBaseRecordInfo(BaseRecordInfo *Expected, BaseRecordInfo *Actual);
 
 void CheckIndex(Index &Expected, Index &Actual);
+
+class ClangDocContextTest : public ::testing::Test {
+protected:
+  ClangDocContextTest();
+  ~ClangDocContextTest() override;
+
+  ClangDocContext
+  getClangDocContext(std::vector<std::string> UserStylesheets = {},
+                     StringRef RepositoryUrl = "",
+                     StringRef RepositoryLinePrefix = "", StringRef Base = "");
+
+  DiagnosticOptions DiagOpts;
+  llvm::IntrusiveRefCntPtr<DiagnosticIDs> DiagID;
+  DiagnosticsEngine Diags;
+};
 
 } // namespace doc
 } // namespace clang

--- a/clang-tools-extra/unittests/clang-doc/HTMLGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/HTMLGeneratorTest.cpp
@@ -25,21 +25,32 @@ static std::unique_ptr<Generator> getHTMLGenerator() {
   return std::move(G.get());
 }
 
-static ClangDocContext
-getClangDocContext(std::vector<std::string> UserStylesheets = {},
-                   StringRef RepositoryUrl = "",
-                   StringRef RepositoryLinePrefix = "", StringRef Base = "") {
-  ClangDocContext CDCtx{
-      {},   "test-project", {}, {}, {}, RepositoryUrl, RepositoryLinePrefix,
-      Base, UserStylesheets};
-  CDCtx.UserStylesheets.insert(
-      CDCtx.UserStylesheets.begin(),
-      "../share/clang/clang-doc-default-stylesheet.css");
-  CDCtx.JsScripts.emplace_back("index.js");
-  return CDCtx;
-}
+class HTMLGeneratorTest : public ClangDocContextTest {
+protected:
+  ClangDocContext
+  getClangDocContext(std::vector<std::string> UserStylesheets = {},
+                     StringRef RepositoryUrl = "",
+                     StringRef RepositoryLinePrefix = "", StringRef Base = "") {
+    ClangDocContext CDCtx{nullptr,
+                          "test-project",
+                          false,
+                          "",
+                          "",
+                          RepositoryUrl,
+                          RepositoryLinePrefix,
+                          Base,
+                          UserStylesheets,
+                          Diags,
+                          false};
+    CDCtx.UserStylesheets.insert(
+        CDCtx.UserStylesheets.begin(),
+        "../share/clang/clang-doc-default-stylesheet.css");
+    CDCtx.JsScripts.emplace_back("index.js");
+    return CDCtx;
+  }
+};
 
-TEST(HTMLGeneratorTest, emitNamespaceHTML) {
+TEST_F(HTMLGeneratorTest, emitNamespaceHTML) {
   NamespaceInfo I;
   I.Name = "Namespace";
   I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -150,7 +161,7 @@ TEST(HTMLGeneratorTest, emitNamespaceHTML) {
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(HTMLGeneratorTest, emitRecordHTML) {
+TEST_F(HTMLGeneratorTest, emitRecordHTML) {
   RecordInfo I;
   I.Name = "r";
   I.Path = "X/Y/Z";
@@ -278,7 +289,7 @@ TEST(HTMLGeneratorTest, emitRecordHTML) {
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(HTMLGeneratorTest, emitFunctionHTML) {
+TEST_F(HTMLGeneratorTest, emitFunctionHTML) {
   FunctionInfo I;
   I.Name = "f";
   I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -338,7 +349,7 @@ TEST(HTMLGeneratorTest, emitFunctionHTML) {
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(HTMLGeneratorTest, emitEnumHTML) {
+TEST_F(HTMLGeneratorTest, emitEnumHTML) {
   EnumInfo I;
   I.Name = "e";
   I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -397,7 +408,7 @@ TEST(HTMLGeneratorTest, emitEnumHTML) {
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(HTMLGeneratorTest, emitCommentHTML) {
+TEST_F(HTMLGeneratorTest, emitCommentHTML) {
   FunctionInfo I;
   I.Name = "f";
   I.DefLoc = Location(10, 10, "test.cpp", true);

--- a/clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp
@@ -34,19 +34,30 @@ static std::unique_ptr<Generator> getHTMLMustacheGenerator() {
   return std::move(G.get());
 }
 
-static ClangDocContext
-getClangDocContext(std::vector<std::string> UserStylesheets = {},
-                   StringRef RepositoryUrl = "",
-                   StringRef RepositoryLinePrefix = "", StringRef Base = "") {
-  ClangDocContext CDCtx{
-      {},   "test-project", {}, {}, {}, RepositoryUrl, RepositoryLinePrefix,
-      Base, UserStylesheets};
-  CDCtx.UserStylesheets.insert(CDCtx.UserStylesheets.begin(), "");
-  CDCtx.JsScripts.emplace_back("");
-  return CDCtx;
-}
+class HTMLMustacheGeneratorTest : public ClangDocContextTest {
+protected:
+  ClangDocContext
+  getClangDocContext(std::vector<std::string> UserStylesheets = {},
+                     StringRef RepositoryUrl = "",
+                     StringRef RepositoryLinePrefix = "", StringRef Base = "") {
+    ClangDocContext CDCtx{nullptr,
+                          "test-project",
+                          false,
+                          "",
+                          "",
+                          RepositoryUrl,
+                          RepositoryLinePrefix,
+                          Base,
+                          UserStylesheets,
+                          Diags,
+                          false};
+    CDCtx.UserStylesheets.insert(CDCtx.UserStylesheets.begin(), "");
+    CDCtx.JsScripts.emplace_back("");
+    return CDCtx;
+  }
+};
 
-TEST(HTMLMustacheGeneratorTest, createResources) {
+TEST_F(HTMLMustacheGeneratorTest, createResources) {
   auto G = getHTMLMustacheGenerator();
   ASSERT_THAT(G, NotNull()) << "Could not find HTMLMustacheGenerator";
   ClangDocContext CDCtx = getClangDocContext();

--- a/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
@@ -13,7 +13,9 @@ static std::unique_ptr<Generator> getJSONGenerator() {
   return std::move(G.get());
 }
 
-TEST(JSONGeneratorTest, emitRecordJSON) {
+class JSONGeneratorTest : public ClangDocContextTest {};
+
+TEST_F(JSONGeneratorTest, emitRecordJSON) {
   RecordInfo I;
   I.Name = "Foo";
   I.IsTypeDef = false;
@@ -55,7 +57,7 @@ TEST(JSONGeneratorTest, emitRecordJSON) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected = R"raw({
   "Bases": [
@@ -186,7 +188,7 @@ TEST(JSONGeneratorTest, emitRecordJSON) {
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(JSONGeneratorTest, emitNamespaceJSON) {
+TEST_F(JSONGeneratorTest, emitNamespaceJSON) {
   NamespaceInfo I;
   I.Name = "Namespace";
   I.Path = "path/to/A";
@@ -208,7 +210,7 @@ TEST(JSONGeneratorTest, emitNamespaceJSON) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected = R"raw({
   "Enums": [

--- a/clang-tools-extra/unittests/clang-doc/MDGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MDGeneratorTest.cpp
@@ -21,7 +21,9 @@ static std::unique_ptr<Generator> getMDGenerator() {
   return std::move(G.get());
 }
 
-TEST(MDGeneratorTest, emitNamespaceMD) {
+class MDGeneratorTest : public ClangDocContextTest {};
+
+TEST_F(MDGeneratorTest, emitNamespaceMD) {
   NamespaceInfo I;
   I.Name = "Namespace";
   I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -39,7 +41,7 @@ TEST(MDGeneratorTest, emitNamespaceMD) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected = R"raw(# namespace Namespace
 
@@ -77,7 +79,7 @@ TEST(MDGeneratorTest, emitNamespaceMD) {
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(MDGeneratorTest, emitRecordMD) {
+TEST_F(MDGeneratorTest, emitRecordMD) {
   RecordInfo I;
   I.Name = "r";
   I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -100,7 +102,7 @@ TEST(MDGeneratorTest, emitRecordMD) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected = R"raw(# class r
 
@@ -144,7 +146,7 @@ ChildStruct
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(MDGeneratorTest, emitFunctionMD) {
+TEST_F(MDGeneratorTest, emitFunctionMD) {
   FunctionInfo I;
   I.Name = "f";
   I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -163,7 +165,7 @@ TEST(MDGeneratorTest, emitFunctionMD) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected = R"raw(### f
 
@@ -176,7 +178,7 @@ TEST(MDGeneratorTest, emitFunctionMD) {
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(MDGeneratorTest, emitEnumMD) {
+TEST_F(MDGeneratorTest, emitEnumMD) {
   EnumInfo I;
   I.Name = "e";
   I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -191,7 +193,7 @@ TEST(MDGeneratorTest, emitEnumMD) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected = R"raw(| enum class e |
 
@@ -207,7 +209,7 @@ TEST(MDGeneratorTest, emitEnumMD) {
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(MDGeneratorTest, emitCommentMD) {
+TEST_F(MDGeneratorTest, emitCommentMD) {
   FunctionInfo I;
   I.Name = "f";
 
@@ -325,7 +327,7 @@ TEST(MDGeneratorTest, emitCommentMD) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected =
       R"raw(### f

--- a/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MergeTest.cpp
@@ -13,7 +13,9 @@
 namespace clang {
 namespace doc {
 
-TEST(MergeTest, mergeNamespaceInfos) {
+class MergeTest : public ClangDocContextTest {};
+
+TEST_F(MergeTest, mergeNamespaceInfos) {
   NamespaceInfo One;
   One.Name = "Namespace";
   One.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -75,7 +77,7 @@ TEST(MergeTest, mergeNamespaceInfos) {
                      InfoAsNamespace(Actual.get().get()));
 }
 
-TEST(MergeTest, mergeRecordInfos) {
+TEST_F(MergeTest, mergeRecordInfos) {
   RecordInfo One;
   One.Name = "r";
   One.IsTypeDef = true;
@@ -153,7 +155,7 @@ TEST(MergeTest, mergeRecordInfos) {
                   InfoAsRecord(Actual.get().get()));
 }
 
-TEST(MergeTest, mergeFunctionInfos) {
+TEST_F(MergeTest, mergeFunctionInfos) {
   FunctionInfo One;
   One.Name = "f";
   One.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -228,7 +230,7 @@ TEST(MergeTest, mergeFunctionInfos) {
                     InfoAsFunction(Actual.get().get()));
 }
 
-TEST(MergeTest, mergeEnumInfos) {
+TEST_F(MergeTest, mergeEnumInfos) {
   EnumInfo One;
   One.Name = "e";
   One.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);

--- a/clang-tools-extra/unittests/clang-doc/YAMLGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/YAMLGeneratorTest.cpp
@@ -22,7 +22,9 @@ static std::unique_ptr<Generator> getYAMLGenerator() {
   return std::move(G.get());
 }
 
-TEST(YAMLGeneratorTest, emitNamespaceYAML) {
+class YAMLGeneratorTest : public ClangDocContextTest {};
+
+TEST_F(YAMLGeneratorTest, emitNamespaceYAML) {
   NamespaceInfo I;
   I.Name = "Namespace";
   I.Path = "path/to/A";
@@ -44,7 +46,7 @@ TEST(YAMLGeneratorTest, emitNamespaceYAML) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected =
       R"raw(---
@@ -77,7 +79,7 @@ ChildEnums:
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(YAMLGeneratorTest, emitRecordYAML) {
+TEST_F(YAMLGeneratorTest, emitRecordYAML) {
   RecordInfo I;
   I.Name = "r";
   I.Path = "path/to/A";
@@ -124,7 +126,7 @@ TEST(YAMLGeneratorTest, emitRecordYAML) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected =
       R"raw(---
@@ -202,7 +204,7 @@ ChildEnums:
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(YAMLGeneratorTest, emitFunctionYAML) {
+TEST_F(YAMLGeneratorTest, emitFunctionYAML) {
   FunctionInfo I;
   I.Name = "f";
   I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -223,7 +225,7 @@ TEST(YAMLGeneratorTest, emitFunctionYAML) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected =
       R"raw(---
@@ -267,7 +269,7 @@ ReturnType:
 // namespace A {
 // enum e { X };
 // }
-TEST(YAMLGeneratorTest, emitSimpleEnumYAML) {
+TEST_F(YAMLGeneratorTest, emitSimpleEnumYAML) {
   EnumInfo I;
   I.Name = "e";
   I.Namespace.emplace_back(EmptySID, "A", InfoType::IT_namespace);
@@ -282,7 +284,7 @@ TEST(YAMLGeneratorTest, emitSimpleEnumYAML) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected =
       R"raw(---
@@ -308,7 +310,7 @@ Members:
 
 // Tests the equivalent of:
 // enum class e : short { X = FOO_BAR + 2 };
-TEST(YAMLGeneratorTest, enumTypedScopedEnumYAML) {
+TEST_F(YAMLGeneratorTest, enumTypedScopedEnumYAML) {
   EnumInfo I;
   I.Name = "e";
 
@@ -320,7 +322,7 @@ TEST(YAMLGeneratorTest, enumTypedScopedEnumYAML) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected =
       R"raw(---
@@ -340,7 +342,7 @@ Members:
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(YAMLGeneratorTest, enumTypedefYAML) {
+TEST_F(YAMLGeneratorTest, enumTypedefYAML) {
   TypedefInfo I;
   I.Name = "MyUsing";
   I.Underlying = TypeInfo("int");
@@ -350,7 +352,7 @@ TEST(YAMLGeneratorTest, enumTypedefYAML) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected =
       R"raw(---
@@ -365,7 +367,7 @@ IsUsing:         true
   EXPECT_EQ(Expected, Actual.str());
 }
 
-TEST(YAMLGeneratorTest, emitCommentYAML) {
+TEST_F(YAMLGeneratorTest, emitCommentYAML) {
   FunctionInfo I;
   I.Name = "f";
   I.DefLoc = Location(10, 10, "test.cpp");
@@ -482,7 +484,7 @@ TEST(YAMLGeneratorTest, emitCommentYAML) {
   assert(G);
   std::string Buffer;
   llvm::raw_string_ostream Actual(Buffer);
-  auto Err = G->generateDocForInfo(&I, Actual, ClangDocContext());
+  auto Err = G->generateDocForInfo(&I, Actual, getClangDocContext());
   assert(!Err);
   std::string Expected =
       R"raw(---


### PR DESCRIPTION
[clang-doc] Use DiagnosticsEngine to handle diagnostic output

Right now we use a combination of outs() and errs() to handle tool
output. Instead, we can use existing diagnostic support in clang and
LLVM to ensure our tool has a consistent behavior with other tools.