### PR TITLE
[ObjCDirectPreconditionThunk] Class realization optimizations

### DIFF
--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -2867,6 +2867,20 @@ CodeGen::RValue CGObjCCommonMac::EmitMessageSend(
     CallSite->setDoesNotReturn();
   }
 
+  // If this was a class method call on a non-weakly-linked class, record it
+  // as realized for the "previously realized" heuristic.
+  if (ClassReceiver && Method && !isWeakLinkedClass(ClassReceiver)) {
+    if (llvm::BasicBlock *CurrentBB = CGF.Builder.GetInsertBlock())
+      // 1. Class methods have forced class realization (regardless direct or
+      // not)
+      // 2. Direct methods whose receiver is not null means the class is
+      // previously realized.
+      if (Method->isClassMethod() ||
+          (Method->isInstanceMethod() && !ReceiverCanBeNull)) {
+        CGF.ObjCRealizedClasses[CurrentBB].insert(ClassReceiver);
+      }
+  }
+
   return nullReturn.complete(CGF, Return, rvalue, ResultType, CallArgs,
                              RequiresNullCheck ? Method : nullptr);
 }

--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -2870,7 +2870,7 @@ CodeGen::RValue CGObjCCommonMac::EmitMessageSend(
   // If this was a class method call on a non-weakly-linked class, record it
   // as realized for the "previously realized" heuristic.
   if (ClassReceiver && Method && !isWeakLinkedClass(ClassReceiver)) {
-    if (llvm::BasicBlock *CurrentBB = CGF.Builder.GetInsertBlock())
+    if (llvm::BasicBlock *CurrentBB = CGF.Builder.GetInsertBlock()) {
       // 1. Class methods have forced class realization (regardless direct or
       // not)
       // 2. Direct methods whose receiver is not null means the class is
@@ -2879,6 +2879,7 @@ CodeGen::RValue CGObjCCommonMac::EmitMessageSend(
           (Method->isInstanceMethod() && !ReceiverCanBeNull)) {
         CGF.ObjCRealizedClasses[CurrentBB].insert(ClassReceiver);
       }
+    }
   }
 
   return nullReturn.complete(CGF, Return, rvalue, ResultType, CallArgs,

--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -397,12 +397,10 @@ bool CGObjCRuntime::canMessageReceiverBeNull(
 
   // If we're emitting a method, and self is const (meaning just ARC, for now),
   // and the receiver is a load of self, then self is a valid object.
-  if (const auto *curMethod =
-          dyn_cast_or_null<ObjCMethodDecl>(CGF.CurCodeDecl)) {
-    const auto *self = curMethod->getSelfDecl();
+  if (auto *curMethod = dyn_cast_or_null<ObjCMethodDecl>(CGF.CurCodeDecl)) {
+    const ImplicitParamDecl *self = curMethod->getSelfDecl();
     if (self->getType().isConstQualified()) {
-      if (const auto *LI =
-              dyn_cast<llvm::LoadInst>(receiver->stripPointerCasts())) {
+      if (auto LI = dyn_cast<llvm::LoadInst>(receiver->stripPointerCasts())) {
         llvm::Value *selfAddr = CGF.GetAddrOfLocalVar(self).emitRawPointer(CGF);
         if (selfAddr == LI->getPointerOperand()) {
           return false;
@@ -420,20 +418,20 @@ bool CGObjCRuntime::canClassObjectBeUnrealized(
   if (!CalleeClassDecl || isWeakLinkedClass(CalleeClassDecl))
     return true;
 
+  const ObjCInterfaceDecl *CanonicalClassDecl =
+      CalleeClassDecl->getCanonicalDecl();
+
   // Heuristic 1: +load method on this class or any subclass
-  // If the class or any of its subclasses has a +load method, it's realized
-  // when the binary is loaded. We cache this information to avoid repeatedly
-  // scanning the translation unit.
-  if (getOrPopulateRealizedClasses().contains(CalleeClassDecl))
+  if (isClassRealizedByLoader(CanonicalClassDecl))
     return false;
 
   // Heuristic 2: using Self / Super
-  // If we're currently executing a method of ClassDecl (or a subclass),
-  // then ClassDecl must already be realized.
+  // If we're inside the body of method declared on CanonicalClassDecl or a
+  // subclass, CanonicalClassDecl must have been realized
   if (const auto *CurMethod =
           dyn_cast_or_null<ObjCMethodDecl>(CGF.CurCodeDecl)) {
-    const ObjCInterfaceDecl *CallerCalssDecl = CurMethod->getClassInterface();
-    if (CallerCalssDecl && CalleeClassDecl->isSuperClassOf(CallerCalssDecl))
+    const ObjCInterfaceDecl *CallerClassDecl = CurMethod->getClassInterface();
+    if (CallerClassDecl && CanonicalClassDecl->isSuperClassOf(CallerClassDecl))
       return false;
   }
 
@@ -444,21 +442,22 @@ bool CGObjCRuntime::canClassObjectBeUnrealized(
   // TODO: Iter over all dominating blocks instead of just looking at the
   // current block. While we can construct a DT using CFG.CurFn, it is expensive
   // to do so repeatly when CGF is still emitting blocks.
-  if (auto *CurBB = CGF.Builder.GetInsertBlock()) {
-    auto It = CGF.ObjCRealizedClasses.find(CurBB);
-    if (It != CGF.ObjCRealizedClasses.end()) {
-      // Check if CalleeClassDecl is the same as or a superclass of any
-      // realized class in the cache. A realized subclass implies the parent
-      // is realized.
-      for (const auto *RealizedClass : It->second) {
-        if (CalleeClassDecl == RealizedClass)
-          return false;
-        if (CalleeClassDecl->isSuperClassOf(RealizedClass)) {
-          // Also cache this class to reduce future `isSuperClassOf` calls
-          It->second.insert(CalleeClassDecl);
-          return false;
-        }
-      }
+  auto *CurBB = CGF.Builder.GetInsertBlock();
+  if (!CurBB)
+    return true;
+  auto It = CGF.ObjCRealizedClasses.find(CurBB);
+  if (It == CGF.ObjCRealizedClasses.end())
+    return true;
+
+  llvm::SmallPtrSet<const ObjCInterfaceDecl *, 4> &BlockCache = It->second;
+  if (BlockCache.contains(CanonicalClassDecl))
+    return false;
+  // Check if CanonicalClassDecl is a superclass of any realized class in
+  // the cache. A realized subclass implies the parent is realized.
+  for (const ObjCInterfaceDecl *RealizedClass : BlockCache) {
+    if (CanonicalClassDecl->isSuperClassOf(RealizedClass)) {
+      BlockCache.insert(CanonicalClassDecl);
+      return false;
     }
   }
 
@@ -466,36 +465,40 @@ bool CGObjCRuntime::canClassObjectBeUnrealized(
   return true;
 }
 
-const RealizedClassSet &CGObjCRuntime::getOrPopulateRealizedClasses() const {
-  if (RealizedClasses)
-    return *RealizedClasses;
-  RealizedClasses = llvm::DenseSet<const ObjCInterfaceDecl *>();
+bool CGObjCRuntime::isClassRealizedByLoader(
+    const ObjCInterfaceDecl *ClassDecl) const {
+  auto populateRealizedClasses = [&]() {
+    RealizedClasses = llvm::DenseSet<const ObjCInterfaceDecl *>();
 
-  ASTContext &Ctx = CGM.getContext();
-  const IdentifierInfo *LoadII = &Ctx.Idents.get("load");
-  Selector LoadSel = Ctx.Selectors.getSelector(0, &LoadII);
+    ASTContext &Ctx = CGM.getContext();
+    const IdentifierInfo *LoadII = &Ctx.Idents.get("load");
+    Selector LoadSel = Ctx.Selectors.getSelector(0, &LoadII);
 
-  TranslationUnitDecl *TUDecl = Ctx.getTranslationUnitDecl();
-  llvm::DenseSet<const ObjCInterfaceDecl *> VisitedClasses;
-  for (const auto *D : TUDecl->decls()) {
-    if (const auto *OID = dyn_cast<ObjCInterfaceDecl>(D)) {
-      if (VisitedClasses.contains(OID))
-        continue;
-      // Check if this class has a +load method
-      if (OID->lookupMethod(LoadSel, /*isInstance=*/false,
-                            /*shallowCategoryLookup=*/false,
-                            /*followSuper=*/false)) {
-        // Add this class and all its superclasses to the realized set
-        const ObjCInterfaceDecl *Cls = OID;
-        while (Cls) {
-          RealizedClasses->insert(Cls);
-          VisitedClasses.insert(Cls);
-          Cls = Cls->getSuperClass();
+    TranslationUnitDecl *TUDecl = Ctx.getTranslationUnitDecl();
+    for (const auto *D : TUDecl->decls()) {
+      if (const auto *OID = dyn_cast<ObjCInterfaceDecl>(D)) {
+        const ObjCInterfaceDecl *CanonicalOID = OID->getCanonicalDecl();
+        if (RealizedClasses->contains(CanonicalOID))
+          continue;
+        // Check if this class has a +load method
+        if (CanonicalOID->lookupMethod(LoadSel, /*isInstance=*/false,
+                                       /*shallowCategoryLookup=*/false,
+                                       /*followSuper=*/false)) {
+          // Add this class and all its superclasses to the realized set
+          const ObjCInterfaceDecl *Cls = CanonicalOID;
+          while (Cls) {
+            RealizedClasses->insert(Cls->getCanonicalDecl());
+            Cls = Cls->getSuperClass();
+          }
         }
       }
     }
-  }
-  return *RealizedClasses;
+  };
+
+  if (!RealizedClasses)
+    populateRealizedClasses();
+
+  return RealizedClasses->contains(ClassDecl);
 }
 
 bool CGObjCRuntime::isWeakLinkedClass(const ObjCInterfaceDecl *ID) {

--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -415,7 +415,7 @@ bool CGObjCRuntime::canMessageReceiverBeNull(
 
 bool CGObjCRuntime::canClassObjectBeUnrealized(
     const ObjCInterfaceDecl *CalleeClassDecl, CodeGenFunction &CGF) const {
-  if (!CalleeClassDecl)
+  if (!CalleeClassDecl || isWeakLinkedClass(CalleeClassDecl))
     return true;
 
   // Heuristic 1: +load method on this class

--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -397,10 +397,12 @@ bool CGObjCRuntime::canMessageReceiverBeNull(
 
   // If we're emitting a method, and self is const (meaning just ARC, for now),
   // and the receiver is a load of self, then self is a valid object.
-  if (const auto *curMethod = dyn_cast_or_null<ObjCMethodDecl>(CGF.CurCodeDecl)) {
+  if (const auto *curMethod =
+          dyn_cast_or_null<ObjCMethodDecl>(CGF.CurCodeDecl)) {
     const auto *self = curMethod->getSelfDecl();
     if (self->getType().isConstQualified()) {
-      if (const auto *LI = dyn_cast<llvm::LoadInst>(receiver->stripPointerCasts())) {
+      if (const auto *LI =
+              dyn_cast<llvm::LoadInst>(receiver->stripPointerCasts())) {
         llvm::Value *selfAddr = CGF.GetAddrOfLocalVar(self).emitRawPointer(CGF);
         if (selfAddr == LI->getPointerOperand()) {
           return false;

--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -397,10 +397,10 @@ bool CGObjCRuntime::canMessageReceiverBeNull(
 
   // If we're emitting a method, and self is const (meaning just ARC, for now),
   // and the receiver is a load of self, then self is a valid object.
-  if (auto curMethod = dyn_cast_or_null<ObjCMethodDecl>(CGF.CurCodeDecl)) {
-    auto self = curMethod->getSelfDecl();
+  if (const auto *curMethod = dyn_cast_or_null<ObjCMethodDecl>(CGF.CurCodeDecl)) {
+    const auto *self = curMethod->getSelfDecl();
     if (self->getType().isConstQualified()) {
-      if (auto LI = dyn_cast<llvm::LoadInst>(receiver->stripPointerCasts())) {
+      if (const auto *LI = dyn_cast<llvm::LoadInst>(receiver->stripPointerCasts())) {
         llvm::Value *selfAddr = CGF.GetAddrOfLocalVar(self).emitRawPointer(CGF);
         if (selfAddr == LI->getPointerOperand()) {
           return false;

--- a/clang/lib/CodeGen/CGObjCRuntime.h
+++ b/clang/lib/CodeGen/CGObjCRuntime.h
@@ -69,13 +69,13 @@ protected:
   CodeGen::CodeGenModule &CGM;
   CGObjCRuntime(CodeGen::CodeGenModule &CGM) : CGM(CGM) {}
 
-  /// Cache of classes that are guaranteed to be realized because they or one
-  /// of their subclasses has a +load method. Lazily populated on first query.
+  /// Cache of classes known to be realized during loading.
   mutable std::optional<RealizedClassSet> RealizedClasses;
 
-  /// Populate the RealizedClasses cache by scanning all ObjCInterfaceDecls
-  /// in the translation unit for +load methods.
-  const RealizedClassSet &getOrPopulateRealizedClasses() const;
+  /// Query the cache to determine if a class is guaranteed to be realized
+  /// because of +load. Construct the cache if by scanning all
+  /// ObjCInterfaceDecls in the translation unit if we haven't done so.
+  bool isClassRealizedByLoader(const ObjCInterfaceDecl *CalleeClassDecl) const;
 
   // Utility functions for unified ivar access. These need to
   // eventually be folded into other places (the structure layout
@@ -352,18 +352,6 @@ public:
                                      QualType resultType,
                                      CallArgList &callArgs);
 
-  /// Check if the receiver of an ObjC message send can be null.
-  /// Returns true if the receiver may be null, false if provably non-null.
-  ///
-  /// This can be overridden by subclasses to add runtime-specific heuristics.
-  /// Base implementation checks:
-  /// - Super dispatch (always non-null)
-  /// - Self in const-qualified methods (ARC)
-  /// - Weak-linked classes
-  ///
-  /// Future enhancements in CGObjCCommonMac override:
-  /// - _Nonnull attributes
-  /// - Results of alloc, new, ObjC literals
   virtual bool canMessageReceiverBeNull(CodeGenFunction &CGF,
                                         const ObjCMethodDecl *method,
                                         bool isSuper,

--- a/clang/lib/CodeGen/CGObjCRuntime.h
+++ b/clang/lib/CodeGen/CGObjCRuntime.h
@@ -342,10 +342,23 @@ public:
                                      QualType resultType,
                                      CallArgList &callArgs);
 
-  bool canMessageReceiverBeNull(CodeGenFunction &CGF,
-                                const ObjCMethodDecl *method, bool isSuper,
-                                const ObjCInterfaceDecl *classReceiver,
-                                llvm::Value *receiver);
+  /// Check if the receiver of an ObjC message send can be null.
+  /// Returns true if the receiver may be null, false if provably non-null.
+  ///
+  /// This can be overridden by subclasses to add runtime-specific heuristics.
+  /// Base implementation checks:
+  /// - Super dispatch (always non-null)
+  /// - Self in const-qualified methods (ARC)
+  /// - Weak-linked classes
+  ///
+  /// Future enhancements in CGObjCCommonMac override:
+  /// - _Nonnull attributes
+  /// - Results of alloc, new, ObjC literals
+  virtual bool canMessageReceiverBeNull(CodeGenFunction &CGF,
+                                        const ObjCMethodDecl *method,
+                                        bool isSuper,
+                                        const ObjCInterfaceDecl *classReceiver,
+                                        llvm::Value *receiver);
 
   /// Check if a class object can be unrealized (not yet initialized).
   /// Returns true if the class may be unrealized, false if provably realized.

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -883,6 +883,15 @@ public:
   /// rethrows.
   SmallVector<llvm::Value *, 8> ObjCEHValueStack;
 
+  /// Per-basic-block cache of ObjC classes that have been realized during
+  /// codegen. When a class method is emitted on a non-weakly-linked class,
+  /// we record it here. This supports the "previously realized" heuristic
+  /// in canClassObjectBeUnrealized. The structure supports future
+  /// dominator-based analysis where we can check dominating blocks.
+  llvm::DenseMap<llvm::BasicBlock *,
+                 llvm::SmallPtrSet<const ObjCInterfaceDecl *, 4>>
+      ObjCRealizedClasses;
+
   /// A class controlling the emission of a finally block.
   class FinallyInfo {
     /// Where the catchall's edge through the cleanup should go.

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -883,11 +883,8 @@ public:
   /// rethrows.
   SmallVector<llvm::Value *, 8> ObjCEHValueStack;
 
-  /// Per-basic-block cache of ObjC classes that have been realized during
-  /// codegen. When a class method is emitted on a non-weakly-linked class,
-  /// we record it here. This supports the "previously realized" heuristic
-  /// in canClassObjectBeUnrealized. The structure supports future
-  /// dominator-based analysis where we can check dominating blocks.
+  /// A cache of objc classes that that are known to have been realized in each
+  /// basic block
   llvm::DenseMap<llvm::BasicBlock *,
                  llvm::SmallPtrSet<const ObjCInterfaceDecl *, 4>>
       ObjCRealizedClasses;

--- a/clang/test/CodeGenObjC/expose-direct-method-opt-class-realization.m
+++ b/clang/test/CodeGenObjC/expose-direct-method-opt-class-realization.m
@@ -1,0 +1,148 @@
+// RUN: %clang_cc1 -emit-llvm -fobjc-arc -triple arm64-apple-darwin10 \
+// RUN:   -fobjc-expose-direct-methods %s -o - | FileCheck %s
+
+// ============================================================================
+// HEURISTIC 1: Classes with +load method skip thunk for class methods
+// because they are guaranteed to be realized when the binary is loaded.
+// ============================================================================
+
+__attribute__((objc_root_class))
+@interface ClassWithLoad
++ (void)load;
++ (int)classDirectMethod __attribute__((objc_direct));
+@end
+
+@implementation ClassWithLoad
+
++ (void)load {
+  // This method causes the class to be realized at load time
+}
+
+// CHECK-LABEL: define hidden i32 @"+[ClassWithLoad classDirectMethod]"(ptr noundef %self)
++ (int)classDirectMethod {
+  return 42;
+}
+
+@end
+
+// A class without +load method for comparison
+__attribute__((objc_root_class))
+@interface ClassWithoutLoad
++ (int)classDirectMethod __attribute__((objc_direct));
+@end
+
+@implementation ClassWithoutLoad
+
+// CHECK-LABEL: define hidden i32 @"+[ClassWithoutLoad classDirectMethod]"(ptr noundef %self)
++ (int)classDirectMethod {
+  return 42;
+}
+
+@end
+
+// CHECK-LABEL: define{{.*}} i32 @testClassWithLoad()
+int testClassWithLoad(void) {
+  // Because ClassWithLoad has +load, it's guaranteed to be realized.
+  // So we should call the implementation directly, NOT through a thunk.
+  //
+  // CHECK: call i32 @"+[ClassWithLoad classDirectMethod]"(ptr noundef
+  // CHECK-NOT: call i32 @"+[ClassWithLoad classDirectMethod]_thunk"
+  return [ClassWithLoad classDirectMethod];
+}
+
+// CHECK-LABEL: define{{.*}} i32 @testClassWithoutLoad()
+int testClassWithoutLoad(void) {
+  // ClassWithoutLoad has no +load, so the class might not be realized.
+  // We need to call through the thunk which will realize the class.
+  //
+  // CHECK: call i32 @"+[ClassWithoutLoad classDirectMethod]_thunk"(ptr noundef
+  return [ClassWithoutLoad classDirectMethod];
+}
+
+// ============================================================================
+// HEURISTIC 2: Calls from within the same class skip thunk
+// because if we're executing a method of the class, it must be realized.
+// ============================================================================
+
+__attribute__((objc_root_class))
+@interface SameClassTest
++ (int)classDirectMethod __attribute__((objc_direct));
++ (int)callerClassMethod __attribute__((objc_direct));
+- (int)callerInstanceMethod __attribute__((objc_direct));
+@end
+
+@implementation SameClassTest
+
+// CHECK-LABEL: define hidden i32 @"+[SameClassTest classDirectMethod]"(ptr noundef %self)
++ (int)classDirectMethod {
+  return 42;
+}
+
+// CHECK-LABEL: define hidden i32 @"+[SameClassTest callerClassMethod]"(ptr noundef %self)
++ (int)callerClassMethod {
+  // Calling a class method from another class method of the SAME class.
+  // The class must be realized (we're already executing a method of it).
+  // Should call implementation directly, NOT through thunk.
+  //
+  // CHECK: call i32 @"+[SameClassTest classDirectMethod]"(ptr noundef
+  // CHECK-NOT: call i32 @"+[SameClassTest classDirectMethod]_thunk"
+  return [SameClassTest classDirectMethod];
+}
+
+// CHECK-LABEL: define hidden i32 @"-[SameClassTest callerInstanceMethod]"(ptr noundef %self)
+- (int)callerInstanceMethod {
+  // Calling a class method from an instance method of the SAME class.
+  // The class must be realized (we're already executing a method of it).
+  // Should call implementation directly, NOT through thunk.
+  //
+  // CHECK: call i32 @"+[SameClassTest classDirectMethod]"(ptr noundef
+  // CHECK-NOT: call i32 @"+[SameClassTest classDirectMethod]_thunk"
+  return [SameClassTest classDirectMethod];
+}
+
+@end
+
+__attribute__((objc_root_class))
+@interface SuperClass
++ (int)superClassMethod __attribute__((objc_direct));
+@end
+
+@implementation SuperClass
+
+// CHECK-LABEL: define hidden i32 @"+[SuperClass superClassMethod]"(ptr noundef %self)
++ (int)superClassMethod {
+  return 100;
+}
+
+@end
+
+@interface SubClass : SuperClass
++ (int)subCallerMethod __attribute__((objc_direct));
+- (int)subInstanceCaller __attribute__((objc_direct));
+@end
+
+@implementation SubClass
+
+// CHECK-LABEL: define hidden i32 @"+[SubClass subCallerMethod]"(ptr noundef %self)
++ (int)subCallerMethod {
+  // Calling a superclass's class method from a subclass method.
+  // SuperClass must be realized because SubClass inherits from it.
+  // Should call implementation directly, NOT through thunk.
+  //
+  // CHECK: call i32 @"+[SuperClass superClassMethod]"(ptr noundef
+  // CHECK-NOT: call i32 @"+[SuperClass superClassMethod]_thunk"
+  return [SuperClass superClassMethod];
+}
+
+// CHECK-LABEL: define hidden i32 @"-[SubClass subInstanceCaller]"(ptr noundef %self)
+- (int)subInstanceCaller {
+  // Calling a superclass's class method from a subclass instance method.
+  // SuperClass must be realized because SubClass inherits from it.
+  // Should call implementation directly, NOT through thunk.
+  //
+  // CHECK: call i32 @"+[SuperClass superClassMethod]"(ptr noundef
+  // CHECK-NOT: call i32 @"+[SuperClass superClassMethod]_thunk"
+  return [SuperClass superClassMethod];
+}
+
+@end

--- a/clang/test/CodeGenObjC/expose-direct-method-opt-class-realization.m
+++ b/clang/test/CodeGenObjC/expose-direct-method-opt-class-realization.m
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -emit-llvm -fobjc-arc -triple arm64-apple-darwin10 \
-// RUN:   -fobjc-expose-direct-methods %s -o - | FileCheck %s
+// RUN:   -fobjc-direct-precondition-thunk %s -o - | FileCheck %s
 
 // ============================================================================
 // HEURISTIC 1: Classes with +load method skip thunk for class methods

--- a/clang/test/CodeGenObjC/expose-direct-method-opt-class-realization.m
+++ b/clang/test/CodeGenObjC/expose-direct-method-opt-class-realization.m
@@ -13,7 +13,7 @@ __attribute__((objc_root_class))
 
 @implementation Root
 
-// CHECK-LABEL: define hidden i32 @"+[Root rootDirectMethod]"(ptr noundef %self)
+// CHECK-LABEL: define hidden i32 @"+[Root rootDirectMethod]D"(ptr noundef %self)
 + (int)rootDirectMethod { return 100; }
 
 @end
@@ -29,7 +29,7 @@ __attribute__((objc_root_class))
   // This method causes the class to be realized at load time
 }
 
-// CHECK-LABEL: define hidden i32 @"+[ClassWithLoad classDirectMethod]"(ptr noundef %self)
+// CHECK-LABEL: define hidden i32 @"+[ClassWithLoad classDirectMethod]D"(ptr noundef %self)
 + (int)classDirectMethod { return 42; }
 
 @end
@@ -41,7 +41,7 @@ __attribute__((objc_root_class))
 
 @implementation ClassWithoutLoad
 
-// CHECK-LABEL: define hidden i32 @"+[ClassWithoutLoad classDirectMethod]"(ptr noundef %self)
+// CHECK-LABEL: define hidden i32 @"+[ClassWithoutLoad classDirectMethod]D"(ptr noundef %self)
 + (int)classDirectMethod {
   return 42;
 }
@@ -53,8 +53,8 @@ int testClassWithLoad(void) {
   // Because ClassWithLoad has +load, it's guaranteed to be realized.
   // So we should call the implementation directly, NOT through a thunk.
   //
-  // CHECK: call i32 @"+[ClassWithLoad classDirectMethod]"(ptr noundef
-  // CHECK-NOT: call i32 @"+[ClassWithLoad classDirectMethod]_thunk"
+  // CHECK: call i32 @"+[ClassWithLoad classDirectMethod]D"(ptr noundef
+  // CHECK-NOT: call i32 @"+[ClassWithLoad classDirectMethod]D_thunk"
   return [ClassWithLoad classDirectMethod];
 }
 
@@ -63,7 +63,7 @@ int testClassWithoutLoad(void) {
   // ClassWithoutLoad has no +load, so the class might not be realized.
   // We need to call through the thunk which will realize the class.
   //
-  // CHECK: call i32 @"+[ClassWithoutLoad classDirectMethod]_thunk"(ptr noundef
+  // CHECK: call i32 @"+[ClassWithoutLoad classDirectMethod]D_thunk"(ptr noundef
   return [ClassWithoutLoad classDirectMethod];
 }
 
@@ -80,48 +80,48 @@ int testClassWithoutLoad(void) {
 
 @implementation SameClassTest
 
-// CHECK-LABEL: define hidden i32 @"+[SameClassTest classDirectMethod]"(ptr noundef %self)
+// CHECK-LABEL: define hidden i32 @"+[SameClassTest classDirectMethod]D"(ptr noundef %self)
 + (int)classDirectMethod {
   return 42;
 }
 
-// CHECK-LABEL: define hidden i32 @"+[SameClassTest callerClassMethod]"(ptr noundef %self)
+// CHECK-LABEL: define hidden i32 @"+[SameClassTest callerClassMethod]D"(ptr noundef %self)
 + (int)callerClassMethod {
   // Calling a class method from another class method of the SAME class.
   // The class must be realized (we're already executing a method of it).
   // Should call implementation directly, NOT through thunk.
   //
-  // CHECK: call i32 @"+[SameClassTest classDirectMethod]"(ptr noundef
-  // CHECK-NOT: call i32 @"+[SameClassTest classDirectMethod]_thunk"
+  // CHECK: call i32 @"+[SameClassTest classDirectMethod]D"(ptr noundef
+  // CHECK-NOT: call i32 @"+[SameClassTest classDirectMethod]D_thunk"
   int a = [SameClassTest classDirectMethod];
 
   // Calling the root class's class method from a subclass method.
   // Root must be realized because SubClass inherits from it.
   // Should call implementation directly, NOT through thunk.
   //
-  // CHECK: call i32 @"+[Root rootDirectMethod]"(ptr noundef
-  // CHECK-NOT: call i32 @"+[Root rootDirectMethod]_thunk"
+  // CHECK: call i32 @"+[Root rootDirectMethod]D"(ptr noundef
+  // CHECK-NOT: call i32 @"+[Root rootDirectMethod]D_thunk"
   int b = [Root rootDirectMethod];
 
   return a + b;
 }
 
-// CHECK-LABEL: define hidden i32 @"-[SameClassTest callerInstanceMethod]"(ptr noundef %self)
+// CHECK-LABEL: define hidden i32 @"-[SameClassTest callerInstanceMethod]D"(ptr noundef %self)
 - (int)callerInstanceMethod {
   // Calling a class method from an instance method of the SAME class.
   // The class must be realized (we're already executing a method of it).
   // Should call implementation directly, NOT through thunk.
   //
-  // CHECK: call i32 @"+[SameClassTest classDirectMethod]"(ptr noundef
-  // CHECK-NOT: call i32 @"+[SameClassTest classDirectMethod]_thunk"
+  // CHECK: call i32 @"+[SameClassTest classDirectMethod]D"(ptr noundef
+  // CHECK-NOT: call i32 @"+[SameClassTest classDirectMethod]D_thunk"
   int a = [SameClassTest classDirectMethod];
 
   // Calling the root class's class method from a subclass instance method.
   // Root must be realized because SubClass inherits from it.
   // Should call implementation directly, NOT through thunk.
   //
-  // CHECK: call i32 @"+[Root rootDirectMethod]"(ptr noundef
-  // CHECK-NOT: call i32 @"+[Root rootDirectMethod]_thunk"
+  // CHECK: call i32 @"+[Root rootDirectMethod]D"(ptr noundef
+  // CHECK-NOT: call i32 @"+[Root rootDirectMethod]D_thunk"
   int b = [Root rootDirectMethod];
 
   return a + b;
@@ -139,28 +139,28 @@ int testClassWithoutLoad(void) {
 int testPreviouslyRealizedParentClass(int flag) {
   if (flag) {
     // First call to ClassWithoutLoad - needs thunk (class might not be realized)
-    // CHECK: call i32 @"+[ClassWithoutLoad classDirectMethod]_thunk"(ptr noundef
+    // CHECK: call i32 @"+[ClassWithoutLoad classDirectMethod]D_thunk"(ptr noundef
     int a = [ClassWithoutLoad classDirectMethod];
 
     // Second call to same class - should skip thunk (class was just realized)
-    // CHECK: call i32 @"+[ClassWithoutLoad classDirectMethod]"(ptr noundef
-    // CHECK-NOT: call i32 @"+[ClassWithoutLoad classDirectMethod]_thunk"
+    // CHECK: call i32 @"+[ClassWithoutLoad classDirectMethod]D"(ptr noundef
+    // CHECK-NOT: call i32 @"+[ClassWithoutLoad classDirectMethod]D_thunk"
     int b = [ClassWithoutLoad classDirectMethod];
 
     // Call to Root (parent of ClassWithoutLoad) - should skip thunk
     // because realizing ClassWithoutLoad also realizes its superclass Root.
-    // CHECK: call i32 @"+[Root rootDirectMethod]"(ptr noundef
-    // CHECK-NOT: call i32 @"+[Root rootDirectMethod]_thunk"
+    // CHECK: call i32 @"+[Root rootDirectMethod]D"(ptr noundef
+    // CHECK-NOT: call i32 @"+[Root rootDirectMethod]D_thunk"
     int c = [Root rootDirectMethod];
     return a + b + c;
 
   }
   // New block, we are not sure if prev block is executed, so we have to conservatively realize again.
-  // CHECK: call i32 @"+[ClassWithoutLoad classDirectMethod]_thunk"
-  // CHECK-NOT: call i32 @"+[ClassWithoutLoad classDirectMethod]"(ptr noundef
+  // CHECK: call i32 @"+[ClassWithoutLoad classDirectMethod]D_thunk"
+  // CHECK-NOT: call i32 @"+[ClassWithoutLoad classDirectMethod]D"(ptr noundef
   int b = [ClassWithoutLoad classDirectMethod];
-  // CHECK: call i32 @"+[Root rootDirectMethod]"(ptr noundef
-  // CHECK-NOT: call i32 @"+[Root rootDirectMethod]_thunk"
+  // CHECK: call i32 @"+[Root rootDirectMethod]D"(ptr noundef
+  // CHECK-NOT: call i32 @"+[Root rootDirectMethod]D_thunk"
   int c = [Root rootDirectMethod];
 
   return b + c;

--- a/clang/test/CodeGenObjC/expose-direct-method-visibility-linkage.m
+++ b/clang/test/CodeGenObjC/expose-direct-method-visibility-linkage.m
@@ -106,7 +106,7 @@ int main() {
     // MAIN_M: call i32 @"-[Foo exportedInstanceMethod:]D_thunk"
     printf("Exported instance: %d\n", [obj exportedInstanceMethod:10]);
 
-    // MAIN_M: call i32 @"+[Foo exportedClassMethod:]D_thunk"
+    // MAIN_M: call i32 @"+[Foo exportedClassMethod:]D"
     printf("Exported class: %d\n", [Foo exportedClassMethod:10]);
 
     return 0;
@@ -116,4 +116,4 @@ int main() {
 // MAIN_M-LABEL: define linkonce_odr hidden void @"-[Foo setExportedValue:]D_thunk"
 // MAIN_M-LABEL: define linkonce_odr hidden i32 @"-[Foo exportedValue]D_thunk"
 // MAIN_M-LABEL: define linkonce_odr hidden i32 @"-[Foo exportedInstanceMethod:]D_thunk"
-// MAIN_M-LABEL: define linkonce_odr hidden i32 @"+[Foo exportedClassMethod:]D_thunk"
+// MAIN_M: declare i32 @"+[Foo exportedClassMethod:]D"

--- a/clang/test/CodeGenObjC/expose-direct-method.m
+++ b/clang/test/CodeGenObjC/expose-direct-method.m
@@ -271,9 +271,11 @@ int useSRet(Root *r) {
     // CHECK: call void @"-[Root getAggregate]D_thunk"
     [r getAggregate].a +
     // TODO: The compiler is not smart enough to know the class object must be realized yet.
-    // CHECK: call i64 @"+[Root classGetComplex]D_thunk"(ptr noundef
+    // CHECK-NOT: call i64 @"+[Root classGetComplex]"(ptr noundef
+    // CHECK: call i64 @"+[Root classGetComplex]_thunk"(ptr noundef
     [Root classGetComplex].a +
-    // CHECK: call void @"+[Root classGetAggregate]D_thunk"(ptr {{.*}}sret
+    // CHECK-NOT: call void @"+[Root classGetAggregate]"(ptr {{.*}}sret
+    // CHECK: call void @"+[Root classGetAggregate]_thunk"(ptr {{.*}}sret
     [Root classGetAggregate].a
   );
 }

--- a/clang/test/CodeGenObjC/expose-direct-method.m
+++ b/clang/test/CodeGenObjC/expose-direct-method.m
@@ -270,11 +270,11 @@ int useSRet(Root *r) {
     // TODO: we should know that this instance is non nil.
     // CHECK: call void @"-[Root getAggregate]D_thunk"
     [r getAggregate].a +
-    // CHECK-NOT: call i64 @"+[Root classGetComplex]"(ptr noundef
-    // CHECK: call i64 @"+[Root classGetComplex]_thunk"(ptr noundef
+    // CHECK-NOT: call i64 @"+[Root classGetComplex]D"(ptr noundef
+    // CHECK: call i64 @"+[Root classGetComplex]D_thunk"(ptr noundef
     [Root classGetComplex].a +
-    // CHECK-NOT: call void @"+[Root classGetAggregate]_thunk"(ptr {{.*}}sret
-    // CHECK: call void @"+[Root classGetAggregate]"(ptr {{.*}}sret
+    // CHECK-NOT: call void @"+[Root classGetAggregate]D_thunk"(ptr {{.*}}sret
+    // CHECK: call void @"+[Root classGetAggregate]D"(ptr {{.*}}sret
     [Root classGetAggregate].a
   );
 }
@@ -293,5 +293,5 @@ int useSRet(Root *r) {
 // CHECK: dummy_ret_block:
 // CHECK:   ret void
 
-// CHECK: define {{.*}} @"+[Root classGetComplex]_thunk"
-// CHECK-NOT: define {{.*}} @"+[Root classGetAggregate]_thunk"
+// CHECK: define {{.*}} @"+[Root classGetComplex]D_thunk"
+// CHECK-NOT: define {{.*}} @"+[Root classGetAggregate]D_thunk"

--- a/clang/test/CodeGenObjC/expose-direct-method.m
+++ b/clang/test/CodeGenObjC/expose-direct-method.m
@@ -270,12 +270,11 @@ int useSRet(Root *r) {
     // TODO: we should know that this instance is non nil.
     // CHECK: call void @"-[Root getAggregate]D_thunk"
     [r getAggregate].a +
-    // TODO: The compiler is not smart enough to know the class object must be realized yet.
     // CHECK-NOT: call i64 @"+[Root classGetComplex]"(ptr noundef
     // CHECK: call i64 @"+[Root classGetComplex]_thunk"(ptr noundef
     [Root classGetComplex].a +
-    // CHECK-NOT: call void @"+[Root classGetAggregate]"(ptr {{.*}}sret
-    // CHECK: call void @"+[Root classGetAggregate]_thunk"(ptr {{.*}}sret
+    // CHECK-NOT: call void @"+[Root classGetAggregate]_thunk"(ptr {{.*}}sret
+    // CHECK: call void @"+[Root classGetAggregate]"(ptr {{.*}}sret
     [Root classGetAggregate].a
   );
 }
@@ -294,39 +293,5 @@ int useSRet(Root *r) {
 // CHECK: dummy_ret_block:
 // CHECK:   ret void
 
-// Class method thunks should have class realization (objc_msgSend)
-// instead of a nil check.
-// CHECK-LABEL: define linkonce_odr hidden i64 @"+[Root classGetComplex]D_thunk"(ptr noundef %self)
-// CHECK: entry:
-// CHECK-NOT: icmp eq ptr
-// CHECK:   call ptr @objc_msgSend
-// CHECK:   musttail call i64 @"+[Root classGetComplex]D"(ptr noundef %self)
-// CHECK:   ret i64
-
-// CHECK-LABEL: define linkonce_odr hidden void @"+[Root classGetAggregate]D_thunk"(ptr {{.*}} sret(%struct.my_aggregate_struct) {{.*}} %agg.result, ptr noundef %self)
-// CHECK: entry:
-// CHECK-NOT: icmp eq ptr
-// CHECK:   call ptr @objc_msgSend
-// CHECK:   musttail call void @"+[Root classGetAggregate]D"(ptr {{.*}} sret(%struct.my_aggregate_struct) {{.*}} %agg.result, ptr noundef %self)
-// CHECK:   ret void
-
-// CHECK-LABEL: define{{.*}} i32 @useWeakRoot()
-int useWeakRoot() {
-  // CHECK: call i32 @"+[WeakRoot classGetInt]D_thunk"
-  return [WeakRoot classGetInt];
-}
-
-// Weakly linked class method thunks should have class realization
-// AND a nil check (the weak class may not exist at runtime).
-// CHECK-LABEL: define linkonce_odr hidden i32 @"+[WeakRoot classGetInt]D_thunk"(ptr noundef %self)
-// CHECK: entry:
-// CHECK:   call ptr @objc_msgSend
-// CHECK:   %[[IS_NIL:.*]] = icmp eq ptr {{.*}}, null
-// CHECK:   br i1 %[[IS_NIL]], label %objc_direct_method.self_is_nil, label %objc_direct_method.cont
-// CHECK: objc_direct_method.self_is_nil:
-// CHECK:   call void @llvm.memset
-// CHECK:   br label %dummy_ret_block
-// CHECK: objc_direct_method.cont:
-// CHECK:   %[[RET:.*]] = musttail call i32 @"+[WeakRoot classGetInt]D"(ptr noundef %self)
-// CHECK:   ret i32 %[[RET]]
-// CHECK: dummy_ret_block:
+// CHECK: define {{.*}} @"+[Root classGetComplex]_thunk"
+// CHECK-NOT: define {{.*}} @"+[Root classGetAggregate]_thunk"


### PR DESCRIPTION
## TL;DR

This is a stack of PRs implementing features to expose direct methods ABI.
You can see the RFC, design, and discussion [here](https://discourse.llvm.org/t/rfc-optimizing-code-size-of-objc-direct-by-exposing-function-symbols-and-moving-nil-checks-to-thunks/88866).

https://github.com/llvm/llvm-project/pull/170616 **Flag `-fobjc-direct-precondition-thunk` set up**
https://github.com/llvm/llvm-project/pull/170617 Code refactoring to ease later reviews
https://github.com/llvm/llvm-project/pull/170618 Thunk generation
https://github.com/llvm/llvm-project/pull/170619 **Optimizations, some class objects can be known to be realized, in which case we can skip the precondition thunk**

Note: This PR is just optimization and optional, it won't impact the overall correctness of the feature. It's ok for `canClassObjectBeUnrealized` to always return `false` if we believe we can implement better analysis in the future.

## Implementation details

Two heuristics where we can infer the class is definitely realized.
For all non-weak-link classe:

1. If it has `+load` defined
2. If the callee is in the same class as the caller, or in the super class of the caller.
3. If a message has been sent (direct or non-direct)  on current class or any sub class in the same basic block. 
    3.1 TODO: "in the same basic block" can be relaxed to "in any dominators"

## Tests

- `expose-direct-method-opt-class-realization.m` 