### PR TITLE
[compiler-rt] [test] refine target_page_size() in lit.common.cfg.py (NFC)

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -971,8 +971,19 @@ def target_page_size():
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
         )
+        # Unix has sysconf,
+        # Windows can use mmap.PAGESIZE
+        # Not using mmap.PAGESIZE everywhere because
+        # it is not available in WASI, but sysconf is.
         out, err = proc.communicate(
-            b'import os; print(os.sysconf("SC_PAGESIZE") if hasattr(os, "sysconf") else "")'
+            b"""
+try:
+    from os import sysconf
+    print(sysconf("SC_PAGESIZE"))
+except ImportError:
+    from mmap import PAGESIZE
+    print(PAGESIZE)
+"""
         )
         return int(out)
     except:

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -971,18 +971,16 @@ def target_page_size():
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
         )
-        # Unix has sysconf,
-        # Windows can use mmap.PAGESIZE
-        # Not using mmap.PAGESIZE everywhere because
-        # it is not available in WASI, but sysconf is.
+        # UNIX (except WASI) and Windows can use mmap.PAGESIZE,
+        # attempt to use os.sysconf for other targets.
         out, err = proc.communicate(
             b"""
 try:
-    from os import sysconf
-    print(sysconf("SC_PAGESIZE"))
-except ImportError:
     from mmap import PAGESIZE
     print(PAGESIZE)
+except ImportError:
+    from os import sysconf
+    print(sysconf("SC_PAGESIZE"))
 """
         )
         return int(out)


### PR DESCRIPTION
Use mmap.PAGESIZE and fallback to os.sysconf if it is not available.
This allows to query the page size on Windows too, which has mmap but not sysconf.

This is a pedantic change because Windows has a fixed page size of 4KiB. I found this solution independently of #168857, and thought it might be worth committing, since this is technically more correct.

[mmap.PAGESIZE implementation in CPython](https://github.com/python/cpython/blob/88cd5d9850d2dc51abe43eb84198904d9870c26e/Modules/mmapmodule.c#L47)