### PR TITLE
[lldb][windows] bump the Windows API minimum version

### DIFF
--- a/lldb/include/lldb/Host/windows/windows.h
+++ b/lldb/include/lldb/Host/windows/windows.h
@@ -9,9 +9,9 @@
 #ifndef LLDB_lldb_windows_h_
 #define LLDB_lldb_windows_h_
 
-#define NTDDI_VERSION NTDDI_VISTA
+#define NTDDI_VERSION NTDDI_WIN10_RS5
 #undef _WIN32_WINNT // undef a previous definition to avoid warning
-#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#define _WIN32_WINNT _WIN32_WINNT_WIN10
 #define WIN32_LEAN_AND_MEAN
 #define NOGDI
 #undef NOMINMAX // undef a previous definition to avoid warning


### PR DESCRIPTION
This patch bumps the required Windows version in LLDB from Vista to Windows 1809 RS5 (Windows 10, Nov 2018).

This is required in order to get the following merged:
- https://github.com/llvm/llvm-project/pull/168729

Please see the following RFC: https://discourse.llvm.org/t/rfc-drop-support-running-llvm-on-windows-vista-7-8/80619/23