### PR TITLE
[MLIR] Test generated build functions with move-only parameter types

### DIFF
--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -33,6 +33,8 @@ static StringLiteral getVisibilityString(SymbolTable::Visibility visibility) {
     return "nested";
   case SymbolTable::Visibility::Public:
     return "public";
+  default:
+    llvm_unreachable("invalid symboltable visibility type");
   }
 }
 
@@ -1636,4 +1638,15 @@ test::TestCreateTensorOp::getBufferType(
     return failure();
 
   return convertTensorToBuffer(getOperation(), options, type);
+}
+
+// Define a custom builder for ManyRegionsOp declared in TestOps.td.
+//  OpBuilder<(ins "::std::unique_ptr<::mlir::Region>":$firstRegion,
+//                 "::std::unique_ptr<::mlir::Region>":$secondRegion)>
+void test::ManyRegionsOp::build(
+    mlir::OpBuilder &builder, mlir::OperationState &state,
+    llvm::SmallVectorImpl<std::unique_ptr<mlir::Region>> &&regions) {
+  for (auto &&regionPtr : std::move(regions))
+    state.addRegion(std::move(regionPtr));
+  ManyRegionsOp::build(builder, state, {}, regions.size());
 }

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -33,8 +33,6 @@ static StringLiteral getVisibilityString(SymbolTable::Visibility visibility) {
     return "nested";
   case SymbolTable::Visibility::Public:
     return "public";
-  default:
-    llvm_unreachable("invalid symboltable visibility type");
   }
 }
 

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2352,6 +2352,24 @@ def IsolatedGraphRegionOp : TEST_Op<"isolated_graph_region",  [
   let assemblyFormat = "attr-dict-with-keyword $region";
 }
 
+def ManyRegionsOp : TEST_Op<"many_regions", []> {
+  let summary = "operation created with move-only objects";
+  let description = [{
+    Test op with multiple regions with a `create` function that
+    takes parameters containing move-only objects.
+  }];
+
+  let regions = (region VariadicRegion<AnyRegion>:$regions);
+  let builders =
+      [OpBuilder<(ins "::std::unique_ptr<::mlir::Region>":$singleRegion), [{
+      $_state.addRegion(std::move(singleRegion));
+      build($_builder, $_state, {}, /*regionsCount=*/1);
+    }]>,
+       // Define in TestOps.cpp.
+       OpBuilder<(ins "::llvm::SmallVectorImpl<::std::unique_ptr<::mlir::"
+                      "Region>>&&":$regions)>];
+}
+
 def AffineScopeOp : TEST_Op<"affine_scope", [AffineScope]> {
   let summary =  "affine scope operation";
   let description = [{


### PR DESCRIPTION
This adds a test of the MLIR TableGen `OpBuilder` syntax with move-only parameters types. Additionally, an overload is added to test defining a builder outside of the TableGen interface.