### PR TITLE
[lldb][windows] fix invalid corefile error message

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -79,8 +79,10 @@ namespace lldb_private {
 
 ProcessSP ProcessWindows::CreateInstance(lldb::TargetSP target_sp,
                                          lldb::ListenerSP listener_sp,
-                                         const FileSpec *,
+                                         const FileSpec *crash_file_path,
                                          bool can_connect) {
+  if (crash_file_path)
+    return nullptr; // Cannot create a Windows process from a crash_file
   return ProcessSP(new ProcessWindows(target_sp, listener_sp));
 }
 

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -210,11 +210,9 @@ void ProcessGDBRemote::Terminate() {
 lldb::ProcessSP ProcessGDBRemote::CreateInstance(
     lldb::TargetSP target_sp, ListenerSP listener_sp,
     const FileSpec *crash_file_path, bool can_connect) {
-  lldb::ProcessSP process_sp;
-  if (crash_file_path == nullptr)
-    process_sp = std::shared_ptr<ProcessGDBRemote>(
-        new ProcessGDBRemote(target_sp, listener_sp));
-  return process_sp;
+  if (crash_file_path)
+    return nullptr; // Cannot create a GDBRemote process from a crash_file
+  return lldb::ProcessSP(new ProcessGDBRemote(target_sp, listener_sp));
 }
 
 void ProcessGDBRemote::DumpPluginHistory(Stream &s) {


### PR DESCRIPTION
This patch fixes a misleading Windows error message when loading an invalid corefile.

Previously, `ProcessWindows::GetInstance` ignored `crash_file_path` and always returned a `Process` instance. LLDB then called `DoLoad`, which isn’t implemented, producing the confusing message: *"windows does not support loading core files."*

This patch adds the same check as `ProcessGDBRemote`, returning a `nullptr` if a `crash_file_path` is provided. The plugin fails correctly and the error message is accurate (*"unknown corefile format"*).

Thanks @da-viper for looking into this with me!

rdar://165755066