### PR TITLE
[Clang] Support __bf16 type for SPIR/SPIR-V (#169012)

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -103,6 +103,10 @@ protected:
     UseAddrSpaceMapMangling = true;
     HasLegalHalfType = true;
     HasFloat16 = true;
+    HasBFloat16 = true;
+    HasFullBFloat16 = true;
+    BFloat16Width = BFloat16Align = 16;
+    BFloat16Format = &llvm::APFloat::BFloat();
     // Define available target features
     // These must be defined in sorted order!
     NoAsmVariants = true;
@@ -396,8 +400,6 @@ public:
     HasFloat16 = true;
     HalfArgsAndReturns = true;
   }
-
-  bool hasBFloat16Type() const override { return true; }
 
   ArrayRef<const char *> getGCCRegNames() const override;
 

--- a/clang/test/CodeGenOpenCL/__bf16.cl
+++ b/clang/test/CodeGenOpenCL/__bf16.cl
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 %s -cl-std=cl3.0 -emit-llvm -o - -triple spir-unknown-unknown | FileCheck %s
+// RUN: %clang_cc1 %s -cl-std=cl3.0 -emit-llvm -o - -triple spirv64-unknown-unknown | FileCheck %s
+
+kernel void test(global __bf16 *a, global __bf16 *b){
+// CHECK-LABEL: spir_kernel void @test(
+// CHECK: fadd bfloat
+// CHECK: fsub bfloat
+// CHECK: fmul bfloat
+// CHECK: fdiv bfloat
+
+  *b += *a;
+  *b -= *a;
+  *b *= *a;
+  *b /= *a;
+}
+
+typedef __bf16 __bf16v4 __attribute((ext_vector_type(4)));
+
+kernel void test_v4(global __bf16v4 *a, global __bf16v4 *b){
+// CHECK-LABEL: spir_kernel void @test_v4(
+// CHECK: fadd <4 x bfloat>
+// CHECK: fsub <4 x bfloat>
+// CHECK: fmul <4 x bfloat>
+// CHECK: fdiv <4 x bfloat>
+
+  *b += *a;
+  *b -= *a;
+  *b *= *a;
+  *b /= *a;
+}
+

--- a/clang/test/SemaSYCL/bf16.cpp
+++ b/clang/test/SemaSYCL/bf16.cpp
@@ -1,8 +1,9 @@
 // RUN: %clang_cc1 -triple spir64 -aux-triple x86_64-unknown-linux-gnu -fsycl-is-device -verify -fsyntax-only %s
+// expected-no-diagnostics
 
 template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
-  kernelFunc(); // expected-note {{called by 'kernel}}
+  kernelFunc();
 }
 
 void host_ok(void) {
@@ -11,9 +12,9 @@ void host_ok(void) {
 
 int main()
 {  host_ok();
-  __bf16 var; // expected-note {{'var' defined here}}
+  __bf16 var;
   kernel<class variables>([=]() {
-    (void)var; // expected-error {{'var' requires 16 bit size '__bf16' type support, but target 'spir64' does not support it}}
+    (void)var;
     int B = sizeof(__bf16);
   });
 


### PR DESCRIPTION
SPIR/SPIR-V are generic targets. Assume they support __bf16.

(cherry picked from commit c4254cd9bb52fb8ef101dcfbcec048447e6c99bb)