### PR TITLE
[KCFI][NFC] Remove unused header

### DIFF
--- a/llvm/lib/Transforms/Utils/ModuleUtils.cpp
+++ b/llvm/lib/Transforms/Utils/ModuleUtils.cpp
@@ -22,7 +22,6 @@
 #include "llvm/Support/Hash.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Transforms/Instrumentation/KCFI.h"
 
 using namespace llvm;
 


### PR DESCRIPTION
In addition to being unused, this forms a layering violation between Transforms/Utils and Transforms/Instrumentation