### PR TITLE
Fix a use-after-free crash in ResetObjCLayout

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -12040,7 +12040,7 @@ bool ASTContext::mergeExtParameterInfo(
 void ASTContext::ResetObjCLayout(const ObjCInterfaceDecl *D) {
   if (auto It = ObjCLayouts.find(D); It != ObjCLayouts.end()) {
     It->second = nullptr;
-    for (auto *SubClass : ObjCSubClasses[D])
+    for (auto *SubClass : ObjCSubClasses.lookup(D))
       ResetObjCLayout(SubClass);
   }
 }


### PR DESCRIPTION
operator[] can potentially cause reallocation and invalidate live iterators if it's called with a key that isn't present in the DenseMap. Call lookup() instead to prevent the function from inserting new entries into the DenseMap for ObjC classes that don't have any subclasses.

rdar://165448332