### PR TITLE
Revert "Revert "[LLDB] Update Shell lit config to handle c8031c3dd743""

### DIFF
--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -226,7 +226,7 @@ def use_support_substitutions(config):
         except OSError:
             res = -1
         if res == 0 and out:
-            sdk_path = lit.util.to_string(out)
+            sdk_path = str(out)
             llvm_config.lit_config.note("using SDKROOT: %r" % sdk_path)
             host_flags += ["-isysroot", sdk_path]
     elif sys.platform != "win32":


### PR DESCRIPTION
Reverts llvm/llvm-project#170288

Turns out this was not the cause of the failure