### PR TITLE
[Clang] Fix `PPChainedCallbacks::EmbedFileNotFound()`

### DIFF
--- a/clang/include/clang/Lex/PPCallbacks.h
+++ b/clang/include/clang/Lex/PPCallbacks.h
@@ -499,10 +499,10 @@ public:
   }
 
   bool EmbedFileNotFound(StringRef FileName) override {
-    bool Skip = First->FileNotFound(FileName);
+    bool Skip = First->EmbedFileNotFound(FileName);
     // Make sure to invoke the second callback, no matter if the first already
     // returned true to skip the file.
-    Skip |= Second->FileNotFound(FileName);
+    Skip |= Second->EmbedFileNotFound(FileName);
     return Skip;
   }
 

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -1398,8 +1398,8 @@ void Preprocessor::HandleDirective(Token &Result) {
     case tok::pp_sccs:
       return HandleIdentSCCSDirective(Result);
     case tok::pp_embed: {
-      if (auto *CurrentFileLexer = getCurrentFileLexer())
-        if (auto FERef = CurrentFileLexer->getFileEntry())
+      if (PreprocessorLexer *CurrentFileLexer = getCurrentFileLexer())
+        if (OptionalFileEntryRef FERef = CurrentFileLexer->getFileEntry())
           return HandleEmbedDirective(SavedHash.getLocation(), Result, *FERef);
       return HandleEmbedDirective(SavedHash.getLocation(), Result, nullptr);
     }

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -1397,11 +1397,12 @@ void Preprocessor::HandleDirective(Token &Result) {
       return HandleIdentSCCSDirective(Result);
     case tok::pp_sccs:
       return HandleIdentSCCSDirective(Result);
-    case tok::pp_embed:
-      return HandleEmbedDirective(SavedHash.getLocation(), Result,
-                                  getCurrentFileLexer()
-                                      ? *getCurrentFileLexer()->getFileEntry()
-                                      : static_cast<FileEntry *>(nullptr));
+    case tok::pp_embed: {
+      if (auto *CurrentFileLexer = getCurrentFileLexer())
+        if (auto FERef = CurrentFileLexer->getFileEntry())
+          return HandleEmbedDirective(SavedHash.getLocation(), Result, *FERef);
+      return HandleEmbedDirective(SavedHash.getLocation(), Result, nullptr);
+    }
     case tok::pp_assert:
       //isExtension = true;  // FIXME: implement #assert
       break;


### PR DESCRIPTION
We've had internal test failures since #166188 landed. The root cause is that `PPChainedCallbacks::EmbedFileNotFound()` incorrectly calls `PPCallbacks::FileNotFound()` not `PPCallbacks::EmbedFileNotFound()`.