### PR TITLE
[LTO][Veclib] Fix vector library handling with LTO

### DIFF
--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -278,7 +278,7 @@ static void runNewPMPasses(const Config &Conf, Module &Mod, TargetMachine *TM,
   RegisterPassPlugins(Conf.PassPlugins, PB);
 
   std::unique_ptr<TargetLibraryInfoImpl> TLII(
-      new TargetLibraryInfoImpl(TM->getTargetTriple()));
+      new TargetLibraryInfoImpl(TM->getTargetTriple(), TM->Options.VecLib));
   if (Conf.Freestanding)
     TLII->disableAllFunctions();
   FAM.registerPass([&] { return TargetLibraryAnalysis(*TLII); });
@@ -444,7 +444,7 @@ static void codegen(const Config &Conf, TargetMachine *TM,
   // keep the pointer and may use it until their destruction. See #138194.
   {
     legacy::PassManager CodeGenPasses;
-    TargetLibraryInfoImpl TLII(Mod.getTargetTriple());
+    TargetLibraryInfoImpl TLII(Mod.getTargetTriple(), TM->Options.VecLib);
     CodeGenPasses.add(new TargetLibraryInfoWrapperPass(TLII));
     // No need to make index available if the module is empty.
     // In theory these passes should not use the index for an empty

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -249,7 +249,7 @@ static void optimizeModule(Module &TheModule, TargetMachine &TM,
   PassBuilder PB(&TM, PTO, PGOOpt, &PIC);
 
   std::unique_ptr<TargetLibraryInfoImpl> TLII(
-      new TargetLibraryInfoImpl(TM.getTargetTriple()));
+      new TargetLibraryInfoImpl(TM.getTargetTriple(), TM.Options.VecLib));
   if (Freestanding)
     TLII->disableAllFunctions();
   FAM.registerPass([&] { return TargetLibraryAnalysis(*TLII); });

--- a/llvm/lib/LTO/UpdateCompilerUsed.cpp
+++ b/llvm/lib/LTO/UpdateCompilerUsed.cpp
@@ -57,7 +57,7 @@ private:
   // same names are added to llvm.compiler.used to prevent them from being
   // deleted by optimizations.
   void initializeLibCalls(const Module &TheModule) {
-    TargetLibraryInfoImpl TLII(TM.getTargetTriple());
+    TargetLibraryInfoImpl TLII(TM.getTargetTriple(), TM.Options.VecLib);
     TargetLibraryInfo TLI(TLII);
 
     // TargetLibraryInfo has info on C runtime library calls on the current

--- a/llvm/test/LTO/AArch64/frem-scalable-veclib.ll
+++ b/llvm/test/LTO/AArch64/frem-scalable-veclib.ll
@@ -1,0 +1,20 @@
+; REQUIRES: aarch64-registered-target
+; RUN: opt -module-summary %s -o %t.bc
+; RUN: llvm-lto2 run %t.bc -o %t.o -save-temps \
+; RUN:   -r %t.bc,compute,px \
+; RUN:   -mcpu=neoverse-v1 -O3 \
+; RUN:   -vector-library=ArmPL
+; RUN: llvm-nm %t.o.1 | FileCheck %s
+
+; This test verifies that the VecLib propagation in LTO prevents a crash
+; when compiling scalable vector frem operations.
+
+; CHECK: compute
+
+target triple = "aarch64-unknown-linux-gnu"
+
+define fastcc <vscale x 2 x double> @compute(<vscale x 2 x double> %0) {
+entry:
+  %1 = frem <vscale x 2 x double> %0, zeroinitializer
+  ret <vscale x 2 x double> %1
+}

--- a/llvm/test/LTO/AArch64/frem-scalable-veclib.ll
+++ b/llvm/test/LTO/AArch64/frem-scalable-veclib.ll
@@ -1,4 +1,3 @@
-; REQUIRES: aarch64-registered-target
 ; RUN: opt -module-summary %s -o %t.bc
 ; RUN: llvm-lto2 run %t.bc -o %t.o -save-temps \
 ; RUN:   -r %t.bc,compute,px \

--- a/llvm/test/LTO/AArch64/frem-scalable-veclib.ll
+++ b/llvm/test/LTO/AArch64/frem-scalable-veclib.ll
@@ -13,8 +13,8 @@
 
 target triple = "aarch64-unknown-linux-gnu"
 
-define fastcc <vscale x 2 x double> @compute(<vscale x 2 x double> %0) {
+define <vscale x 2 x double> @compute(<vscale x 2 x double> %a, <vscale x 2 x double> %b) {
 entry:
-  %1 = frem <vscale x 2 x double> %0, zeroinitializer
-  ret <vscale x 2 x double> %1
+  %rem = frem <vscale x 2 x double> %a, %b
+  ret <vscale x 2 x double> %rem
 }

--- a/llvm/test/LTO/AArch64/veclib-armpl-lto.ll
+++ b/llvm/test/LTO/AArch64/veclib-armpl-lto.ll
@@ -1,0 +1,25 @@
+; REQUIRES: aarch64-registered-target
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-lto -exported-symbol=compute -exported-symbol=armpl_vsinq_f64 -o %t.o %t.bc
+; RUN: llvm-nm %t.o | FileCheck %s
+
+; This test ensures that ArmPL vector library functions are preserved through
+; the old LTO API (llvm-lto). TargetLibraryInfoImpl in LTO backend passes 
+; receive the VecLib parameter from TargetMachine Options.
+
+; CHECK: armpl_vsinq_f64
+; CHECK: compute
+
+target triple = "aarch64-unknown-linux-gnu"
+
+@llvm.compiler.used = appending global [1 x ptr] [ptr @armpl_vsinq_f64], section "llvm.metadata"
+
+declare aarch64_vector_pcs <2 x double> @armpl_vsinq_f64(<2 x double>)
+
+define void @compute(ptr %out, ptr %in) {
+entry:
+  %v = load <2 x double>, ptr %in, align 16
+  %result = call aarch64_vector_pcs <2 x double> @armpl_vsinq_f64(<2 x double> %v)
+  store <2 x double> %result, ptr %out, align 16
+  ret void
+}

--- a/llvm/test/LTO/AArch64/veclib-armpl-lto.ll
+++ b/llvm/test/LTO/AArch64/veclib-armpl-lto.ll
@@ -1,4 +1,3 @@
-; REQUIRES: aarch64-registered-target
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-lto -exported-symbol=compute -exported-symbol=armpl_vsinq_f64 -o %t.o %t.bc
 ; RUN: llvm-nm %t.o | FileCheck %s

--- a/llvm/test/LTO/AArch64/veclib-armpl-lto2.ll
+++ b/llvm/test/LTO/AArch64/veclib-armpl-lto2.ll
@@ -1,0 +1,27 @@
+; REQUIRES: aarch64-registered-target
+; RUN: opt -module-summary %s -o %t.bc
+; RUN: llvm-lto2 run -save-temps -o %t.o %t.bc \
+; RUN:   -r=%t.bc,compute,px \
+; RUN:   -r=%t.bc,armpl_vsinq_f64
+; RUN: llvm-dis %t.o.1.5.precodegen.bc -o - | FileCheck %s
+
+; This test ensures that ArmPL vector library functions are preserved through
+; the new LTO API (llvm-lto2). TargetLibraryInfoImpl in LTO backend passes 
+; receive the VecLib parameter from TargetMachine Options.
+
+; CHECK: @llvm.compiler.used = appending global [1 x ptr] [ptr @armpl_vsinq_f64]
+; CHECK: declare aarch64_vector_pcs <2 x double> @armpl_vsinq_f64(<2 x double>)
+
+target triple = "aarch64-unknown-linux-gnu"
+
+@llvm.compiler.used = appending global [1 x ptr] [ptr @armpl_vsinq_f64], section "llvm.metadata"
+
+declare aarch64_vector_pcs <2 x double> @armpl_vsinq_f64(<2 x double>)
+
+define void @compute(ptr %out, ptr %in) {
+entry:
+  %v = load <2 x double>, ptr %in, align 16
+  %result = call aarch64_vector_pcs <2 x double> @armpl_vsinq_f64(<2 x double> %v)
+  store <2 x double> %result, ptr %out, align 16
+  ret void
+}

--- a/llvm/test/LTO/AArch64/veclib-armpl-lto2.ll
+++ b/llvm/test/LTO/AArch64/veclib-armpl-lto2.ll
@@ -1,4 +1,3 @@
-; REQUIRES: aarch64-registered-target
 ; RUN: opt -module-summary %s -o %t.bc
 ; RUN: llvm-lto2 run -save-temps -o %t.o %t.bc \
 ; RUN:   -r=%t.bc,compute,px \


### PR DESCRIPTION
Commit #167996 moved VecLib into TargetOptions and ensured clang properly sets it. However, some LTO backend code paths were still creating _TargetLibraryInfoImpl_ without passing the VecLib parameter from `TargetMachine::Options`.

This PR completes the fix by ensuring that:

_LTOBackend.cpp, ThinLTOCodeGenerator.cpp, UpdateCompilerUsed.cpp_ all pass `TM->Options.VecLib` when constructing _TargetLibraryInfoImpl_.

Without this fix, vector library information (e.g., -fveclib=ArmPL) would not be properly recognized during LTO optimization and code generation, potentially causing incorrect optimizations or linker errors when vector library functions are referenced.
