### PR TITLE
[flang][docs] Fix title and text in the release notes page

### DIFF
--- a/flang/docs/ReleaseNotes.md
+++ b/flang/docs/ReleaseNotes.md
@@ -1,7 +1,7 @@
 <!-- If you want to modify sections/contents permanently, you should modify both
 ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 
-# Flang {{release}} {{in_progress}}Release Notes
+# Flang {{version}} {{in_progress}}Release Notes
 
 > **warning**
 >
@@ -12,7 +12,7 @@ ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 ## Introduction
 
 This document contains the release notes for the Flang Fortran frontend,
-part of the LLVM Compiler Infrastructure, release {{release}}. Here we
+part of the LLVM Compiler Infrastructure, release {{version}}. Here we
 describe the status of Flang in some detail, including major
 improvements from the previous release and new feature work. For the
 general LLVM release notes, see [the LLVM

--- a/flang/docs/ReleaseNotes.md
+++ b/flang/docs/ReleaseNotes.md
@@ -1,18 +1,18 @@
 <!-- If you want to modify sections/contents permanently, you should modify both
 ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 
-# Flang |version| (In-Progress) Release Notes
+# Flang {{release}} {{in_progress}}Release Notes
 
 > **warning**
 >
-> These are in-progress notes for the upcoming LLVM |version| release.
+> These are in-progress notes for the upcoming LLVM {{version}} release.
 > Release notes for previous releases can be found on [the Download
 > Page](https://releases.llvm.org/download.html).
 
 ## Introduction
 
 This document contains the release notes for the Flang Fortran frontend,
-part of the LLVM Compiler Infrastructure, release |version|. Here we
+part of the LLVM Compiler Infrastructure, release {{release}}. Here we
 describe the status of Flang in some detail, including major
 improvements from the previous release and new feature work. For the
 general LLVM release notes, see [the LLVM
@@ -44,7 +44,6 @@ page](https://llvm.org/releases/).
 ## Build System Changes
 
 ## New Issues Found
-
 
 ## Additional Information
 

--- a/flang/docs/ReleaseNotesTemplate.txt
+++ b/flang/docs/ReleaseNotesTemplate.txt
@@ -1,7 +1,7 @@
 <!-- If you want to modify sections/contents permanently, you should modify both
 ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 
-# Flang {{release}} {{in_progress}}Release Notes
+# Flang {{version}} {{in_progress}}Release Notes
 
 > **warning**
 >
@@ -12,7 +12,7 @@ ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 ## Introduction
 
 This document contains the release notes for the Flang Fortran frontend,
-part of the LLVM Compiler Infrastructure, release {{release}}. Here we
+part of the LLVM Compiler Infrastructure, release {{version}}. Here we
 describe the status of Flang in some detail, including major
 improvements from the previous release and new feature work. For the
 general LLVM release notes, see [the LLVM

--- a/flang/docs/ReleaseNotesTemplate.txt
+++ b/flang/docs/ReleaseNotesTemplate.txt
@@ -1,18 +1,18 @@
 <!-- If you want to modify sections/contents permanently, you should modify both
 ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 
-# Flang |version| (In-Progress) Release Notes
+# Flang {{release}} {{in_progress}}Release Notes
 
 > **warning**
 >
-> These are in-progress notes for the upcoming LLVM |version| release.
+> These are in-progress notes for the upcoming LLVM {{version}} release.
 > Release notes for previous releases can be found on [the Download
 > Page](https://releases.llvm.org/download.html).
 
 ## Introduction
 
 This document contains the release notes for the Flang Fortran frontend,
-part of the LLVM Compiler Infrastructure, release |version|. Here we
+part of the LLVM Compiler Infrastructure, release {{release}}. Here we
 describe the status of Flang in some detail, including major
 improvements from the previous release and new feature work. For the
 general LLVM release notes, see [the LLVM

--- a/flang/docs/conf.py
+++ b/flang/docs/conf.py
@@ -48,15 +48,11 @@ myst_heading_anchors = 6
 
 # Enable myst's substitution extension since markdown files cannot use the
 # |version| and |release| substitutions available to .rst files.
-myst_enable_extensions = [
-    'substitution'
-]
+myst_enable_extensions = ["substitution"]
 
 # The substitutions to use in markdown files. This contains unconditional
 # substitutions, but more may be added once the configuration is obtained.
-myst_substitutions = {
-    'in_progress': "(In-Progress) " if tags.has("PreRelease") else ""
-}
+myst_substitutions = {"in_progress": "(In-Progress) " if tags.has("PreRelease") else ""}
 
 # It is not clear who calls setup and when. In any case, when it is called, the
 # configurations options are available. These include, among the other things,
@@ -66,10 +62,9 @@ myst_substitutions = {
 # See llvm/cmake/modules/AddSphinxTarget.cmake for details on how sphinx-build
 # is invoked.
 def setup(sphinx):
-    sphinx.config.myst_substitutions.update({
-        'release': sphinx.config.release,
-        'version': sphinx.config.version
-    })
+    sphinx.config.myst_substitutions.update(
+        {'release': sphinx.config.release, 'version': sphinx.config.version}
+    )
 
 import sphinx
 

--- a/flang/docs/conf.py
+++ b/flang/docs/conf.py
@@ -46,6 +46,31 @@ source_suffix = {
 }
 myst_heading_anchors = 6
 
+# Enable myst's substitution extension since markdown files cannot use the
+# |version| and |release| substitutions available to .rst files.
+myst_enable_extensions = [
+    'substitution'
+]
+
+# The substitutions to use in markdown files. This contains unconditional
+# substitutions, but more may be added once the configuration is obtained.
+myst_substitutions = {
+    'in_progress': "(In-Progress) " if tags.has("PreRelease") else ""
+}
+
+# It is not clear who calls setup and when. In any case, when it is called, the
+# configurations options are available. These include, among the other things,
+# the values of the -D options passed to sphinx-build. Populate the myst
+# substitutions dictionary as needed.
+#
+# See llvm/cmake/modules/AddSphinxTarget.cmake for details on how sphinx-build
+# is invoked.
+def setup(sphinx):
+    sphinx.config.myst_substitutions.update({
+        'release': sphinx.config.release,
+        'version': sphinx.config.version
+    })
+
 import sphinx
 
 # The encoding of source files.

--- a/flang/docs/conf.py
+++ b/flang/docs/conf.py
@@ -10,6 +10,7 @@
 # serve to show the default.
 
 from datetime import date
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -277,8 +278,9 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
 
-# This can be treated as its own sphinx extension. The setup function will be
-# called by sphinx. Register a callback to be called when the configuration has
+
+# This can be treated as its own sphinx extension. setup() will be called by
+# sphinx. In it, register a function to be called when the configuration has
 # been initialized. The configuration will contain the values of the -D options
 # passed to sphinx-build on the command line.
 #
@@ -291,5 +293,6 @@ def setup(app):
 # Override the myst_parser substitutions map after the configuration has been
 # initialized.
 def myst_substitutions_update(app, config):
-    config.myst_substitutions["release"] = config.release
-    config.myst_substitutions["version"] = config.version
+    config.myst_substitutions.update(
+        {"release": config.release, "version": config.version}
+    )

--- a/flang/docs/conf.py
+++ b/flang/docs/conf.py
@@ -63,7 +63,7 @@ myst_substitutions = {"in_progress": "(In-Progress) " if tags.has("PreRelease") 
 # is invoked.
 def setup(sphinx):
     sphinx.config.myst_substitutions.update(
-        {'release': sphinx.config.release, 'version': sphinx.config.version}
+        {"release": sphinx.config.release, "version": sphinx.config.version}
     )
 
 import sphinx

--- a/flang/docs/conf.py
+++ b/flang/docs/conf.py
@@ -54,6 +54,7 @@ myst_enable_extensions = ["substitution"]
 # substitutions, but more may be added once the configuration is obtained.
 myst_substitutions = {"in_progress": "(In-Progress) " if tags.has("PreRelease") else ""}
 
+
 # It is not clear who calls setup and when. In any case, when it is called, the
 # configurations options are available. These include, among the other things,
 # the values of the -D options passed to sphinx-build. Populate the myst

--- a/flang/docs/conf.py
+++ b/flang/docs/conf.py
@@ -54,19 +54,6 @@ myst_enable_extensions = ["substitution"]
 # substitutions, but more may be added once the configuration is obtained.
 myst_substitutions = {"in_progress": "(In-Progress) " if tags.has("PreRelease") else ""}
 
-
-# It is not clear who calls setup and when. In any case, when it is called, the
-# configurations options are available. These include, among the other things,
-# the values of the -D options passed to sphinx-build. Populate the myst
-# substitutions dictionary as needed.
-#
-# See llvm/cmake/modules/AddSphinxTarget.cmake for details on how sphinx-build
-# is invoked.
-def setup(sphinx):
-    sphinx.config.myst_substitutions.update(
-        {"release": sphinx.config.release, "version": sphinx.config.version}
-    )
-
 import sphinx
 
 # The encoding of source files.
@@ -289,3 +276,20 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
+
+# This can be treated as its own sphinx extension. The setup function will be
+# called by sphinx. Register a callback to be called when the configuration has
+# been initialized. The configuration will contain the values of the -D options
+# passed to sphinx-build on the command line.
+#
+# See llvm/cmake/modules/AddSphinxTarget.cmake for details on how sphinx-build
+# is invoked.
+def setup(app):
+    app.connect("config-inited", myst_substitutions_update)
+
+
+# Override the myst_parser substitutions map after the configuration has been
+# initialized.
+def myst_substitutions_update(app, config):
+    config.myst_substitutions["release"] = config.release
+    config.myst_substitutions["version"] = config.version


### PR DESCRIPTION
The title of the release notes page always showed "|version| (In-Progress)". This has been fixed so the release version is shown as expected. '(In-Progress)' is now only shown on non-release branches. Unlike clang, flang does not use ${LLVM_VERSION_SUFFIX}, so even on non-release branches the 'git' suffix will not be shown.

----------------------------------------------------------------------
What the notes currently look like:

<img width="972" height="413" alt="flang-broken" src="https://github.com/user-attachments/assets/95602a3d-7292-4521-a5d3-607b19336877" />

What the notes look like after this fix:

<img width="950" height="418" alt="flang-release-fixed" src="https://github.com/user-attachments/assets/b38a05c2-96e6-4a12-a2d8-57becdf8a1d2" />