### PR TITLE
[MC] Add section for ray tracing continuations global variables

### DIFF
--- a/llvm/include/llvm/MC/MCObjectFileInfo.h
+++ b/llvm/include/llvm/MC/MCObjectFileInfo.h
@@ -81,6 +81,9 @@ protected:
   /// section to emit import call data to.
   MCSection *ImportCallSection = nullptr;
 
+  /// Section for ray tracing global variables.
+  MCSection *RayTracingGlobalVariableSection = nullptr;
+
   // Dwarf sections for debug info.  If a target supports debug info, these must
   // be set.
   MCSection *DwarfAbbrevSection = nullptr;
@@ -278,6 +281,7 @@ public:
   MCSection *getLSDASection() const { return LSDASection; }
   MCSection *getImportCallSection() const { return ImportCallSection; }
   MCSection *getCompactUnwindSection() const { return CompactUnwindSection; }
+  MCSection *getRayTracingGlobalVariableSection() const { return RayTracingGlobalVariableSection; }
   MCSection *getDwarfAbbrevSection() const { return DwarfAbbrevSection; }
   MCSection *getDwarfInfoSection() const { return DwarfInfoSection; }
   MCSection *getDwarfInfoSection(uint64_t Hash) const {

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -560,6 +560,10 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
       Ctx->getELFSection(".pseudo_probe_desc", DebugSecType, 0);
 
   LLVMStatsSection = Ctx->getELFSection(".llvm_stats", ELF::SHT_PROGBITS, 0);
+
+  // Custom section for ray tracing global variables.
+  RayTracingGlobalVariableSection = Ctx->getELFSection(".lgc.rt.global.variables",
+                                                    ELF::SHT_PROGBITS, 0);
 }
 
 void MCObjectFileInfo::initGOFFMCObjectFileInfo(const Triple &T) {


### PR DESCRIPTION
Add section for ray tracing continuations global variables that doesn't have the SHF_ALLOC flag for them to be set into instead of .rel.data.ro.