### PR TITLE
[Support] Optimize DebugCounter hot path (NFC)

### DIFF
--- a/llvm/include/llvm/Support/DebugCounter.h
+++ b/llvm/include/llvm/Support/DebugCounter.h
@@ -158,7 +158,7 @@ public:
 #ifdef NDEBUG
     return false;
 #else
-    return instance().Enabled || instance().ShouldPrintCounter;
+    return instance().Enabled;
 #endif
   }
 

--- a/llvm/lib/Support/DebugCounter.cpp
+++ b/llvm/lib/Support/DebugCounter.cpp
@@ -135,7 +135,11 @@ struct DebugCounterOwner : DebugCounter {
       cl::Optional,
       cl::location(this->ShouldPrintCounter),
       cl::init(false),
-      cl::desc("Print out debug counter info after all counters accumulated")};
+      cl::desc("Print out debug counter info after all counters accumulated"),
+      cl::callback([&](const bool &Value) {
+        if (Value)
+          enableAllCounters();
+      })};
   cl::opt<bool, true> PrintDebugCounterQueries{
       "print-debug-counter-queries",
       cl::Hidden,


### PR DESCRIPTION
When enabling ShouldPrintCounter, also set Enabled, so that we only have to check one of them. This cuts down the cost of (disabled) debug counters by half.