### PR TITLE
[mlir][OpenMP] Fix assert in processing of dist_schedule

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -5515,7 +5515,7 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::applyWorkshareLoop(
   case OMPScheduleType::BaseStatic:
   case OMPScheduleType::BaseDistribute:
     assert((!ChunkSize || !DistScheduleChunkSize) &&
-                             "No chunk size with static-chunked schedule");
+           "No chunk size with static-chunked schedule");
     if (IsOrdered && !HasDistSchedule)
       return applyDynamicWorkshareLoop(DL, CLI, AllocaIP, EffectiveScheduleType,
                                        NeedsBarrier, ChunkSize);

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -5514,7 +5514,7 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::applyWorkshareLoop(
   switch (EffectiveScheduleType & ~OMPScheduleType::ModifierMask) {
   case OMPScheduleType::BaseStatic:
   case OMPScheduleType::BaseDistribute:
-    assert(!ChunkSize || !DistScheduleChunkSize &&
+    assert((!ChunkSize || !DistScheduleChunkSize) &&
                              "No chunk size with static-chunked schedule");
     if (IsOrdered && !HasDistSchedule)
       return applyDynamicWorkshareLoop(DL, CLI, AllocaIP, EffectiveScheduleType,


### PR DESCRIPTION
When #152736 was initially merged, the assert that checks for the chunksize when applying a static-chunked schedule was incorrect. While it would not have changed the behaviour of the assert, the string attached to it would have been emitted in cases where it was simplified.

This was raised here: https://github.com/llvm/llvm-project/pull/152736#discussion_r2578314276

Testing for this was explored, but this assert is a last chance failure point that should never be reached as applyWorkshareLoop decides the `EffectiveScheduleType` based on the existence of `ChunkSize` or `DistScheduleChunkSize`, so this will only trigger if there are issues with that conversion, and UnitTesting already exists for `applyWorkshareLoop`