### PR TITLE
[clang-tidy] Avoid expensive AST traversal in RedundantTypenameCheck

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -18,9 +18,9 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::readability {
 
 void RedundantTypenameCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(traverse(TK_IgnoreUnlessSpelledInSource,
-                              typeLoc().bind("typeLoc")),
-                     this);
+  Finder->addMatcher(
+      traverse(TK_IgnoreUnlessSpelledInSource, typeLoc().bind("typeLoc")),
+      this);
 
   if (!getLangOpts().CPlusPlus20)
     return;

--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -19,7 +19,7 @@ namespace clang::tidy::readability {
 
 void RedundantTypenameCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(traverse(TK_IgnoreUnlessSpelledInSource,
-                              typeLoc().bind("nonDependentTypeLoc")),
+                              typeLoc().bind("typeLoc")),
                      this);
 
   if (!getLangOpts().CPlusPlus20)

--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -19,7 +19,11 @@ namespace clang::tidy::readability {
 
 void RedundantTypenameCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
-      typeLoc(unless(hasAncestor(decl(isInstantiated())))).bind("typeLoc"),
+      typeLoc(loc(TypeMatcher(anyOf(typedefType(), tagType(),
+                                    deducedTemplateSpecializationType(),
+                                    templateSpecializationType()))),
+              unless(hasAncestor(decl(isInstantiated()))))
+          .bind("nonDependentTypeLoc"),
       this);
 
   if (!getLangOpts().CPlusPlus20)

--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -18,13 +18,9 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::readability {
 
 void RedundantTypenameCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(
-      typeLoc(loc(TypeMatcher(anyOf(typedefType(), tagType(),
-                                    deducedTemplateSpecializationType(),
-                                    templateSpecializationType()))),
-              unless(hasAncestor(decl(isInstantiated()))))
-          .bind("nonDependentTypeLoc"),
-      this);
+  Finder->addMatcher(traverse(TK_IgnoreUnlessSpelledInSource,
+                              typeLoc().bind("nonDependentTypeLoc")),
+                     this);
 
   if (!getLangOpts().CPlusPlus20)
     return;


### PR DESCRIPTION
In Fuchsia, we have several files that take over 2 hours for this check to run, where as it only takes 8 seconds to finish without the RedundantTypenameCheck.  We can avoid this exponential behavior by limiting the use of hasAncestor to typeLocs for the types that are actually used in the checking logic.

With this patch, the wall time for the check with --enable-profile goes from 6724 seconds (about 2 hours) to down to a reasonable 0.1753 seconds under c++17, and 347 seconds under C++20.