### PR TITLE
[libc++] Fix module_std_compat.sh.cpp with new versions of clang-tidy

### DIFF
--- a/libcxx/utils/libcxx/test/modules.py
+++ b/libcxx/utils/libcxx/test/modules.py
@@ -166,7 +166,7 @@ class module_test_generator:
             f'" > {self.tmp_prefix}.{header}.cppm'
         )
 
-        # Extract the information of the module partition using lang-tidy
+        # Extract the information of the module partition using clang-tidy
         print(
             f"// RUN: {self.clang_tidy} {self.tmp_prefix}.{header}.cppm "
             "  --checks='-*,libcpp-header-exportable-declarations' "
@@ -222,6 +222,7 @@ class module_test_generator:
         print(f'// RUN: echo -e "' f"{include}" f'" > {self.tmp_prefix}.{header}.cpp')
         print(
             f"// RUN: {self.clang_tidy} {self.tmp_prefix}.{header}.cpp "
+            "  --system-headers "
             "  --checks='-*,libcpp-header-exportable-declarations' "
             "  -config='{CheckOptions: [ "
             "    {"


### PR DESCRIPTION
clang-tidy doesn't run checks anymore in system headers by default in new versions to reduce runtime. In this case it's problematic, since we want to check system headers.
