### PR TITLE
[NFC] [clang-tidy] Fix potential SA issues.

### DIFF
--- a/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.h
+++ b/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.h
@@ -137,7 +137,7 @@ private:
   std::unique_ptr<Preprocessor> PP;
   bool EnteredMainFile = false;
   bool StartedLexing = false;
-  Token CurrentToken;
+  Token CurrentToken = Token();
 };
 
 } // namespace tooling

--- a/clang-tools-extra/clang-tidy/bugprone/FloatLoopCounterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/FloatLoopCounterCheck.cpp
@@ -31,7 +31,7 @@ void FloatLoopCounterCheck::registerMatchers(MatchFinder *Finder) {
 
 void FloatLoopCounterCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *FS = Result.Nodes.getNodeAs<ForStmt>("for");
-  if (!FS) return; // Check if FS is null and exit if it is.
+  assert(FS && "FS should not be null");
 
   diag(FS->getInc()->getBeginLoc(), "loop induction expression should not have "
                                     "floating-point type")

--- a/clang-tools-extra/clang-tidy/bugprone/FloatLoopCounterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/FloatLoopCounterCheck.cpp
@@ -31,6 +31,7 @@ void FloatLoopCounterCheck::registerMatchers(MatchFinder *Finder) {
 
 void FloatLoopCounterCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *FS = Result.Nodes.getNodeAs<ForStmt>("for");
+  if (!FS) return; // Check if FS is null and exit if it is.
 
   diag(FS->getInc()->getBeginLoc(), "loop induction expression should not have "
                                     "floating-point type")

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsAvoidUncheckedContainerAccessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsAvoidUncheckedContainerAccessCheck.cpp
@@ -179,6 +179,12 @@ void ProBoundsAvoidUncheckedContainerAccessCheck::check(
     // Case: a.operator[](i) or a->operator[](i)
     const auto *Callee = dyn_cast<MemberExpr>(MCE->getCallee());
 
+    if (!Callee) {
+      diag(MatchedExpr->getCallee()->getBeginLoc(), "invalid member expression")
+          << MatchedExpr->getCallee()->getSourceRange();
+      return;
+    }
+
     if (FixMode == At) {
       // Cases: a.operator[](i) => a.at(i) and a->operator[](i) => a->at(i)
 

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsAvoidUncheckedContainerAccessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsAvoidUncheckedContainerAccessCheck.cpp
@@ -177,13 +177,7 @@ void ProBoundsAvoidUncheckedContainerAccessCheck::check(
     }
   } else if (const auto *MCE = dyn_cast<CXXMemberCallExpr>(MatchedExpr)) {
     // Case: a.operator[](i) or a->operator[](i)
-    const auto *Callee = dyn_cast<MemberExpr>(MCE->getCallee());
-
-    if (!Callee) {
-      diag(MatchedExpr->getCallee()->getBeginLoc(), "invalid member expression")
-          << MatchedExpr->getCallee()->getSourceRange();
-      return;
-    }
+    const auto *Callee = cast<MemberExpr>(MCE->getCallee());
 
     if (FixMode == At) {
       // Cases: a.operator[](i) => a.at(i) and a->operator[](i) => a->at(i)


### PR DESCRIPTION
This patch addresses issues identified by the static analyzers, which appear to be legitimate problems.

`FloatLoopCounterCheck.cpp`: "Dereferencing a pointer that might be `nullptr` FS when calling `getInc`".
`ProBoundsAvoidUncheckedContainerAccessCheck.cpp`: "Dereferencing a pointer that might be `nullptr Callee` when calling `getBeginLoc`".
`ExpandModularHeadersPPCallbacks.cpp`:  Non-static class member `CurrentToken.Flags` is not initialized in this constructor nor in any functions that it calls. (line #101).