### PR TITLE
[CMake] Set LLVM_USE_LINKER for external projects when using lld

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -38,6 +38,13 @@ endfunction()
 
 include(LLVMExternalProjectUtils)
 
+# If lld is available in the toolchain but LLVM_USE_LINKER is not set,
+# default to using lld. This ensures -fuse-ld=lld is passed to the compiler,
+# which is required because CMAKE_LINKER has no effect when using clang.
+if(TARGET lld AND NOT LLVM_USE_LINKER)
+  set(LLVM_USE_LINKER lld)
+endif()
+
 if(NOT LLVM_BUILD_RUNTIMES)
   set(EXTRA_ARGS EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
## Summary

When lld is in TOOLCHAIN_TOOLS, LLVMExternalProjectUtils sets CMAKE_LINKER to ld.lld for external projects. However, clang does not use CMAKE_LINKER on Linux - it requires `-fuse-ld=lld` to be passed via linker flags.

This causes build failures when `LLVM_ENABLE_LTO=ON`, because the runtimes build ends up using the system linker (e.g., `/usr/bin/ld`) which cannot process LLVM bitcode in static archives:

```bash
/usr/bin/ld: libclangTidy.a: error adding symbols: file format not recognized
```

Fix this by setting `LLVM_USE_LINKER=lld`, which allows HandleLLVMOptions.cmake to properly append `-fuse-ld=lld` to the linker flags.

## Test plan

- [x] Build LLVM with `-DLLVM_ENABLE_LTO=ON -DLLVM_ENABLE_RUNTIMES=all` (previously failed, now succeeds)
- [x] Verify runtimes link with lld instead of system linker