### PR TITLE
[Clang] Added clang diagnostic when snprintf/vsnprintf uses sizeof(de…

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -444,6 +444,9 @@ Improvements to Clang's diagnostics
   comparison operators when mixed with bitwise operators in enum value initializers.
   This can be locally disabled by explicitly casting the initializer value.
 
+- Clang now emits ``-Wsizeof-pointer-memaccess`` when snprintf/vsnprintf use the sizeof 
+  the destination buffer(dynamically allocated) in the len parameter(#GH162366)
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -895,10 +895,6 @@ def warn_sizeof_pointer_type_memaccess : Warning<
   "argument to 'sizeof' in %0 call is the same pointer type %1 as the "
   "%select{destination|source}2; expected %3 or an explicit length">,
   InGroup<SizeofPointerMemaccess>;
-def warn_sizeof_pointer_dest_type_memacess : Warning<
-  "argument to 'sizeof' in %0 call is the same expression as the "
-  "destination; did you mean to put an explicit length?">,
-  InGroup<SizeofPointerMemaccess>;
 def warn_strlcpycat_wrong_size : Warning<
   "size argument in %0 call appears to be size of the source; "
   "expected the size of the destination">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -895,6 +895,10 @@ def warn_sizeof_pointer_type_memaccess : Warning<
   "argument to 'sizeof' in %0 call is the same pointer type %1 as the "
   "%select{destination|source}2; expected %3 or an explicit length">,
   InGroup<SizeofPointerMemaccess>;
+def warn_sizeof_pointer_dest_type_memacess : Warning<
+  "argument to 'sizeof' in %0 call is the same expression as the "
+  "destination; did you mean to put an explicit length?">,
+  InGroup<SizeofPointerMemaccess>;
 def warn_strlcpycat_wrong_size : Warning<
   "size argument in %0 call appears to be size of the source; "
   "expected the size of the destination">,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3043,6 +3043,9 @@ private:
   void CheckMemaccessArguments(const CallExpr *Call, unsigned BId,
                                IdentifierInfo *FnName);
 
+  bool CheckSizeOfExpression(const Expr *SizeOfArg, const Expr *Dest,
+                             llvm::FoldingSetNodeID SizeOfArgID,
+                             IdentifierInfo *FnName);
   // Warn if the user has made the 'size' argument to strlcpy or strlcat
   // be the size of the source, instead of the destination.
   void CheckStrlcpycatArguments(const CallExpr *Call, IdentifierInfo *FnName);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3043,9 +3043,9 @@ private:
   void CheckMemaccessArguments(const CallExpr *Call, unsigned BId,
                                IdentifierInfo *FnName);
 
-  bool CheckSizeOfExpression(const Expr *SizeOfArg, const Expr *Dest,
-                             llvm::FoldingSetNodeID SizeOfArgID,
-                             IdentifierInfo *FnName);
+  bool CheckSizeofMemaccessArgument(const Expr *SizeOfArg, const Expr *Dest,
+                                    llvm::FoldingSetNodeID SizeOfArgID,
+                                    IdentifierInfo *FnName);
   // Warn if the user has made the 'size' argument to strlcpy or strlcat
   // be the size of the source, instead of the destination.
   void CheckStrlcpycatArguments(const CallExpr *Call, IdentifierInfo *FnName);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3044,7 +3044,6 @@ private:
                                IdentifierInfo *FnName);
 
   bool CheckSizeofMemaccessArgument(const Expr *SizeOfArg, const Expr *Dest,
-                                    llvm::FoldingSetNodeID SizeOfArgID,
                                     IdentifierInfo *FnName);
   // Warn if the user has made the 'size' argument to strlcpy or strlcat
   // be the size of the source, instead of the destination.

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -10373,9 +10373,9 @@ bool Sema::CheckSizeofMemaccessArgument(const Expr *LenExpr, const Expr *Dest,
     unsigned ActionIdx = 0; // Default is to suggest dereferencing.
     StringRef ReadableName = FnName->getName();
 
-    if (const UnaryOperator *UnaryOp = dyn_cast<UnaryOperator>(Dest))
-      if (UnaryOp->getOpcode() == UO_AddrOf)
-        ActionIdx = 1; // If its an address-of operator, just remove it.
+    if (const UnaryOperator *UnaryOp = dyn_cast<UnaryOperator>(Dest);
+        UnaryOp && UnaryOp->getOpcode() == UO_AddrOf)
+      ActionIdx = 1; // If its an address-of operator, just remove it.
     if (!PointeeTy->isIncompleteType() &&
         (Context.getTypeSize(PointeeTy) == Context.getCharWidth()))
       ActionIdx = 2; // If the pointee's size is sizeof(char),

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1449,10 +1449,8 @@ void Sema::checkFortifiedBuiltinMemoryFunction(FunctionDecl *FD,
       }
     }
     DestinationSize = ComputeSizeArgument(0);
-    const Expr *LenArg = TheCall->getArg(1)->IgnoreParenImpCasts();
-    const Expr *Dest = TheCall->getArg(0)->IgnoreParenImpCasts();
-    if (const auto *DestCast = dyn_cast_or_null<CastExpr>(Dest))
-      Dest = DestCast->getSubExprAsWritten();
+    const Expr *LenArg = TheCall->getArg(1)->IgnoreCasts();
+    const Expr *Dest = TheCall->getArg(0)->IgnoreCasts();
     IdentifierInfo *FnInfo = FD->getIdentifier();
     CheckSizeofMemaccessArgument(LenArg, Dest, FnInfo);
   }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1455,7 +1455,7 @@ void Sema::checkFortifiedBuiltinMemoryFunction(FunctionDecl *FD,
       Dest = DestCast->getSubExprAsWritten();
     llvm::FoldingSetNodeID SizeOfArgID;
     IdentifierInfo *FnInfo = FD->getIdentifier();
-    CheckSizeOfExpression(LenArg, Dest, SizeOfArgID, FnInfo);
+    CheckSizeofMemaccessArgument(LenArg, Dest, SizeOfArgID, FnInfo);
   }
   }
 
@@ -10245,7 +10245,7 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
       // actually comparing the expressions for equality. Because computing the
       // expression IDs can be expensive, we only do this if the diagnostic is
       // enabled.
-      if (CheckSizeOfExpression(LenExpr, Dest, SizeOfArgID, FnName))
+      if (CheckSizeofMemaccessArgument(LenExpr, Dest, SizeOfArgID, FnName))
         break;
 
       // Also check for cases where the sizeof argument is the exact same
@@ -10349,9 +10349,9 @@ void Sema::CheckMemaccessArguments(const CallExpr *Call,
   }
 }
 
-bool Sema::CheckSizeOfExpression(const Expr *LenExpr, const Expr *Dest,
-                                 llvm::FoldingSetNodeID SizeOfArgID,
-                                 IdentifierInfo *FnName) {
+bool Sema::CheckSizeofMemaccessArgument(const Expr *LenExpr, const Expr *Dest,
+                                        llvm::FoldingSetNodeID SizeOfArgID,
+                                        IdentifierInfo *FnName) {
   const Expr *SizeOfArg = getSizeOfExprArg(LenExpr);
   if (!SizeOfArg)
     return false;

--- a/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
+++ b/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
@@ -190,10 +190,109 @@ void strcpy_and_friends() {
 }
 
 extern "C" int snprintf(char* buffer, __SIZE_TYPE__ buf_size, const char* format, ...);
+extern "C" int vsnprintf(char* buffer, __SIZE_TYPE__ buf_size, const char* format, __builtin_va_list arg);
 extern "C" void* malloc(unsigned size);
+
+// This is a dependent context by none of the actual operations are dependent.
+template <class T> void fooNone() {
+   char* a = (char*) malloc(20);
+   const char* b = "Hello World";
+   snprintf(a, sizeof(a), "%s", b); // #fooNone_diagnostic
+    // expected-warning@#fooNone_diagnostic {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#fooNone_diagnostic {{did you mean to provide an explicit length?}}
+}
+
+template <class T> void fooType() {
+   T a = (T) malloc(20); // #fooType_error
+   const char* b = "Hello World";
+   snprintf((char *)a, sizeof(a), "%s", b);// #fooType_diagnostic
+}
+
+template <class T> void fooTypePtr() {
+   T *a = (T *) malloc(20);
+   const char* b = "Hello World";
+   snprintf((char *)a, sizeof(a), "%s", b);// #fooTypePtr_diagnostic
+}
 
 void check_prints(){
     char* a = (char*) malloc(20);
     const char* b = "Hello World";
-    snprintf(a, sizeof(a), "%s", b); // expected-warning{{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}} expected-note {{did you mean to provide an explicit length?}}
+    snprintf(a, sizeof(a), "%s", b); // #CheckBasePrint
+    // expected-warning@#CheckBasePrint {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#CheckBasePrint {{did you mean to provide an explicit length?}}
+
+    snprintf((char*)a, sizeof(a), "%s", b); // #CheckCastPrint
+    // expected-warning@#CheckCastPrint {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#CheckCastPrint {{did you mean to provide an explicit length?}}
+
+    __builtin_va_list list;
+    vsnprintf(a, sizeof(a), "%s", list);  // #VSNprintCheck
+    // expected-warning@#VSNprintCheck {{'vsnprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#VSNprintCheck {{did you mean to provide an explicit length?}}
+
+    vsnprintf((char*)a, sizeof(a), "%s", list);  // #VSNprintCastCheck
+    // expected-warning@#VSNprintCastCheck {{'vsnprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#VSNprintCastCheck {{did you mean to provide an explicit length?}}
+
+    //No diagnostic output when dest is an array
+    char c[20];
+    const char* d = "Hello World";
+    snprintf(c, sizeof(c), "%s", d); // expected-none
+
+    //No diagnostic output when len is a exact number
+    char* e = (char*) malloc(20);
+    const char* f = "Hello World";
+    snprintf(e, 20, "%s", f); // expected-none
+
+    //Template tests
+    fooNone<int>(); // #fooNone_int_call
+    // expected-warning@#fooNone_diagnostic {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#fooNone_diagnostic {{did you mean to provide an explicit length?}}
+    // expected-note@#fooNone_int_call {{in instantiation of function template specialization 'fooNone<int>' requested here}}
+
+    fooNone<char>();// #fooNone_char_call
+    // expected-warning@#fooNone_diagnostic {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#fooNone_diagnostic {{did you mean to provide an explicit length?}}
+    // expected-note@#fooNone_char_call {{in instantiation of function template specialization 'fooNone<char>' requested here}}
+
+    fooNone<char*>();// #fooNone_charptr_call
+    // expected-warning@#fooNone_diagnostic {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#fooNone_diagnostic {{did you mean to provide an explicit length?}}
+    // expected-note@#fooNone_charptr_call {{in instantiation of function template specialization 'fooNone<char *>' requested here}}
+
+
+    fooNone<void>();// #fooNone_void_call
+    // expected-warning@#fooNone_diagnostic {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#fooNone_diagnostic {{did you mean to provide an explicit length?}}
+    // expected-note@#fooNone_void_call {{in instantiation of function template specialization 'fooNone<void>' requested here}}
+
+    fooType<char*>();// #fooType_charptr_call
+    // expected-warning@#fooType_diagnostic {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#fooType_diagnostic {{did you mean to provide an explicit length?}}
+    // expected-note@#fooType_charptr_call {{in instantiation of function template specialization 'fooType<char *>' requested here}}
+
+    fooType<void*>();// #fooType_voidptr_call
+    // expected-warning@#fooType_diagnostic {{'snprintf' call operates on objects of type 'void' while the size is based on a different type 'void *'}}
+    // expected-note@#fooType_diagnostic {{did you mean to dereference the argument to 'sizeof' (and multiply it by the number of elements)?}}
+    // expected-note@#fooType_voidptr_call {{in instantiation of function template specialization 'fooType<void *>' requested here}}
+    
+    fooType<char>(); // #fooType_char_call
+    // expected-error@#fooType_error {{cast from pointer to smaller type 'char' loses information}}
+    // expected-note@#fooType_char_call {{in instantiation of function template specialization 'fooType<char>' requested here}}
+
+    fooTypePtr<char>(); // #fooTypePtr_char_call
+    // expected-warning@#fooTypePtr_diagnostic {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#fooTypePtr_diagnostic {{did you mean to provide an explicit length?}}
+    // expected-note@#fooTypePtr_char_call {{in instantiation of function template specialization 'fooTypePtr<char>' requested here}}
+
+    fooTypePtr<char*>(); // #fooTypePtr_charptr_call
+    // expected-warning@#fooTypePtr_diagnostic {{'snprintf' call operates on objects of type 'char *' while the size is based on a different type 'char **'}}
+    // expected-note@#fooTypePtr_diagnostic {{did you mean to dereference the argument to 'sizeof' (and multiply it by the number of elements)?}}
+    // expected-note@#fooTypePtr_charptr_call {{in instantiation of function template specialization 'fooTypePtr<char *>' requested here}}
+
+    fooTypePtr<void*>(); // #fooTypePtr_void_call
+    // expected-warning@#fooTypePtr_diagnostic {{'snprintf' call operates on objects of type 'void *' while the size is based on a different type 'void **'}}
+    // expected-note@#fooTypePtr_diagnostic {{did you mean to dereference the argument to 'sizeof' (and multiply it by the number of elements)?}}
+    // expected-note@#fooTypePtr_void_call {{in instantiation of function template specialization 'fooTypePtr<void *>' requested here}}
+
 }

--- a/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
+++ b/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
@@ -195,5 +195,5 @@ extern "C" void* malloc(unsigned size);
 void check_prints(){
     char* a = (char*) malloc(20);
     const char* b = "Hello World";
-    snprintf(a, sizeof(a), "%s", b); // expected-warning{{argument to 'sizeof' in 'snprintf' call is the same expression as the destination; did you mean to put an explicit length?}}
+    snprintf(a, sizeof(a), "%s", b); // expected-warning{{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}} expected-note {{did you mean to provide an explicit length?}}
 }

--- a/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
+++ b/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
@@ -188,3 +188,12 @@ void strcpy_and_friends() {
   strndup(FOO, sizeof(FOO)); // \
       // expected-warning {{'strndup' call operates on objects of type 'const char' while the size is based on a different type 'const char *'}} expected-note{{did you mean to provide an explicit length?}}
 }
+
+extern "C" int snprintf(char* buffer, __SIZE_TYPE__ buf_size, const char* format, ...);
+extern "C" void* malloc(unsigned size);
+
+void check_prints(){
+    char* a = (char*) malloc(20);
+    const char* b = "Hello World";
+    snprintf(a, sizeof(a), "%s", b); // expected-warning{{argument to 'sizeof' in 'snprintf' call is the same expression as the destination; did you mean to put an explicit length?}}
+}

--- a/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
+++ b/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
@@ -225,6 +225,10 @@ void check_prints(){
     // expected-warning@#CheckCastPrint {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
     // expected-note@#CheckCastPrint {{did you mean to provide an explicit length?}}
 
+    snprintf((char*)(char*)a, sizeof(a), "%s", b); // #CheckDoubleCastPrint
+    // expected-warning@#CheckDoubleCastPrint {{'snprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#CheckDoubleCastPrint {{did you mean to provide an explicit length?}}
+
     __builtin_va_list list;
     vsnprintf(a, sizeof(a), "%s", list);  // #VSNprintCheck
     // expected-warning@#VSNprintCheck {{'vsnprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
@@ -233,6 +237,10 @@ void check_prints(){
     vsnprintf((char*)a, sizeof(a), "%s", list);  // #VSNprintCastCheck
     // expected-warning@#VSNprintCastCheck {{'vsnprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
     // expected-note@#VSNprintCastCheck {{did you mean to provide an explicit length?}}
+
+    vsnprintf((char*)(char*)a, sizeof(a), "%s", list);  // #VSNprintDoubleCastCheck
+    // expected-warning@#VSNprintDoubleCastCheck {{'vsnprintf' call operates on objects of type 'char' while the size is based on a different type 'char *'}}
+    // expected-note@#VSNprintDoubleCastCheck {{did you mean to provide an explicit length?}}
 
     //No diagnostic output when dest is an array
     char c[20];


### PR DESCRIPTION
…st) for the len parameter

Closes: [#162366](https://github.com/llvm/llvm-project/issues/162366)