### PR TITLE
[MemProf] Require x86 for memprof-pgho.cpp test

### DIFF
--- a/clang/test/CodeGen/distributed-thin-lto/memprof-pgho.cpp
+++ b/clang/test/CodeGen/distributed-thin-lto/memprof-pgho.cpp
@@ -1,6 +1,8 @@
 // Test end-to-end ThinLTO optimization pipeline with PGHO, that it does not
 // interfere with other allocation instrumentation features.
 //
+// REQUIRES: x86-registered-target
+//
 // RUN: split-file %s %t
 // RUN: llvm-profdata merge %t/memprof.yaml -o %t/use.memprofdata
 //


### PR DESCRIPTION
This requires an x86 build, otherwise the test will fail with:

	Error running ThinLTO backend: No available targets are compatible with triple "x86_64-unknown-linux-gnu"