### PR TITLE
[Mips] Mark function calls as possibly changing FCSR (FCR31)

### DIFF
--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -2940,6 +2940,11 @@ SDValue MipsTargetLowering::lowerSTRICT_FP_TO_INT(SDValue Op,
   return DAG.getMergeValues({Result, Op.getOperand(0)}, Loc);
 }
 
+ArrayRef<MCPhysReg> MipsTargetLowering::getRoundingControlRegisters() const {
+  static const MCPhysReg RCRegs[] = {Mips::FCR31};
+  return RCRegs;
+}
+
 //===----------------------------------------------------------------------===//
 //                      Calling Convention Implementation
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Mips/MipsISelLowering.h
+++ b/llvm/lib/Target/Mips/MipsISelLowering.h
@@ -507,6 +507,8 @@ class TargetRegisterClass;
 
     int getCPURegisterIndex(StringRef Name) const;
 
+    ArrayRef<MCPhysReg> getRoundingControlRegisters() const override;
+
     /// Emit a sign-extension using sll/sra, seb, or seh appropriately.
     MachineBasicBlock *emitSignExtendToI32InReg(MachineInstr &MI,
                                                 MachineBasicBlock *BB,

--- a/llvm/test/CodeGen/Mips/strict-fp-func.ll
+++ b/llvm/test/CodeGen/Mips/strict-fp-func.ll
@@ -1,0 +1,11 @@
+; RUN: llc -mtriple=mips -stop-after=finalize-isel %s -o - | FileCheck %s
+
+define float @func_02(float %x, float %y) strictfp nounwind {
+; CHECK-LABEL: name: func_02
+; CHECK:       JAL @func_01, {{.*}}, implicit-def $fcr31
+  %call = call float @func_01(float %x) strictfp
+  %res = call float @llvm.experimental.constrained.fadd.f32(float %call, float %y, metadata !"round.dynamic", metadata !"fpexcept.ignore") strictfp
+  ret float %res
+}
+
+declare float @func_01(float)


### PR DESCRIPTION
This patch does the same changes as D143001 for AArch64 and #160699 for ARM.