### PR TITLE
[libunwind](TestOnly) Mark failing tests as unsupported on Apple targets

### DIFF
--- a/libunwind/test/bad_unwind_info.pass.cpp
+++ b/libunwind/test/bad_unwind_info.pass.cpp
@@ -12,6 +12,7 @@
 // this scenario.
 // REQUIRES: target={{(aarch64|s390x|x86_64)-.+}}
 // UNSUPPORTED: target={{.*-windows.*}}
+// UNSUPPORTED: target={{.*-apple.*}}
 
 // GCC doesn't support __attribute__((naked)) on AArch64.
 // UNSUPPORTED: gcc

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -16,6 +16,7 @@
 // REQUIRES: target={{x86_64-.+}}
 // REQUIRES: objcopy-available
 // UNSUPPORTED: target={{.*-windows.*}}
+// UNSUPPORTED: target={{.*-apple.*}}
 
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan

--- a/libunwind/test/remember_state_leak.pass.sh.s
+++ b/libunwind/test/remember_state_leak.pass.sh.s
@@ -8,6 +8,7 @@
 
 # REQUIRES: target={{x86_64-.+}}
 # UNSUPPORTED: target={{.*-windows.*}}
+# UNSUPPORTED: target={{.*-apple.*}}
 
 # Inline assembly isn't supported by Memory Sanitizer
 # UNSUPPORTED: msan

--- a/libunwind/test/signal_unwind.pass.cpp
+++ b/libunwind/test/signal_unwind.pass.cpp
@@ -10,6 +10,7 @@
 // Ensure that the unwinder can cope with the signal handler.
 // REQUIRES: target={{(aarch64|loongarch64|riscv64|s390x|x86_64)-.+}}
 // UNSUPPORTED: target={{.*-windows.*}}
+// UNSUPPORTED: target={{.*-apple.*}}
 
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan

--- a/libunwind/test/unwind_leaffunction.pass.cpp
+++ b/libunwind/test/unwind_leaffunction.pass.cpp
@@ -10,6 +10,7 @@
 // Ensure that leaf function can be unwund.
 // REQUIRES: target={{(aarch64|loongarch64|riscv64|s390x|x86_64)-.+}}
 // UNSUPPORTED: target={{.*-windows.*}}
+// UNSUPPORTED: target={{.*-apple.*}}
 
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan


### PR DESCRIPTION
#167642 introduced a number of test failures on one of our stage 2 builds: https://ci.swift.org/job/llvm.org/job/clang-stage2-Rthinlto/1403/. This PR marks these tests as unsupported on `.*-apple.*` targets.