### PR TITLE
[flang][docs] Tweak in-progress warning in the release notes page

### DIFF
--- a/flang/docs/ReleaseNotes.md
+++ b/flang/docs/ReleaseNotes.md
@@ -3,11 +3,12 @@ ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 
 # Flang {{version}} {{in_progress}}Release Notes
 
-> **warning**
->
-> These are in-progress notes for the upcoming LLVM {{version}} release.
-> Release notes for previous releases can be found on [the Download
-> Page](https://releases.llvm.org/download.html).
+```{only} PreRelease
+```{warning}
+ These are in-progress notes for the upcoming LLVM {{version}} release.
+ Release notes for previous releases can be found on [the Download
+ Page](https://releases.llvm.org/download.html).
+```
 
 ## Introduction
 

--- a/flang/docs/ReleaseNotes.md
+++ b/flang/docs/ReleaseNotes.md
@@ -3,12 +3,13 @@ ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 
 # Flang {{version}} {{in_progress}}Release Notes
 
-```{only} PreRelease
+````{only} PreRelease
 ```{warning}
  These are in-progress notes for the upcoming LLVM {{version}} release.
  Release notes for previous releases can be found on [the Download
  Page](https://releases.llvm.org/download.html).
 ```
+````
 
 ## Introduction
 

--- a/flang/docs/ReleaseNotesTemplate.txt
+++ b/flang/docs/ReleaseNotesTemplate.txt
@@ -3,12 +3,13 @@ ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 
 # Flang {{version}} {{in_progress}}Release Notes
 
-```{only} PreRelease
+````{only} PreRelease
 ```{warning}
 These are in-progress notes for the upcoming LLVM {{version}} release.
 Release notes for previous releases can be found on [the Download
 Page](https://releases.llvm.org/download.html).
 ```
+````
 
 ## Introduction
 

--- a/flang/docs/ReleaseNotesTemplate.txt
+++ b/flang/docs/ReleaseNotesTemplate.txt
@@ -3,11 +3,12 @@ ReleaseNotes.md and ReleaseNotesTemplate.txt. -->
 
 # Flang {{version}} {{in_progress}}Release Notes
 
-> **warning**
->
-> These are in-progress notes for the upcoming LLVM {{version}} release.
-> Release notes for previous releases can be found on [the Download
-> Page](https://releases.llvm.org/download.html).
+```{only} PreRelease
+```{warning}
+These are in-progress notes for the upcoming LLVM {{version}} release.
+Release notes for previous releases can be found on [the Download
+Page](https://releases.llvm.org/download.html).
+```
 
 ## Introduction
 


### PR DESCRIPTION
Reformat the in-progress warning message in the release notes page. This is now rendered in a style similar to that of clang. The warning will now be hidden on release builds of the documentation.

----------------------------------------------------------------
Currently, the warning that the release notes are "in-progress" for an upcoming release is displayed in the documentation of both [current](https://flang.llvm.org/docs/ReleaseNotes.html) and [release](https://releases.llvm.org/21.1.0/tools/flang/docs/ReleaseNotes.html) builds. 

By contrast, in clang, the warning is not displayed on the release notes for a [release](https://releases.llvm.org/21.1.0/tools/clang/docs/ReleaseNotes.html) (the warning would [otherwise](https://clang.llvm.org/docs/ReleaseNotes.html) be displayed after the table of contents).

With this change, the non-release flang release notes page will appear as shown below. 

<img width="945" height="432" alt="flang-current" src="https://github.com/user-attachments/assets/a962a0a8-29d7-4bd6-8d06-8ad9b59f314c" />
