### PR TITLE
[Clang] Add TimeTraceScope to Sema::CheckConstraintSatisfaction

### DIFF
--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -30,6 +30,7 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Support/TimeProfiler.h"
 
 using namespace clang;
 using namespace sema;
@@ -1182,6 +1183,10 @@ bool Sema::CheckConstraintSatisfaction(
     const MultiLevelTemplateArgumentList &TemplateArgsLists,
     SourceRange TemplateIDRange, ConstraintSatisfaction &OutSatisfaction,
     const ConceptReference *TopLevelConceptId, Expr **ConvertedExpr) {
+  llvm::TimeTraceScope TimeScope(
+      "CheckConstraintSatisfaction", [TemplateIDRange, this] {
+        return TemplateIDRange.printToString(getSourceManager());
+      });
   if (AssociatedConstraints.empty()) {
     OutSatisfaction.IsSatisfied = true;
     return false;

--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -272,11 +272,14 @@ TEST(TimeProfilerTest, ClassTemplateInstantiations) {
   ASSERT_EQ(R"(
 Frontend (test.cc)
 | ParseClass (S)
+| CheckConstraintSatisfaction (<test.cc:9:21, col:29>)
 | InstantiateClass (S<double>, test.cc:9)
 | InstantiateFunction (S<double>::foo, test.cc:5)
 | ParseDeclarationOrFunctionDefinition (test.cc:11:5)
 | | ParseFunctionDefinition (user)
+| | | CheckConstraintSatisfaction (<test.cc:12:7, col:12>)
 | | | InstantiateClass (S<int>, test.cc:3)
+| | | CheckConstraintSatisfaction (<test.cc:13:7, col:14>)
 | | | InstantiateClass (S<float>, test.cc:3)
 | | | DeferInstantiation (S<float>::foo)
 | PerformPendingInstantiations


### PR DESCRIPTION
Evaluating concepts can take quite a bit of time and it's not necessarily obvious what's part of that and what not. This scope makes it clear which parts are concept evaluation and where they are invoked.
