### PR TITLE
[libclc] Fix memory fence scope mapping for OpenCL

### DIFF
--- a/libclc/opencl/include/clc/opencl/synchronization/utils.h
+++ b/libclc/opencl/include/clc/opencl/synchronization/utils.h
@@ -13,16 +13,15 @@
 #include <clc/mem_fence/clc_mem_semantic.h>
 #include <clc/opencl/synchronization/cl_mem_fence_flags.h>
 
-_CLC_INLINE int __opencl_get_memory_scope(cl_mem_fence_flags flag) {
-  int memory_scope = 0;
+static _CLC_INLINE int __opencl_get_memory_scope(cl_mem_fence_flags flag) {
   if (flag & CLK_GLOBAL_MEM_FENCE)
-    memory_scope |= __MEMORY_SCOPE_DEVICE;
+    return __MEMORY_SCOPE_DEVICE;
   if (flag & CLK_LOCAL_MEM_FENCE)
-    memory_scope |= __MEMORY_SCOPE_WRKGRP;
-  return memory_scope;
+    return __MEMORY_SCOPE_WRKGRP;
+  return __MEMORY_SCOPE_SINGLE;
 }
 
-_CLC_INLINE __CLC_MemorySemantics
+static _CLC_INLINE __CLC_MemorySemantics
 __opencl_get_memory_semantics(cl_mem_fence_flags flag) {
   if ((flag & CLK_LOCAL_MEM_FENCE) && (flag & CLK_GLOBAL_MEM_FENCE))
     return __CLC_MEMORY_LOCAL | __CLC_MEMORY_GLOBAL;


### PR DESCRIPTION
The function `__opencl_get_memory_scope` incorrectly assumed that the
Clang built-in `__MEMORY_SCOPE_*` macros defined as bitmasks, while they
are actually defined as distinct integer values. This led to incorrect
mapping of OpenCL memory fence flags to LLVM memory scopes, causing
issues in generated code.

The fix involves updating the `__opencl_get_memory_scope` function to
return the correct `__MEMORY_SCOPE_*` values based on the provided
`cl_mem_fence_flags`. Additionally, the `__opencl_get_memory_semantics`
and the `__opencl_get_memory_scope` functions are marked as `static`
to avoid potential multiple definition issues during linking.