### PR TITLE
lldbgdbremote.md: Update `qWasmLocal` result description

### DIFF
--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -2505,7 +2505,7 @@ variables.
 
 Get the value of a Wasm function argument or local variable for the given frame
 index at the given variable index. The indexes are encoded as base 10. The
-result is a hex-encoded address from where to read the value.
+result is a hex-encoded little-endian value of the local.
 
 
 ```

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -2490,7 +2490,7 @@ stack traces.
 
 Get the value of a Wasm global variable for the given frame index at the given
 variable index. The indexes are encoded as base 10. The result is a hex-encoded
-address from where to read the value.
+little-endian value of the global.
 
 ```
 send packet: $qWasmGlobal:0;2#cb
@@ -2521,7 +2521,7 @@ variables.
 
 Get the value of a Wasm local variable from the Wasm operand stack, for the
 given frame index at the given variable index. The indexes are encoded as base
-10. The result is a hex-encoded address from where to read value.
+10. The result is a hex-encoded little-endian value from the stack at the given index.
 
 ```
 send packet: $qWasmStackValue:0;2#cb


### PR DESCRIPTION
The current description mistakenly specified that an address of a local value in some address space is returned. When testing this with Wasm runtimes that already implement this command, it can be observed that the value itself is returned. The value itself may be an address for languages that use shadow stack in Wasm linear memory, but the value of an arbitrary local does not always contain that address.