### PR TITLE
[bazel] update bazel build for PluginScriptedProcess

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -2142,11 +2142,14 @@ cc_library(
         ":PluginObjectFilePlaceholder",
         ":PluginProcessUtility",
         "//lldb:Core",
+        "//lldb:CoreHeaders",
         "//lldb:Host",
         "//lldb:InterpreterHeaders",
+        "//lldb:SymbolHeaders",
         "//lldb:Target",
         "//lldb:TargetHeaders",
         "//lldb:Utility",
+        "//llvm:Support",
     ],
 )
 


### PR DESCRIPTION
Adding the following dependencies to PluginScriptedProcess:
-         "//lldb:CoreHeaders",
-         "//lldb:SymbolHeaders",
-         "//llvm:Support",

For c50802cbee3f6f25059422ba0edcc455e395a207