### PR TITLE
[clang][BufferUsage] Fix crash when parsing invalid format string

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -528,6 +528,7 @@ Bug Fixes in This Version
 - Fixed false-positive shadow diagnostics for lambdas in explicit object member functions. (#GH163731)
 - Fix an assertion failure when a ``target_clones`` attribute is only on the
   forward declaration of a multiversioned function. (#GH165517) (#GH129483)
+- Fix a crash caused by invalid format string in printf-like functions with ``-Wunsafe-buffer-usage-in-libc-call`` option enabled. (#GH170496)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -832,6 +832,7 @@ static bool hasUnsafeFormatOrSArg(const CallExpr *Call, const Expr *&UnsafeArg,
     unsigned FmtArgIdx;
     const Expr *&UnsafeArg;
     ASTContext &Ctx;
+    bool UnsafeArgSet;
 
     // Returns an `Expr` representing the precision if specified, null
     // otherwise.
@@ -872,7 +873,8 @@ static bool hasUnsafeFormatOrSArg(const CallExpr *Call, const Expr *&UnsafeArg,
   public:
     StringFormatStringHandler(const CallExpr *Call, unsigned FmtArgIdx,
                               const Expr *&UnsafeArg, ASTContext &Ctx)
-        : Call(Call), FmtArgIdx(FmtArgIdx), UnsafeArg(UnsafeArg), Ctx(Ctx) {}
+        : Call(Call), FmtArgIdx(FmtArgIdx), UnsafeArg(UnsafeArg), Ctx(Ctx),
+          UnsafeArgSet(false) {}
 
     bool HandlePrintfSpecifier(const analyze_printf::PrintfSpecifier &FS,
                                const char *startSpecifier,
@@ -910,8 +912,11 @@ static bool hasUnsafeFormatOrSArg(const CallExpr *Call, const Expr *&UnsafeArg,
           return true;
       // Handle unsafe case:
       UnsafeArg = Call->getArg(ArgIdx); // output
+      UnsafeArgSet = true;
       return false; // returning false stops parsing immediately
     }
+
+    bool isUnsafeArgSet() { return UnsafeArgSet; }
   };
 
   const Expr *Fmt = Call->getArg(FmtArgIdx);
@@ -922,15 +927,17 @@ static bool hasUnsafeFormatOrSArg(const CallExpr *Call, const Expr *&UnsafeArg,
       StringFormatStringHandler Handler(Call, FmtArgIdx, UnsafeArg, Ctx);
 
       return analyze_format_string::ParsePrintfString(
-          Handler, FmtStr.begin(), FmtStr.end(), Ctx.getLangOpts(),
-          Ctx.getTargetInfo(), isKprintf);
+                 Handler, FmtStr.begin(), FmtStr.end(), Ctx.getLangOpts(),
+                 Ctx.getTargetInfo(), isKprintf) &&
+             Handler.isUnsafeArgSet();
     }
 
     if (auto FmtStr = SL->tryEvaluateString(Ctx)) {
       StringFormatStringHandler Handler(Call, FmtArgIdx, UnsafeArg, Ctx);
       return analyze_format_string::ParsePrintfString(
-          Handler, FmtStr->data(), FmtStr->data() + FmtStr->size(),
-          Ctx.getLangOpts(), Ctx.getTargetInfo(), isKprintf);
+                 Handler, FmtStr->data(), FmtStr->data() + FmtStr->size(),
+                 Ctx.getLangOpts(), Ctx.getTargetInfo(), isKprintf) &&
+             Handler.isUnsafeArgSet();
     }
   }
   // If format is not a string literal, we cannot analyze the format string.

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
@@ -248,3 +248,8 @@ void test(StrBuff& str)
   LibC.strcpy(buff);
   LibC.memcpy(buff, buff, 64);
 }
+
+void dontCrashForInvalidFormatString() {
+  snprintf((char*)0, 0, "%");
+  snprintf((char*)0, 0, "\0");
+}


### PR DESCRIPTION
`clang::analyze_format_string::ParsePrintfString` also returns `true` when we get an invalid or erroneous format string, so `UnsafeArg` will not be set, but `hasUnsafeFormatOrSArg`'s caller assumes `UnsafeArg` will be valid when it returns true, which leads to crash.

Closes #169629 