### PR TITLE
[CodeGen][NFC] Update Doxygen references to renamed parameters

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1277,7 +1277,7 @@ public:
 
   /// Return true when there is potentially a faster code sequence
   /// for an instruction chain ending in \p Root. All potential patterns are
-  /// returned in the \p Pattern vector. Pattern should be sorted in priority
+  /// returned in the \p Patterns vector. Patterns should be sorted in priority
   /// order since the pattern evaluator stops checking as soon as it finds a
   /// faster sequence.
   /// \param Root - Instruction that could be combined with one of its operands
@@ -1379,7 +1379,7 @@ public:
   /// has to decide whether the actual replacement is beneficial or not.
   /// \param Root - Instruction that could be combined with one of its operands
   /// \param Pattern - Combination pattern for Root
-  /// \param InsInstrs - Vector of new instructions that implement P
+  /// \param InsInstrs - Vector of new instructions that implement Pattern
   /// \param DelInstrs - Old instructions, including Root, that could be
   /// replaced by InsInstr
   /// \param InstIdxForVirtReg - map of virtual register to instruction in


### PR DESCRIPTION
The parameters were renamed in cfe0393b8269b85e199025b2350277563f43cd29 and 6e70c370e5e8eb5d9035c65d6c4f2a2687e099b6.