### PR TITLE
[MsgPack] Use JSON schema boolean resolution rules

### DIFF
--- a/llvm/unittests/BinaryFormat/MsgPackDocumentTest.cpp
+++ b/llvm/unittests/BinaryFormat/MsgPackDocumentTest.cpp
@@ -420,3 +420,77 @@ TEST(MsgPackDocument, TestInputYAMLMap) {
   ASSERT_EQ(SS.getKind(), Type::String);
   ASSERT_EQ(SS.getString(), "2");
 }
+
+TEST(MsgPackDocument, TestInputYAMLBoolean) {
+  Document Doc;
+  auto GetFirst = [](Document &Doc) { return Doc.getRoot().getArray()[0]; };
+  auto ToYAML = [](Document &Doc) {
+    std::string S;
+    raw_string_ostream OS(S);
+    Doc.toYAML(OS);
+    return S;
+  };
+
+  bool Ok;
+
+  Ok = Doc.fromYAML("- n\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::String);
+  ASSERT_EQ(GetFirst(Doc).getString(), "n");
+  ASSERT_EQ(ToYAML(Doc), "---\n- n\n...\n");
+
+  Ok = Doc.fromYAML("- y\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::String);
+  ASSERT_EQ(GetFirst(Doc).getString(), "y");
+  ASSERT_EQ(ToYAML(Doc), "---\n- y\n...\n");
+
+  Ok = Doc.fromYAML("- no\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::String);
+  ASSERT_EQ(GetFirst(Doc).getString(), "no");
+  ASSERT_EQ(ToYAML(Doc), "---\n- no\n...\n");
+
+  Ok = Doc.fromYAML("- yes\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::String);
+  ASSERT_EQ(GetFirst(Doc).getString(), "yes");
+  ASSERT_EQ(ToYAML(Doc), "---\n- yes\n...\n");
+
+  Ok = Doc.fromYAML("- false\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::Boolean);
+  ASSERT_EQ(GetFirst(Doc).getBool(), false);
+  ASSERT_EQ(ToYAML(Doc), "---\n- false\n...\n");
+
+  Ok = Doc.fromYAML("- true\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::Boolean);
+  ASSERT_EQ(GetFirst(Doc).getBool(), true);
+  ASSERT_EQ(ToYAML(Doc), "---\n- true\n...\n");
+
+  Ok = Doc.fromYAML("- !str false\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::String);
+  ASSERT_EQ(GetFirst(Doc).getString(), "false");
+  ASSERT_EQ(ToYAML(Doc), "---\n- !str 'false'\n...\n");
+
+  Ok = Doc.fromYAML("- !str true\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::String);
+  ASSERT_EQ(GetFirst(Doc).getString(), "true");
+  ASSERT_EQ(ToYAML(Doc), "---\n- !str 'true'\n...\n");
+
+  // FIXME: A fix for these requires changes in YAMLParser/YAMLTraits.
+  Ok = Doc.fromYAML("- \"false\"\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::Boolean);
+  ASSERT_EQ(GetFirst(Doc).getBool(), false);
+  ASSERT_EQ(ToYAML(Doc), "---\n- false\n...\n");
+
+  Ok = Doc.fromYAML("- \"true\"\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::Boolean);
+  ASSERT_EQ(GetFirst(Doc).getBool(), true);
+  ASSERT_EQ(ToYAML(Doc), "---\n- true\n...\n");
+}

--- a/llvm/unittests/BinaryFormat/MsgPackDocumentTest.cpp
+++ b/llvm/unittests/BinaryFormat/MsgPackDocumentTest.cpp
@@ -421,7 +421,7 @@ TEST(MsgPackDocument, TestInputYAMLMap) {
   ASSERT_EQ(SS.getString(), "2");
 }
 
-TEST(MsgPackDocument, TestInputYAMLBoolean) {
+TEST(MsgPackDocument, TestYAMLBoolean) {
   Document Doc;
   auto GetFirst = [](Document &Doc) { return Doc.getRoot().getArray()[0]; };
   auto ToYAML = [](Document &Doc) {
@@ -480,6 +480,18 @@ TEST(MsgPackDocument, TestInputYAMLBoolean) {
   ASSERT_EQ(GetFirst(Doc).getKind(), Type::String);
   ASSERT_EQ(GetFirst(Doc).getString(), "true");
   ASSERT_EQ(ToYAML(Doc), "---\n- !str 'true'\n...\n");
+
+  Ok = Doc.fromYAML("- !bool false\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::Boolean);
+  ASSERT_EQ(GetFirst(Doc).getBool(), false);
+  ASSERT_EQ(ToYAML(Doc), "---\n- false\n...\n");
+
+  Ok = Doc.fromYAML("- !bool true\n");
+  ASSERT_TRUE(Ok);
+  ASSERT_EQ(GetFirst(Doc).getKind(), Type::Boolean);
+  ASSERT_EQ(GetFirst(Doc).getBool(), true);
+  ASSERT_EQ(ToYAML(Doc), "---\n- true\n...\n");
 
   // FIXME: A fix for these requires changes in YAMLParser/YAMLTraits.
   Ok = Doc.fromYAML("- \"false\"\n");


### PR DESCRIPTION
Since YAMLIO generally knows the types ahead of time (since it primarily functions to (de)serialize concrete C++ types) "tag resolution" isn't really a meaningful isssue.

With MsgPackDocument we permit arbitrary documents with arbitrary type nodes, and so the YAML "NO" problem is an issue.

Address this in MsgPackDocument itself to avoid a significant and far-reaching backwards-incompatible change to YAMLIO (although we could still consider tightening things up there in the future). Use the "JSON Schema" for tag resolution where the only literals to resolve to bool by default are "true" and "false".