### PR TITLE
DAG: Use more RTLIB helper functions for getting libcall from type

### DIFF
--- a/llvm/include/llvm/CodeGen/RuntimeLibcallUtil.h
+++ b/llvm/include/llvm/CodeGen/RuntimeLibcallUtil.h
@@ -22,6 +22,46 @@
 namespace llvm {
 namespace RTLIB {
 
+/// \return The SHL_* value for the given types, or UNKNOWN_LIBCALL if there is
+/// none.
+LLVM_ABI Libcall getSHL(EVT VT);
+
+/// \return The SRL_* value for the given types, or UNKNOWN_LIBCALL if there is
+/// none.
+LLVM_ABI Libcall getSRL(EVT VT);
+
+/// \return The SRA_* value for the given types, or UNKNOWN_LIBCALL if there is
+/// none.
+LLVM_ABI Libcall getSRA(EVT VT);
+
+/// \return The MUL_* value for the given types, or UNKNOWN_LIBCALL if there is
+/// none.
+LLVM_ABI Libcall getMUL(EVT VT);
+
+/// \return The MULO_* value for the given types, or UNKNOWN_LIBCALL if there is
+/// none.
+LLVM_ABI Libcall getMULO(EVT VT);
+
+/// \return The SDIV_* value for the given types, or UNKNOWN_LIBCALL if there is
+/// none.
+LLVM_ABI Libcall getSDIV(EVT VT);
+
+/// \return The UDIV_* value for the given types, or UNKNOWN_LIBCALL if there is
+/// none.
+LLVM_ABI Libcall getUDIV(EVT VT);
+
+/// \return The SREM_* value for the given types, or UNKNOWN_LIBCALL if there is
+/// none.
+LLVM_ABI Libcall getSREM(EVT VT);
+
+/// \return The UREM_* value for the given types, or UNKNOWN_LIBCALL if there is
+/// none.
+LLVM_ABI Libcall getUREM(EVT VT);
+
+/// \return The CTPOP_* value for the given types, or UNKNOWN_LIBCALL if there
+/// is none.
+LLVM_ABI Libcall getCTPOP(EVT VT);
+
 /// GetFPLibCall - Helper to return the right libcall for the given floating
 /// point type, or UNKNOWN_LIBCALL if there is none.
 LLVM_ABI Libcall getFPLibCall(EVT VT, Libcall Call_F32, Libcall Call_F64,
@@ -90,7 +130,23 @@ LLVM_ABI Libcall getSINCOS_STRET(EVT RetVT);
 
 /// getMODF - Return the MODF_* value for the given types, or
 /// UNKNOWN_LIBCALL if there is none.
-LLVM_ABI Libcall getMODF(EVT RetVT);
+LLVM_ABI Libcall getMODF(EVT VT);
+
+/// \return the LROUND_* value for the given types, or UNKNOWN_LIBCALL if there
+/// is none.
+LLVM_ABI Libcall getLROUND(EVT VT);
+
+/// \return the LLROUND_* value for the given types, or UNKNOWN_LIBCALL if there
+/// is none.
+LLVM_ABI Libcall getLLROUND(EVT VT);
+
+/// \return the LRINT_* value for the given types, or UNKNOWN_LIBCALL if there
+/// is none.
+LLVM_ABI Libcall getLRINT(EVT RetVT);
+
+/// \return the LLRINT_* value for the given types, or UNKNOWN_LIBCALL if there
+/// is none.
+LLVM_ABI Libcall getLLRINT(EVT RetVT);
 
 /// Return the SYNC_FETCH_AND_* value for the given opcode and type, or
 /// UNKNOWN_LIBCALL if there is none.

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -4097,13 +4097,7 @@ void DAGTypeLegalizer::ExpandIntRes_CTPOP(SDNode *N, SDValue &Lo, SDValue &Hi) {
   SDLoc DL(N);
 
   if (TLI.getOperationAction(ISD::CTPOP, VT) == TargetLoweringBase::LibCall) {
-    RTLIB::Libcall LC = RTLIB::UNKNOWN_LIBCALL;
-    if (VT == MVT::i32)
-      LC = RTLIB::CTPOP_I32;
-    else if (VT == MVT::i64)
-      LC = RTLIB::CTPOP_I64;
-    else if (VT == MVT::i128)
-      LC = RTLIB::CTPOP_I128;
+    RTLIB::Libcall LC = RTLIB::getCTPOP(VT);
     assert(LC != RTLIB::UNKNOWN_LIBCALL && TLI.getLibcallName(LC) &&
            "LibCall explicitly requested, but not available");
     TargetLowering::MakeLibCallOptions CallOptions;
@@ -4236,55 +4230,19 @@ void DAGTypeLegalizer::ExpandIntRes_XROUND_XRINT(SDNode *N, SDValue &Lo,
   RTLIB::Libcall LC = RTLIB::UNKNOWN_LIBCALL;
   if (N->getOpcode() == ISD::LROUND ||
       N->getOpcode() == ISD::STRICT_LROUND) {
-    if (VT == MVT::f32)
-      LC = RTLIB::LROUND_F32;
-    else if (VT == MVT::f64)
-      LC = RTLIB::LROUND_F64;
-    else if (VT == MVT::f80)
-      LC = RTLIB::LROUND_F80;
-    else if (VT == MVT::f128)
-      LC = RTLIB::LROUND_F128;
-    else if (VT == MVT::ppcf128)
-      LC = RTLIB::LROUND_PPCF128;
+    LC = RTLIB::getLROUND(VT);
     assert(LC != RTLIB::UNKNOWN_LIBCALL && "Unexpected lround input type!");
   } else if (N->getOpcode() == ISD::LRINT ||
              N->getOpcode() == ISD::STRICT_LRINT) {
-    if (VT == MVT::f32)
-      LC = RTLIB::LRINT_F32;
-    else if (VT == MVT::f64)
-      LC = RTLIB::LRINT_F64;
-    else if (VT == MVT::f80)
-      LC = RTLIB::LRINT_F80;
-    else if (VT == MVT::f128)
-      LC = RTLIB::LRINT_F128;
-    else if (VT == MVT::ppcf128)
-      LC = RTLIB::LRINT_PPCF128;
+    LC = RTLIB::getLRINT(VT);
     assert(LC != RTLIB::UNKNOWN_LIBCALL && "Unexpected lrint input type!");
   } else if (N->getOpcode() == ISD::LLROUND ||
       N->getOpcode() == ISD::STRICT_LLROUND) {
-    if (VT == MVT::f32)
-      LC = RTLIB::LLROUND_F32;
-    else if (VT == MVT::f64)
-      LC = RTLIB::LLROUND_F64;
-    else if (VT == MVT::f80)
-      LC = RTLIB::LLROUND_F80;
-    else if (VT == MVT::f128)
-      LC = RTLIB::LLROUND_F128;
-    else if (VT == MVT::ppcf128)
-      LC = RTLIB::LLROUND_PPCF128;
+    LC = RTLIB::getLLROUND(VT);
     assert(LC != RTLIB::UNKNOWN_LIBCALL && "Unexpected llround input type!");
   } else if (N->getOpcode() == ISD::LLRINT ||
              N->getOpcode() == ISD::STRICT_LLRINT) {
-    if (VT == MVT::f32)
-      LC = RTLIB::LLRINT_F32;
-    else if (VT == MVT::f64)
-      LC = RTLIB::LLRINT_F64;
-    else if (VT == MVT::f80)
-      LC = RTLIB::LLRINT_F80;
-    else if (VT == MVT::f128)
-      LC = RTLIB::LLRINT_F128;
-    else if (VT == MVT::ppcf128)
-      LC = RTLIB::LLRINT_PPCF128;
+    LC = RTLIB::getLLRINT(VT);
     assert(LC != RTLIB::UNKNOWN_LIBCALL && "Unexpected llrint input type!");
   } else
     llvm_unreachable("Unexpected opcode!");
@@ -4444,15 +4402,7 @@ void DAGTypeLegalizer::ExpandIntRes_MUL(SDNode *N,
     return;
 
   // If nothing else, we can make a libcall.
-  RTLIB::Libcall LC = RTLIB::UNKNOWN_LIBCALL;
-  if (VT == MVT::i16)
-    LC = RTLIB::MUL_I16;
-  else if (VT == MVT::i32)
-    LC = RTLIB::MUL_I32;
-  else if (VT == MVT::i64)
-    LC = RTLIB::MUL_I64;
-  else if (VT == MVT::i128)
-    LC = RTLIB::MUL_I128;
+  RTLIB::Libcall LC = RTLIB::getMUL(VT);
 
   if (LC == RTLIB::UNKNOWN_LIBCALL || !TLI.getLibcallName(LC)) {
     // Perform a wide multiplication where the wide type is the original VT and
@@ -4824,15 +4774,7 @@ void DAGTypeLegalizer::ExpandIntRes_SDIV(SDNode *N,
     return;
   }
 
-  RTLIB::Libcall LC = RTLIB::UNKNOWN_LIBCALL;
-  if (VT == MVT::i16)
-    LC = RTLIB::SDIV_I16;
-  else if (VT == MVT::i32)
-    LC = RTLIB::SDIV_I32;
-  else if (VT == MVT::i64)
-    LC = RTLIB::SDIV_I64;
-  else if (VT == MVT::i128)
-    LC = RTLIB::SDIV_I128;
+  RTLIB::Libcall LC = RTLIB::getSDIV(VT);
   assert(LC != RTLIB::UNKNOWN_LIBCALL && "Unsupported SDIV!");
 
   TargetLowering::MakeLibCallOptions CallOptions;
@@ -5039,35 +4981,14 @@ void DAGTypeLegalizer::ExpandIntRes_Shift(SDNode *N,
   bool isSigned;
   if (Opc == ISD::SHL) {
     isSigned = false; /*sign irrelevant*/
-    if (VT == MVT::i16)
-      LC = RTLIB::SHL_I16;
-    else if (VT == MVT::i32)
-      LC = RTLIB::SHL_I32;
-    else if (VT == MVT::i64)
-      LC = RTLIB::SHL_I64;
-    else if (VT == MVT::i128)
-      LC = RTLIB::SHL_I128;
+    LC = RTLIB::getSHL(VT);
   } else if (Opc == ISD::SRL) {
     isSigned = false;
-    if (VT == MVT::i16)
-      LC = RTLIB::SRL_I16;
-    else if (VT == MVT::i32)
-      LC = RTLIB::SRL_I32;
-    else if (VT == MVT::i64)
-      LC = RTLIB::SRL_I64;
-    else if (VT == MVT::i128)
-      LC = RTLIB::SRL_I128;
+    LC = RTLIB::getSRL(VT);
   } else {
     assert(Opc == ISD::SRA && "Unknown shift!");
     isSigned = true;
-    if (VT == MVT::i16)
-      LC = RTLIB::SRA_I16;
-    else if (VT == MVT::i32)
-      LC = RTLIB::SRA_I32;
-    else if (VT == MVT::i64)
-      LC = RTLIB::SRA_I64;
-    else if (VT == MVT::i128)
-      LC = RTLIB::SRA_I128;
+    LC = RTLIB::getSRA(VT);
   }
 
   if (LC != RTLIB::UNKNOWN_LIBCALL && TLI.getLibcallName(LC)) {
@@ -5153,15 +5074,7 @@ void DAGTypeLegalizer::ExpandIntRes_SREM(SDNode *N,
     return;
   }
 
-  RTLIB::Libcall LC = RTLIB::UNKNOWN_LIBCALL;
-  if (VT == MVT::i16)
-    LC = RTLIB::SREM_I16;
-  else if (VT == MVT::i32)
-    LC = RTLIB::SREM_I32;
-  else if (VT == MVT::i64)
-    LC = RTLIB::SREM_I64;
-  else if (VT == MVT::i128)
-    LC = RTLIB::SREM_I128;
+  RTLIB::Libcall LC = RTLIB::getSREM(VT);
   assert(LC != RTLIB::UNKNOWN_LIBCALL && "Unsupported SREM!");
 
   TargetLowering::MakeLibCallOptions CallOptions;
@@ -5244,13 +5157,7 @@ void DAGTypeLegalizer::ExpandIntRes_XMULO(SDNode *N,
   Type *PtrTy = PtrVT.getTypeForEVT(*DAG.getContext());
 
   // Replace this with a libcall that will check overflow.
-  RTLIB::Libcall LC = RTLIB::UNKNOWN_LIBCALL;
-  if (VT == MVT::i32)
-    LC = RTLIB::MULO_I32;
-  else if (VT == MVT::i64)
-    LC = RTLIB::MULO_I64;
-  else if (VT == MVT::i128)
-    LC = RTLIB::MULO_I128;
+  RTLIB::Libcall LC = RTLIB::getMULO(VT);
 
   // If we don't have the libcall or if the function we are compiling is the
   // implementation of the expected libcall (avoid inf-loop), expand inline.
@@ -5341,15 +5248,7 @@ void DAGTypeLegalizer::ExpandIntRes_UDIV(SDNode *N,
     }
   }
 
-  RTLIB::Libcall LC = RTLIB::UNKNOWN_LIBCALL;
-  if (VT == MVT::i16)
-    LC = RTLIB::UDIV_I16;
-  else if (VT == MVT::i32)
-    LC = RTLIB::UDIV_I32;
-  else if (VT == MVT::i64)
-    LC = RTLIB::UDIV_I64;
-  else if (VT == MVT::i128)
-    LC = RTLIB::UDIV_I128;
+  RTLIB::Libcall LC = RTLIB::getUDIV(VT);
   assert(LC != RTLIB::UNKNOWN_LIBCALL && "Unsupported UDIV!");
 
   TargetLowering::MakeLibCallOptions CallOptions;
@@ -5384,15 +5283,7 @@ void DAGTypeLegalizer::ExpandIntRes_UREM(SDNode *N,
     }
   }
 
-  RTLIB::Libcall LC = RTLIB::UNKNOWN_LIBCALL;
-  if (VT == MVT::i16)
-    LC = RTLIB::UREM_I16;
-  else if (VT == MVT::i32)
-    LC = RTLIB::UREM_I32;
-  else if (VT == MVT::i64)
-    LC = RTLIB::UREM_I64;
-  else if (VT == MVT::i128)
-    LC = RTLIB::UREM_I128;
+  RTLIB::Libcall LC = RTLIB::getUREM(VT);
   assert(LC != RTLIB::UNKNOWN_LIBCALL && "Unsupported UREM!");
 
   TargetLowering::MakeLibCallOptions CallOptions;

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -103,6 +103,125 @@ static cl::opt<bool> DisableStrictNodeMutation("disable-strictnode-mutation",
        cl::desc("Don't mutate strict-float node to a legalize node"),
        cl::init(false), cl::Hidden);
 
+LLVM_ABI RTLIB::Libcall RTLIB::getSHL(EVT VT) {
+  if (VT == MVT::i16)
+    return RTLIB::SHL_I16;
+  if (VT == MVT::i32)
+    return RTLIB::SHL_I32;
+  if (VT == MVT::i64)
+    return RTLIB::SHL_I64;
+  if (VT == MVT::i128)
+    return RTLIB::SHL_I128;
+
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+LLVM_ABI RTLIB::Libcall RTLIB::getSRL(EVT VT) {
+  if (VT == MVT::i16)
+    return RTLIB::SRL_I16;
+  if (VT == MVT::i32)
+    return RTLIB::SRL_I32;
+  if (VT == MVT::i64)
+    return RTLIB::SRL_I64;
+  if (VT == MVT::i128)
+    return RTLIB::SRL_I128;
+
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+LLVM_ABI RTLIB::Libcall RTLIB::getSRA(EVT VT) {
+  if (VT == MVT::i16)
+    return RTLIB::SRA_I16;
+  if (VT == MVT::i32)
+    return RTLIB::SRA_I32;
+  if (VT == MVT::i64)
+    return RTLIB::SRA_I64;
+  if (VT == MVT::i128)
+    return RTLIB::SRA_I128;
+
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+LLVM_ABI RTLIB::Libcall RTLIB::getMUL(EVT VT) {
+  if (VT == MVT::i16)
+    return RTLIB::MUL_I16;
+  if (VT == MVT::i32)
+    return RTLIB::MUL_I32;
+  if (VT == MVT::i64)
+    return RTLIB::MUL_I64;
+  if (VT == MVT::i128)
+    return RTLIB::MUL_I128;
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+LLVM_ABI RTLIB::Libcall RTLIB::getMULO(EVT VT) {
+  if (VT == MVT::i32)
+    return RTLIB::MULO_I32;
+  if (VT == MVT::i64)
+    return RTLIB::MULO_I64;
+  if (VT == MVT::i128)
+    return RTLIB::MULO_I128;
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+LLVM_ABI RTLIB::Libcall RTLIB::getSDIV(EVT VT) {
+  if (VT == MVT::i16)
+    return RTLIB::SDIV_I16;
+  if (VT == MVT::i32)
+    return RTLIB::SDIV_I32;
+  if (VT == MVT::i64)
+    return RTLIB::SDIV_I64;
+  if (VT == MVT::i128)
+    return RTLIB::SDIV_I128;
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+LLVM_ABI RTLIB::Libcall RTLIB::getUDIV(EVT VT) {
+  if (VT == MVT::i16)
+    return RTLIB::UDIV_I16;
+  if (VT == MVT::i32)
+    return RTLIB::UDIV_I32;
+  if (VT == MVT::i64)
+    return RTLIB::UDIV_I64;
+  if (VT == MVT::i128)
+    return RTLIB::UDIV_I128;
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+LLVM_ABI RTLIB::Libcall RTLIB::getSREM(EVT VT) {
+  if (VT == MVT::i16)
+    return RTLIB::SREM_I16;
+  if (VT == MVT::i32)
+    return RTLIB::SREM_I32;
+  if (VT == MVT::i64)
+    return RTLIB::SREM_I64;
+  if (VT == MVT::i128)
+    return RTLIB::SREM_I128;
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+LLVM_ABI RTLIB::Libcall RTLIB::getUREM(EVT VT) {
+  if (VT == MVT::i16)
+    return RTLIB::UREM_I16;
+  if (VT == MVT::i32)
+    return RTLIB::UREM_I32;
+  if (VT == MVT::i64)
+    return RTLIB::UREM_I64;
+  if (VT == MVT::i128)
+    return RTLIB::UREM_I128;
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+LLVM_ABI RTLIB::Libcall RTLIB::getCTPOP(EVT VT) {
+  if (VT == MVT::i32)
+    return RTLIB::CTPOP_I32;
+  if (VT == MVT::i64)
+    return RTLIB::CTPOP_I64;
+  if (VT == MVT::i128)
+    return RTLIB::CTPOP_I128;
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
 /// GetFPLibCall - Helper to return the right libcall for the given floating
 /// point type, or UNKNOWN_LIBCALL if there is none.
 RTLIB::Libcall RTLIB::getFPLibCall(EVT VT,
@@ -495,6 +614,64 @@ RTLIB::Libcall RTLIB::getMODF(EVT RetVT) {
 
   return getFPLibCall(RetVT, MODF_F32, MODF_F64, MODF_F80, MODF_F128,
                       MODF_PPCF128);
+}
+
+RTLIB::Libcall RTLIB::getLROUND(EVT VT) {
+  if (VT == MVT::f32)
+    return RTLIB::LROUND_F32;
+  if (VT == MVT::f64)
+    return RTLIB::LROUND_F64;
+  if (VT == MVT::f80)
+    return RTLIB::LROUND_F80;
+  if (VT == MVT::f128)
+    return RTLIB::LROUND_F128;
+  if (VT == MVT::ppcf128)
+    return RTLIB::LROUND_PPCF128;
+
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+RTLIB::Libcall RTLIB::getLLROUND(EVT VT) {
+  if (VT == MVT::f32)
+    return RTLIB::LLROUND_F32;
+  if (VT == MVT::f64)
+    return RTLIB::LLROUND_F64;
+  if (VT == MVT::f80)
+    return RTLIB::LLROUND_F80;
+  if (VT == MVT::f128)
+    return RTLIB::LLROUND_F128;
+  if (VT == MVT::ppcf128)
+    return RTLIB::LLROUND_PPCF128;
+
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+RTLIB::Libcall RTLIB::getLRINT(EVT VT) {
+  if (VT == MVT::f32)
+    return RTLIB::LRINT_F32;
+  if (VT == MVT::f64)
+    return RTLIB::LRINT_F64;
+  if (VT == MVT::f80)
+    return RTLIB::LRINT_F80;
+  if (VT == MVT::f128)
+    return RTLIB::LRINT_F128;
+  if (VT == MVT::ppcf128)
+    return RTLIB::LRINT_PPCF128;
+  return RTLIB::UNKNOWN_LIBCALL;
+}
+
+RTLIB::Libcall RTLIB::getLLRINT(EVT VT) {
+  if (VT == MVT::f32)
+    return RTLIB::LLRINT_F32;
+  if (VT == MVT::f64)
+    return RTLIB::LLRINT_F64;
+  if (VT == MVT::f80)
+    return RTLIB::LLRINT_F80;
+  if (VT == MVT::f128)
+    return RTLIB::LLRINT_F128;
+  if (VT == MVT::ppcf128)
+    return RTLIB::LLRINT_PPCF128;
+  return RTLIB::UNKNOWN_LIBCALL;
 }
 
 RTLIB::Libcall RTLIB::getOutlineAtomicHelper(const Libcall (&LC)[5][4],


### PR DESCRIPTION
We had a set of utilities which was only used for some set of
floating point libcalls. Add more, most of which are for integer
operations.

Ideally we would generate these functions from tablegen.