### PR TITLE
GlobalISel: Use LibcallLoweringInfo analysis in legalizer

### DIFF
--- a/llvm/include/llvm/Analysis/RuntimeLibcallInfo.h
+++ b/llvm/include/llvm/Analysis/RuntimeLibcallInfo.h
@@ -31,6 +31,8 @@ public:
 
   RTLIB::RuntimeLibcallsInfo run(const Module &M, ModuleAnalysisManager &);
 
+  operator bool() const { return LibcallsInfo.has_value(); }
+
 private:
   friend AnalysisInfoMixin<RuntimeLibraryAnalysis>;
   static AnalysisKey Key;

--- a/llvm/include/llvm/CodeGen/GlobalISel/Legalizer.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/Legalizer.h
@@ -33,6 +33,7 @@ class LegalizerInfo;
 class MachineIRBuilder;
 class MachineInstr;
 class GISelChangeObserver;
+class LibcallLoweringInfo;
 class LostDebugLocObserver;
 
 class LLVM_ABI Legalizer : public MachineFunctionPass {
@@ -70,11 +71,11 @@ public:
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 
-  static MFResult
-  legalizeMachineFunction(MachineFunction &MF, const LegalizerInfo &LI,
-                          ArrayRef<GISelChangeObserver *> AuxObservers,
-                          LostDebugLocObserver &LocObserver,
-                          MachineIRBuilder &MIRBuilder, GISelValueTracking *VT);
+  static MFResult legalizeMachineFunction(
+      MachineFunction &MF, const LegalizerInfo &LI,
+      ArrayRef<GISelChangeObserver *> AuxObservers,
+      LostDebugLocObserver &LocObserver, MachineIRBuilder &MIRBuilder,
+      const LibcallLoweringInfo *Libcalls, GISelValueTracking *VT);
 };
 } // End namespace llvm.
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
@@ -59,7 +59,10 @@ private:
   MachineRegisterInfo &MRI;
   const LegalizerInfo &LI;
   const TargetLowering &TLI;
-  GISelValueTracking *VT;
+
+  // FIXME: Should probably make Libcalls mandatory
+  const LibcallLoweringInfo *Libcalls = nullptr;
+  GISelValueTracking *VT = nullptr;
 
 public:
   enum LegalizeResult {
@@ -78,12 +81,15 @@ public:
   /// Expose LegalizerInfo so the clients can re-use.
   const LegalizerInfo &getLegalizerInfo() const { return LI; }
   const TargetLowering &getTargetLowering() const { return TLI; }
+  const LibcallLoweringInfo *getLibcallLoweringInfo() { return Libcalls; }
   GISelValueTracking *getValueTracking() const { return VT; }
 
   LLVM_ABI LegalizerHelper(MachineFunction &MF, GISelChangeObserver &Observer,
-                           MachineIRBuilder &B);
+                           MachineIRBuilder &B,
+                           const LibcallLoweringInfo *Libcalls = nullptr);
   LLVM_ABI LegalizerHelper(MachineFunction &MF, const LegalizerInfo &LI,
                            GISelChangeObserver &Observer, MachineIRBuilder &B,
+                           const LibcallLoweringInfo *Libcalls = nullptr,
                            GISelValueTracking *VT = nullptr);
 
   /// Replace \p MI by a sequence of legal instructions that can implement the
@@ -177,6 +183,37 @@ public:
   /// Legalize a single operand \p OpIdx of the machine instruction \p MI as a
   /// def by inserting a G_BITCAST from \p CastTy
   LLVM_ABI void bitcastDst(MachineInstr &MI, LLT CastTy, unsigned OpIdx);
+
+  // Useful for libcalls where all operands have the same type.
+  LLVM_ABI LegalizeResult
+  simpleLibcall(MachineInstr &MI, MachineIRBuilder &MIRBuilder, unsigned Size,
+                Type *OpType, LostDebugLocObserver &LocObserver) const;
+
+  LLVM_ABI LegalizeResult conversionLibcall(MachineInstr &MI, Type *ToType,
+                                            Type *FromType,
+                                            LostDebugLocObserver &LocObserver,
+                                            bool IsSigned = false) const;
+
+  /// Helper function that creates a libcall to the given \p Name using the
+  /// given calling convention \p CC.
+  LLVM_ABI LegalizeResult createLibcall(const char *Name,
+                                        const CallLowering::ArgInfo &Result,
+                                        ArrayRef<CallLowering::ArgInfo> Args,
+                                        CallingConv::ID CC,
+                                        LostDebugLocObserver &LocObserver,
+                                        MachineInstr *MI = nullptr) const;
+
+  /// Helper function that creates the given libcall.
+  LLVM_ABI LegalizeResult createLibcall(RTLIB::Libcall Libcall,
+                                        const CallLowering::ArgInfo &Result,
+                                        ArrayRef<CallLowering::ArgInfo> Args,
+                                        LostDebugLocObserver &LocObserver,
+                                        MachineInstr *MI = nullptr) const;
+
+  /// Create a libcall to memcpy et al.
+  LLVM_ABI LegalizeResult
+  createMemLibcall(MachineRegisterInfo &MRI, MachineInstr &MI,
+                   LostDebugLocObserver &LocObserver) const;
 
 private:
   LegalizeResult
@@ -278,17 +315,13 @@ private:
                               bool IsVolatile);
 
   // Implements floating-point environment read/write via library function call.
-  LegalizeResult createGetStateLibcall(MachineIRBuilder &MIRBuilder,
-                                       MachineInstr &MI,
+  LegalizeResult createGetStateLibcall(MachineInstr &MI,
                                        LostDebugLocObserver &LocObserver);
-  LegalizeResult createSetStateLibcall(MachineIRBuilder &MIRBuilder,
-                                       MachineInstr &MI,
+  LegalizeResult createSetStateLibcall(MachineInstr &MI,
                                        LostDebugLocObserver &LocObserver);
-  LegalizeResult createResetStateLibcall(MachineIRBuilder &MIRBuilder,
-                                         MachineInstr &MI,
+  LegalizeResult createResetStateLibcall(MachineInstr &MI,
                                          LostDebugLocObserver &LocObserver);
-  LegalizeResult createFCMPLibcall(MachineIRBuilder &MIRBuilder,
-                                   MachineInstr &MI,
+  LegalizeResult createFCMPLibcall(MachineInstr &MI,
                                    LostDebugLocObserver &LocObserver);
 
   MachineInstrBuilder
@@ -538,26 +571,6 @@ public:
                                             unsigned MaxLen = 0);
   LLVM_ABI LegalizeResult lowerVAArg(MachineInstr &MI);
 };
-
-/// Helper function that creates a libcall to the given \p Name using the given
-/// calling convention \p CC.
-LLVM_ABI LegalizerHelper::LegalizeResult
-createLibcall(MachineIRBuilder &MIRBuilder, const char *Name,
-              const CallLowering::ArgInfo &Result,
-              ArrayRef<CallLowering::ArgInfo> Args, CallingConv::ID CC,
-              LostDebugLocObserver &LocObserver, MachineInstr *MI = nullptr);
-
-/// Helper function that creates the given libcall.
-LLVM_ABI LegalizerHelper::LegalizeResult
-createLibcall(MachineIRBuilder &MIRBuilder, RTLIB::Libcall Libcall,
-              const CallLowering::ArgInfo &Result,
-              ArrayRef<CallLowering::ArgInfo> Args,
-              LostDebugLocObserver &LocObserver, MachineInstr *MI = nullptr);
-
-/// Create a libcall to memcpy et al.
-LLVM_ABI LegalizerHelper::LegalizeResult
-createMemLibcall(MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI,
-                 MachineInstr &MI, LostDebugLocObserver &LocObserver);
 
 } // End namespace llvm.
 

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
@@ -60,7 +60,6 @@ private:
   const LegalizerInfo &LI;
   const TargetLowering &TLI;
 
-  // FIXME: Should probably make Libcalls mandatory
   const LibcallLoweringInfo *Libcalls = nullptr;
   GISelValueTracking *VT = nullptr;
 
@@ -84,6 +83,7 @@ public:
   const LibcallLoweringInfo *getLibcallLoweringInfo() { return Libcalls; }
   GISelValueTracking *getValueTracking() const { return VT; }
 
+  // FIXME: Should probably make Libcalls mandatory
   LLVM_ABI LegalizerHelper(MachineFunction &MF, GISelChangeObserver &Observer,
                            MachineIRBuilder &B,
                            const LibcallLoweringInfo *Libcalls = nullptr);

--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerHelper.h
@@ -189,11 +189,6 @@ public:
   simpleLibcall(MachineInstr &MI, MachineIRBuilder &MIRBuilder, unsigned Size,
                 Type *OpType, LostDebugLocObserver &LocObserver) const;
 
-  LLVM_ABI LegalizeResult conversionLibcall(MachineInstr &MI, Type *ToType,
-                                            Type *FromType,
-                                            LostDebugLocObserver &LocObserver,
-                                            bool IsSigned = false) const;
-
   /// Helper function that creates a libcall to the given \p Name using the
   /// given calling convention \p CC.
   LLVM_ABI LegalizeResult createLibcall(const char *Name,
@@ -209,6 +204,11 @@ public:
                                         ArrayRef<CallLowering::ArgInfo> Args,
                                         LostDebugLocObserver &LocObserver,
                                         MachineInstr *MI = nullptr) const;
+
+  LLVM_ABI LegalizeResult conversionLibcall(MachineInstr &MI, Type *ToType,
+                                            Type *FromType,
+                                            LostDebugLocObserver &LocObserver,
+                                            bool IsSigned = false) const;
 
   /// Create a libcall to memcpy et al.
   LLVM_ABI LegalizeResult

--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -493,6 +493,8 @@ LLVM_ABI FunctionPass *createInterleavedLoadCombinePass();
 ///
 LLVM_ABI ModulePass *createLowerEmuTLSPass();
 
+LLVM_ABI ModulePass *createLibcallLoweringInfoWrapper();
+
 /// This pass lowers the \@llvm.load.relative and \@llvm.objc.* intrinsics to
 /// instructions.  This is unsafe to do earlier because a pass may combine the
 /// constant initializer into the load, which may result in an overflowing

--- a/llvm/lib/CodeGen/ExpandIRInsts.cpp
+++ b/llvm/lib/CodeGen/ExpandIRInsts.cpp
@@ -1153,7 +1153,7 @@ public:
 
     const LibcallLoweringInfo &Libcalls =
         getAnalysis<LibcallLoweringInfoWrapper>().getLibcallLowering(
-            *Subtarget);
+            *F.getParent(), *Subtarget);
 
     if (OptLevel != CodeGenOptLevel::None && !F.hasOptNone())
       AC = &getAnalysis<AssumptionCacheTracker>().getAssumptionCache(F);

--- a/llvm/lib/CodeGen/GlobalISel/Legalizer.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Legalizer.cpp
@@ -343,7 +343,8 @@ bool Legalizer::runOnMachineFunction(MachineFunction &MF) {
   const TargetSubtargetInfo &Subtarget = MF.getSubtarget();
 
   const LibcallLoweringInfo &Libcalls =
-      getAnalysis<LibcallLoweringInfoWrapper>().getLibcallLowering(Subtarget);
+      getAnalysis<LibcallLoweringInfoWrapper>().getLibcallLowering(
+          *MF.getFunction().getParent(), Subtarget);
 
   // This allows Known Bits Analysis in the legalizer.
   GISelValueTracking *VT =

--- a/llvm/lib/CodeGen/GlobalISel/Legalizer.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Legalizer.cpp
@@ -73,6 +73,7 @@ char Legalizer::ID = 0;
 INITIALIZE_PASS_BEGIN(Legalizer, DEBUG_TYPE,
                       "Legalize the Machine IR a function's Machine IR", false,
                       false)
+INITIALIZE_PASS_DEPENDENCY(LibcallLoweringInfoWrapper)
 INITIALIZE_PASS_DEPENDENCY(TargetPassConfig)
 INITIALIZE_PASS_DEPENDENCY(GISelCSEAnalysisWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(GISelValueTrackingAnalysisLegacy)
@@ -83,6 +84,7 @@ INITIALIZE_PASS_END(Legalizer, DEBUG_TYPE,
 Legalizer::Legalizer() : MachineFunctionPass(ID) { }
 
 void Legalizer::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<LibcallLoweringInfoWrapper>();
   AU.addRequired<TargetPassConfig>();
   AU.addRequired<GISelCSEAnalysisWrapperPass>();
   AU.addPreserved<GISelCSEAnalysisWrapperPass>();
@@ -172,12 +174,11 @@ public:
 };
 } // namespace
 
-Legalizer::MFResult
-Legalizer::legalizeMachineFunction(MachineFunction &MF, const LegalizerInfo &LI,
-                                   ArrayRef<GISelChangeObserver *> AuxObservers,
-                                   LostDebugLocObserver &LocObserver,
-                                   MachineIRBuilder &MIRBuilder,
-                                   GISelValueTracking *VT) {
+Legalizer::MFResult Legalizer::legalizeMachineFunction(
+    MachineFunction &MF, const LegalizerInfo &LI,
+    ArrayRef<GISelChangeObserver *> AuxObservers,
+    LostDebugLocObserver &LocObserver, MachineIRBuilder &MIRBuilder,
+    const LibcallLoweringInfo *Libcalls, GISelValueTracking *VT) {
   MIRBuilder.setMF(MF);
   MachineRegisterInfo &MRI = MF.getRegInfo();
 
@@ -216,7 +217,7 @@ Legalizer::legalizeMachineFunction(MachineFunction &MF, const LegalizerInfo &LI,
   // Now install the observer as the delegate to MF.
   // This will keep all the observers notified about new insertions/deletions.
   RAIIMFObsDelInstaller Installer(MF, WrapperObserver);
-  LegalizerHelper Helper(MF, LI, WrapperObserver, MIRBuilder, VT);
+  LegalizerHelper Helper(MF, LI, WrapperObserver, MIRBuilder, Libcalls, VT);
   LegalizationArtifactCombiner ArtCombiner(MIRBuilder, MRI, LI, VT);
   bool Changed = false;
   SmallVector<MachineInstr *, 128> RetryList;
@@ -339,13 +340,18 @@ bool Legalizer::runOnMachineFunction(MachineFunction &MF) {
   if (VerifyDebugLocs > DebugLocVerifyLevel::None)
     AuxObservers.push_back(&LocObserver);
 
+  const TargetSubtargetInfo &Subtarget = MF.getSubtarget();
+
+  const LibcallLoweringInfo &Libcalls =
+      getAnalysis<LibcallLoweringInfoWrapper>().getLibcallLowering(Subtarget);
+
   // This allows Known Bits Analysis in the legalizer.
   GISelValueTracking *VT =
       &getAnalysis<GISelValueTrackingAnalysisLegacy>().get(MF);
 
-  const LegalizerInfo &LI = *MF.getSubtarget().getLegalizerInfo();
+  const LegalizerInfo &LI = *Subtarget.getLegalizerInfo();
   MFResult Result = legalizeMachineFunction(MF, LI, AuxObservers, LocObserver,
-                                            *MIRBuilder, VT);
+                                            *MIRBuilder, &Libcalls, VT);
 
   if (Result.FailedOn) {
     reportGISelFailure(MF, MORE, "gisel-legalize",

--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -748,6 +748,28 @@ LegalizerHelper::emitModfLibcall(MachineInstr &MI, MachineIRBuilder &MIRBuilder,
   return LegalizerHelper::Legalized;
 }
 
+static RTLIB::Libcall getConvRTLibDesc(unsigned Opcode, Type *ToType,
+                                       Type *FromType) {
+  auto ToMVT = MVT::getVT(ToType);
+  auto FromMVT = MVT::getVT(FromType);
+
+  switch (Opcode) {
+  case TargetOpcode::G_FPEXT:
+    return RTLIB::getFPEXT(FromMVT, ToMVT);
+  case TargetOpcode::G_FPTRUNC:
+    return RTLIB::getFPROUND(FromMVT, ToMVT);
+  case TargetOpcode::G_FPTOSI:
+    return RTLIB::getFPTOSINT(FromMVT, ToMVT);
+  case TargetOpcode::G_FPTOUI:
+    return RTLIB::getFPTOUINT(FromMVT, ToMVT);
+  case TargetOpcode::G_SITOFP:
+    return RTLIB::getSINTTOFP(FromMVT, ToMVT);
+  case TargetOpcode::G_UITOFP:
+    return RTLIB::getUINTTOFP(FromMVT, ToMVT);
+  }
+  llvm_unreachable("Unsupported libcall function");
+}
+
 LegalizerHelper::LegalizeResult LegalizerHelper::conversionLibcall(
     MachineInstr &MI, Type *ToType, Type *FromType,
     LostDebugLocObserver &LocObserver, bool IsSigned) const {
@@ -980,28 +1002,6 @@ createAtomicLibcall(MachineIRBuilder &MIRBuilder, MachineInstr &MI) {
     return LegalizerHelper::UnableToLegalize;
 
   return LegalizerHelper::Legalized;
-}
-
-static RTLIB::Libcall getConvRTLibDesc(unsigned Opcode, Type *ToType,
-                                       Type *FromType) {
-  auto ToMVT = MVT::getVT(ToType);
-  auto FromMVT = MVT::getVT(FromType);
-
-  switch (Opcode) {
-  case TargetOpcode::G_FPEXT:
-    return RTLIB::getFPEXT(FromMVT, ToMVT);
-  case TargetOpcode::G_FPTRUNC:
-    return RTLIB::getFPROUND(FromMVT, ToMVT);
-  case TargetOpcode::G_FPTOSI:
-    return RTLIB::getFPTOSINT(FromMVT, ToMVT);
-  case TargetOpcode::G_FPTOUI:
-    return RTLIB::getFPTOUINT(FromMVT, ToMVT);
-  case TargetOpcode::G_SITOFP:
-    return RTLIB::getSINTTOFP(FromMVT, ToMVT);
-  case TargetOpcode::G_UITOFP:
-    return RTLIB::getUINTTOFP(FromMVT, ToMVT);
-  }
-  llvm_unreachable("Unsupported libcall function");
 }
 
 static RTLIB::Libcall

--- a/llvm/lib/CodeGen/LibcallLoweringInfo.cpp
+++ b/llvm/lib/CodeGen/LibcallLoweringInfo.cpp
@@ -59,9 +59,8 @@ char LibcallLoweringInfoWrapper::ID = 0;
 
 LibcallLoweringInfoWrapper::LibcallLoweringInfoWrapper() : ImmutablePass(ID) {}
 
-bool LibcallLoweringInfoWrapper::doInitialization(Module &M) {
-  Result.init(&getAnalysis<RuntimeLibraryInfoWrapper>().getRTLCI(M));
-  return false;
+void LibcallLoweringInfoWrapper::initializePass() {
+  RuntimeLibcallsWrapper = &getAnalysis<RuntimeLibraryInfoWrapper>();
 }
 
 void LibcallLoweringInfoWrapper::getAnalysisUsage(AnalysisUsage &AU) const {
@@ -70,3 +69,7 @@ void LibcallLoweringInfoWrapper::getAnalysisUsage(AnalysisUsage &AU) const {
 }
 
 void LibcallLoweringInfoWrapper::releaseMemory() { Result.clear(); }
+
+ModulePass *llvm::createLibcallLoweringInfoWrapper() {
+  return new LibcallLoweringInfoWrapper();
+}

--- a/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
+++ b/llvm/lib/CodeGen/PreISelIntrinsicLowering.cpp
@@ -778,7 +778,7 @@ public:
 
   bool runOnModule(Module &M) override {
     const LibcallLoweringModuleAnalysisResult &ModuleLibcalls =
-        getAnalysis<LibcallLoweringInfoWrapper>().getResult();
+        getAnalysis<LibcallLoweringInfoWrapper>().getResult(M);
 
     auto LookupTTI = [this](Function &F) -> TargetTransformInfo & {
       return this->getAnalysis<TargetTransformInfoWrapperPass>().getTTI(F);

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -617,6 +617,8 @@ TargetPassConfig::TargetPassConfig(TargetMachine &TM, PassManagerBase &PM)
   // including this pass itself.
   initializeCodeGen(PR);
 
+  initializeLibcallLoweringInfoWrapperPass(PR);
+
   // Also register alias analysis passes required by codegen passes.
   initializeBasicAAWrapperPassPass(PR);
   initializeAAResultsWrapperPassPass(PR);

--- a/llvm/lib/Target/ARM/ARMLegalizerInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMLegalizerInfo.cpp
@@ -365,10 +365,10 @@ bool ARMLegalizerInfo::legalizeCustom(LegalizerHelper &Helper, MachineInstr &MI,
     StructType *RetTy = StructType::get(Ctx, {ArgTy, ArgTy}, /* Packed */ true);
     Register RetRegs[] = {MRI.createGenericVirtualRegister(LLT::scalar(32)),
                           OriginalResult};
-    auto Status = createLibcall(MIRBuilder, Libcall, {RetRegs, RetTy, 0},
-                                {{MI.getOperand(1).getReg(), ArgTy, 0},
-                                 {MI.getOperand(2).getReg(), ArgTy, 0}},
-                                LocObserver, &MI);
+    auto Status = Helper.createLibcall(Libcall, {RetRegs, RetTy, 0},
+                                       {{MI.getOperand(1).getReg(), ArgTy, 0},
+                                        {MI.getOperand(2).getReg(), ArgTy, 0}},
+                                       LocObserver, &MI);
     if (Status != LegalizerHelper::Legalized)
       return false;
     break;
@@ -401,11 +401,11 @@ bool ARMLegalizerInfo::legalizeCustom(LegalizerHelper &Helper, MachineInstr &MI,
     SmallVector<Register, 2> Results;
     for (auto Libcall : Libcalls) {
       auto LibcallResult = MRI.createGenericVirtualRegister(LLT::scalar(32));
-      auto Status = createLibcall(MIRBuilder, Libcall.LibcallID,
-                                  {LibcallResult, RetTy, 0},
-                                  {{MI.getOperand(2).getReg(), ArgTy, 0},
-                                   {MI.getOperand(3).getReg(), ArgTy, 0}},
-                                  LocObserver, &MI);
+      auto Status =
+          Helper.createLibcall(Libcall.LibcallID, {LibcallResult, RetTy, 0},
+                               {{MI.getOperand(2).getReg(), ArgTy, 0},
+                                {MI.getOperand(3).getReg(), ArgTy, 0}},
+                               LocObserver, &MI);
 
       if (Status != LegalizerHelper::Legalized)
         return false;

--- a/llvm/unittests/CodeGen/GlobalISel/GISelMITest.h
+++ b/llvm/unittests/CodeGen/GlobalISel/GISelMITest.h
@@ -124,6 +124,8 @@ protected:
     B.setMF(*MF);
     MRI = &MF->getRegInfo();
     B.setInsertPt(*EntryMBB, EntryMBB->end());
+    RTLCI.emplace(TM->getTargetTriple());
+    LibcallLowering.emplace(*RTLCI, MF->getSubtarget());
   }
 
   LLVMContext Context;
@@ -135,6 +137,8 @@ protected:
   MachineBasicBlock *EntryMBB;
   MachineIRBuilder B;
   MachineRegisterInfo *MRI;
+  std::optional<RTLIB::RuntimeLibcallsInfo> RTLCI;
+  std::optional<LibcallLoweringInfo> LibcallLowering;
 };
 
 class AArch64GISelMITest : public GISelMITest {

--- a/llvm/unittests/CodeGen/GlobalISel/LegalizerHelperTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/LegalizerHelperTest.cpp
@@ -2050,7 +2050,7 @@ TEST_F(AArch64GISelMITest, LibcallFPExt) {
       B.buildInstr(TargetOpcode::G_FPEXT, {S128}, {Copies[1]});
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   LostDebugLocObserver DummyLocObserver("");
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
               Helper.libcall(*MIBFPExt1, DummyLocObserver));
@@ -2094,7 +2094,7 @@ TEST_F(AArch64GISelMITest, LibcallFPTrunc) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBFPTrunc1, DummyLocObserver));
 
@@ -2162,7 +2162,7 @@ TEST_F(AArch64GISelMITest, LibcallMul) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBMul32, DummyLocObserver));
@@ -2220,7 +2220,7 @@ TEST_F(AArch64GISelMITest, LibcallSRem) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBSRem32, DummyLocObserver));
@@ -2278,7 +2278,7 @@ TEST_F(AArch64GISelMITest, LibcallURem) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBURem32, DummyLocObserver));
@@ -2337,7 +2337,7 @@ TEST_F(AArch64GISelMITest, LibcallCtlzZeroUndef) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBCtlz32, DummyLocObserver));
@@ -2389,7 +2389,7 @@ TEST_F(AArch64GISelMITest, LibcallFAdd) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBAdd32, DummyLocObserver));
@@ -2442,7 +2442,7 @@ TEST_F(AArch64GISelMITest, LibcallFSub) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBSub32, DummyLocObserver));
@@ -2494,7 +2494,7 @@ TEST_F(AArch64GISelMITest, LibcallFMul) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   LostDebugLocObserver DummyLocObserver("");
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
@@ -2548,7 +2548,7 @@ TEST_F(AArch64GISelMITest, LibcallFDiv) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBDiv32, DummyLocObserver));
@@ -2599,7 +2599,7 @@ TEST_F(AArch64GISelMITest, LibcallFExp) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBExp32, DummyLocObserver));
@@ -2647,7 +2647,7 @@ TEST_F(AArch64GISelMITest, LibcallFExp2) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBExp232, DummyLocObserver));
@@ -2695,7 +2695,7 @@ TEST_F(AArch64GISelMITest, LibcallFRem) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBFRem32, DummyLocObserver));
@@ -2743,7 +2743,7 @@ TEST_F(AArch64GISelMITest, LibcallFPow) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBPow32, DummyLocObserver));
@@ -2792,7 +2792,7 @@ TEST_F(AArch64GISelMITest, LibcallFMa) {
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
   LostDebugLocObserver DummyLocObserver("");
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.libcall(*MIBMa32, DummyLocObserver));
@@ -2839,7 +2839,7 @@ TEST_F(AArch64GISelMITest, LibcallFCeil) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   LostDebugLocObserver DummyLocObserver("");
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
@@ -2887,7 +2887,7 @@ TEST_F(AArch64GISelMITest, LibcallFFloor) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   LostDebugLocObserver DummyLocObserver("");
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
@@ -2935,7 +2935,7 @@ TEST_F(AArch64GISelMITest, LibcallFMinNum) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   LostDebugLocObserver DummyLocObserver("");
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
@@ -2986,7 +2986,7 @@ TEST_F(AArch64GISelMITest, LibcallFMaxNum) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   LostDebugLocObserver DummyLocObserver("");
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
@@ -3037,7 +3037,7 @@ TEST_F(AArch64GISelMITest, LibcallFSqrt) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   LostDebugLocObserver DummyLocObserver("");
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
@@ -3085,7 +3085,7 @@ TEST_F(AArch64GISelMITest, LibcallFRint) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   LostDebugLocObserver DummyLocObserver("");
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
@@ -3136,7 +3136,7 @@ TEST_F(AArch64GISelMITest, LibcallFNearbyInt) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   LostDebugLocObserver DummyLocObserver("");
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
@@ -3181,7 +3181,7 @@ TEST_F(AArch64GISelMITest, NarrowScalarExtract) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.narrowScalar(*MIBExtractS32, 1, S32));
@@ -3229,7 +3229,7 @@ TEST_F(AArch64GISelMITest, LowerInsert) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.lower(*InsertS64S32, 0, LLT{}));
@@ -3307,7 +3307,7 @@ TEST_F(AArch64GISelMITest, LowerFFloor) {
   auto Floor = B.buildFFloor(LLT::scalar(64), Copies[0], MachineInstr::MIFlag::FmNoInfs);
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   // Perform Legalization
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.lower(*Floor, 0, LLT()));
@@ -3340,7 +3340,7 @@ TEST_F(AArch64GISelMITest, LowerBSWAP) {
   auto BSwap = B.buildBSwap(LLT::fixed_vector(2, 32), Cast);
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   // Perform Legalization
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.lower(*BSwap, 0, LLT()));
@@ -3417,7 +3417,7 @@ TEST_F(AArch64GISelMITest, LowerUDIVREM) {
       B.buildInstr(TargetOpcode::G_UDIVREM, {S64, S64}, {Copies[0], Copies[1]});
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   // Perform Legalization
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.lower(*UDivrem, 0, S64));
@@ -3451,7 +3451,7 @@ TEST_F(AArch64GISelMITest, LowerSelect) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
   // Perform Legalization
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
             Helper.lower(*SELECT, 0, S32));
@@ -3492,7 +3492,7 @@ TEST_F(AArch64GISelMITest, WidenUnmerge) {
 
   AInfo Info(MF->getSubtarget());
   DummyGISelObserver Observer;
-  LegalizerHelper Helper(*MF, Info, Observer, B);
+  LegalizerHelper Helper(*MF, Info, Observer, B, &*LibcallLowering);
 
   // Perform Legalization
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
@@ -3701,10 +3701,11 @@ TEST_F(AArch64GISelMITest, CreateLibcall) {
 
   LLVMContext &Ctx = MF->getFunction().getContext();
   auto *RetTy = Type::getVoidTy(Ctx);
+  LegalizerHelper Helper(*MF, Info, Observer, B);
 
   EXPECT_EQ(LegalizerHelper::LegalizeResult::Legalized,
-            createLibcall(B, "abort", {{}, RetTy, 0}, {}, CallingConv::C,
-                          DummyLocObserver, nullptr));
+            Helper.createLibcall("abort", {{}, RetTy, 0}, {}, CallingConv::C,
+                                 DummyLocObserver, nullptr));
 
   auto CheckStr = R"(
   CHECK: ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp

--- a/llvm/unittests/CodeGen/GlobalISel/LegalizerTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/LegalizerTest.cpp
@@ -69,7 +69,7 @@ TEST_F(AArch64GISelMITest, BasicLegalizerTest) {
   GISelValueTracking VT(*MF);
 
   Legalizer::MFResult Result = Legalizer::legalizeMachineFunction(
-      *MF, LI, {&LocObserver}, LocObserver, B, &VT);
+      *MF, LI, {&LocObserver}, LocObserver, B, /*Libcalls=*/nullptr, &VT);
 
   EXPECT_TRUE(isNullMIPtr(Result.FailedOn));
   EXPECT_TRUE(Result.Changed);
@@ -161,7 +161,7 @@ TEST_F(AArch64GISelMITest, UnorderedArtifactCombiningTest) {
   //  the process follows def-use chains, making them shorter at each step, thus
   //  combining everything that can be combined in O(n) time.
   Legalizer::MFResult Result = Legalizer::legalizeMachineFunction(
-      *MF, LI, {&LocObserver}, LocObserver, B, &VT);
+      *MF, LI, {&LocObserver}, LocObserver, B, /*Libcalls=*/nullptr, &VT);
 
   EXPECT_TRUE(isNullMIPtr(Result.FailedOn));
   EXPECT_TRUE(Result.Changed);
@@ -201,7 +201,7 @@ TEST_F(AArch64GISelMITest, UnorderedArtifactCombiningManyCopiesTest) {
   GISelValueTracking VT(*MF);
 
   Legalizer::MFResult Result = Legalizer::legalizeMachineFunction(
-      *MF, LI, {&LocObserver}, LocObserver, B, &VT);
+      *MF, LI, {&LocObserver}, LocObserver, B, /*Libcalls=*/nullptr, &VT);
 
   EXPECT_TRUE(isNullMIPtr(Result.FailedOn));
   EXPECT_TRUE(Result.Changed);


### PR DESCRIPTION
This is mostly boilerplate to move various freestanding utility
functions into LegalizerHelper. LibcallLoweringInfo is currently
optional, mostly because threading it through assorted other
uses of LegalizerHelper is more difficult.

I had a lot of trouble getting this to work in the legacy pass
manager with setRequiresCodeGenSCCOrder, and am not happy with the
result. A sub-pass manager is introduced and this is invalidated,
so we're re-computing this unnecessarily.