### PR TITLE
[libc++] Fix num_get base parsing

### DIFF
--- a/libcxx/include/__locale_dir/num.h
+++ b/libcxx/include/__locale_dir/num.h
@@ -436,6 +436,7 @@ protected:
         ++__first;
         if (__first == __last) {
           __err |= ios_base::eofbit;
+          __v = 0;
           return __first;
         }
         // __c2 == 'x' || __c2 == 'X'
@@ -444,6 +445,7 @@ protected:
           ++__first;
         } else {
           __base = 8;
+          __parsed_num = true; // We only swallowed '0', so we've started to parse a number
         }
       } else {
         __base = 10;

--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp
@@ -670,5 +670,101 @@ int main(int, char**)
       assert(v == std::numeric_limits<long>::min());
     }
 
+  { // Check that auto-detection of the base works properly
+    ios.flags(ios.flags() & ~std::ios::basefield);
+    { // zeroes
+      {
+        v                          = -1;
+        const char str[]           = "0";
+        std::ios_base::iostate err = ios.goodbit;
+
+        cpp17_input_iterator<const char*> iter =
+            f.get(cpp17_input_iterator<const char*>(str), cpp17_input_iterator<const char*>(str + 1), ios, err, v);
+        assert(base(iter) == str + 1);
+        assert(err == ios.eofbit);
+        assert(v == 0);
+      }
+      {
+        v                          = -1;
+        const char str[]           = "00";
+        std::ios_base::iostate err = ios.goodbit;
+
+        cpp17_input_iterator<const char*> iter =
+            f.get(cpp17_input_iterator<const char*>(str), cpp17_input_iterator<const char*>(str + 2), ios, err, v);
+        assert(base(iter) == str + 2);
+        assert(err == ios.eofbit);
+        assert(v == 0);
+      }
+      {
+        v                          = -1;
+        const char str[]           = "0x0";
+        std::ios_base::iostate err = ios.goodbit;
+
+        cpp17_input_iterator<const char*> iter =
+            f.get(cpp17_input_iterator<const char*>(str), cpp17_input_iterator<const char*>(str + 3), ios, err, v);
+        assert(base(iter) == str + 3);
+        assert(err == ios.eofbit);
+        assert(v == 0);
+      }
+      {
+        v                          = -1;
+        const char str[]           = "0X0";
+        std::ios_base::iostate err = ios.goodbit;
+
+        cpp17_input_iterator<const char*> iter =
+            f.get(cpp17_input_iterator<const char*>(str), cpp17_input_iterator<const char*>(str + 3), ios, err, v);
+        assert(base(iter) == str + 3);
+        assert(err == ios.eofbit);
+        assert(v == 0);
+      }
+    }
+    { // first character after base is out of range
+      {
+        v                          = -1;
+        const char str[]           = "08";
+        std::ios_base::iostate err = ios.goodbit;
+
+        cpp17_input_iterator<const char*> iter =
+            f.get(cpp17_input_iterator<const char*>(str), cpp17_input_iterator<const char*>(str + 2), ios, err, v);
+        assert(base(iter) == str + 1);
+        assert(err == ios.goodbit);
+        assert(v == 0);
+      }
+      {
+        v                          = -1;
+        const char str[]           = "1a";
+        std::ios_base::iostate err = ios.goodbit;
+
+        cpp17_input_iterator<const char*> iter =
+            f.get(cpp17_input_iterator<const char*>(str), cpp17_input_iterator<const char*>(str + 2), ios, err, v);
+        assert(base(iter) == str + 1);
+        assert(err == ios.goodbit);
+        assert(v == 1);
+      }
+      {
+        v                          = -1;
+        const char str[]           = "0xg";
+        std::ios_base::iostate err = ios.goodbit;
+
+        cpp17_input_iterator<const char*> iter =
+            f.get(cpp17_input_iterator<const char*>(str), cpp17_input_iterator<const char*>(str + 3), ios, err, v);
+        assert(base(iter) == str + 2);
+        assert(err == ios.failbit);
+        assert(v == 0);
+      }
+      {
+        v                          = -1;
+        const char str[]           = "0Xg";
+        std::ios_base::iostate err = ios.goodbit;
+
+        cpp17_input_iterator<const char*> iter =
+            f.get(cpp17_input_iterator<const char*>(str), cpp17_input_iterator<const char*>(str + 3), ios, err, v);
+        assert(base(iter) == str + 2);
+        assert(err == ios.failbit);
+        assert(v == 0);
+      }
+    }
+  }
+
   return 0;
 }


### PR DESCRIPTION
This fixes two bugs reported in #121795 and adds regression tests. Specifically, these bugs are in the base detection mechanism. The first bug is that the out parameter isn't set when the stream only contains zero and after that is the end of the stream. The second one is that we don't consider `0` to be a number, and instead we only parse it as the start of an octal literal.