### PR TITLE
[mlir][gpu] Remove redundant memory effects from gpu.subgroup_mma load/store ops

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/GPUOps.td
@@ -1799,8 +1799,7 @@ def GPU_SetDefaultDeviceOp : GPU_Op<"set_default_device",
   let assemblyFormat = "attr-dict $devIndex";
 }
 
-def GPU_SubgroupMmaLoadMatrixOp : GPU_Op<"subgroup_mma_load_matrix",
-    [MemoryEffects<[MemRead]>]>{
+def GPU_SubgroupMmaLoadMatrixOp : GPU_Op<"subgroup_mma_load_matrix"> {
 
   let summary = "GPU warp synchronous matrix load";
 
@@ -1845,8 +1844,7 @@ def GPU_SubgroupMmaLoadMatrixOp : GPU_Op<"subgroup_mma_load_matrix",
   let hasVerifier = 1;
 }
 
-def GPU_SubgroupMmaStoreMatrixOp : GPU_Op<"subgroup_mma_store_matrix",
-    [MemoryEffects<[MemWrite]>]>{
+def GPU_SubgroupMmaStoreMatrixOp : GPU_Op<"subgroup_mma_store_matrix"> {
 
   let summary = "GPU warp synchronous matrix store";
 


### PR DESCRIPTION
The gpu.subgroup_mma_load_matrix and gpu.subgroup_mma_store_matrix ops declare memory effects at the op and operands levels. Op level memory effects traits do not add any additional information and they complicate memory analysis, e.g. they prevent lowering of the scf.parallel to gpu if loop's body contains gpu.subgroup_mma_store op.

Remove redundant op level memory effects traits to simplify analysis and make it consistent with other similar ops.