### PR TITLE
Revert "[LLDB] Update Shell lit config to handle c8031c3dd743"

### DIFF
--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -226,7 +226,7 @@ def use_support_substitutions(config):
         except OSError:
             res = -1
         if res == 0 and out:
-            sdk_path = str(out)
+            sdk_path = lit.util.to_string(out)
             llvm_config.lit_config.note("using SDKROOT: %r" % sdk_path)
             host_flags += ["-isysroot", sdk_path]
     elif sys.platform != "win32":


### PR DESCRIPTION
Reverts llvm/llvm-project#170225

See failures in https://ci.swift.org/view/all/job/llvm.org/job/as-lldb-cmake/36912/

```
[2025-12-02T01:20:37.083Z] # .---command stderr------------
[2025-12-02T01:20:37.083Z] # | clang: warning: no such sysroot directory: 'b/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' [-Wmissing-sysroot]
[2025-12-02T01:20:37.083Z] # | clang: warning: argument unused during compilation: '-fmodules-cache-path=/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/lldb-build/lldb-test-build.noindex/module-cache-clang/lldb-shell' [-Wunused-command-line-argument]
[2025-12-02T01:20:37.083Z] # | /Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/lldb-build/tools/lldb/test/Shell/Settings/Output/TestFrameFormatFunctionPrefix.test.tmp/main.m:2:13: warning: non-void function does not return a value [-Wreturn-type]
[2025-12-02T01:20:37.083Z] # |     2 | int func() {}
[2025-12-02T01:20:37.083Z] # |       |             ^
[2025-12-02T01:20:37.083Z] # | /Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake/lldb-build/tools/lldb/test/Shell/Settings/Output/TestFrameFormatFunctionPrefix.test.tmp/main.m:3:21: warning: non-void function does not return a value [-Wreturn-type]
[2025-12-02T01:20:37.083Z] # |     3 | int bar() { func(); }
[2025-12-02T01:20:37.083Z] # |       |                     ^
[2025-12-02T01:20:37.083Z] # | 2 warnings generated.
[2025-12-02T01:20:37.083Z] # | ld: library 'System' not found
[2025-12-02T01:20:37.083Z] # | clang: error: linker command failed with exit code 1 (use -v to see invocation)
[2025-12-02T01:20:37.083Z] # `-----------------------------
[2025-12-02T01:20:37.083Z] # error: command failed with exit status: 1
```