### PR TITLE
[libc][wctype] Add cmake flag for configuring wctype implementation used

### DIFF
--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -130,5 +130,11 @@
       "value": true,
       "doc": "Add nullptr checks in the library's implementations to some functions for which passing nullptr is undefined behavior."
     }
+  },
+  "wctype": {
+    "LIBC_CONF_WCTYPE_MODE": {
+      "value": "LIBC_WCTYPE_MODE_ASCII",
+      "doc": "The implementation used for wctype, acceptable values are LIBC_WCTYPE_MODE_ASCII and LIBC_WCTYPE_MODE_UTF8."
+    }
   }
 }

--- a/libc/docs/configure.rst
+++ b/libc/docs/configure.rst
@@ -64,3 +64,5 @@ to learn about the defaults for your platform and target.
     - ``LIBC_CONF_THREAD_MODE``: The implementation used for Mutex, acceptable values are LIBC_THREAD_MODE_PLATFORM, LIBC_THREAD_MODE_SINGLE, and LIBC_THREAD_MODE_EXTERNAL.
 * **"time" options**
     - ``LIBC_CONF_TIME_64BIT``: Force the size of time_t to 64 bits, even on platforms where compatibility considerations would otherwise make it 32-bit.
+* **"wctype" options**
+    - ``LIBC_CONF_WCTYPE_MODE``: The implementation used for wctype, acceptable values are LIBC_WCTYPE_MODE_ASCII and LIBC_WCTYPE_MODE_UTF8.


### PR DESCRIPTION
#170525 

Based on our [RFC](https://discourse.llvm.org/t/rfc-libc-wctype-header-implementation/88941/10), we are starting the implementation of the wctype header with C.UTF8 support. This implementation will increase the binary size by approximately ~70KB, so this PR introduces a flag so that this is configurable, allowing the user to choose between a simple ASCII implementation or the full Unicode one.