### PR TITLE
Fix VarArgs FixedStack object on AIX.

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -7384,9 +7384,27 @@ SDValue PPCTargetLowering::LowerFormalArguments_AIX(
   FuncInfo->setMinReservedArea(CallerReservedArea);
 
   if (isVarArg) {
-    FuncInfo->setVarArgsFrameIndex(
-        MFI.CreateFixedObject(PtrByteSize, CCInfo.getStackSize(), true));
-    SDValue FIN = DAG.getFrameIndex(FuncInfo->getVarArgsFrameIndex(), PtrVT);
+    int VAListIndex = 0;
+    // If some of the non-fixed arguments are passed in register then the fixed
+    // stack object we spill into is not immutable. Create a fixed stack object
+    // that overlaps the remainder of the parameter save area.
+    if (CCInfo.getStackSize() < (LinkageSize + MinParameterSaveArea)) {
+      unsigned FixedStackSize =
+          LinkageSize + MinParameterSaveArea - CCInfo.getStackSize();
+      VAListIndex =
+          MFI.CreateFixedObject(FixedStackSize, CCInfo.getStackSize(),
+                                /* IsImmutable */ false, /* IsAliased */ true);
+    } else {
+      // All the arguments passed through ellipses are on the stack. Create a
+      // dummy fixed stack object the same size as a pointer since we don't
+      // know the actual size.
+      VAListIndex =
+          MFI.CreateFixedObject(PtrByteSize, CCInfo.getStackSize(),
+                                /* IsImmutable */ true, /* IsAliased */ true);
+    }
+
+    FuncInfo->setVarArgsFrameIndex(VAListIndex);
+    SDValue FIN = DAG.getFrameIndex(VAListIndex, PtrVT);
 
     static const MCPhysReg GPR_32[] = {PPC::R3, PPC::R4, PPC::R5, PPC::R6,
                                        PPC::R7, PPC::R8, PPC::R9, PPC::R10};
@@ -7398,17 +7416,19 @@ SDValue PPCTargetLowering::LowerFormalArguments_AIX(
     // The fixed integer arguments of a variadic function are stored to the
     // VarArgsFrameIndex on the stack so that they may be loaded by
     // dereferencing the result of va_next.
-    for (unsigned GPRIndex =
-             (CCInfo.getStackSize() - LinkageSize) / PtrByteSize;
-         GPRIndex < NumGPArgRegs; ++GPRIndex) {
+    for (unsigned
+             GPRIndex = (CCInfo.getStackSize() - LinkageSize) / PtrByteSize,
+             Offset = 0;
+         GPRIndex < NumGPArgRegs; ++GPRIndex, Offset += PtrByteSize) {
 
       const Register VReg =
           IsPPC64 ? MF.addLiveIn(GPR_64[GPRIndex], &PPC::G8RCRegClass)
                   : MF.addLiveIn(GPR_32[GPRIndex], &PPC::GPRCRegClass);
 
       SDValue Val = DAG.getCopyFromReg(Chain, dl, VReg, PtrVT);
-      SDValue Store =
-          DAG.getStore(Val.getValue(1), dl, Val, FIN, MachinePointerInfo());
+      MachinePointerInfo MPI =
+          MachinePointerInfo::getFixedStack(MF, VAListIndex, Offset);
+      SDValue Store = DAG.getStore(Val.getValue(1), dl, Val, FIN, MPI);
       MemOps.push_back(Store);
       // Increment the address for the next argument to store.
       SDValue PtrOff = DAG.getConstant(PtrByteSize, dl, PtrVT);

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -7385,7 +7385,7 @@ SDValue PPCTargetLowering::LowerFormalArguments_AIX(
 
   if (isVarArg) {
     int VAListIndex = 0;
-    // If some of the non-fixed arguments are passed in register then the fixed
+    // If any of the optional arguments are passed in register then the fixed
     // stack object we spill into is not immutable. Create a fixed stack object
     // that overlaps the remainder of the parameter save area.
     if (CCInfo.getStackSize() < (LinkageSize + MinParameterSaveArea)) {

--- a/llvm/test/CodeGen/PowerPC/aix32-cc-abi-vaarg-mir.ll
+++ b/llvm/test/CodeGen/PowerPC/aix32-cc-abi-vaarg-mir.ll
@@ -8,22 +8,22 @@ define i32 @int_va_arg(i32 %a, ...) local_unnamed_addr  {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   renamable $r11 = ADDI %fixed-stack.0, 0
   ; CHECK-NEXT:   STW killed renamable $r4, 0, %fixed-stack.0 :: (store (s32) into %fixed-stack.0)
-  ; CHECK-NEXT:   STW killed renamable $r6, 8, %fixed-stack.0 :: (store (s32))
-  ; CHECK-NEXT:   STW killed renamable $r7, 12, %fixed-stack.0 :: (store (s32))
-  ; CHECK-NEXT:   STW killed renamable $r8, 16, %fixed-stack.0 :: (store (s32))
-  ; CHECK-NEXT:   STW killed renamable $r9, 20, %fixed-stack.0 :: (store (s32))
-  ; CHECK-NEXT:   STW killed renamable $r10, 24, %fixed-stack.0 :: (store (s32))
+  ; CHECK-NEXT:   STW killed renamable $r5, 4, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 4)
+  ; CHECK-NEXT:   STW killed renamable $r6, 8, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 8)
+  ; CHECK-NEXT:   STW killed renamable $r7, 12, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 12)
+  ; CHECK-NEXT:   STW killed renamable $r8, 16, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 16)
+  ; CHECK-NEXT:   STW killed renamable $r9, 20, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 20)
+  ; CHECK-NEXT:   STW killed renamable $r10, 24, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 24)
   ; CHECK-NEXT:   STW renamable $r11, 0, %stack.0.arg1 :: (store (s32) into %ir.arg1)
   ; CHECK-NEXT:   STW killed renamable $r11, 0, %stack.1.arg2 :: (store (s32) into %ir.arg2)
   ; CHECK-NEXT:   renamable $r4 = ADDI %fixed-stack.0, 4
   ; CHECK-NEXT:   STW renamable $r4, 0, %stack.0.arg1 :: (store (s32) into %ir.arg1)
-  ; CHECK-NEXT:   renamable $r6 = LWZ 0, %fixed-stack.0 :: (load (s32) from %ir.argp.cur)
+  ; CHECK-NEXT:   renamable $r5 = LWZ 0, %fixed-stack.0 :: (load (s32) from %ir.argp.cur)
   ; CHECK-NEXT:   STW killed renamable $r4, 0, %stack.1.arg2 :: (store (s32) into %ir.arg2)
   ; CHECK-NEXT:   renamable $r4 = LWZ 0, %fixed-stack.0 :: (load (s32) from %ir.argp.cur2)
-  ; CHECK-NEXT:   renamable $r3 = nsw ADD4 killed renamable $r6, killed renamable $r3
+  ; CHECK-NEXT:   renamable $r3 = nsw ADD4 killed renamable $r5, killed renamable $r3
   ; CHECK-NEXT:   renamable $r4 = RLWINM killed renamable $r4, 1, 0, 30
   ; CHECK-NEXT:   renamable $r3 = nsw ADD4 killed renamable $r3, killed renamable $r4
-  ; CHECK-NEXT:   STW killed renamable $r5, 4, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 4)
   ; CHECK-NEXT:   BLR implicit $lr, implicit $rm, implicit $r3
 entry:
   %arg1 = alloca ptr, align 4
@@ -115,12 +115,12 @@ define double @double_va_arg(double %a, ...) local_unnamed_addr  {
   ; CHECK-NEXT:   liveins: $f1, $r5, $r6, $r7, $r8, $r9, $r10
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   renamable $r3 = ADDI %fixed-stack.0, 0
-  ; CHECK-NEXT:   STW killed renamable $r7, 8, %fixed-stack.0 :: (store (s32), align 8)
+  ; CHECK-NEXT:   STW killed renamable $r7, 8, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 8, align 8)
   ; CHECK-NEXT:   STW renamable $r5, 0, %fixed-stack.0 :: (store (s32) into %fixed-stack.0, align 16)
   ; CHECK-NEXT:   STW renamable $r6, 4, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 4)
-  ; CHECK-NEXT:   STW killed renamable $r8, 12, %fixed-stack.0 :: (store (s32))
+  ; CHECK-NEXT:   STW killed renamable $r8, 12, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 12)
   ; CHECK-NEXT:   STW killed renamable $r9, 16, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 16, align 16)
-  ; CHECK-NEXT:   STW killed renamable $r10, 20, %fixed-stack.0 :: (store (s32))
+  ; CHECK-NEXT:   STW killed renamable $r10, 20, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 20)
   ; CHECK-NEXT:   STW renamable $r3, 0, %stack.0.arg1 :: (store (s32) into %ir.arg1)
   ; CHECK-NEXT:   STW killed renamable $r3, 0, %stack.1.arg2 :: (store (s32) into %ir.arg2)
   ; CHECK-NEXT:   STW renamable $r5, 0, %stack.2 :: (store (s32) into %stack.2, align 8)

--- a/llvm/test/CodeGen/PowerPC/aix32-cc-abi-vaarg.ll
+++ b/llvm/test/CodeGen/PowerPC/aix32-cc-abi-vaarg.ll
@@ -7,21 +7,21 @@ define i32 @int_va_arg(i32 %a, ...) local_unnamed_addr  {
 ; CHECK-NEXT:    addi 11, 1, 28
 ; CHECK-NEXT:    stw 4, 28(1)
 ; CHECK-NEXT:    addi 4, 1, 32
-; CHECK-NEXT:    stw 6, 36(1)
+; CHECK-NEXT:    stw 5, 32(1)
 ; CHECK-NEXT:    stw 11, -4(1)
 ; CHECK-NEXT:    stw 11, -8(1)
 ; CHECK-NEXT:    stw 4, -4(1)
-; CHECK-NEXT:    lwz 6, 28(1)
+; CHECK-NEXT:    lwz 5, 28(1)
 ; CHECK-NEXT:    stw 4, -8(1)
-; CHECK-NEXT:    add 3, 6, 3
+; CHECK-NEXT:    add 3, 5, 3
 ; CHECK-NEXT:    lwz 4, 28(1)
 ; CHECK-NEXT:    slwi 4, 4, 1
-; CHECK-NEXT:    stw 7, 40(1)
+; CHECK-NEXT:    stw 6, 36(1)
 ; CHECK-NEXT:    add 3, 3, 4
+; CHECK-NEXT:    stw 7, 40(1)
 ; CHECK-NEXT:    stw 8, 44(1)
 ; CHECK-NEXT:    stw 9, 48(1)
 ; CHECK-NEXT:    stw 10, 52(1)
-; CHECK-NEXT:    stw 5, 32(1)
 ; CHECK-NEXT:    blr
 entry:
   %arg1 = alloca ptr, align 4

--- a/llvm/test/CodeGen/PowerPC/aix32-vector-vararg-callee.ll
+++ b/llvm/test/CodeGen/PowerPC/aix32-vector-vararg-callee.ll
@@ -17,11 +17,11 @@ define <4 x i32> @callee(i32 %count, ...) {
   ; CHECK:   [[COPY6:%[0-9]+]]:gprc = COPY $r4
   ; CHECK:   STW [[COPY6]], 0, %fixed-stack.0 :: (store (s32) into %fixed-stack.0)
   ; CHECK:   STW [[COPY5]], 4, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 4)
-  ; CHECK:   STW [[COPY4]], 8, %fixed-stack.0 :: (store (s32))
-  ; CHECK:   STW [[COPY3]], 12, %fixed-stack.0 :: (store (s32))
-  ; CHECK:   STW [[COPY2]], 16, %fixed-stack.0 :: (store (s32))
-  ; CHECK:   STW [[COPY1]], 20, %fixed-stack.0 :: (store (s32))
-  ; CHECK:   STW [[COPY]], 24, %fixed-stack.0 :: (store (s32))
+  ; CHECK:   STW [[COPY4]], 8, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 8)
+  ; CHECK:   STW [[COPY3]], 12, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 12)
+  ; CHECK:   STW [[COPY2]], 16, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 16)
+  ; CHECK:   STW [[COPY1]], 20, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 20)
+  ; CHECK:   STW [[COPY]], 24, %fixed-stack.0 :: (store (s32) into %fixed-stack.0 + 24)
   ; CHECK:   LIFETIME_START %stack.0.arg_list
   ; CHECK:   [[ADDI:%[0-9]+]]:gprc = ADDI %fixed-stack.0, 0
   ; CHECK:   STW killed [[ADDI]], 0, %stack.0.arg_list :: (store (s32) into %ir.arg_list)

--- a/llvm/test/CodeGen/PowerPC/aix64-cc-abi-vaarg-mir.ll
+++ b/llvm/test/CodeGen/PowerPC/aix64-cc-abi-vaarg-mir.ll
@@ -7,23 +7,23 @@ define i32 @int_va_arg(i32 %a, ...) local_unnamed_addr  {
   ; CHECK-NEXT:   liveins: $x3, $x4, $x5, $x6, $x7, $x8, $x9, $x10
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   renamable $x11 = ADDI8 %fixed-stack.0, 0
-  ; CHECK-NEXT:   STD killed renamable $x6, 16, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD killed renamable $x7, 24, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD killed renamable $x8, 32, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD killed renamable $x9, 40, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD killed renamable $x10, 48, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD renamable $x11, 0, %stack.1.arg2 :: (store (s64) into %ir.arg2)
-  ; CHECK-NEXT:   renamable $x6 = LD 0, %stack.1.arg2 :: (load (s64) from %ir.arg2)
-  ; CHECK-NEXT:   renamable $x7 = disjoint ADDI8 %fixed-stack.0, 4
-  ; CHECK-NEXT:   renamable $r8 = LWZ 0, %fixed-stack.0 :: (load (s32) from %fixed-stack.0, align 8)
-  ; CHECK-NEXT:   renamable $x9 = ADDI8 renamable $x6, 4
   ; CHECK-NEXT:   STD killed renamable $x4, 0, %fixed-stack.0 :: (store (s64) into %fixed-stack.0)
   ; CHECK-NEXT:   STD killed renamable $x5, 8, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 8)
+  ; CHECK-NEXT:   STD killed renamable $x6, 16, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 16)
+  ; CHECK-NEXT:   STD killed renamable $x7, 24, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 24)
+  ; CHECK-NEXT:   STD killed renamable $x8, 32, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 32)
+  ; CHECK-NEXT:   STD killed renamable $x9, 40, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 40)
+  ; CHECK-NEXT:   STD killed renamable $x10, 48, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 48)
+  ; CHECK-NEXT:   STD renamable $x11, 0, %stack.1.arg2 :: (store (s64) into %ir.arg2)
+  ; CHECK-NEXT:   renamable $x4 = LD 0, %stack.1.arg2 :: (load (s64) from %ir.arg2)
+  ; CHECK-NEXT:   renamable $x5 = disjoint ADDI8 %fixed-stack.0, 4
   ; CHECK-NEXT:   STD killed renamable $x11, 0, %stack.0.arg1 :: (store (s64) into %ir.arg1)
-  ; CHECK-NEXT:   STD killed renamable $x7, 0, %stack.0.arg1 :: (store (s64) into %ir.arg1)
-  ; CHECK-NEXT:   STD killed renamable $x9, 0, %stack.1.arg2 :: (store (s64) into %ir.arg2)
-  ; CHECK-NEXT:   renamable $r4 = LWZ 0, killed renamable $x6 :: (load (s32))
-  ; CHECK-NEXT:   renamable $r3 = nsw ADD4 killed renamable $r8, renamable $r3, implicit killed $x3
+  ; CHECK-NEXT:   STD killed renamable $x5, 0, %stack.0.arg1 :: (store (s64) into %ir.arg1)
+  ; CHECK-NEXT:   renamable $r5 = LWZ 0, %fixed-stack.0 :: (load (s32) from %fixed-stack.0, align 8)
+  ; CHECK-NEXT:   renamable $x6 = ADDI8 renamable $x4, 4
+  ; CHECK-NEXT:   STD killed renamable $x6, 0, %stack.1.arg2 :: (store (s64) into %ir.arg2)
+  ; CHECK-NEXT:   renamable $r4 = LWZ 0, killed renamable $x4 :: (load (s32))
+  ; CHECK-NEXT:   renamable $r3 = nsw ADD4 killed renamable $r5, renamable $r3, implicit killed $x3
   ; CHECK-NEXT:   renamable $r4 = RLWINM killed renamable $r4, 1, 0, 30
   ; CHECK-NEXT:   renamable $r3 = nsw ADD4 killed renamable $r3, killed renamable $r4, implicit-def $x3
   ; CHECK-NEXT:   BLR8 implicit $lr8, implicit $rm, implicit $x3
@@ -101,22 +101,22 @@ define double @double_va_arg(double %a, ...) local_unnamed_addr  {
   ; CHECK-NEXT:   liveins: $f1, $x4, $x5, $x6, $x7, $x8, $x9, $x10
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   renamable $x3 = ADDI8 %fixed-stack.0, 0
-  ; CHECK-NEXT:   STD killed renamable $x6, 16, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD killed renamable $x7, 24, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD killed renamable $x8, 32, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD killed renamable $x9, 40, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD killed renamable $x10, 48, %fixed-stack.0 :: (store (s64))
-  ; CHECK-NEXT:   STD renamable $x3, 0, %stack.1.arg2 :: (store (s64) into %ir.arg2)
-  ; CHECK-NEXT:   renamable $x6 = LD 0, %stack.1.arg2 :: (load (s64) from %ir.arg2)
-  ; CHECK-NEXT:   renamable $x7 = ADDI8 %fixed-stack.0, 8
   ; CHECK-NEXT:   STD killed renamable $x4, 0, %fixed-stack.0 :: (store (s64) into %fixed-stack.0)
-  ; CHECK-NEXT:   STD killed renamable $x3, 0, %stack.0.arg1 :: (store (s64) into %ir.arg1)
-  ; CHECK-NEXT:   STD killed renamable $x7, 0, %stack.0.arg1 :: (store (s64) into %ir.arg1)
-  ; CHECK-NEXT:   renamable $f0 = LFD 0, %fixed-stack.0 :: (load (s64))
-  ; CHECK-NEXT:   renamable $x3 = ADDI8 renamable $x6, 8
   ; CHECK-NEXT:   STD killed renamable $x5, 8, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 8)
+  ; CHECK-NEXT:   STD killed renamable $x6, 16, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 16)
+  ; CHECK-NEXT:   STD killed renamable $x7, 24, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 24)
+  ; CHECK-NEXT:   STD killed renamable $x8, 32, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 32)
+  ; CHECK-NEXT:   STD killed renamable $x9, 40, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 40)
+  ; CHECK-NEXT:   STD killed renamable $x10, 48, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 48)
+  ; CHECK-NEXT:   STD renamable $x3, 0, %stack.1.arg2 :: (store (s64) into %ir.arg2)
+  ; CHECK-NEXT:   renamable $x4 = LD 0, %stack.1.arg2 :: (load (s64) from %ir.arg2)
+  ; CHECK-NEXT:   renamable $x5 = ADDI8 %fixed-stack.0, 8
+  ; CHECK-NEXT:   STD killed renamable $x3, 0, %stack.0.arg1 :: (store (s64) into %ir.arg1)
+  ; CHECK-NEXT:   STD killed renamable $x5, 0, %stack.0.arg1 :: (store (s64) into %ir.arg1)
+  ; CHECK-NEXT:   renamable $f0 = LFD 0, %fixed-stack.0 :: (load (s64))
+  ; CHECK-NEXT:   renamable $x3 = ADDI8 renamable $x4, 8
   ; CHECK-NEXT:   STD killed renamable $x3, 0, %stack.1.arg2 :: (store (s64) into %ir.arg2)
-  ; CHECK-NEXT:   renamable $f2 = LFD 0, killed renamable $x6 :: (load (s64))
+  ; CHECK-NEXT:   renamable $f2 = LFD 0, killed renamable $x4 :: (load (s64))
   ; CHECK-NEXT:   renamable $f0 = nofpexcept FADD killed renamable $f0, killed renamable $f1, implicit $rm
   ; CHECK-NEXT:   renamable $f1 = nofpexcept FADD killed renamable $f2, renamable $f2, implicit $rm
   ; CHECK-NEXT:   renamable $f1 = nofpexcept FADD killed renamable $f0, killed renamable $f1, implicit $rm

--- a/llvm/test/CodeGen/PowerPC/aix64-cc-abi-vaarg.ll
+++ b/llvm/test/CodeGen/PowerPC/aix64-cc-abi-vaarg.ll
@@ -5,24 +5,24 @@
 define i32 @int_va_arg(i32 %a, ...) local_unnamed_addr  {
 ; CHECK-LABEL: int_va_arg:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    addi 11, 1, 56
 ; CHECK-NEXT:    std 4, 56(1)
-; CHECK-NEXT:    addi 4, 1, 56
-; CHECK-NEXT:    std 4, -16(1)
+; CHECK-NEXT:    addi 4, 1, 60
+; CHECK-NEXT:    std 11, -16(1)
+; CHECK-NEXT:    std 11, -8(1)
 ; CHECK-NEXT:    std 4, -8(1)
 ; CHECK-NEXT:    ld 4, -16(1)
-; CHECK-NEXT:    std 5, 64(1)
-; CHECK-NEXT:    addi 5, 1, 60
-; CHECK-NEXT:    std 5, -8(1)
-; CHECK-NEXT:    addi 5, 4, 4
 ; CHECK-NEXT:    std 6, 72(1)
+; CHECK-NEXT:    addi 6, 4, 4
+; CHECK-NEXT:    std 5, 64(1)
 ; CHECK-NEXT:    std 7, 80(1)
 ; CHECK-NEXT:    std 8, 88(1)
 ; CHECK-NEXT:    std 9, 96(1)
 ; CHECK-NEXT:    std 10, 104(1)
-; CHECK-NEXT:    std 5, -16(1)
-; CHECK-NEXT:    lwz 11, 56(1)
+; CHECK-NEXT:    std 6, -16(1)
+; CHECK-NEXT:    lwz 5, 56(1)
 ; CHECK-NEXT:    lwz 4, 0(4)
-; CHECK-NEXT:    add 3, 11, 3
+; CHECK-NEXT:    add 3, 5, 3
 ; CHECK-NEXT:    slwi 4, 4, 1
 ; CHECK-NEXT:    add 3, 3, 4
 ; CHECK-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/aix64-vector-vararg-callee.ll
+++ b/llvm/test/CodeGen/PowerPC/aix64-vector-vararg-callee.ll
@@ -17,11 +17,11 @@ define <4 x i32> @callee(i32 signext %count, ...) {
   ; CHECK:   [[COPY6:%[0-9]+]]:g8rc = COPY $x4
   ; CHECK:   STD [[COPY6]], 0, %fixed-stack.0 :: (store (s64) into %fixed-stack.0)
   ; CHECK:   STD [[COPY5]], 8, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 8)
-  ; CHECK:   STD [[COPY4]], 16, %fixed-stack.0 :: (store (s64))
-  ; CHECK:   STD [[COPY3]], 24, %fixed-stack.0 :: (store (s64))
-  ; CHECK:   STD [[COPY2]], 32, %fixed-stack.0 :: (store (s64))
-  ; CHECK:   STD [[COPY1]], 40, %fixed-stack.0 :: (store (s64))
-  ; CHECK:   STD [[COPY]], 48, %fixed-stack.0 :: (store (s64))
+  ; CHECK:   STD [[COPY4]], 16, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 16)
+  ; CHECK:   STD [[COPY3]], 24, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 24)
+  ; CHECK:   STD [[COPY2]], 32, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 32)
+  ; CHECK:   STD [[COPY1]], 40, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 40)
+  ; CHECK:   STD [[COPY]], 48, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 48)
   ; CHECK:   LIFETIME_START %stack.0.arg_list
   ; CHECK:   [[ADDI8_:%[0-9]+]]:g8rc = ADDI8 %fixed-stack.0, 0
   ; CHECK:   STD killed [[ADDI8_]], 0, %stack.0.arg_list :: (store (s64) into %ir.arg_list)

--- a/llvm/test/CodeGen/PowerPC/aix64-vector-vararg-fixed-callee.ll
+++ b/llvm/test/CodeGen/PowerPC/aix64-vector-vararg-fixed-callee.ll
@@ -15,7 +15,7 @@ define double @callee(i32 signext %count, <4 x i32> %vsi, double %next, ...) {
   ; CHECK:   [[COPY2:%[0-9]+]]:g8rc = COPY $x8
   ; CHECK:   STD [[COPY2]], 0, %fixed-stack.0 :: (store (s64) into %fixed-stack.0)
   ; CHECK:   STD [[COPY1]], 8, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 8)
-  ; CHECK:   STD [[COPY]], 16, %fixed-stack.0 :: (store (s64))
+  ; CHECK:   STD [[COPY]], 16, %fixed-stack.0 :: (store (s64) into %fixed-stack.0 + 16)
   ; CHECK:   LIFETIME_START %stack.0.arg_list
   ; CHECK:   [[ADDI8_:%[0-9]+]]:g8rc = ADDI8 %fixed-stack.0, 0
   ; CHECK:   STD killed [[ADDI8_]], 0, %stack.0.arg_list :: (store (s64) into %ir.arg_list)


### PR DESCRIPTION
Create a mutable aliased fixed stack object for the va_list when any of the optional arguments are passed in gprs. Since we need to spill the gpr registers into the parameter save area the stack object is not immutable, and since the values will almost certainly be accessed through the IR value for a va_list make the stack object aliased as well.