### PR TITLE
[ObjCDirectPreconditionThunk] Adding a flag to  with objc_direct symbols' prefix 

### DIFF
--- a/clang/include/clang/AST/DeclObjC.h
+++ b/clang/include/clang/AST/DeclObjC.h
@@ -482,12 +482,6 @@ public:
   /// True if the method is tagged as objc_direct
   bool isDirectMethod() const;
 
-  /// Check if this direct method can move precondition-check to thunk.
-  /// Variadic functions cannot use thunks (musttail incompatible with va_arg)
-  bool canHavePreconditionThunk() const {
-    return isDirectMethod() && !isVariadic();
-  }
-
   /// True if the method has a parameter that's destroyed in the callee.
   bool hasParamDestroyedInCallee() const;
 

--- a/clang/include/clang/AST/DeclObjC.h
+++ b/clang/include/clang/AST/DeclObjC.h
@@ -482,9 +482,9 @@ public:
   /// True if the method is tagged as objc_direct
   bool isDirectMethod() const;
 
-  /// Check if this direct method can move nil-check to thunk.
+  /// Check if this direct method can move precondition-check to thunk.
   /// Variadic functions cannot use thunks (musttail incompatible with va_arg)
-  bool canHaveNilCheckThunk() const {
+  bool canHavePreconditionThunk() const {
     return isDirectMethod() && !isVariadic();
   }
 

--- a/clang/include/clang/AST/DeclObjC.h
+++ b/clang/include/clang/AST/DeclObjC.h
@@ -482,6 +482,12 @@ public:
   /// True if the method is tagged as objc_direct
   bool isDirectMethod() const;
 
+  /// Check if this direct method can move nil-check to thunk.
+  /// Variadic functions cannot use thunks (musttail incompatible with va_arg)
+  bool canHaveNilCheckThunk() const {
+    return isDirectMethod() && !isVariadic();
+  }
+
   /// True if the method has a parameter that's destroyed in the callee.
   bool hasParamDestroyedInCallee() const;
 

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -210,8 +210,8 @@ ENUM_CODEGENOPT(ObjCDispatchMethod, ObjCDispatchMethodKind, 2, Legacy, Benign)
 /// Replace certain message sends with calls to ObjC runtime entrypoints
 CODEGENOPT(ObjCConvertMessagesToRuntimeCalls , 1, 1, Benign)
 CODEGENOPT(ObjCAvoidHeapifyLocalBlocks, 1, 0, Benign)
-/// Expose objc_direct method symbols publicly and optimize nil checks.
-CODEGENOPT(ObjCExposeDirectMethods, 1, 0, Benign)
+/// Generate direct method precondition thunks to expose symbols and optimize nil checks.
+CODEGENOPT(ObjCDirectPreconditionThunk, 1, 0, Benign)
 
 
 // The optimization options affect frontend options, which in turn do affect the AST.

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -210,6 +210,8 @@ ENUM_CODEGENOPT(ObjCDispatchMethod, ObjCDispatchMethodKind, 2, Legacy, Benign)
 /// Replace certain message sends with calls to ObjC runtime entrypoints
 CODEGENOPT(ObjCConvertMessagesToRuntimeCalls , 1, 1, Benign)
 CODEGENOPT(ObjCAvoidHeapifyLocalBlocks, 1, 0, Benign)
+/// Expose objc_direct method symbols publicly and optimize nil checks.
+CODEGENOPT(ObjCExposeDirectMethods, 1, 0, Benign)
 
 
 // The optimization options affect frontend options, which in turn do affect the AST.

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -155,6 +155,9 @@ def warn_drv_unsupported_diag_option_for_flang : Warning<
 def warn_drv_unsupported_option_for_processor : Warning<
   "ignoring '%0' option as it is not currently supported for processor '%1'">,
   InGroup<OptionIgnored>;
+def warn_drv_unsupported_option_for_runtime : Warning<
+  "ignoring '%0' option as it is not currently supported for runtime '%1'">,
+  InGroup<OptionIgnored>;
 def warn_drv_unsupported_openmp_library : Warning<
   "the library '%0=%1' is not supported, OpenMP will not be enabled">,
   InGroup<OptionIgnored>;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -3778,7 +3778,7 @@ defm objc_avoid_heapify_local_blocks : BoolFOption<"objc-avoid-heapify-local-blo
 defm objc_direct_precondition_thunk : BoolFOption<"objc-direct-precondition-thunk",
   CodeGenOpts<"ObjCDirectPreconditionThunk">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option],
-          "Move direct methods' precondition checks to thunks">,
+          "Move precondition checks for direct methods into thunks">,
   NegFlag<SetFalse>>;
 defm disable_block_signature_string : BoolFOption<"disable-block-signature-string",
   CodeGenOpts<"DisableBlockSignatureString">, DefaultFalse,

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -3775,10 +3775,10 @@ defm objc_avoid_heapify_local_blocks : BoolFOption<"objc-avoid-heapify-local-blo
   PosFlag<SetTrue, [], [ClangOption], "Try">,
   NegFlag<SetFalse, [], [ClangOption], "Don't try">,
   BothFlags<[], [CC1Option], " to avoid heapifying local blocks">>;
-defm objc_expose_direct_methods : BoolFOption<"objc-expose-direct-methods",
-  CodeGenOpts<"ObjCExposeDirectMethods">, DefaultFalse,
+defm objc_direct_precondition_thunk : BoolFOption<"objc-direct-precondition-thunk",
+  CodeGenOpts<"ObjCDirectPreconditionThunk">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option],
-          "Expose direct method symbols and move nil checks to caller-side thunks">,
+          "Move direct methods' precondition checks to thunks">,
   NegFlag<SetFalse>>;
 defm disable_block_signature_string : BoolFOption<"disable-block-signature-string",
   CodeGenOpts<"DisableBlockSignatureString">, DefaultFalse,

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -3775,6 +3775,11 @@ defm objc_avoid_heapify_local_blocks : BoolFOption<"objc-avoid-heapify-local-blo
   PosFlag<SetTrue, [], [ClangOption], "Try">,
   NegFlag<SetFalse, [], [ClangOption], "Don't try">,
   BothFlags<[], [CC1Option], " to avoid heapifying local blocks">>;
+defm objc_expose_direct_methods : BoolFOption<"objc-expose-direct-methods",
+  CodeGenOpts<"ObjCExposeDirectMethods">, DefaultFalse,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option],
+          "Expose direct method symbols and move nil checks to caller-side thunks">,
+  NegFlag<SetFalse>>;
 defm disable_block_signature_string : BoolFOption<"disable-block-signature-string",
   CodeGenOpts<"DisableBlockSignatureString">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption], "Disable">,

--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -413,13 +413,6 @@ bool CGObjCRuntime::canMessageReceiverBeNull(
   return true;
 }
 
-bool CGObjCRuntime::canClassObjectBeUnrealized(
-    const ObjCInterfaceDecl *CalleeClassDecl, CodeGenFunction &CGF) const {
-  // TODO
-  // Otherwise, assume it can be unrealized.
-  return true;
-}
-
 bool CGObjCRuntime::isWeakLinkedClass(const ObjCInterfaceDecl *ID) {
   do {
     if (ID->isWeakImported())

--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -415,7 +415,7 @@ bool CGObjCRuntime::canMessageReceiverBeNull(
 
 bool CGObjCRuntime::canClassObjectBeUnrealized(
     const ObjCInterfaceDecl *CalleeClassDecl, CodeGenFunction &CGF) const {
-
+  // TODO
   // Otherwise, assume it can be unrealized.
   return true;
 }

--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -382,11 +382,9 @@ CGObjCRuntime::getMessageSendInfo(const ObjCMethodDecl *method,
   return MessageSendInfo(argsInfo, signatureType);
 }
 
-bool CGObjCRuntime::canMessageReceiverBeNull(CodeGenFunction &CGF,
-                                             const ObjCMethodDecl *method,
-                                             bool isSuper,
-                                       const ObjCInterfaceDecl *classReceiver,
-                                             llvm::Value *receiver) {
+bool CGObjCRuntime::canMessageReceiverBeNull(
+    CodeGenFunction &CGF, const ObjCMethodDecl *method, bool isSuper,
+    const ObjCInterfaceDecl *classReceiver, llvm::Value *receiver) {
   // Super dispatch assumes that self is non-null; even the messenger
   // doesn't have a null check internally.
   if (isSuper)
@@ -399,8 +397,7 @@ bool CGObjCRuntime::canMessageReceiverBeNull(CodeGenFunction &CGF,
 
   // If we're emitting a method, and self is const (meaning just ARC, for now),
   // and the receiver is a load of self, then self is a valid object.
-  if (auto curMethod =
-               dyn_cast_or_null<ObjCMethodDecl>(CGF.CurCodeDecl)) {
+  if (auto curMethod = dyn_cast_or_null<ObjCMethodDecl>(CGF.CurCodeDecl)) {
     auto self = curMethod->getSelfDecl();
     if (self->getType().isConstQualified()) {
       if (auto LI = dyn_cast<llvm::LoadInst>(receiver->stripPointerCasts())) {
@@ -413,6 +410,13 @@ bool CGObjCRuntime::canMessageReceiverBeNull(CodeGenFunction &CGF,
   }
 
   // Otherwise, assume it can be null.
+  return true;
+}
+
+bool CGObjCRuntime::canClassObjectBeUnrealized(
+    const ObjCInterfaceDecl *CalleeClassDecl, CodeGenFunction &CGF) const {
+
+  // Otherwise, assume it can be unrealized.
   return true;
 }
 
@@ -466,11 +470,11 @@ clang::CodeGen::emitObjCProtocolObject(CodeGenModule &CGM,
 }
 
 std::string CGObjCRuntime::getSymbolNameForMethod(const ObjCMethodDecl *OMD,
-                                                  bool includeCategoryName) {
+                                                  bool includeCategoryName,
+                                                  bool includePrefixByte) {
   std::string buffer;
   llvm::raw_string_ostream out(buffer);
-  CGM.getCXXABI().getMangleContext().mangleObjCMethodName(OMD, out,
-                                       /*includePrefixByte=*/true,
-                                       includeCategoryName);
+  CGM.getCXXABI().getMangleContext().mangleObjCMethodName(
+      OMD, out, includePrefixByte, includeCategoryName);
   return buffer;
 }

--- a/clang/lib/CodeGen/CGObjCRuntime.h
+++ b/clang/lib/CodeGen/CGObjCRuntime.h
@@ -329,16 +329,6 @@ public:
                                 const ObjCInterfaceDecl *classReceiver,
                                 llvm::Value *receiver);
 
-  /// Check if a class object can be unrealized (not yet initialized).
-  /// Returns true if the class may be unrealized, false if provably realized.
-  ///
-  /// TODO: Returns false if:
-  /// - An instance method on the same class was called in a dominating path
-  /// - The class was explicitly realized earlier in control flow
-  /// - Note: [Parent foo] does NOT realize Child (inheritance care needed)
-  virtual bool canClassObjectBeUnrealized(const ObjCInterfaceDecl *ClassDecl,
-                                          CodeGenFunction &CGF) const;
-
   static bool isWeakLinkedClass(const ObjCInterfaceDecl *cls);
 
   /// Destroy the callee-destroyed arguments of the given method,

--- a/clang/lib/CodeGen/CGObjCRuntime.h
+++ b/clang/lib/CodeGen/CGObjCRuntime.h
@@ -324,31 +324,15 @@ public:
                                      QualType resultType,
                                      CallArgList &callArgs);
 
-  /// Check if the receiver of an ObjC message send can be null.
-  /// Returns true if the receiver may be null, false if provably non-null.
-  ///
-  /// This can be overridden by subclasses to add runtime-specific heuristics.
-  /// Base implementation checks:
-  /// - Super dispatch (always non-null)
-  /// - Self in const-qualified methods (ARC)
-  /// - Weak-linked classes
-  ///
-  /// Future enhancements in CGObjCCommonMac override:
-  /// - _Nonnull attributes
-  /// - Results of alloc, new, ObjC literals
-  virtual bool canMessageReceiverBeNull(CodeGenFunction &CGF,
-                                        const ObjCMethodDecl *method,
-                                        bool isSuper,
+  bool canMessageReceiverBeNull(CodeGenFunction &CGF,
+                                const ObjCMethodDecl *method, bool isSuper,
                                 const ObjCInterfaceDecl *classReceiver,
                                 llvm::Value *receiver);
 
   /// Check if a class object can be unrealized (not yet initialized).
   /// Returns true if the class may be unrealized, false if provably realized.
   ///
-  /// STUB IMPLEMENTATION: Base class always returns true (conservative).
-  /// Subclasses can override to add runtime-specific dominating-call analysis.
-  ///
-  /// Future: Returns false if:
+  /// TODO: Returns false if:
   /// - An instance method on the same class was called in a dominating path
   /// - The class was explicitly realized earlier in control flow
   /// - Note: [Parent foo] does NOT realize Child (inheritance care needed)

--- a/clang/lib/CodeGen/CGObjCRuntime.h
+++ b/clang/lib/CodeGen/CGObjCRuntime.h
@@ -117,7 +117,8 @@ public:
   virtual ~CGObjCRuntime();
 
   std::string getSymbolNameForMethod(const ObjCMethodDecl *method,
-                                     bool includeCategoryName = true);
+                                     bool includeCategoryName = true,
+                                     bool includePrefixByte = true);
 
   /// Generate the function required to register all Objective-C components in
   /// this compilation unit with the runtime library.
@@ -322,10 +323,38 @@ public:
   MessageSendInfo getMessageSendInfo(const ObjCMethodDecl *method,
                                      QualType resultType,
                                      CallArgList &callArgs);
-  bool canMessageReceiverBeNull(CodeGenFunction &CGF,
-                                const ObjCMethodDecl *method, bool isSuper,
+
+  /// Check if the receiver of an ObjC message send can be null.
+  /// Returns true if the receiver may be null, false if provably non-null.
+  ///
+  /// This can be overridden by subclasses to add runtime-specific heuristics.
+  /// Base implementation checks:
+  /// - Super dispatch (always non-null)
+  /// - Self in const-qualified methods (ARC)
+  /// - Weak-linked classes
+  ///
+  /// Future enhancements in CGObjCCommonMac override:
+  /// - _Nonnull attributes
+  /// - Results of alloc, new, ObjC literals
+  virtual bool canMessageReceiverBeNull(CodeGenFunction &CGF,
+                                        const ObjCMethodDecl *method,
+                                        bool isSuper,
                                 const ObjCInterfaceDecl *classReceiver,
                                 llvm::Value *receiver);
+
+  /// Check if a class object can be unrealized (not yet initialized).
+  /// Returns true if the class may be unrealized, false if provably realized.
+  ///
+  /// STUB IMPLEMENTATION: Base class always returns true (conservative).
+  /// Subclasses can override to add runtime-specific dominating-call analysis.
+  ///
+  /// Future: Returns false if:
+  /// - An instance method on the same class was called in a dominating path
+  /// - The class was explicitly realized earlier in control flow
+  /// - Note: [Parent foo] does NOT realize Child (inheritance care needed)
+  virtual bool canClassObjectBeUnrealized(const ObjCInterfaceDecl *ClassDecl,
+                                          CodeGenFunction &CGF) const;
+
   static bool isWeakLinkedClass(const ObjCInterfaceDecl *cls);
 
   /// Destroy the callee-destroyed arguments of the given method,

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -720,6 +720,9 @@ public:
   /// Check if a direct method should use precondition thunks (exposed symbols).
   /// This applies to ALL direct methods (including variadic).
   /// Returns false if OMD is null or not a direct method.
+  ///
+  /// Also checks the runtime family, as the attribute objc_direct is only
+  /// respected in the NeXT runtime right now.
   bool usePreconditionThunk(const ObjCMethodDecl *OMD) const {
     return OMD && OMD->isDirectMethod() &&
            getLangOpts().ObjCRuntime.isNeXTFamily() &&

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -731,19 +731,18 @@ public:
 
   /// Check if a direct method should use precondition thunks at call sites.
   /// This applies only to non-variadic direct methods.
-  /// Returns false if OMD is null or not eligible for thunks (e.g. variadic
+  /// Returns false if OMD is null or not eligible for thunks (variadic
   /// methods).
   bool shouldHavePreconditionThunk(const ObjCMethodDecl *OMD) const {
-    return OMD && usePreconditionThunk(OMD) && OMD->canHavePreconditionThunk();
+    return OMD && usePreconditionThunk(OMD) && !OMD->isVariadic();
   }
 
   /// Check if a direct method should have inline precondition checks at call
-  /// sites. This applies to direct methods that cannot use thunks (e.g.,
-  /// variadic methods). These methods get exposed symbols but need inline
-  /// precondition checks instead of thunks.
-  /// Returns false if OMD is null or not eligible.
+  /// sites. This applies to direct methods that cannot use thunks (variadic
+  /// methods). These methods get exposed symbols but need inline precondition
+  /// checks instead of thunks. Returns false if OMD is null or not eligible.
   bool shouldHavePreconditionInline(const ObjCMethodDecl *OMD) const {
-    return OMD && usePreconditionThunk(OMD) && !OMD->canHavePreconditionThunk();
+    return OMD && usePreconditionThunk(OMD) && OMD->isVariadic();
   }
 
   const std::string &getModuleNameHash() const { return ModuleNameHash; }

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -721,10 +721,11 @@ public:
   /// This applies to ALL direct methods (including variadic).
   /// Returns false if OMD is null or not a direct method.
   ///
-  /// Also checks the runtime family, as the attribute objc_direct is only
-  /// respected in the NeXT runtime right now.
+  /// Also checks the runtime family, currently we only support NeXT.
+  /// TODO: Add support for GNUStep as well.
   bool usePreconditionThunk(const ObjCMethodDecl *OMD) const {
     return OMD && OMD->isDirectMethod() &&
+           getLangOpts().ObjCRuntime.allowsDirectDispatch() &&
            getLangOpts().ObjCRuntime.isNeXTFamily() &&
            getCodeGenOpts().ObjCDirectPreconditionThunk;
   }

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -717,30 +717,30 @@ public:
   /// Return true iff an Objective-C runtime has been configured.
   bool hasObjCRuntime() { return !!ObjCRuntime; }
 
-  /// Check if a direct method should have its symbol exposed (no \01 prefix).
+  /// Check if a direct method should use precondition thunks (exposed symbols).
   /// This applies to ALL direct methods (including variadic).
   /// Returns false if OMD is null or not a direct method.
-  bool shouldExposeSymbol(const ObjCMethodDecl *OMD) const {
+  bool usePreconditionThunk(const ObjCMethodDecl *OMD) const {
     return OMD && OMD->isDirectMethod() &&
            getLangOpts().ObjCRuntime.isNeXTFamily() &&
-           getCodeGenOpts().ObjCExposeDirectMethods;
+           getCodeGenOpts().ObjCDirectPreconditionThunk;
   }
 
-  /// Check if a direct method should use nil-check thunks at call sites.
+  /// Check if a direct method should use precondition thunks at call sites.
   /// This applies only to non-variadic direct methods.
-  /// Variadic methods cannot use thunks (musttail incompatible with va_arg).
-  /// Returns false if OMD is null or not eligible for thunks.
-  bool shouldHaveNilCheckThunk(const ObjCMethodDecl *OMD) const {
-    return OMD && shouldExposeSymbol(OMD) && OMD->canHaveNilCheckThunk();
+  /// Returns false if OMD is null or not eligible for thunks (e.g. variadic
+  /// methods).
+  bool shouldHavePreconditionThunk(const ObjCMethodDecl *OMD) const {
+    return OMD && usePreconditionThunk(OMD) && OMD->canHavePreconditionThunk();
   }
 
-  /// Check if a direct method should have inline nil checks at call sites.
-  /// This applies to direct methods that cannot use thunks (e.g., variadic
-  /// methods). These methods get exposed symbols but need inline nil checks
-  /// instead of thunks. Returns false if OMD is null or not eligible for inline
-  /// nil checks.
-  bool shouldHaveNilCheckInline(const ObjCMethodDecl *OMD) const {
-    return OMD && shouldExposeSymbol(OMD) && !OMD->canHaveNilCheckThunk();
+  /// Check if a direct method should have inline precondition checks at call
+  /// sites. This applies to direct methods that cannot use thunks (e.g.,
+  /// variadic methods). These methods get exposed symbols but need inline
+  /// precondition checks instead of thunks.
+  /// Returns false if OMD is null or not eligible.
+  bool shouldHavePreconditionInline(const ObjCMethodDecl *OMD) const {
+    return OMD && usePreconditionThunk(OMD) && !OMD->canHavePreconditionThunk();
   }
 
   const std::string &getModuleNameHash() const { return ModuleNameHash; }

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -717,6 +717,32 @@ public:
   /// Return true iff an Objective-C runtime has been configured.
   bool hasObjCRuntime() { return !!ObjCRuntime; }
 
+  /// Check if a direct method should have its symbol exposed (no \01 prefix).
+  /// This applies to ALL direct methods (including variadic).
+  /// Returns false if OMD is null or not a direct method.
+  bool shouldExposeSymbol(const ObjCMethodDecl *OMD) const {
+    return OMD && OMD->isDirectMethod() &&
+           getLangOpts().ObjCRuntime.isNeXTFamily() &&
+           getCodeGenOpts().ObjCExposeDirectMethods;
+  }
+
+  /// Check if a direct method should use nil-check thunks at call sites.
+  /// This applies only to non-variadic direct methods.
+  /// Variadic methods cannot use thunks (musttail incompatible with va_arg).
+  /// Returns false if OMD is null or not eligible for thunks.
+  bool shouldHaveNilCheckThunk(const ObjCMethodDecl *OMD) const {
+    return OMD && shouldExposeSymbol(OMD) && OMD->canHaveNilCheckThunk();
+  }
+
+  /// Check if a direct method should have inline nil checks at call sites.
+  /// This applies to direct methods that cannot use thunks (e.g., variadic
+  /// methods). These methods get exposed symbols but need inline nil checks
+  /// instead of thunks. Returns false if OMD is null or not eligible for inline
+  /// nil checks.
+  bool shouldHaveNilCheckInline(const ObjCMethodDecl *OMD) const {
+    return OMD && shouldExposeSymbol(OMD) && !OMD->canHaveNilCheckThunk();
+  }
+
   const std::string &getModuleNameHash() const { return ModuleNameHash; }
 
   /// Return a reference to the configured OpenCL runtime.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4097,6 +4097,8 @@ static void RenderObjCOptions(const ToolChain &TC, const Driver &D,
   }
 
   // Forward -fobjc-direct-precondition-thunk to cc1
+  // Defaults to false and needs explict turn on for now
+  // TODO: switch to default true and needs explict turn off in the future.
   if (Args.hasFlag(options::OPT_fobjc_direct_precondition_thunk,
                    options::OPT_fno_objc_direct_precondition_thunk, false))
     CmdArgs.push_back("-fobjc-direct-precondition-thunk");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4099,10 +4099,16 @@ static void RenderObjCOptions(const ToolChain &TC, const Driver &D,
   // Forward -fobjc-direct-precondition-thunk to cc1
   // Defaults to false and needs explict turn on for now
   // TODO: switch to default true and needs explict turn off in the future.
+  // TODO: add support for other runtimes
   if (Args.hasFlag(options::OPT_fobjc_direct_precondition_thunk,
-                   options::OPT_fno_objc_direct_precondition_thunk, false))
-    CmdArgs.push_back("-fobjc-direct-precondition-thunk");
-
+                   options::OPT_fno_objc_direct_precondition_thunk, false)) {
+    if (Runtime.isNeXTFamily()) {
+      CmdArgs.push_back("-fobjc-direct-precondition-thunk");
+    } else {
+      D.Diag(diag::warn_drv_unsupported_option_for_runtime)
+          << "-fobjc-direct-precondition-thunk" << Runtime.getAsString();
+    }
+  }
   // When ObjectiveC legacy runtime is in effect on MacOSX, turn on the option
   // to do Array/Dictionary subscripting by default.
   if (Arch == llvm::Triple::x86 && T.isMacOSX() &&

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4097,7 +4097,8 @@ static void RenderObjCOptions(const ToolChain &TC, const Driver &D,
   }
 
   // Forward -fobjc-expose-direct-methods to cc1
-  if (Args.hasArg(options::OPT_fobjc_expose_direct_methods))
+  if (Args.hasFlag(options::OPT_fobjc_expose_direct_methods,
+                   options::OPT_fno_objc_expose_direct_methods, false))
     CmdArgs.push_back("-fobjc-expose-direct-methods");
 
   // When ObjectiveC legacy runtime is in effect on MacOSX, turn on the option

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4096,10 +4096,10 @@ static void RenderObjCOptions(const ToolChain &TC, const Driver &D,
     }
   }
 
-  // Forward -fobjc-expose-direct-methods to cc1
-  if (Args.hasFlag(options::OPT_fobjc_expose_direct_methods,
-                   options::OPT_fno_objc_expose_direct_methods, false))
-    CmdArgs.push_back("-fobjc-expose-direct-methods");
+  // Forward -fobjc-direct-precondition-thunk to cc1
+  if (Args.hasFlag(options::OPT_fobjc_direct_precondition_thunk,
+                   options::OPT_fno_objc_direct_precondition_thunk, false))
+    CmdArgs.push_back("-fobjc-direct-precondition-thunk");
 
   // When ObjectiveC legacy runtime is in effect on MacOSX, turn on the option
   // to do Array/Dictionary subscripting by default.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4096,6 +4096,10 @@ static void RenderObjCOptions(const ToolChain &TC, const Driver &D,
     }
   }
 
+  // Forward -fobjc-expose-direct-methods to cc1
+  if (Args.hasArg(options::OPT_fobjc_expose_direct_methods))
+    CmdArgs.push_back("-fobjc-expose-direct-methods");
+
   // When ObjectiveC legacy runtime is in effect on MacOSX, turn on the option
   // to do Array/Dictionary subscripting by default.
   if (Arch == llvm::Triple::x86 && T.isMacOSX() &&

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -607,6 +607,15 @@
 // CHECK_DIRECT_PRECONDITION_THUNK: "-fobjc-direct-precondition-thunk"
 // CHECK_NO_DIRECT_PRECONDITION_THUNK-NOT: -fobjc-direct-precondition-thunk
 
+// Test that -fobjc-direct-precondition-thunk emits a warning when used with GNU runtime
+// and that the flag is not passed to cc1.
+// RUN: %clang --target=x86_64-linux-gnu -fobjc-runtime=gnustep-2.0 -fobjc-direct-precondition-thunk -### -c -xobjective-c %s 2>&1 | FileCheck -check-prefix=CHECK_GNUSTEP_WARN %s
+// CHECK_GNUSTEP_WARN: warning: ignoring '-fobjc-direct-precondition-thunk' option as it is not currently supported for runtime 'gnustep-2.0' [-Woption-ignored]
+// CHECK_GNUSTEP_WARN-NOT: "-fobjc-direct-precondition-thunk"
+// RUN: %clang --target=x86_64-linux-gnu -fobjc-runtime=gcc -fobjc-direct-precondition-thunk -### -c -xobjective-c %s 2>&1 | FileCheck -check-prefix=CHECK_GCC_WARN %s
+// CHECK_GCC_WARN: warning: ignoring '-fobjc-direct-precondition-thunk' option as it is not currently supported for runtime 'gcc' [-Woption-ignored]
+// CHECK_GCC_WARN-NOT: "-fobjc-direct-precondition-thunk"
+
 // RUN: %clang -### -S -fjmc --target=x86_64-unknown-linux %s 2>&1 | FileCheck -check-prefixes=CHECK_JMC_WARN,CHECK_NOJMC %s
 // RUN: %clang -### -S -fjmc --target=x86_64-pc-windows-msvc %s 2>&1 | FileCheck -check-prefixes=CHECK_JMC_WARN,CHECK_NOJMC %s
 // RUN: %clang -### -S -fjmc -g --target=x86_64-pc-windows-msvc %s 2>&1 | FileCheck -check-prefix=CHECK_JMC %s

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -599,11 +599,11 @@
 // CHECK_DISABLE_DIRECT: -fobjc-disable-direct-methods-for-testing
 // CHECK_NO_DISABLE_DIRECT-NOT: -fobjc-disable-direct-methods-for-testing
 
-// RUN: %clang -### -xobjective-c -fobjc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_DIRECT_PRECONDITION_THUNK %s
-// RUN: %clang -### -xobjective-c -fno-objc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_NO_DIRECT_PRECONDITION_THUNK %s
-// RUN: %clang -### -xobjective-c -fobjc-direct-precondition-thunk -fno-objc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_NO_DIRECT_PRECONDITION_THUNK %s
-// RUN: %clang -### -xobjective-c -fno-objc-direct-precondition-thunk -fobjc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_DIRECT_PRECONDITION_THUNK %s
-// RUN: %clang -### -xobjective-c %s 2>&1 | FileCheck -check-prefix=CHECK_NO_DIRECT_PRECONDITION_THUNK %s
+// RUN: %clang -### --target=arm64-apple-macos10 -xobjective-c -fobjc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_DIRECT_PRECONDITION_THUNK %s
+// RUN: %clang -### --target=arm64-apple-macos10 -xobjective-c -fno-objc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_NO_DIRECT_PRECONDITION_THUNK %s
+// RUN: %clang -### --target=arm64-apple-macos10 -xobjective-c -fobjc-direct-precondition-thunk -fno-objc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_NO_DIRECT_PRECONDITION_THUNK %s
+// RUN: %clang -### --target=arm64-apple-macos10 -xobjective-c -fno-objc-direct-precondition-thunk -fobjc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_DIRECT_PRECONDITION_THUNK %s
+// RUN: %clang -### --target=arm64-apple-macos10 -xobjective-c %s 2>&1 | FileCheck -check-prefix=CHECK_NO_DIRECT_PRECONDITION_THUNK %s
 // CHECK_DIRECT_PRECONDITION_THUNK: "-fobjc-direct-precondition-thunk"
 // CHECK_NO_DIRECT_PRECONDITION_THUNK-NOT: -fobjc-direct-precondition-thunk
 

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -599,6 +599,14 @@
 // CHECK_DISABLE_DIRECT: -fobjc-disable-direct-methods-for-testing
 // CHECK_NO_DISABLE_DIRECT-NOT: -fobjc-disable-direct-methods-for-testing
 
+// RUN: %clang -### -xobjective-c -fobjc-expose-direct-methods %s 2>&1 | FileCheck -check-prefix=CHECK_EXPOSE_DIRECT %s
+// RUN: %clang -### -xobjective-c -fno-objc-expose-direct-methods %s 2>&1 | FileCheck -check-prefix=CHECK_NO_EXPOSE_DIRECT %s
+// RUN: %clang -### -xobjective-c -fobjc-expose-direct-methods -fno-objc-expose-direct-methods %s 2>&1 | FileCheck -check-prefix=CHECK_NO_EXPOSE_DIRECT %s
+// RUN: %clang -### -xobjective-c -fno-objc-expose-direct-methods -fobjc-expose-direct-methods %s 2>&1 | FileCheck -check-prefix=CHECK_EXPOSE_DIRECT %s
+// RUN: %clang -### -xobjective-c %s 2>&1 | FileCheck -check-prefix=CHECK_NO_EXPOSE_DIRECT %s
+// CHECK_EXPOSE_DIRECT: "-fobjc-expose-direct-methods"
+// CHECK_NO_EXPOSE_DIRECT-NOT: -fobjc-expose-direct-methods
+
 // RUN: %clang -### -S -fjmc --target=x86_64-unknown-linux %s 2>&1 | FileCheck -check-prefixes=CHECK_JMC_WARN,CHECK_NOJMC %s
 // RUN: %clang -### -S -fjmc --target=x86_64-pc-windows-msvc %s 2>&1 | FileCheck -check-prefixes=CHECK_JMC_WARN,CHECK_NOJMC %s
 // RUN: %clang -### -S -fjmc -g --target=x86_64-pc-windows-msvc %s 2>&1 | FileCheck -check-prefix=CHECK_JMC %s

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -599,13 +599,13 @@
 // CHECK_DISABLE_DIRECT: -fobjc-disable-direct-methods-for-testing
 // CHECK_NO_DISABLE_DIRECT-NOT: -fobjc-disable-direct-methods-for-testing
 
-// RUN: %clang -### -xobjective-c -fobjc-expose-direct-methods %s 2>&1 | FileCheck -check-prefix=CHECK_EXPOSE_DIRECT %s
-// RUN: %clang -### -xobjective-c -fno-objc-expose-direct-methods %s 2>&1 | FileCheck -check-prefix=CHECK_NO_EXPOSE_DIRECT %s
-// RUN: %clang -### -xobjective-c -fobjc-expose-direct-methods -fno-objc-expose-direct-methods %s 2>&1 | FileCheck -check-prefix=CHECK_NO_EXPOSE_DIRECT %s
-// RUN: %clang -### -xobjective-c -fno-objc-expose-direct-methods -fobjc-expose-direct-methods %s 2>&1 | FileCheck -check-prefix=CHECK_EXPOSE_DIRECT %s
-// RUN: %clang -### -xobjective-c %s 2>&1 | FileCheck -check-prefix=CHECK_NO_EXPOSE_DIRECT %s
-// CHECK_EXPOSE_DIRECT: "-fobjc-expose-direct-methods"
-// CHECK_NO_EXPOSE_DIRECT-NOT: -fobjc-expose-direct-methods
+// RUN: %clang -### -xobjective-c -fobjc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_DIRECT_PRECONDITION_THUNK %s
+// RUN: %clang -### -xobjective-c -fno-objc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_NO_DIRECT_PRECONDITION_THUNK %s
+// RUN: %clang -### -xobjective-c -fobjc-direct-precondition-thunk -fno-objc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_NO_DIRECT_PRECONDITION_THUNK %s
+// RUN: %clang -### -xobjective-c -fno-objc-direct-precondition-thunk -fobjc-direct-precondition-thunk %s 2>&1 | FileCheck -check-prefix=CHECK_DIRECT_PRECONDITION_THUNK %s
+// RUN: %clang -### -xobjective-c %s 2>&1 | FileCheck -check-prefix=CHECK_NO_DIRECT_PRECONDITION_THUNK %s
+// CHECK_DIRECT_PRECONDITION_THUNK: "-fobjc-direct-precondition-thunk"
+// CHECK_NO_DIRECT_PRECONDITION_THUNK-NOT: -fobjc-direct-precondition-thunk
 
 // RUN: %clang -### -S -fjmc --target=x86_64-unknown-linux %s 2>&1 | FileCheck -check-prefixes=CHECK_JMC_WARN,CHECK_NOJMC %s
 // RUN: %clang -### -S -fjmc --target=x86_64-pc-windows-msvc %s 2>&1 | FileCheck -check-prefixes=CHECK_JMC_WARN,CHECK_NOJMC %s


### PR DESCRIPTION
## TL;DR

This is a stack of PRs implementing features to expose direct methods ABI.
You can see the RFC, design, and discussion [here](https://discourse.llvm.org/t/rfc-optimizing-code-size-of-objc-direct-by-exposing-function-symbols-and-moving-nil-checks-to-thunks/88866).

The stack of the following four PRs completes the whole feature.

https://github.com/llvm/llvm-project/pull/170616 **Flag `-fobjc-direct-precondition-thunk` set up**
https://github.com/llvm/llvm-project/pull/170617 Code refactoring to ease later reviews
https://github.com/llvm/llvm-project/pull/170618 Thunk generation
https://github.com/llvm/llvm-project/pull/170619 Optimizations, some class objects can be known to be realized

## Implementation details

1. Add a flag. I used `-fobjc-direct-precondition-thunk` instead of `-fobjc-direct-caller-thunks` as discussed in this PR.

2. Clean up and set up helper functions to implement later
    a. `canMessageReceiverBeNull` / `canClassObjectBeUnrealized` these two functions will be helpful later to determine which function (true implementation or nil check thunk) we should dispatch a call to. Formatting.
    b. `getSymbolNameForMethod` has a new argument `includePrefixByte`, which allows us to erase the prefixing `\01` when the flag is enabled
    c. `usePreconditionThunk` is the single source of truth of what we should do. It not only checks for the flag, but also whether the method is qualified and we are in the right runtime. A method that `usePreconditionThunk` is either `shouldHavePreconditionThunk` or `shouldHavePreconditionInline`.

## Tests

Driver tests