### PR TITLE
[mlir][MemRefToLLVM] Support atomic_rmw lowering for floats

### DIFF
--- a/mlir/test/Conversion/MemRefToLLVM/generic-atomic-rmw-flt.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/generic-atomic-rmw-flt.mlir
@@ -1,0 +1,22 @@
+// RUN: mlir-opt -finalize-memref-to-llvm %s | FileCheck %s
+
+// CHECK-LABEL: func @atomic_rmw_f32
+func.func @atomic_rmw_f32(%mem : memref<f32>, %val : f32) {
+  // CHECK: %[[LOADED_F32:.*]] = llvm.load %{{.*}} : !llvm.ptr -> f32
+  // CHECK: llvm.br ^[[LOOP:.*]](%[[LOADED_F32]] : f32)
+
+  // CHECK: ^[[LOOP]](%[[ITER_F32:.*]]: f32):
+  // CHECK-NEXT: %[[ITER_I32:.*]] = llvm.bitcast %[[ITER_F32]] : f32 to i32
+  // CHECK-NEXT: %[[NEW_VAL_I32:.*]] = llvm.bitcast %{{.*}} : f32 to i32
+  // CHECK-NEXT: %[[RES:.*]] = llvm.cmpxchg %{{.*}}, %[[ITER_I32]], %[[NEW_VAL_I32]] acq_rel monotonic : !llvm.ptr, i32
+  // CHECK-NEXT: %[[NEW_LOADED_I32:.*]] = llvm.extractvalue %[[RES]][0]
+  // CHECK-NEXT: %[[OK:.*]] = llvm.extractvalue %[[RES]][1]
+  // CHECK-NEXT: %[[NEW_LOADED_F32:.*]] = llvm.bitcast %[[NEW_LOADED_I32]] : i32 to f32
+  // CHECK-NEXT: llvm.cond_br %[[OK]], ^[[END:.*]], ^[[LOOP]](%[[NEW_LOADED_F32]] : f32)
+
+  %x = memref.generic_atomic_rmw %mem[] : memref<f32> {
+  ^bb0(%current_val: f32):
+    memref.atomic_yield %val : f32
+  }
+  return
+}


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/64493

This patch enables `memref.generic_atomic_rmw` to handle floating-point types during conversion to LLVM IR. Previously, this caused a crash because `llvm.cmpxchg` only supports integer and pointer operands.

1. Bitcasting floating-point operands to their corresponding integer types (e.g., `f32` -> `i32`) before emitting the `cmpxchg` instruction. This implements bitwise comparison semantics, treating floats as bits (e.g., distinguishing `-0.0` and `+0.0`), which is the standard approach given LLVM's lack of a native `fcmpxchg`.
2. Fixing a value mapping issue in `GenericAtomicRMWOpLowering` by replacing `lookup` with `lookupOrDefault`. This ensures that values defined outside the atomic region (such as captured SSA values) are correctly handled.
3. Added a regression test: mlir/test/Conversion/MemRefToLLVM/generic-atomic-rmw-flt.mlir.