### PR TITLE
[flang] Initializers for proc pointers in module files

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -1069,6 +1069,15 @@ void ModFileWriter::PutProcEntity(llvm::raw_ostream &os, const Symbol &symbol) {
         PutPassName(os, details.passName());
       },
       attrs);
+  if (symbol.owner().IsDerivedType()) {
+    if (const auto &init{details.init()}) {
+      if (const Symbol *symbol{*init}) {
+        os << "=>" << symbol->name();
+      } else {
+        os << "=>NULL()";
+      }
+    }
+  }
   os << '\n';
 }
 

--- a/flang/test/Semantics/modfile75.f90
+++ b/flang/test/Semantics/modfile75.f90
@@ -1,0 +1,28 @@
+! RUN: %python %S/test_modfile.py %s %flang_fc1
+module m
+  type dt
+    procedure(sub), pointer, nopass :: p1 => sub
+    procedure(sub), pointer, nopass :: p2 => null()
+    procedure(sub), pointer, nopass :: p3
+  end type
+  procedure(sub), pointer :: p4 => sub
+  procedure(sub), pointer :: p5 => null()
+ contains
+  subroutine sub
+  end
+end
+
+!Expect: m.mod
+!module m
+!type::dt
+!procedure(sub),nopass,pointer::p1=>sub
+!procedure(sub),nopass,pointer::p2=>NULL()
+!procedure(sub),nopass,pointer::p3
+!end type
+!intrinsic::null
+!procedure(sub),pointer::p4
+!procedure(sub),pointer::p5
+!contains
+!subroutine sub()
+!end
+!end


### PR DESCRIPTION
Default initializers for procedure pointer components are missing from module files; add them.

Fixes https://github.com/llvm/llvm-project/issues/170331.