### PR TITLE
fix: update readfile to cat

### DIFF
--- a/clang-tools-extra/clangd/test/system-include-extractor.test
+++ b/clang-tools-extra/clangd/test/system-include-extractor.test
@@ -6,7 +6,7 @@
 # Create a bin directory to store the mock-driver and add it to the path
 # RUN: mkdir -p %t.dir/bin
 # RUN: %python -c "print(__import__('os').environ['PATH'])" > %t.path
-# RUN: export PATH=%t.dir/bin:%{readfile:%t.path}
+# RUN: export PATH=%t.dir/bin:$(cat %t.path)
 # Generate a mock-driver that will print %temp_dir%/my/dir and
 # %temp_dir%/my/dir2 as include search paths.
 # RUN: echo '#!/bin/sh' >> %t.dir/bin/my_driver.sh


### PR DESCRIPTION
Updating readfile to cat since this seems to be failing for `clangd-ubuntu-tsan`