### PR TITLE
Fix lit testing to support standalone testing

### DIFF
--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -9,6 +9,10 @@ import lit.formats
 from lit.llvm import llvm_config
 
 # Configuration file for the 'lit' test runner.
+# Note that lit can be tested in a "standalone" mode, where it is run
+# without using the LLVM build directory.
+# In this case the llvm_config object is not available, and we expect
+# tools like FileCheck to be available in the PATH.
 
 # name: The name of this test suite.
 config.name = "lit"
@@ -39,7 +43,6 @@ lit_path = os.path.abspath(lit_path)
 
 # Required because some tests import the lit module
 if llvm_config:
-    llvm_config.use_default_substitutions()
     llvm_config.with_environment("PYTHONPATH", lit_path, append_path=True)
 else:
     config.environment["PYTHONPATH"] = lit_path

--- a/llvm/utils/lit/tests/windows-pools.py
+++ b/llvm/utils/lit/tests/windows-pools.py
@@ -1,7 +1,7 @@
 # Create a directory with 20 files and check the number of pools and workers per pool that lit will use.
 
 # RUN: rm -Rf %t.dir && mkdir -p %t.dir
-# RUN: %python -c "for i in range(20): open(rf'%t.dir/file{i}.txt', 'w').write('RUN:')"
+# RUN: %{python} -c "for i in range(20): open(rf'%t.dir/file{i}.txt', 'w').write('RUN:')"
 
 # RUN:  echo "import lit.formats" > %t.dir/lit.cfg
 # RUN:  echo "config.name = \"top-level-suite\"" >> %t.dir/lit.cfg


### PR DESCRIPTION
To be able to test lit without having a configuration of LLVM, we need to support invocations that are not going through the lit.site.cfg and thus don't have a llvm_config set-up.