### PR TITLE
[lldb] support breakpoint by name on abi_tagged functions

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -544,8 +544,6 @@ bool CPlusPlusLanguage::CxxMethodName::NameMatches(llvm::StringRef full_name,
                                                    MatchOptions options) {
   constexpr llvm::StringRef abi_prefix = "[abi:";
   constexpr char abi_end = ']';
-  constexpr char open_angle = '<';
-  constexpr char close_angle = '>';
   size_t f_idx = 0;
   size_t p_idx = 0;
 
@@ -584,16 +582,15 @@ bool CPlusPlusLanguage::CxxMethodName::NameMatches(llvm::StringRef full_name,
     }
 
     // Skip template_tags.
-    if (options.skip_templates && in_char == open_angle &&
-        ma_char != open_angle) {
+    if (options.skip_templates && in_char == '<' && ma_char != '<') {
       size_t depth = 1;
       size_t tmp_idx = f_idx + 1;
       bool found_end = false;
       for (; tmp_idx < full_name.size(); ++tmp_idx) {
         const char cur = full_name[tmp_idx];
-        if (cur == open_angle)
+        if (cur == '<')
           depth++;
-        else if (cur == close_angle) {
+        else if (cur == '>') {
           depth--;
 
           if (depth == 0) {

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -35,7 +35,6 @@
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
-#include "lldb/Utility/NameMatches.h"
 #include "lldb/Utility/RegularExpression.h"
 #include "lldb/ValueObject/ValueObjectVariable.h"
 
@@ -644,6 +643,8 @@ static llvm::StringRef NextContext(llvm::StringRef context, size_t &end_pos) {
       return context.substr(idx + 1, end_pos - idx);
     }
 
+    // in contexts you cannot have a standlone bracket such
+    // as `operator<` use only one variable to track depth.
     if (val == '<' || val == '(' || val == '[')
       depth++;
     else if (val == '>' || val == ')' || val == ']')
@@ -659,7 +660,7 @@ bool CPlusPlusLanguage::CxxMethodName::ContainsContext(
   size_t full_pos = full_name.size();
   size_t pat_pos = pattern.size();
 
-  // We loop as long as there are contexts left in the identifier.
+  // We loop as long as there are contexts left in the full_name.
   while (full_pos != llvm::StringRef::npos) {
     size_t next_full_pos = full_pos;
     const llvm::StringRef full_ctx = NextContext(full_name, next_full_pos);
@@ -681,8 +682,8 @@ bool CPlusPlusLanguage::CxxMethodName::ContainsContext(
     if (next_pat_pos == llvm::StringRef::npos)
       return false;
 
-    // context does not match. advance the identifier cursor (consume the
-    // current identifier context) and resest the path cursor to the beginning.
+    // context does not match. advance the full_name cursor (consume the
+    // current full_namecontext) and resest the path cursor to the beginning.
     full_pos = next_full_pos;
     pat_pos = 0;
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -551,7 +551,7 @@ bool CPlusPlusLanguage::CxxMethodName::NameMatches(llvm::StringRef full_name,
 
   while (f_idx < full_name.size()) {
     const char in_char = full_name[f_idx];
-    // input may have extra abi_tag / template so we still loop
+    // Input may have extra abi_tag / template so we still loop.
     const bool match_empty = p_idx >= pattern.size();
     const char ma_char = match_empty ? '\0' : pattern[p_idx];
 
@@ -568,7 +568,7 @@ bool CPlusPlusLanguage::CxxMethodName::NameMatches(llvm::StringRef full_name,
           if (match_tag_end != llvm::StringRef::npos) {
             const size_t ma_tag_len = match_tag_end - p_idx + 1;
 
-            // match may only have only one of the input's abi_tags.
+            // Match may only have only one of the input's abi_tags.
             // we only skip if the abi_tag matches.
             if ((in_tag_len == ma_tag_len) &&
                 full_name.substr(f_idx, in_tag_len) ==
@@ -583,7 +583,7 @@ bool CPlusPlusLanguage::CxxMethodName::NameMatches(llvm::StringRef full_name,
       }
     }
 
-    // skip template_tags.
+    // Skip template_tags.
     if (options.skip_templates && in_char == open_angle &&
         ma_char != open_angle) {
       size_t depth = 1;
@@ -609,7 +609,7 @@ bool CPlusPlusLanguage::CxxMethodName::NameMatches(llvm::StringRef full_name,
       }
     }
 
-    // input contains characters that are not in match.
+    // Input contains characters that are not in match.
     if (match_empty || in_char != ma_char)
       return false;
 
@@ -621,6 +621,26 @@ bool CPlusPlusLanguage::CxxMethodName::NameMatches(llvm::StringRef full_name,
   return p_idx == pattern.size();
 }
 
+/// Extracts the next context component from a C++ scope resolution string.
+///
+/// This function parses a C++ qualified name (e.g., "ns::Class<T>::method")
+/// from right to left, extracting one scope context at a time. It handles
+/// nested templates, abi_tags and array brackets while searching
+/// for scope resolution operators (::).
+/// \param context The full context string to parse (e.g.,
+/// "std::vector<int>::size")
+/// \param end_pos [in,out] The position to start searching backwards from. On
+///                 return, contains the position of the previous scope
+///                 separator (::), or llvm::StringRef::npos if no more
+///                 components exist.
+///
+/// Example:
+///   llvm::StringRef scope = "ns::inner::Class<int>";
+///   size_t pos = scope.size();
+///
+///   ctx1 = NextContext(context, pos); // returns "Class<int>", pos = 9
+///   ctx2 = NextContext(context, pos); // returns "inner", pos = 2
+///   ctx3 = NextContext(context, pos); // returns "ns", pos = StringRef::npos
 static llvm::StringRef NextContext(llvm::StringRef context, size_t &end_pos) {
   if (end_pos == llvm::StringRef::npos)
     return {};
@@ -643,7 +663,7 @@ static llvm::StringRef NextContext(llvm::StringRef context, size_t &end_pos) {
       return context.substr(idx + 1, end_pos - idx);
     }
 
-    // in contexts you cannot have a standlone bracket such
+    // In contexts, you cannot have a standlone bracket such
     // as `operator<` use only one variable to track depth.
     if (val == '<' || val == '(' || val == '[')
       depth++;
@@ -682,8 +702,8 @@ bool CPlusPlusLanguage::CxxMethodName::ContainsContext(
     if (next_pat_pos == llvm::StringRef::npos)
       return false;
 
-    // context does not match. advance the full_name cursor (consume the
-    // current full_namecontext) and resest the path cursor to the beginning.
+    // context does not match. advance the full_name pos (consume the
+    // current full_name context) and reset the pat_pos to the beginning.
     full_pos = next_full_pos;
     pat_pos = 0;
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
@@ -56,8 +56,8 @@ public:
     // | MyClass::foo()       | OClass::foo |                       | false   |
     // | bar::foo<int>        | foo         | no_skip_template      | false   |
     ///
-    bool NameMatches(llvm::StringRef full_name, llvm::StringRef pattern,
-                     MatchOptions options);
+    static bool NameMatches(llvm::StringRef full_name, llvm::StringRef pattern,
+                            MatchOptions options);
 
     /// Checks if a pattern appears as a suffix of contexts within a full C++
     /// name, uses the same \a MatchOption as \a NameMatches.
@@ -67,8 +67,8 @@ public:
     /// \param options Configuration for name matching (passed to NameMatches)
     /// \return true if the pattern is found as a suffix context or the whole
     /// context, false otherwise
-    bool ContainsContext(llvm::StringRef full_name, llvm::StringRef pattern,
-                         MatchOptions options);
+    static bool ContainsContext(llvm::StringRef full_name,
+                                llvm::StringRef pattern, MatchOptions options);
 
   protected:
     void Parse() override;

--- a/lldb/test/API/functionalities/breakpoint/cpp/abi_tag/Makefile
+++ b/lldb/test/API/functionalities/breakpoint/cpp/abi_tag/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/breakpoint/cpp/abi_tag/TestCPPBreakpointLocationsAbiTag.py
+++ b/lldb/test/API/functionalities/breakpoint/cpp/abi_tag/TestCPPBreakpointLocationsAbiTag.py
@@ -15,7 +15,6 @@ class Case(TypedDict, total=True):
 
 @skipIfWindows  # abi_tags is not supported
 class TestCPPBreakpointLocationsAbiTag(TestBase):
-
     def verify_breakpoint_names(self, target: lldb.SBTarget, bp_dict: Case):
         name = bp_dict["name"]
         matches = bp_dict["matches"]

--- a/lldb/test/API/functionalities/breakpoint/cpp/abi_tag/TestCPPBreakpointLocationsAbiTag.py
+++ b/lldb/test/API/functionalities/breakpoint/cpp/abi_tag/TestCPPBreakpointLocationsAbiTag.py
@@ -1,0 +1,90 @@
+"""
+Test breakpoint on function with abi_tags.
+"""
+
+import lldb
+from typing import List, Set, TypedDict
+from lldbsuite.test.decorators import skipIfWindows
+from lldbsuite.test.lldbtest import VALID_TARGET, TestBase
+
+
+class Case(TypedDict, total=True):
+    name: str
+    matches: Set[str]
+
+
+@skipIfWindows  # abi_tags is not supported
+class TestCPPBreakpointLocationsAbiTag(TestBase):
+
+    def verify_breakpoint_names(self, target: lldb.SBTarget, bp_dict: Case):
+        name = bp_dict["name"]
+        matches = bp_dict["matches"]
+        bp: lldb.SBBreakpoint = target.BreakpointCreateByName(name)
+
+        for location in bp:
+            self.assertTrue(location.IsValid(), f"Expected valid location {location}")
+
+        expected_matches = set(location.addr.function.name for location in bp)
+
+        self.assertSetEqual(expected_matches, matches)
+
+    def test_breakpoint_name_with_abi_tag(self):
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        target: lldb.SBTarget = self.dbg.CreateTarget(exe)
+        self.assertTrue(target, VALID_TARGET)
+
+        test_cases: List[Case] = [
+            Case(
+                name="foo",
+                matches={
+                    "foo[abi:FOO]()",
+                    "StaticStruct[abi:STATIC_STRUCT]::foo[abi:FOO][abi:FOO2]()",
+                    "Struct[abi:STRUCT]::foo[abi:FOO]()",
+                    "ns::NamespaceStruct[abi:NAMESPACE_STRUCT]::foo[abi:FOO]()",
+                    "ns::foo[abi:NAMESPACE_FOO]()",
+                    "TemplateStruct[abi:TEMPLATE_STRUCT]<int>::foo[abi:FOO]()",
+                    "void TemplateStruct[abi:TEMPLATE_STRUCT]<int>::foo[abi:FOO_TEMPLATE]<long>(long)",
+                },
+            ),
+            Case(
+                name="StaticStruct::foo",
+                matches={"StaticStruct[abi:STATIC_STRUCT]::foo[abi:FOO][abi:FOO2]()"},
+            ),
+            Case(name="Struct::foo", matches={"Struct[abi:STRUCT]::foo[abi:FOO]()"}),
+            Case(
+                name="TemplateStruct::foo",
+                matches={
+                    "TemplateStruct[abi:TEMPLATE_STRUCT]<int>::foo[abi:FOO]()",
+                    "void TemplateStruct[abi:TEMPLATE_STRUCT]<int>::foo[abi:FOO_TEMPLATE]<long>(long)",
+                },
+            ),
+            Case(name="ns::foo", matches={"ns::foo[abi:NAMESPACE_FOO]()"}),
+            # operators
+            Case(
+                name="operator<",
+                matches={
+                    "Struct[abi:STRUCT]::operator<(int)",
+                    "bool TemplateStruct[abi:TEMPLATE_STRUCT]<int>::operator<[abi:OPERATOR]<int>(int)",
+                },
+            ),
+            Case(
+                name="TemplateStruct::operator<<",
+                matches={
+                    "bool TemplateStruct[abi:TEMPLATE_STRUCT]<int>::operator<<[abi:operator]<int>(int)"
+                },
+            ),
+            Case(
+                name="operator<<",
+                matches={
+                    "bool TemplateStruct[abi:TEMPLATE_STRUCT]<int>::operator<<[abi:operator]<int>(int)"
+                },
+            ),
+            Case(
+                name="operator==",
+                matches={"operator==[abi:OPERATOR](wrap_int const&, wrap_int const&)"},
+            ),
+        ]
+
+        for case in test_cases:
+            self.verify_breakpoint_names(target, case)

--- a/lldb/test/API/functionalities/breakpoint/cpp/abi_tag/main.cpp
+++ b/lldb/test/API/functionalities/breakpoint/cpp/abi_tag/main.cpp
@@ -1,0 +1,118 @@
+
+struct wrap_int {
+  int inner{};
+};
+[[gnu::abi_tag("OPERATOR")]]
+bool operator==(const wrap_int & /*unused*/, const wrap_int & /*unused*/) {
+  return true;
+}
+
+[[gnu::abi_tag("FOO")]]
+static int foo() {
+  return 0;
+}
+
+struct [[gnu::abi_tag("STATIC_STRUCT")]] StaticStruct {
+  [[gnu::abi_tag("FOO", "FOO2")]]
+  static int foo() {
+    return 10;
+  };
+};
+
+struct [[gnu::abi_tag("STRUCT")]] Struct {
+  [[gnu::abi_tag("FOO")]]
+  int foo() {
+    return 10;
+  };
+
+  bool operator<(int val) { return false; }
+
+  [[gnu::abi_tag("ops")]]
+  unsigned int operator[](int val) {
+    return val;
+  }
+
+  [[gnu::abi_tag("FOO")]]
+  ~Struct() {}
+};
+
+namespace ns {
+struct [[gnu::abi_tag("NAMESPACE_STRUCT")]] NamespaceStruct {
+  [[gnu::abi_tag("FOO")]]
+  int foo() {
+    return 10;
+  }
+};
+
+[[gnu::abi_tag("NAMESPACE_FOO")]]
+void end_with_foo() {}
+
+[[gnu::abi_tag("NAMESPACE_FOO")]]
+void foo() {}
+} // namespace ns
+
+template <typename Type>
+class [[gnu::abi_tag("TEMPLATE_STRUCT")]] TemplateStruct {
+
+  [[gnu::abi_tag("FOO")]]
+  void foo() {
+    int something = 32;
+  }
+
+public:
+  void foo_pub() { this->foo(); }
+
+  template <typename ArgType>
+  [[gnu::abi_tag("FOO_TEMPLATE")]]
+  void foo(ArgType val) {
+    val = 20;
+  }
+
+  template <typename Ty>
+  [[gnu::abi_tag("OPERATOR")]]
+  bool operator<(Ty val) {
+    return false;
+  }
+
+  template <typename Ty>
+  [[gnu::abi_tag("operator")]]
+  bool operator<<(Ty val) {
+    return false;
+  }
+};
+
+int main() {
+  // standalone
+  const int res1 = foo();
+
+  // static
+  const int res2 = StaticStruct::foo();
+
+  // normal
+  {
+    Struct normal;
+    const int res3 = normal.foo();
+    const bool operator_lessthan_res = normal < 10;
+  }
+
+  // namespace
+  ns::NamespaceStruct ns_struct;
+  const int res4 = ns_struct.foo();
+
+  ns::foo();
+
+  // template struct
+  TemplateStruct<int> t_struct;
+  t_struct.foo_pub();
+  const long into_param = 0;
+  t_struct.foo(into_param);
+
+  const bool t_ops_lessthan = t_struct < 20;
+  const bool t_ops_leftshift = t_struct << 30;
+
+  // standalone operator
+  wrap_int lhs;
+  wrap_int rhs;
+  const bool res6 = lhs == rhs;
+  return 0;
+}


### PR DESCRIPTION
This PR adds support for setting breakpoints on functions annotated with the gnu::abi_tag attribute.

Functions decorated with gnu::abi_tag can now be matched by their base name. 
For example:
```cpp
[[gnu::abi_tag("cxx11")]]
int foo() { }
```

The command `breakpoint set --name foo` will now successfully match and set a breakpoint on the above function.

Current Limitation

This PR does not include support for explicitly specifying the ABI tag in the breakpoint name. The following syntax is not currently supported: `breakpoint set --name foo[abi:cxx11]`. This will require changes on how we currently lookup and match names in the debug info. 