### PR TITLE
[lldb] Fix Doxygen warning in SBTrace.h

### DIFF
--- a/lldb/include/lldb/API/SBTrace.h
+++ b/lldb/include/lldb/API/SBTrace.h
@@ -39,7 +39,7 @@ public:
   SBTraceCursor CreateNewCursor(SBError &error, SBThread &thread);
 
   /// Save the trace to the specified directory, which will be created if
-  /// needed. This will also create a file \a <directory>/trace.json with the
+  /// needed. This will also create a file <directory>/trace.json with the
   /// main properties of the trace session, along with others files which
   /// contain the actual trace data. The trace.json file can be used later as
   /// input for the "trace load" command to load the trace in LLDB, or for the


### PR DESCRIPTION
## Summary
- Remove errant `\a` command before `<directory>` in `SaveToDisk` documentation
- The `\a` Doxygen command expects a word argument, but `<directory>` starts with `<` which Doxygen interprets as HTML
- This fixes: `/home/zfogg/src/github.com/llvm/llvm-project/lldb/include/lldb/API/SBTrace.h:60: Warning 564: Error parsing Doxygen command a: No word followed the command. Command ignored.`

## Test plan
- Build LLDB with Doxygen enabled and verify warning no longer appears