### PR TITLE
[flang][NFC] Strip trailing whitespace from tests (9 of N)

### DIFF
--- a/flang/test/Lower/OpenMP/Todo/reduction-task.f90
+++ b/flang/test/Lower/OpenMP/Todo/reduction-task.f90
@@ -8,5 +8,5 @@ subroutine reduction_task()
 
   !$omp parallel reduction(task, +:i)
   i = i + 1
-  !$omp end parallel 
+  !$omp end parallel
 end subroutine reduction_task

--- a/flang/test/Lower/OpenMP/allocatable-array-bounds.f90
+++ b/flang/test/Lower/OpenMP/allocatable-array-bounds.f90
@@ -47,7 +47,7 @@
 subroutine read_write_section()
     integer, allocatable :: sp_read(:)
     integer, allocatable :: sp_write(:)
-    allocate(sp_read(10)) 
+    allocate(sp_read(10))
     allocate(sp_write(10))
     sp_write = (/0,0,0,0,0,0,0,0,0,0/)
     sp_read = (/1,2,3,4,5,6,7,8,9,10/)

--- a/flang/test/Lower/OpenMP/allocatable-map.f90
+++ b/flang/test/Lower/OpenMP/allocatable-map.f90
@@ -6,7 +6,7 @@
 !HLFIRDIALECT: %[[POINTER_MAP:.*]] = omp.map.info var_ptr(%[[POINTER]]#1 : !fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.box<!fir.ptr<i32>>) map_clauses(always, to) capture(ByRef) members(%[[POINTER_MAP_MEMBER]] : [0] : !fir.llvm_ptr<!fir.ref<i32>>) -> !fir.ref<!fir.box<!fir.ptr<i32>>> {name = "point"}
 !HLFIRDIALECT: omp.target map_entries(%[[POINTER_MAP]] -> {{.*}}, %[[POINTER_MAP_MEMBER]] -> {{.*}} : !fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.llvm_ptr<!fir.ref<i32>>) {
 subroutine pointer_routine()
-    integer, pointer :: point 
+    integer, pointer :: point
 !$omp target map(tofrom:point)
     point = 1
 !$omp end target

--- a/flang/test/Lower/OpenMP/atomic-capture.f90
+++ b/flang/test/Lower/OpenMP/atomic-capture.f90
@@ -7,7 +7,7 @@
 
 
 program OmpAtomicCapture
-    use omp_lib                                                                                                       
+    use omp_lib
 
 !CHECK: %[[VAL_X_ALLOCA:.*]] = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFEx"}
 !CHECK: %[[VAL_X_DECLARE:.*]]:2 = hlfir.declare %[[VAL_X_ALLOCA]] {{.*}}
@@ -25,7 +25,7 @@ program OmpAtomicCapture
 !CHECK: omp.atomic.read %[[VAL_X_DECLARE]]#0 = %[[VAL_Y_DECLARE]]#0 : !fir.ref<i32>, !fir.ref<i32>, i32
 !CHECK: }
     !$omp atomic hint(omp_sync_hint_uncontended) capture
-        y = x * y 
+        y = x * y
         x = y
     !$omp end atomic
 
@@ -43,7 +43,7 @@ program OmpAtomicCapture
 !CHECK: }
     !$omp atomic hint(omp_lock_hint_nonspeculative) capture acquire
         x = y
-        y = 2 * 10 + (8 - x) 
+        y = 2 * 10 + (8 - x)
     !$omp end atomic
 end program
 

--- a/flang/test/Lower/OpenMP/atomic-read-complex.f90
+++ b/flang/test/Lower/OpenMP/atomic-read-complex.f90
@@ -15,7 +15,7 @@ program atomic_read_complex
   complex(4) :: c41, c42
   ! Test complex(8) - double precision (16 bytes)
   complex(8) :: c81, c82
-  
+
   c42 = (1.0_4, 1.0_4)
   c82 = (1.0_8, 1.0_8)
 
@@ -25,7 +25,7 @@ program atomic_read_complex
   ! CHECK: call void @__atomic_load(i64 8, ptr {{.*}}, ptr {{.*}}, i32 {{.*}})
 !$omp atomic read
   c41 = c42
-  
+
   ! Double precision complex: 16 bytes (this was broken before the fix)
   ! CHECK: call void @__atomic_load(i64 16, ptr {{.*}}, ptr {{.*}}, i32 {{.*}})
 !$omp atomic read

--- a/flang/test/Lower/OpenMP/atomic-update.f90
+++ b/flang/test/Lower/OpenMP/atomic-update.f90
@@ -73,7 +73,7 @@ program OmpAtomicUpdate
 !CHECK: omp.yield(%[[TEMP]] : i32)
 !CHECK: }
    !$omp atomic update
-        a = a + b 
+        a = a + b
 
 !CHECK: %[[VAL_c1:.*]] = arith.constant 1 : i32
 !CHECK: omp.atomic.update %[[VAL_Y_DECLARE]]#0 : !fir.ref<i32> {
@@ -81,7 +81,7 @@ program OmpAtomicUpdate
 !CHECK: %[[TEMP:.*]] = arith.addi %[[ARG]], %[[VAL_c1]] : i32
 !CHECK: omp.yield(%[[TEMP]] : i32)
 !CHECK: }
-   !$omp atomic 
+   !$omp atomic
         y = y + 1
 
 !CHECK: %[[VAL_X_LOADED:.*]] = fir.load %[[VAL_X_DECLARE]]#0 : !fir.ref<i32>
@@ -91,7 +91,7 @@ program OmpAtomicUpdate
 !CHECK: omp.yield(%[[TEMP]] : i32)
 !CHECK: }
     !$omp atomic update
-        z = x * z 
+        z = x * z
 
 !CHECK: %[[VAL_c1:.*]] = arith.constant 1 : i32
 !CHECK: omp.atomic.update hint(uncontended) memory_order(relaxed) %[[VAL_X_DECLARE]]#0 : !fir.ref<i32> {
@@ -110,7 +110,7 @@ program OmpAtomicUpdate
 !CHECK:  %[[TEMP:.*]] = arith.select {{.*}} : i32
 !CHECK:  omp.yield(%[[TEMP]] : i32)
 !CHECK: }
-    !$omp atomic update relaxed 
+    !$omp atomic update relaxed
         y = max(y, c, d)
 
 !CHECK: %[[VAL_X_LOADED:.*]] = fir.load %[[VAL_X_DECLARE]]#0 : !fir.ref<i32>
@@ -211,7 +211,7 @@ program OmpAtomicUpdate
 !CHECK: %[[RESULT:.*]] = fir.convert %[[EXT]] : (f32) -> i32
 !CHECK: omp.yield(%[[RESULT]] : i32)
   !$omp atomic update
-    w = w + g  
+    w = w + g
 end program OmpAtomicUpdate
 
 ! Check that the clean-ups associated with the function call

--- a/flang/test/Lower/OpenMP/atomic-write-complex.f90
+++ b/flang/test/Lower/OpenMP/atomic-write-complex.f90
@@ -13,19 +13,19 @@ program atomic_write_complex
 
   ! Test complex(4) - single precision (8 bytes)
   complex(4) :: c41, c42
-  ! Test complex(8) - double precision (16 bytes)  
+  ! Test complex(8) - double precision (16 bytes)
   complex(8) :: c81, c82
-  
+
   c42 = (1.0_4, 1.0_4)
   c82 = (1.0_8, 1.0_8)
 
   ! CHECK-LABEL: define {{.*}} @_QQmain
-  
+
   ! Single precision complex: 8 bytes
   ! CHECK: call void @__atomic_store(i64 8, ptr {{.*}}, ptr {{.*}}, i32 {{.*}})
 !$omp atomic write
   c41 = c42
-  
+
   ! Double precision complex: 16 bytes (this was broken before the fix)
   ! CHECK: call void @__atomic_store(i64 16, ptr {{.*}}, ptr {{.*}}, i32 {{.*}})
 !$omp atomic write

--- a/flang/test/Lower/OpenMP/copyin.f90
+++ b/flang/test/Lower/OpenMP/copyin.f90
@@ -335,7 +335,7 @@ subroutine common_2()
   integer :: y
   common /d/ x, y
   !$omp threadprivate(/d/)
-  
+
   !$omp parallel do copyin(/d/)
      do i = 1, x
         y = y + i

--- a/flang/test/Lower/OpenMP/declare-target-func-and-subr.f90
+++ b/flang/test/Lower/OpenMP/declare-target-func-and-subr.f90
@@ -1,8 +1,8 @@
 !RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 %s -o - | FileCheck %s --check-prefixes ALL,HOST
 !RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -fopenmp-is-device %s -o - | FileCheck %s --check-prefixes ALL,DEVICE
 
-! Check specification valid forms of declare target with functions 
-! utilising device_type and to clauses as well as the default 
+! Check specification valid forms of declare target with functions
+! utilising device_type and to clauses as well as the default
 ! zero clause declare target
 
 ! DEVICE-LABEL: func.func @_QPfunc_t_device()
@@ -94,8 +94,8 @@ END FUNCTION FUNC_NAME_AS_RESULT
 
 !! -----
 
-! Check specification valid forms of declare target with subroutines 
-! utilising device_type and to clauses as well as the default 
+! Check specification valid forms of declare target with subroutines
+! utilising device_type and to clauses as well as the default
 ! zero clause declare target
 
 ! DEVICE-LABEL: func.func @_QPsubr_t_device()

--- a/flang/test/Lower/OpenMP/default-clause-byref.f90
+++ b/flang/test/Lower/OpenMP/default-clause-byref.f90
@@ -197,21 +197,21 @@ subroutine nested_default_clause_tests
 !CHECK: }
 !CHECK: omp.terminator
 !CHECK: }
-    !$omp parallel  firstprivate(x) private(y) shared(w) default(private)  
+    !$omp parallel  firstprivate(x) private(y) shared(w) default(private)
         !$omp parallel default(private)
            y = 20
-           x = 10 
-        !$omp end parallel 
+           x = 10
+        !$omp end parallel
 
-        !$omp parallel default(firstprivate) shared(y) private(w) 
+        !$omp parallel default(firstprivate) shared(y) private(w)
             y = 30
-            w = 40 
+            w = 40
             z = 50
             k = 40
         !$omp end parallel
     !$omp end parallel
-    
-    
+
+
 !CHECK: omp.parallel private({{.*}} {{.*}}#0 -> %[[PRIVATE_X:.*]], {{.*}} {{.*}}#0 -> %[[PRIVATE_Y:.*]], {{.*}} {{.*}}#0 -> %[[PRIVATE_Z:.*]] : {{.*}}) {
 !CHECK: %[[PRIVATE_X_DECL:.*]]:2 = hlfir.declare %[[PRIVATE_X]] {uniq_name = "_QFnested_default_clause_testsEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 !CHECK: %[[PRIVATE_Y_DECL:.*]]:2 = hlfir.declare %[[PRIVATE_Y]] {uniq_name = "_QFnested_default_clause_testsEy"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
@@ -240,8 +240,8 @@ subroutine nested_default_clause_tests
         !$omp parallel default(private) shared(z)
             w = x + z
         !$omp end parallel
-    !$omp end parallel    
-    
+    !$omp end parallel
+
 !CHECK: omp.parallel private({{.*}} {{.*}}#0 -> %[[PRIVATE_X:.*]], {{.*}} {{.*}}#0 -> %[[PRIVATE_Y:.*]], {{.*}} {{.*}}#0 -> %[[PRIVATE_W:.*]], {{.*}} {{.*}}#0 -> %[[PRIVATE_Z:.*]] : {{.*}}) {
 !CHECK: %[[PRIVATE_X_DECL:.*]]:2 = hlfir.declare %[[PRIVATE_X]] {uniq_name = "_QFnested_default_clause_testsEx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 !CHECK: %[[PRIVATE_Y_DECL:.*]]:2 = hlfir.declare %[[PRIVATE_Y]] {uniq_name = "_QFnested_default_clause_testsEy"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
@@ -283,7 +283,7 @@ subroutine nested_default_clause_tests
 !CHECK: omp.terminator
 !CHECK: }
 !CHECK: return
-!CHECK: } 
+!CHECK: }
 	!$omp parallel default(firstprivate)
 		!$omp single
 			x = y

--- a/flang/test/Lower/OpenMP/default-clause.f90
+++ b/flang/test/Lower/OpenMP/default-clause.f90
@@ -432,7 +432,7 @@ end subroutine
 !CHECK:   %[[VAR_X_DECLARE_INNER:.*]] = hlfir.declare %[[CONVERT_INNER]] storage(%[[BLK_THREADPRIVATE_INNER]][0]) {uniq_name = "_QFthreadprivate_with_defaultEx"} : (!fir.ref<i32>, !fir.ref<!fir.array<4xi8>>) -> (!fir.ref<i32>, !fir.ref<i32>)
 subroutine threadprivate_with_default
         integer :: x
-        common /blk/ x 
+        common /blk/ x
         !$omp threadprivate (/blk/)
 
         !$omp parallel do default(private)

--- a/flang/test/Lower/OpenMP/delayed-privatization-private-firstprivate.f90
+++ b/flang/test/Lower/OpenMP/delayed-privatization-private-firstprivate.f90
@@ -31,6 +31,6 @@ end subroutine
 ! CHECK:  %[[VAR2_DECL:.*]]:2 = hlfir.declare %[[VAR2_ALLOC]]
 
 ! CHECK:  omp.parallel private(
-! CHECK-SAME: @[[VAR1_PRIVATIZER_SYM]] %[[VAR1_DECL]]#0 -> %{{[^,]+}}, 
+! CHECK-SAME: @[[VAR1_PRIVATIZER_SYM]] %[[VAR1_DECL]]#0 -> %{{[^,]+}},
 ! CHECK-SAME: @[[VAR2_PRIVATIZER_SYM]] %[[VAR2_DECL]]#0 -> %{{.*}} :
 ! CHECK-SAME: !fir.ref<i32>, !fir.ref<i32>) {

--- a/flang/test/Lower/OpenMP/derived-type-map.f90
+++ b/flang/test/Lower/OpenMP/derived-type-map.f90
@@ -12,8 +12,8 @@ subroutine mapType_derived_implicit
       integer(4) :: array(10)
       integer(4) :: int
     end type scalar_and_array
-    type(scalar_and_array) :: scalar_arr 
-    
+    type(scalar_and_array) :: scalar_arr
+
     !$omp target
        scalar_arr%int = 1
     !$omp end target
@@ -49,8 +49,8 @@ subroutine mapType_derived_explicit
       integer(4) :: array(10)
       integer(4) :: int
     end type scalar_and_array
-    type(scalar_and_array) :: scalar_arr 
-    
+    type(scalar_and_array) :: scalar_arr
+
     !$omp target map(tofrom: scalar_arr)
        scalar_arr%int = 1
     !$omp end target
@@ -69,8 +69,8 @@ subroutine mapType_derived_explicit_single_member
       integer(4) :: array(10)
       integer(4) :: int
     end type scalar_and_array
-    type(scalar_and_array) :: scalar_arr 
-    
+    type(scalar_and_array) :: scalar_arr
+
     !$omp target map(tofrom: scalar_arr%array)
        scalar_arr%array(1) = 1
     !$omp end target
@@ -90,13 +90,13 @@ subroutine mapType_derived_explicit_multiple_members
       integer(4) :: array(10)
       integer(4) :: int
     end type scalar_and_array
-    type(scalar_and_array) :: scalar_arr 
-    
+    type(scalar_and_array) :: scalar_arr
+
     !$omp target map(tofrom: scalar_arr%int, scalar_arr%real)
        scalar_arr%int = 1
     !$omp end target
 end subroutine mapType_derived_explicit_multiple_members
-  
+
 !CHECK: %[[ALLOCA:.*]] = fir.alloca !fir.type<_QFmaptype_derived_explicit_member_with_boundsTscalar_and_array{real:f32,array:!fir.array<10xi32>,int:i32}> {bindc_name = "scalar_arr", uniq_name = "_QFmaptype_derived_explicit_member_with_boundsEscalar_arr"}
 !CHECK: %[[DECLARE:.*]]:2 = hlfir.declare %[[ALLOCA]] {uniq_name = "_QFmaptype_derived_explicit_member_with_boundsEscalar_arr"} : (!fir.ref<!fir.type<_QFmaptype_derived_explicit_member_with_boundsTscalar_and_array{real:f32,array:!fir.array<10xi32>,int:i32}>>) -> (!fir.ref<!fir.type<_QFmaptype_derived_explicit_member_with_boundsTscalar_and_array{real:f32,array:!fir.array<10xi32>,int:i32}>>, !fir.ref<!fir.type<_QFmaptype_derived_explicit_member_with_boundsTscalar_and_array{real:f32,array:!fir.array<10xi32>,int:i32}>>)
 !CHECK: %[[MEMBER:.*]] = hlfir.designate %[[DECLARE]]#0{"array"}   shape %{{.*}} : (!fir.ref<!fir.type<_QFmaptype_derived_explicit_member_with_boundsTscalar_and_array{real:f32,array:!fir.array<10xi32>,int:i32}>>, !fir.shape<1>) -> !fir.ref<!fir.array<10xi32>>
@@ -113,8 +113,8 @@ subroutine mapType_derived_explicit_member_with_bounds
       integer(4) :: array(10)
       integer(4) :: int
     end type scalar_and_array
-    type(scalar_and_array) :: scalar_arr 
-    
+    type(scalar_and_array) :: scalar_arr
+
     !$omp target map(tofrom: scalar_arr%array(2:5))
        scalar_arr%array(3) = 3
     !$omp end target
@@ -141,8 +141,8 @@ subroutine mapType_derived_nested_explicit_single_member
     type(nested) :: nest
     integer(4) :: int
   end type scalar_and_array
-  
-  type(scalar_and_array) :: scalar_arr 
+
+  type(scalar_and_array) :: scalar_arr
 
   !$omp target map(tofrom: scalar_arr%nest%array)
     scalar_arr%nest%array(1) = 1
@@ -173,7 +173,7 @@ subroutine mapType_derived_nested_explicit_multiple_members
     integer(4) :: int
   end type scalar_and_array
 
-  type(scalar_and_array) :: scalar_arr 
+  type(scalar_and_array) :: scalar_arr
 
   !$omp target map(tofrom: scalar_arr%nest%int, scalar_arr%nest%real)
     scalar_arr%nest%int = 1
@@ -205,9 +205,9 @@ subroutine mapType_derived_nested_explicit_member_with_bounds
     type(nested) :: nest
     integer(4) :: int
   end type scalar_and_array
-  
-  type(scalar_and_array) :: scalar_arr 
-  
+
+  type(scalar_and_array) :: scalar_arr
+
   !$omp target map(tofrom: scalar_arr%nest%array(2:5))
     scalar_arr%nest%array(3) = 3
   !$omp end target
@@ -239,7 +239,7 @@ subroutine mapType_multilpe_derived_nested_explicit_member
     type(nested) :: nest
     integer(4) :: int
   end type scalar_and_array
-  
+
   type(scalar_and_array) :: scalar_arr1
   type(scalar_and_array) :: scalar_arr2
 

--- a/flang/test/Lower/OpenMP/distribute.f90
+++ b/flang/test/Lower/OpenMP/distribute.f90
@@ -104,7 +104,7 @@ subroutine distribute_allocate()
   ! CHECK-NEXT: omp.loop_nest
   do i = 1, 10
     x = i
-    ! CHECK: omp.yield 
+    ! CHECK: omp.yield
   end do
 
   !$omp end distribute

--- a/flang/test/Lower/OpenMP/generic-loop-rewriting.f90
+++ b/flang/test/Lower/OpenMP/generic-loop-rewriting.f90
@@ -38,12 +38,12 @@ end subroutine target_teams_loop
 !CHECK:             %[[UB:.*]] = arith.constant 10 : i32
 !CHECK:             %[[STEP:.*]] = arith.constant 1 : i32
 
-!CHECK:             omp.parallel private(@{{.*}} %[[I_DECL]]#0 
+!CHECK:             omp.parallel private(@{{.*}} %[[I_DECL]]#0
 !CHECK-SAME:          -> %[[I_PRIV_ARG:[^[:space:]]+]] : !fir.ref<i32>) {
 !CHECK:               omp.distribute {
 !CHECK:                 omp.wsloop {
 
-!CHECK:                   omp.loop_nest (%{{.*}}) : i32 = 
+!CHECK:                   omp.loop_nest (%{{.*}}) : i32 =
 !CHECK-SAME:                (%[[LB]]) to (%[[UB]]) inclusive step (%[[STEP]]) {
 !CHECK:                     %[[I_PRIV_DECL:.*]]:2 = hlfir.declare %[[I_PRIV_ARG]]
 !CHECK:                     hlfir.assign %{{.*}} to %[[I_PRIV_DECL]]#0 : i32, !fir.ref<i32>

--- a/flang/test/Lower/OpenMP/host-eval.f90
+++ b/flang/test/Lower/OpenMP/host-eval.f90
@@ -7,7 +7,7 @@ subroutine teams()
   ! BOTH: omp.target
 
   ! HOST-SAME: host_eval(%{{.*}} -> %[[NUM_TEAMS:.*]], %{{.*}} -> %[[THREAD_LIMIT:.*]] : i32, i32)
-  
+
   ! DEVICE-NOT: host_eval({{.*}})
   ! DEVICE-SAME: {
   !$omp target
@@ -32,9 +32,9 @@ end subroutine teams
 ! BOTH-LABEL: func.func @_QPdistribute_parallel_do
 subroutine distribute_parallel_do()
   ! BOTH: omp.target
-  
+
   ! HOST-SAME: host_eval(%{{.*}} -> %[[LB:.*]], %{{.*}} -> %[[UB:.*]], %{{.*}} -> %[[STEP:.*]], %{{.*}} -> %[[NUM_THREADS:.*]] : i32, i32, i32, i32)
-  
+
   ! DEVICE-NOT: host_eval({{.*}})
   ! DEVICE-SAME: {
 
@@ -94,9 +94,9 @@ end subroutine distribute_parallel_do
 ! BOTH-LABEL: func.func @_QPdistribute_parallel_do_simd
 subroutine distribute_parallel_do_simd()
   ! BOTH: omp.target
-  
+
   ! HOST-SAME: host_eval(%{{.*}} -> %[[LB:.*]], %{{.*}} -> %[[UB:.*]], %{{.*}} -> %[[STEP:.*]], %{{.*}} -> %[[NUM_THREADS:.*]] : i32, i32, i32, i32)
-  
+
   ! DEVICE-NOT: host_eval({{.*}})
   ! DEVICE-SAME: {
 
@@ -159,9 +159,9 @@ end subroutine distribute_parallel_do_simd
 ! BOTH-LABEL: func.func @_QPdistribute
 subroutine distribute()
   ! BOTH: omp.target
-  
+
   ! HOST-SAME: host_eval(%{{.*}} -> %[[LB:.*]], %{{.*}} -> %[[UB:.*]], %{{.*}} -> %[[STEP:.*]] : i32, i32, i32)
-  
+
   ! DEVICE-NOT: host_eval({{.*}})
   ! DEVICE-SAME: {
 
@@ -209,9 +209,9 @@ end subroutine distribute
 ! BOTH-LABEL: func.func @_QPdistribute_simd
 subroutine distribute_simd()
   ! BOTH: omp.target
-  
+
   ! HOST-SAME: host_eval(%{{.*}} -> %[[LB:.*]], %{{.*}} -> %[[UB:.*]], %{{.*}} -> %[[STEP:.*]] : i32, i32, i32)
-  
+
   ! DEVICE-NOT: host_eval({{.*}})
   ! DEVICE-SAME: {
 
@@ -262,9 +262,9 @@ end subroutine distribute_simd
 ! BOTH-LABEL: func.func @_QPloop
 subroutine loop()
   ! BOTH: omp.target
-  
+
   ! HOST-SAME: host_eval(%{{.*}} -> %[[LB:.*]], %{{.*}} -> %[[UB:.*]], %{{.*}} -> %[[STEP:.*]] : i32, i32, i32)
-  
+
   ! DEVICE-NOT: host_eval({{.*}})
   ! DEVICE-SAME: {
 

--- a/flang/test/Lower/OpenMP/lastprivate-iv.f90
+++ b/flang/test/Lower/OpenMP/lastprivate-iv.f90
@@ -96,7 +96,7 @@ subroutine lastprivate_iv_i1
 end subroutine
 
 !CHECK:    omp.wsloop private(@_QFlastprivate_iv_pointerEi_private_box_ptr_i32 %{{.*}}#0 -> %[[PRIVATE_IV:.*]] : !fir.ref<!fir.box<!fir.ptr<i32>>>) {
-!CHECK:      omp.loop_nest (%[[LOOP_INDEX:.*]]) : i64 
+!CHECK:      omp.loop_nest (%[[LOOP_INDEX:.*]]) : i64
 !CHECK:        %[[PRIVATE_IV_DECL:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFlastprivate_iv_pointerEi"} : (!fir.ref<!fir.box<!fir.ptr<i32>>>) -> (!fir.ref<!fir.box<!fir.ptr<i32>>>, !fir.ref<!fir.box<!fir.ptr<i32>>>)
 !CHECK:        %[[LOOP_INDEX_INCR:.*]] = arith.addi %[[LOOP_INDEX]], %{{.*}} : i64
 !CHECK:        fir.if %{{.*}} {

--- a/flang/test/Lower/OpenMP/loop-directive.f90
+++ b/flang/test/Lower/OpenMP/loop-directive.f90
@@ -112,7 +112,7 @@ subroutine test_nested_directives
 
   ! CHECK: omp.teams {
 
-  ! Verify the first `loop` directive was combined with `target teams` into 
+  ! Verify the first `loop` directive was combined with `target teams` into
   ! `target teams distribute parallel do`.
   ! CHECK:   omp.parallel {{.*}} {
   ! CHECK:     omp.distribute {
@@ -371,7 +371,7 @@ subroutine teams_loop_cannot_be_parallel_for_with_reductions
   ! CHECK: %[[ADD_RED:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QF{{.*}}Ex"}
   ! CHECK: %[[MUL_RED:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QF{{.*}}Ey"}
   ! CHECK: omp.teams reduction(
-  ! CHECK-SAME:  @add_reduction_i32 %[[ADD_RED]]#0 -> %[[ADD_RED_ARG:[^[:space:]]*]], 
+  ! CHECK-SAME:  @add_reduction_i32 %[[ADD_RED]]#0 -> %[[ADD_RED_ARG:[^[:space:]]*]],
   ! CHECK-SAME:  @multiply_reduction_i32 %[[MUL_RED]]#0 -> %[[MUL_RED_ARG:.*]] : {{.*}}) {
 
   ! CHECK:       omp.distribute private(@{{.*}} %{{.*}} -> %{{.*}}, @{{.*}} %{{.*}} -> %{{.*}} : {{.*}}) {

--- a/flang/test/Lower/OpenMP/map-no-modifier-v60.f90
+++ b/flang/test/Lower/OpenMP/map-no-modifier-v60.f90
@@ -9,4 +9,3 @@ subroutine f00
   !$omp target map(x)
   !$omp end target
 end
-  

--- a/flang/test/Lower/OpenMP/masked_taskloop.f90
+++ b/flang/test/Lower/OpenMP/masked_taskloop.f90
@@ -3,18 +3,18 @@
 ! RUN:  bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
 ! RUN:  %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
 
-! CHECK-LABEL:  omp.private {type = private} 
+! CHECK-LABEL:  omp.private {type = private}
 ! CHECK-SAME:        @[[I_PRIVATE:.*]] : i32
 
-! CHECK-LABEL:  omp.private 
-! CHECK-SAME:      {type = firstprivate} @[[J_FIRSTPRIVATE:.*]] : i32 
+! CHECK-LABEL:  omp.private
+! CHECK-SAME:      {type = firstprivate} @[[J_FIRSTPRIVATE:.*]] : i32
 ! CHECK-SAME:      copy {
-! CHECK:            hlfir.assign 
+! CHECK:            hlfir.assign
 
 ! CHECK-LABEL:  func.func @_QPtest_masked_taskloop() {
 ! CHECK:          %[[VAL_0:.*]] = fir.dummy_scope : !fir.dscope
 ! CHECK:          %[[ALLOCA_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFtest_masked_taskloopEi"}
-! CHECK:          %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOCA_I]] 
+! CHECK:          %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOCA_I]]
 ! CHECK-SAME:         {uniq_name = "_QFtest_masked_taskloopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:          %[[ALLOCA_J:.*]] = fir.address_of(@_QFtest_masked_taskloopEj) : !fir.ref<i32>
 ! CHECK:          %[[DECL_J:.*]]:2 = hlfir.declare %[[ALLOCA_J]] {uniq_name = "_QFtest_masked_taskloopEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
@@ -51,5 +51,5 @@ subroutine test_masked_taskloop
   do i=1,10
    j = j + 1
   end do
-  !$omp end masked taskloop 
+  !$omp end masked taskloop
 end subroutine

--- a/flang/test/Lower/OpenMP/master_taskloop_simd.f90
+++ b/flang/test/Lower/OpenMP/master_taskloop_simd.f90
@@ -6,7 +6,7 @@
 subroutine test_master_taskloop_simd()
   integer :: i, j = 1
   !CHECK: not yet implemented: Composite TASKLOOP SIMD
-  !$omp master taskloop simd 
+  !$omp master taskloop simd
   do i=1,10
    j = j + 1
   end do

--- a/flang/test/Lower/OpenMP/multiple-entry-points.f90
+++ b/flang/test/Lower/OpenMP/multiple-entry-points.f90
@@ -36,7 +36,7 @@ subroutine process_a(n, a)
   return
 
   entry process_b(n, b)
-    
+
   !$omp parallel
   do i = 1, n
     a(i) = i * i

--- a/flang/test/Lower/OpenMP/parallel-lastprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/parallel-lastprivate-clause-scalar.f90
@@ -18,10 +18,10 @@
 !CHECK: %[[ARG1_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG1_PVT]] typeparams %[[FIVE]] {uniq_name = "_QFlastprivate_characterEarg1"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
 !CHECK: %[[UNIT:.*]] = arith.constant 6 : i32
 !CHECK-NEXT: %[[ADDR:.*]] = fir.address_of(@_QQclX
-!CHECK-NEXT: %[[CVT0:.*]] = fir.convert %[[ADDR]] 
+!CHECK-NEXT: %[[CVT0:.*]] = fir.convert %[[ADDR]]
 !CHECK-NEXT: %[[CNST:.*]] = arith.constant
 !CHECK-NEXT: %[[CALL_BEGIN_IO:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[UNIT]], %[[CVT0]], %[[CNST]]) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-!CHECK-NEXT: %[[CVT_0_1:.*]] = fir.convert %[[ARG1_PVT_DECL]]#0 
+!CHECK-NEXT: %[[CVT_0_1:.*]] = fir.convert %[[ARG1_PVT_DECL]]#0
 !CHECK-NEXT: %[[CVT_0_2:.*]] = fir.convert %[[FIVE]]
 !CHECK-NEXT: %[[CALL_OP_ASCII:.*]] = fir.call @_FortranAioOutputAscii(%[[CALL_BEGIN_IO]], %[[CVT_0_1]], %[[CVT_0_2]])
 !CHECK-NEXT: %[[CALL_END_IO:.*]] = fir.call @_FortranAioEndIoStatement(%[[CALL_BEGIN_IO]])
@@ -45,7 +45,7 @@
 
 subroutine lastprivate_character(arg1)
         character(5) :: arg1
-!$OMP PARALLEL 
+!$OMP PARALLEL
 !$OMP DO LASTPRIVATE(arg1)
 do n = 1, 5
         arg1(n:n) = 'c'
@@ -82,7 +82,7 @@ end subroutine
 
 subroutine lastprivate_int(arg1)
         integer :: arg1
-!$OMP PARALLEL 
+!$OMP PARALLEL
 !$OMP DO LASTPRIVATE(arg1)
 do n = 1, 5
         arg1 = 2
@@ -123,7 +123,7 @@ end subroutine
 
 subroutine mult_lastprivate_int(arg1, arg2)
         integer :: arg1, arg2
-!$OMP PARALLEL 
+!$OMP PARALLEL
 !$OMP DO LASTPRIVATE(arg1) LASTPRIVATE(arg2)
 do n = 1, 5
         arg1 = 2
@@ -165,7 +165,7 @@ end subroutine
 
 subroutine mult_lastprivate_int2(arg1, arg2)
         integer :: arg1, arg2
-!$OMP PARALLEL 
+!$OMP PARALLEL
 !$OMP DO LASTPRIVATE(arg1, arg2)
 do n = 1, 5
         arg1 = 2
@@ -207,7 +207,7 @@ end subroutine
 
 subroutine firstpriv_lastpriv_int(arg1, arg2)
         integer :: arg1, arg2
-!$OMP PARALLEL 
+!$OMP PARALLEL
 !$OMP DO FIRSTPRIVATE(arg1) LASTPRIVATE(arg2)
 do n = 1, 5
         arg1 = 2
@@ -250,7 +250,7 @@ end subroutine
 
 subroutine firstpriv_lastpriv_int2(arg1)
         integer :: arg1
-!$OMP PARALLEL 
+!$OMP PARALLEL
 !$OMP DO FIRSTPRIVATE(arg1) LASTPRIVATE(arg1)
 do n = 1, 5
         arg1 = 2

--- a/flang/test/Lower/OpenMP/parallel-masked-taskloop.f90
+++ b/flang/test/Lower/OpenMP/parallel-masked-taskloop.f90
@@ -3,7 +3,7 @@
 ! RUN: bbc -emit-hlfir -fopenmp -fopenmp-version=50 -o - %s 2>&1 | FileCheck %s
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 -o - %s 2>&1 | FileCheck %s
 
-! CHECK-LABEL:  omp.private {type = private} 
+! CHECK-LABEL:  omp.private {type = private}
 ! CHECK-SAME:        @[[I_PRIVATE:.*]] : i32
 ! CHECK-LABEL:    func.func @_QPtest_parallel_master_taskloop() {
 ! CHECK:          %[[VAL0:.*]] = fir.dummy_scope : !fir.dscope
@@ -44,5 +44,5 @@ subroutine test_parallel_master_taskloop
   do i=1,10
    j = j + 1
   end do
-  !$omp end parallel masked taskloop 
+  !$omp end parallel masked taskloop
 end subroutine

--- a/flang/test/Lower/OpenMP/parallel-master-taskloop-simd.f90
+++ b/flang/test/Lower/OpenMP/parallel-master-taskloop-simd.f90
@@ -6,7 +6,7 @@
 subroutine test_parallel_master_taskloop_simd
   integer :: i, j = 1
   !CHECK: not yet implemented: Composite TASKLOOP SIMD
-  !$omp parallel master taskloop simd 
+  !$omp parallel master taskloop simd
   do i=1,10
    j = j + 1
   end do

--- a/flang/test/Lower/OpenMP/parallel-reduction-mixed.f90
+++ b/flang/test/Lower/OpenMP/parallel-reduction-mixed.f90
@@ -8,7 +8,7 @@ subroutine proc
   implicit none
   real(8),allocatable :: F(:)
   real(8),allocatable :: A(:)
-   
+
   integer :: I
 
 !$omp parallel private(A) reduction(+:F,I)
@@ -20,7 +20,7 @@ end subroutine proc
 !CHECK: call void (ptr, i32, ptr, ...)
 !CHECK-SAME: @__kmpc_fork_call(ptr {{.*}}, i32 1, ptr @[[OMP_PAR:.*]], {{.*}})
 
-!CHECK: define internal void @[[OMP_PAR]](ptr {{.*}} %[[TID_ADDR:.*]], ptr noalias 
+!CHECK: define internal void @[[OMP_PAR]](ptr {{.*}} %[[TID_ADDR:.*]], ptr noalias
 !CHECK:  %[[TID_LOCAL:.*]] = alloca i32
 !CHECK:  %[[TID:.*]] = load i32, ptr %[[TID_ADDR]]
 !CHECK:  store i32 %[[TID]], ptr %[[TID_LOCAL]]

--- a/flang/test/Lower/OpenMP/parallel-wsloop-firstpriv.f90
+++ b/flang/test/Lower/OpenMP/parallel-wsloop-firstpriv.f90
@@ -3,7 +3,7 @@
 
 ! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s
 
-! CHECK: func @_QPomp_do_firstprivate(%[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}) 
+! CHECK: func @_QPomp_do_firstprivate(%[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"})
 subroutine omp_do_firstprivate(a)
   ! CHECK: %[[ARG0_DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFomp_do_firstprivateEa"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
   integer::a
@@ -31,7 +31,7 @@ subroutine omp_do_firstprivate(a)
   call bar(a)
 end subroutine omp_do_firstprivate
 
-! CHECK: func @_QPomp_do_firstprivate2(%[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.ref<i32> {fir.bindc_name = "n"}) 
+! CHECK: func @_QPomp_do_firstprivate2(%[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "a"}, %[[ARG1:.*]]: !fir.ref<i32> {fir.bindc_name = "n"})
 subroutine omp_do_firstprivate2(a, n)
   ! CHECK:  %[[ARG0_DECL:.*]]:2 = hlfir.declare %[[ARG0]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFomp_do_firstprivate2Ea"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
   ! CHECK:  %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFomp_do_firstprivate2En"} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)

--- a/flang/test/Lower/OpenMP/private-commonblock.f90
+++ b/flang/test/Lower/OpenMP/private-commonblock.f90
@@ -75,7 +75,7 @@ subroutine private_clause_commonblock()
   real::b(10)
   character(5):: c, d(5)
   common /blk/ a, b, c, d
-  
+
   call sub1(a, b, c, d)
   !$omp parallel private(/blk/)
         call sub2(a, b, c, d)

--- a/flang/test/Lower/OpenMP/privatize_predetermined_only_when_defined_by_eval.f90
+++ b/flang/test/Lower/OpenMP/privatize_predetermined_only_when_defined_by_eval.f90
@@ -15,7 +15,7 @@ subroutine privatize_predetermined_when_defined_by_eval
       enddo
     enddo
 
-    !$omp do 
+    !$omp do
     do j=1,ii
     enddo
   !$omp end parallel

--- a/flang/test/Lower/OpenMP/sections.f90
+++ b/flang/test/Lower/OpenMP/sections.f90
@@ -12,7 +12,7 @@
 !CHECK:   %[[CONST_1:.*]] = arith.constant 4 : i64
 !CHECK:   %[[PRIVATE_ETA:.*]] = fir.alloca f32 {bindc_name = "eta", pinned, uniq_name = "_QFEeta"}
 !CHECK:   %[[PRIVATE_ETA_DECL:.*]]:2 = hlfir.declare %[[PRIVATE_ETA]] {uniq_name = "_QFEeta"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
-!CHECK:   %[[PRIVATE_DOUBLE_COUNT:.*]] = fir.alloca i32 {bindc_name = "double_count", pinned, uniq_name = "_QFEdouble_count"} 
+!CHECK:   %[[PRIVATE_DOUBLE_COUNT:.*]] = fir.alloca i32 {bindc_name = "double_count", pinned, uniq_name = "_QFEdouble_count"}
 !CHECK:   %[[PRIVATE_DOUBLE_COUNT_DECL:.*]]:2 = hlfir.declare %[[PRIVATE_DOUBLE_COUNT]] {uniq_name = "_QFEdouble_count"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 !CHECK:   omp.sections allocate(%[[CONST_1]] : i64 -> %[[COUNT_DECL]]#0 : !fir.ref<i32>)  {
 !CHECK:     omp.section {
@@ -79,7 +79,7 @@ program sample
 end program sample
 
 !CHECK: func @_QPfirstprivate(%[[ARG:.*]]: !fir.ref<f32> {fir.bindc_name = "alpha"}) {
-!CHECK:   %[[ARG_DECL:.*]]:2 = hlfir.declare %[[ARG]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFfirstprivateEalpha"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>) 
+!CHECK:   %[[ARG_DECL:.*]]:2 = hlfir.declare %[[ARG]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFfirstprivateEalpha"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
 !CHECK:   %[[PRIVATE_ALPHA:.*]] = fir.alloca f32 {bindc_name = "alpha", pinned, uniq_name = "_QFfirstprivateEalpha"}
 !CHECK:   %[[PRIVATE_ALPHA_DECL:.*]]:2 = hlfir.declare %[[PRIVATE_ALPHA]] {uniq_name = "_QFfirstprivateEalpha"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
 !CHECK:   %[[TEMP:.*]] = fir.load %[[ARG_DECL]]#0 : !fir.ref<f32>

--- a/flang/test/Lower/OpenMP/shared-loop.f90
+++ b/flang/test/Lower/OpenMP/shared-loop.f90
@@ -2,14 +2,14 @@
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
 
 ! --- Check that with shared(i) the variable outside the parallel section
-! --- is updated. 
+! --- is updated.
 ! CHECK-LABEL:  func.func @_QPomploop()
 ! CHECK:    %[[ALLOC_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFomploopEi"}
 ! CHECK:    %[[DECL_I:.*]]:2 = hlfir.declare %[[ALLOC_I]] {uniq_name = "_QFomploopEi"} :
 ! CHECK:    omp.parallel {
 ! CHECK:      omp.sections {
 ! CHECK:        omp.section {
-! CHECK:          %[[RES:.*]] = fir.do_loop %[[ARG0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[ARG1:.*]] = 
+! CHECK:          %[[RES:.*]] = fir.do_loop %[[ARG0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[ARG1:.*]] =
 ! CHECK:            fir.store %[[ARG1]] to %[[DECL_I]]#0
 ! CHECK:            hlfir.assign
 ! CHECK:            %[[LOAD_I:.*]] = fir.load %[[DECL_I]]#0
@@ -47,7 +47,7 @@ end subroutine
 ! CHECK:      %[[DECL_PRIV_I:.*]]:2 = hlfir.declare %[[ALLOC_PRIV_I]]
 ! CHECK:      omp.sections {
 ! CHECK:        omp.section {
-! CHECK:          %[[RES:.*]] = fir.do_loop %[[ARG0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[ARG1:.*]] = 
+! CHECK:          %[[RES:.*]] = fir.do_loop %[[ARG0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[ARG1:.*]] =
 ! CHECK-NOT:            fir.store %[[ARG1]] to %[[DECL_I]]#1
 ! CHECK:            fir.store %[[ARG1]] to %[[DECL_PRIV_I]]#0
 ! CHECK:            hlfir.assign
@@ -87,7 +87,7 @@ end subroutine
 ! CHECK:      %[[DECL_PRIV_I:.*]]:2 = hlfir.declare %[[ALLOC_PRIV_I]]
 ! CHECK:      omp.sections {
 ! CHECK:        omp.section {
-! CHECK:          %[[RES:.*]] = fir.do_loop %[[ARG0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[ARG1:.*]] = 
+! CHECK:          %[[RES:.*]] = fir.do_loop %[[ARG0:.*]] = %{{.*}} to %{{.*}} step %{{.*}} iter_args(%[[ARG1:.*]] =
 ! CHECK-NOT:            fir.store %[[ARG1]] to %[[DECL_I]]#1
 ! CHECK:            fir.store %[[ARG1]] to %[[DECL_PRIV_I]]#0
 ! CHECK:            hlfir.assign
@@ -115,6 +115,3 @@ subroutine omploop3
     !$omp end sections
   !$omp end parallel
 end subroutine
-
-
- 

--- a/flang/test/Lower/OpenMP/simd.f90
+++ b/flang/test/Lower/OpenMP/simd.f90
@@ -270,7 +270,7 @@ subroutine lastprivate_with_simd
   integer :: i
   real :: sum
 
-  
+
 !CHECK: omp.simd private(@_QFlastprivate_with_simdEsum_private_f32 %[[VAR_SUM_DECLARE]]#0 -> %[[VAR_SUM_PINNED:.*]], @{{.*}}) {
 !CHECK: omp.loop_nest (%[[ARG:.*]]) : i32 = ({{.*}} to ({{.*}}) inclusive step ({{.*}}) {
 !CHECK: %[[VAR_SUM_PINNED_DECLARE:.*]]:2 = hlfir.declare %[[VAR_SUM_PINNED]] {{.*}}

--- a/flang/test/Lower/OpenMP/single.f90
+++ b/flang/test/Lower/OpenMP/single.f90
@@ -74,7 +74,7 @@ end subroutine single_allocate
 !===============================================================================
 
 ! CHECK-LABEL: func.func @_QPsingle_privatization(
-! CHECK-SAME:                                     %[[X:.*]]: !fir.ref<f32> {fir.bindc_name = "x"}, 
+! CHECK-SAME:                                     %[[X:.*]]: !fir.ref<f32> {fir.bindc_name = "x"},
 ! CHECK-SAME:                                     %[[Y:.*]]: !fir.ref<f64> {fir.bindc_name = "y"}) {
 ! CHECK:           %[[X_DECL:.*]]:2 = hlfir.declare %[[X]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFsingle_privatizationEx"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
 ! CHECK:           %[[Y_DECL:.*]]:2 = hlfir.declare %[[Y]] dummy_scope %{{[0-9]+}} arg {{[0-9]+}} {uniq_name = "_QFsingle_privatizationEy"} : (!fir.ref<f64>, !fir.dscope) -> (!fir.ref<f64>, !fir.ref<f64>)

--- a/flang/test/Lower/OpenMP/target-enter-data-default-openmp52.f90
+++ b/flang/test/Lower/OpenMP/target-enter-data-default-openmp52.f90
@@ -22,6 +22,6 @@ contains
   !CHECK-52: omp.map.info var_ptr(%2 : !fir.ref<!fir.box<!fir.heap<f32>>>, !fir.box<!fir.heap<f32>>) map_clauses(from) capture(ByRef) members(%4 : [0] : !fir.llvm_ptr<!fir.ref<f32>>) -> !fir.ref<!fir.box<!fir.heap<f32>>> {name = "a"}
   !CHECK-51: from, release and delete map types are permitted
   deallocate(A)
-  
+
   end subroutine finalize
 end module test

--- a/flang/test/Lower/OpenMP/task.f90
+++ b/flang/test/Lower/OpenMP/task.f90
@@ -212,7 +212,7 @@ subroutine task_firstprivate
   type mytype
   integer :: x
   end type mytype
- 
+
   !CHECK: %[[INT_ALLOCA:.+]] = fir.alloca i32 {bindc_name = "int_var", uniq_name = "_QFtask_firstprivateEint_var"}
   !CHECK: %[[INT_VAR:.+]]:2 = hlfir.declare %[[INT_ALLOCA]] {uniq_name = "_QFtask_firstprivateEint_var"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
   !CHECK: %[[MYTYPE_ALLOCA:.+]] = fir.alloca !fir.type<_QFtask_firstprivateTmytype{x:i32}> {bindc_name = "mytype_var", uniq_name = "_QFtask_firstprivateEmytype_var"}

--- a/flang/test/Lower/OpenMP/taskgroup-task-array-reduction.f90
+++ b/flang/test/Lower/OpenMP/taskgroup-task-array-reduction.f90
@@ -24,7 +24,7 @@
 ! CHECK:            %[[VAL_3:.*]] = fir.alloca !fir.box<!fir.array<?xf32>>
 ! CHECK:            fir.store %[[VAL_2]]#0 to %[[VAL_3]] : !fir.ref<!fir.box<!fir.array<?xf32>>>
 ! CHECK:            omp.taskgroup task_reduction(byref @add_reduction_byref_box_Uxf32 %[[VAL_3]] -> %[[VAL_4:.*]]: !fir.ref<!fir.box<!fir.array<?xf32>>>) {
-! CHECK:              %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] 
+! CHECK:              %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]]
 ! CHECK-SAME:         {uniq_name = "_QFtask_reductionEx"} : (!fir.ref<!fir.box<!fir.array<?xf32>>>) -> (!fir.ref<!fir.box<!fir.array<?xf32>>>, !fir.ref<!fir.box<!fir.array<?xf32>>>)
 ! CHECK:              omp.task in_reduction(byref @add_reduction_byref_box_Uxf32 %[[VAL_5]]#0 -> %[[VAL_6:.*]] : !fir.ref<!fir.box<!fir.array<?xf32>>>) {
 !                       [...]

--- a/flang/test/Lower/OpenMP/taskgroup-task_reduction01.f90
+++ b/flang/test/Lower/OpenMP/taskgroup-task_reduction01.f90
@@ -16,7 +16,7 @@
 !CHECK:         %[[VAL_0:.*]] = fir.alloca i32 {bindc_name = "res", uniq_name = "_QFomp_taskgroup_task_reductionEres"}
 !CHECK:         %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "_QFomp_taskgroup_task_reductionEres"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 !CHECK:         omp.taskgroup task_reduction(@[[RED_I32_NAME]]  %[[VAL_1]]#0 -> %[[VAL_2:.*]] : !fir.ref<i32>) {
-!CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] 
+!CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]]
 !CHECK-SAME:      {uniq_name = "_QFomp_taskgroup_task_reductionEres"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 !CHECK:           %[[VAL_4:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<i32>
 !CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32

--- a/flang/test/Lower/OpenMP/taskloop-cancel.f90
+++ b/flang/test/Lower/OpenMP/taskloop-cancel.f90
@@ -1,7 +1,7 @@
 ! RUN: bbc -emit-hlfir -fopenmp -o - %s -fopenmp-version=50 2>&1 | FileCheck %s
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s -fopenmp-version=50 2>&1 | FileCheck %s
 
-! CHECK-LABEL:  omp.private {type = private} 
+! CHECK-LABEL:  omp.private {type = private}
 ! CHECK-SAME:        @[[I_PRIVATE:.*]] : i32
 
 ! CHECK-LABEL: func.func @_QPomp_taskloop() {

--- a/flang/test/Lower/OpenMP/taskloop-grainsize.f90
+++ b/flang/test/Lower/OpenMP/taskloop-grainsize.f90
@@ -27,7 +27,7 @@
 ! CHECK:          %[[GRAINSIZE:.*]] = arith.constant 10 : i32
 subroutine test_grainsize
    integer :: i, x
-   ! CHECK:          omp.taskloop grainsize(%[[GRAINSIZE]]: i32) 
+   ! CHECK:          omp.taskloop grainsize(%[[GRAINSIZE]]: i32)
    ! CHECK-SAME:        private(@[[X_FIRSTPRIVATE]] %[[DECL_X]]#0 -> %[[ARG0:.*]], @[[I_PRIVATE]] %[[DECL_I]]#0 -> %[[ARG1:.*]] : !fir.ref<i32>, !fir.ref<i32>) {
    ! CHECK:            omp.loop_nest (%[[ARG2:.*]]) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
    !$omp taskloop grainsize(10)

--- a/flang/test/Lower/OpenMP/taskloop-numtasks.f90
+++ b/flang/test/Lower/OpenMP/taskloop-numtasks.f90
@@ -27,7 +27,7 @@
 ! CHECK:          %[[VAL_NUMTASKS:.*]] = arith.constant 10 : i32
 subroutine test_num_tasks
    integer :: i, x
-   ! CHECK:          omp.taskloop num_tasks(%[[VAL_NUMTASKS]]: i32) 
+   ! CHECK:          omp.taskloop num_tasks(%[[VAL_NUMTASKS]]: i32)
    ! CHECK-SAME:        private(@[[X_FIRSTPRIVATE]] %[[DECL_X]]#0 -> %[[ARG0:.*]], @[[I_PRIVATE]] %[[DECL_I]]#0 -> %[[ARG1:.*]] : !fir.ref<i32>, !fir.ref<i32>) {
    ! CHECK:            omp.loop_nest (%[[ARG2:.*]]) : i32 = (%{{.*}}) to (%{{.*}}) inclusive step (%{{.*}}) {
    !$omp taskloop num_tasks(10)

--- a/flang/test/Lower/OpenMP/taskloop.f90
+++ b/flang/test/Lower/OpenMP/taskloop.f90
@@ -32,19 +32,19 @@
 ! CHECK-LABEL:  omp.private
 ! CHECK-SAME:       {type = private} @[[X_PRIVATE_TEST_ALLOCATE:.*]] : i32
 
-! CHECK-LABEL:  omp.private 
+! CHECK-LABEL:  omp.private
 ! CHECK-SAME:       {type = private} @[[I_PRIVATE_TEST2:.*]] : i32
 
-! CHECK-LABEL:  omp.private 
+! CHECK-LABEL:  omp.private
 ! CHECK-SAME:       {type = private} @[[RES_PRIVATE_TEST2:.*]] : i32
 
-! CHECK-LABEL:  omp.private 
+! CHECK-LABEL:  omp.private
 ! CHECK-SAME:       {type = private} @[[I_PRIVATE:.*]] : i32
 
-! CHECK-LABEL:  omp.private 
-! CHECK-SAME:        {type = firstprivate} @[[RES_FIRSTPRIVATE:.*]] : i32 
+! CHECK-LABEL:  omp.private
+! CHECK-SAME:        {type = firstprivate} @[[RES_FIRSTPRIVATE:.*]] : i32
 ! CHECK-SAME:   copy {
-! CHECK:         hlfir.assign 
+! CHECK:         hlfir.assign
 
 ! CHECK-LABEL:  func.func @_QPomp_taskloop
 ! CHECK:          %[[ALLOCA_I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFomp_taskloopEi"}

--- a/flang/test/Lower/OpenMP/workdistribute-saxpy-two-2d.f90
+++ b/flang/test/Lower/OpenMP/workdistribute-saxpy-two-2d.f90
@@ -21,7 +21,7 @@ subroutine target_teams_workdistribute(a, x, y, rows, cols)
   ! CHECK: fir.do_loop
 
   y = a * x + y
-  
+
   ! CHECK: omp.target
   ! CHECK: omp.teams
   ! CHECK: omp.parallel
@@ -29,7 +29,7 @@ subroutine target_teams_workdistribute(a, x, y, rows, cols)
   ! CHECK: omp.wsloop
   ! CHECK: omp.loop_nest
   ! CHECK: fir.do_loop
-  
+
   y = a * y + x
 
   !$omp end target teams workdistribute
@@ -54,14 +54,14 @@ subroutine teams_workdistribute(a, x, y, rows, cols)
   ! CHECK: fir.do_loop
 
   y = a * x + y
-  
+
   ! CHECK: omp.teams
   ! CHECK: omp.parallel
   ! CHECK: omp.distribute
   ! CHECK: omp.wsloop
   ! CHECK: omp.loop_nest
   ! CHECK: fir.do_loop
-  
+
   y = a * y + x
 
   !$omp end teams workdistribute

--- a/flang/test/Lower/OpenMP/workdistribute-scalar-assign.f90
+++ b/flang/test/Lower/OpenMP/workdistribute-scalar-assign.f90
@@ -11,7 +11,7 @@ subroutine target_teams_workdistribute_scalar_assign()
   ! CHECK: omp.distribute
   ! CHECK: omp.wsloop
   ! CHECK: omp.loop_nest
-  
+
   !$omp target teams workdistribute
   aa = 20
   !$omp end target teams workdistribute

--- a/flang/test/Lower/OpenMP/wsloop-chunks.f90
+++ b/flang/test/Lower/OpenMP/wsloop-chunks.f90
@@ -50,7 +50,7 @@ do i=1, 9
 ! CHECK:             omp.yield
 ! CHECK:           }
 ! CHECK:         }
-  
+
 end do
 !$OMP END DO NOWAIT
 chunk = 6


### PR DESCRIPTION
Only some fortran source files in flang/test/Lower/OpenMP have been modified. More cleanups will be performed in subsequent commits.