### PR TITLE
[clang-tidy] Fix false-positive in inconsistent-declaration-parameter-name

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/InconsistentDeclarationParameterNameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/InconsistentDeclarationParameterNameCheck.cpp
@@ -107,6 +107,10 @@ findDifferingParamsInDeclaration(const FunctionDecl *ParameterSourceDeclaration,
 
   while (SourceParamIt != ParameterSourceDeclaration->param_end() &&
          OtherParamIt != OtherDeclaration->param_end()) {
+    if ((*SourceParamIt)->isParameterPack() !=
+        (*OtherParamIt)->isParameterPack())
+      break;
+
     auto SourceParamName = (*SourceParamIt)->getName();
     auto OtherParamName = (*OtherParamIt)->getName();
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -545,6 +545,11 @@ Changes in existing checks
   adding parentheses when the inner expression are implicitly converted
   multiple times.
 
+- Improved :doc:`readability-inconsistent-declaration-parameter-name
+  <clang-tidy/checks/readability/inconsistent-declaration-parameter-name>` check
+  by not enforcing parameter name consistency between a variadic parameter pack
+  in the primary template and specific parameters in its specializations.
+
 - Improved :doc:`readability-qualified-auto
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option
   `IgnoreAliasing`, that allows not looking at underlying types of type aliases.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name.cpp
@@ -211,6 +211,6 @@ void variadicFunction2WithWarning(int fixed, int a) {}
 
 template<>
 // CHECK-MESSAGES: :[[@LINE+3]]:6: warning: function template specialization 'variadicFunction2WithWarning<float>' has a primary template
-// CHECK-MESSAGES: :[[@LINE-9]]:6: note: the primary template declaration seen here
+// CHECK-MESSAGES: :[[@LINE-7]]:6: note: the primary template declaration seen here
 // CHECK-MESSAGES: :[[@LINE+1]]:6: note: differing parameters are named here: ('wrong'), in primary template declaration: ('fixed')
 void variadicFunction2WithWarning(int wrong, float a) {}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name.cpp
@@ -198,21 +198,15 @@ template<typename... Args>
 void variadicFunctionNoWarning(Args... args);
 
 template<>
-// CHECK-NOT: warning: function template specialization 'variadicFunctionNoWarning<int>'
-// CHECK-NOT: readability-inconsistent-declaration-parameter-name
 void variadicFunctionNoWarning(int a) {}
 
 template<>
-// CHECK-NOT: warning: function template specialization 'variadicFunctionNoWarning<int, int>'
-// CHECK-NOT: readability-inconsistent-declaration-parameter-name
 void variadicFunctionNoWarning(int a, int b) {}
 
 template<typename... Args>
 void variadicFunction2WithWarning(int fixed, Args... args);
 
 template<>
-// CHECK-NOT: warning: function template specialization 'variadicFunction2WithWarning<int>'
-// CHECK-NOT: readability-inconsistent-declaration-parameter-name
 void variadicFunction2WithWarning(int fixed, int a) {}
 
 template<>

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/inconsistent-declaration-parameter-name.cpp
@@ -191,3 +191,32 @@ struct S {
 void S::f(int y)
 {
 }
+
+//////////////////////////////////////////////////////
+
+template<typename... Args>
+void variadicFunctionNoWarning(Args... args);
+
+template<>
+// CHECK-NOT: warning: function template specialization 'variadicFunctionNoWarning<int>'
+// CHECK-NOT: readability-inconsistent-declaration-parameter-name
+void variadicFunctionNoWarning(int a) {}
+
+template<>
+// CHECK-NOT: warning: function template specialization 'variadicFunctionNoWarning<int, int>'
+// CHECK-NOT: readability-inconsistent-declaration-parameter-name
+void variadicFunctionNoWarning(int a, int b) {}
+
+template<typename... Args>
+void variadicFunction2WithWarning(int fixed, Args... args);
+
+template<>
+// CHECK-NOT: warning: function template specialization 'variadicFunction2WithWarning<int>'
+// CHECK-NOT: readability-inconsistent-declaration-parameter-name
+void variadicFunction2WithWarning(int fixed, int a) {}
+
+template<>
+// CHECK-MESSAGES: :[[@LINE+3]]:6: warning: function template specialization 'variadicFunction2WithWarning<float>' has a primary template
+// CHECK-MESSAGES: :[[@LINE-9]]:6: note: the primary template declaration seen here
+// CHECK-MESSAGES: :[[@LINE+1]]:6: note: differing parameters are named here: ('wrong'), in primary template declaration: ('fixed')
+void variadicFunction2WithWarning(int wrong, float a) {}


### PR DESCRIPTION
Closes #169195