### PR TITLE
[clang] Only use CheckVectorOperands for fixed-length vector operands

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8671,7 +8671,7 @@ def err_conditional_vector_has_void : Error<
 def err_conditional_vector_operand_type
     : Error<"enumeration type %0 is not allowed in a vector conditional">;
 def err_conditional_vector_cond_result_mismatch
-    : Error<"cannot mix vectors and extended vectors in a vector conditional">;
+    : Error<"cannot mix vectors and %select{sizeless|extended}0 vectors in a vector conditional">;
 def err_conditional_vector_mismatched
     : Error<"vector operands to the vector conditional must be the same type "
             "%diff{($ and $)|}0,1}">;

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -5689,8 +5689,10 @@ QualType Sema::CheckVectorConditionalTypes(ExprResult &Cond, ExprResult &LHS,
   QualType LHSType = LHS.get()->getType();
   QualType RHSType = RHS.get()->getType();
 
-  bool LHSIsVector = LHSType->isVectorType() || LHSType->isSizelessVectorType();
-  bool RHSIsVector = RHSType->isVectorType() || RHSType->isSizelessVectorType();
+  bool LHSSizelessVector = LHSType->isSizelessVectorType();
+  bool RHSSizelessVector = RHSType->isSizelessVectorType();
+  bool LHSIsVector = LHSType->isVectorType() || LHSSizelessVector;
+  bool RHSIsVector = RHSType->isVectorType() || RHSSizelessVector;
 
   auto GetVectorInfo =
       [&](QualType Type) -> std::pair<QualType, llvm::ElementCount> {
@@ -5708,7 +5710,7 @@ QualType Sema::CheckVectorConditionalTypes(ExprResult &Cond, ExprResult &LHS,
   if (LHSIsVector && RHSIsVector) {
     if (CondType->isExtVectorType() != LHSType->isExtVectorType()) {
       Diag(QuestionLoc, diag::err_conditional_vector_cond_result_mismatch)
-          << /*isExtVector*/ CondType->isExtVectorType();
+          << /*isExtVectorNotSizeless=*/1;
       return {};
     }
 
@@ -5720,18 +5722,22 @@ QualType Sema::CheckVectorConditionalTypes(ExprResult &Cond, ExprResult &LHS,
     }
     ResultType = Context.getCommonSugaredType(LHSType, RHSType);
   } else if (LHSIsVector || RHSIsVector) {
-    if (CondType->isSizelessVectorType())
+    bool ResultSizeless = LHSSizelessVector || RHSSizelessVector;
+    if (ResultSizeless != CondType->isSizelessVectorType()) {
+      Diag(QuestionLoc, diag::err_conditional_vector_cond_result_mismatch)
+          << /*isExtVectorNotSizeless=*/0;
+      return {};
+    }
+    if (ResultSizeless)
       ResultType = CheckSizelessVectorOperands(LHS, RHS, QuestionLoc,
                                                /*IsCompAssign*/ false,
                                                ArithConvKind::Conditional);
-    else if (LHSType->isVectorType() || RHSType->isVectorType())
+    else
       ResultType = CheckVectorOperands(
           LHS, RHS, QuestionLoc, /*isCompAssign*/ false, /*AllowBothBool*/ true,
           /*AllowBoolConversions*/ false,
           /*AllowBoolOperation*/ true,
           /*ReportInvalid*/ true);
-    else
-      return InvalidOperands(QuestionLoc, LHS, RHS);
     if (ResultType.isNull())
       return {};
   } else {

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -5724,12 +5724,14 @@ QualType Sema::CheckVectorConditionalTypes(ExprResult &Cond, ExprResult &LHS,
       ResultType = CheckSizelessVectorOperands(LHS, RHS, QuestionLoc,
                                                /*IsCompAssign*/ false,
                                                ArithConvKind::Conditional);
-    else
+    else if (LHSType->isVectorType() || LHSType->isVectorType())
       ResultType = CheckVectorOperands(
           LHS, RHS, QuestionLoc, /*isCompAssign*/ false, /*AllowBothBool*/ true,
           /*AllowBoolConversions*/ false,
           /*AllowBoolOperation*/ true,
           /*ReportInvalid*/ true);
+    else
+      return InvalidOperands(QuestionLoc, LHS, RHS);
     if (ResultType.isNull())
       return {};
   } else {

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -5724,7 +5724,7 @@ QualType Sema::CheckVectorConditionalTypes(ExprResult &Cond, ExprResult &LHS,
       ResultType = CheckSizelessVectorOperands(LHS, RHS, QuestionLoc,
                                                /*IsCompAssign*/ false,
                                                ArithConvKind::Conditional);
-    else if (LHSType->isVectorType() || LHSType->isVectorType())
+    else if (LHSType->isVectorType() || RHSType->isVectorType())
       ResultType = CheckVectorOperands(
           LHS, RHS, QuestionLoc, /*isCompAssign*/ false, /*AllowBothBool*/ true,
           /*AllowBoolConversions*/ false,

--- a/clang/test/Sema/AArch64/sve-vector-conditional-op.cpp
+++ b/clang/test/Sema/AArch64/sve-vector-conditional-op.cpp
@@ -22,6 +22,16 @@ auto error_sve_vector_result_matched_element_count(__SVBool_t svbool, __SVUint32
   return svbool ? a : b;
 }
 
+auto error_fixed_cond_mixed_scalar_and_vector_operands(fixed_vector cond, unsigned char a, __SVUint8_t b) {
+  // expected-error@+1 {{invalid operands to binary expression ('unsigned char' and '__SVUint8_t')}}
+  return cond ? a : b;
+}
+
+auto error_scalable_cond_mixed_scalar_and_vector_operands(__SVBool_t svbool, unsigned char a, fixed_vector b) {
+  // expected-error@+1 {{cannot convert between vector and non-scalar values ('unsigned char' and 'fixed_vector' (vector of 1 'int' value))}}
+  return svbool ? a : b;
+}
+
 // The following cases should be supported:
 
 __SVBool_t cond_svbool(__SVBool_t a, __SVBool_t b) {

--- a/clang/test/Sema/AArch64/sve-vector-conditional-op.cpp
+++ b/clang/test/Sema/AArch64/sve-vector-conditional-op.cpp
@@ -23,12 +23,12 @@ auto error_sve_vector_result_matched_element_count(__SVBool_t svbool, __SVUint32
 }
 
 auto error_fixed_cond_mixed_scalar_and_vector_operands(fixed_vector cond, unsigned char a, __SVUint8_t b) {
-  // expected-error@+1 {{invalid operands to binary expression ('unsigned char' and '__SVUint8_t')}}
+  // expected-error@+1 {{cannot mix vectors and sizeless vectors in a vector conditional}}
   return cond ? a : b;
 }
 
 auto error_scalable_cond_mixed_scalar_and_vector_operands(__SVBool_t svbool, unsigned char a, fixed_vector b) {
-  // expected-error@+1 {{cannot convert between vector and non-scalar values ('unsigned char' and 'fixed_vector' (vector of 1 'int' value))}}
+  // expected-error@+1 {{cannot mix vectors and sizeless vectors in a vector conditional}}
   return svbool ? a : b;
 }
 


### PR DESCRIPTION
Fixes #170279