### PR TITLE
[clangd] Add designator hints for parenthesis aggregate initialization

### DIFF
--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -704,15 +704,12 @@ public:
       return true;
 
     if (const auto *CXXRecord = E->getType()->getAsCXXRecordDecl()) {
-      const auto &InitExprs = E->getInitExprs();
+      const auto &InitExprs = E->getUserSpecifiedInitExprs();
       size_t InitInx = 0;
 
-      // Inherited members are first
-      for (const auto &Base : CXXRecord->bases()) {
-        std::ignore = Base;
-        // For a base record, just use its name
-        // Base of base requires its own initialization; ParenListInitExpr or
-        // InitListExpr will be invoked separately for them
+      // Inherited members are first, skip them for now.
+      // FIXME: '.base=' or 'base:' hint?
+      for (const auto &_ : CXXRecord->bases()) {
         InitInx++;
       }
 

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1834,6 +1834,24 @@ TEST(DesignatorHints, BasicParenInit) {
                         ExpectedHint{".z=", "z"});
 }
 
+TEST(DesignatorHints, BasicParenInitDerived) {
+  assertDesignatorHints(R"cpp(
+    struct S1 {
+      int a;
+      int b;
+    };
+
+    struct S2 : S1 { 
+      int c;
+      int d; 
+    };
+    S2 s2 ({$a[[0]], $b[[0]]}, $c[[0]], $d[[0]]);
+  )cpp",
+                        // ExpectedHint{"S1:", "S1"},
+                        ExpectedHint{".a=", "a"}, ExpectedHint{".b=", "b"},
+                        ExpectedHint{".c=", "c"}, ExpectedHint{".d=", "d"});
+}
+
 TEST(InlayHints, RestrictRange) {
   Annotations Code(R"cpp(
     auto a = false;

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1147,20 +1147,6 @@ TEST(ParameterHints, CopyOrMoveConstructor) {
   )cpp");
 }
 
-TEST(ParameterHints, AggregateInit) {
-  // FIXME: This is not implemented yet, but it would be a natural
-  // extension to show member names as hints here.
-  assertParameterHints(R"cpp(
-    struct Point {
-      int x;
-      int y;
-    };
-    void bar() {
-      Point p{41, 42};
-    }
-  )cpp");
-}
-
 TEST(ParameterHints, UserDefinedLiteral) {
   // Do not hint call to user-defined literal operator.
   assertParameterHints(R"cpp(
@@ -1746,6 +1732,19 @@ TEST(TypeHints, SubstTemplateParameterAliases) {
 }
 
 TEST(DesignatorHints, Basic) {
+  assertDesignatorHints(R"cpp(
+    struct Point {
+      int x;
+      int y;
+    };
+    void bar() {
+      Point p{$x[[41]], $y[[42]]};
+    }
+  )cpp",
+                        ExpectedHint{".x=", "x"}, ExpectedHint{".y=", "y"});
+}
+
+TEST(DesignatorHints, BasicArray) {
   assertDesignatorHints(R"cpp(
     struct S { int x, y, z; };
     S s {$x[[1]], $y[[2+2]]};

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1852,6 +1852,32 @@ TEST(DesignatorHints, BasicParenInitDerived) {
                         ExpectedHint{".c=", "c"}, ExpectedHint{".d=", "d"});
 }
 
+TEST(DesignatorHints, BasicParenInitTemplate) {
+  assertDesignatorHints(R"cpp(
+    template <typename T>
+    struct S1 {
+      int a;
+      int b;
+      T* ptr;
+    };
+
+    struct S2 : S1<S2> {
+      int c;
+      int d;
+      S1<int> mem;
+    };
+
+    int main() {
+      S2 sa ({$a1[[0]], $b1[[0]]}, $c[[0]], $d[[0]], $mem[[S1<int>($a2[[1]], $b2[[2]], $ptr[[nullptr]])]]);
+    }
+  )cpp",
+                        ExpectedHint{".a=", "a1"}, ExpectedHint{".b=", "b1"},
+                        ExpectedHint{".c=", "c"}, ExpectedHint{".d=", "d"},
+                        ExpectedHint{".mem=", "mem"}, ExpectedHint{".a=", "a2"},
+                        ExpectedHint{".b=", "b2"},
+                        ExpectedHint{".ptr=", "ptr"});
+}
+
 TEST(InlayHints, RestrictRange) {
   Annotations Code(R"cpp(
     auto a = false;

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1821,6 +1821,19 @@ TEST(DesignatorHints, NoCrash) {
                         ExpectedHint{".b=", "b"});
 }
 
+TEST(DesignatorHints, BasicParenInit) {
+  assertDesignatorHints(R"cpp(
+    struct S { 
+      int x;
+      int y;
+      int z; 
+    };
+    S s ($x[[1]], $y[[2+2]], $z[[4]]);
+  )cpp",
+                        ExpectedHint{".x=", "x"}, ExpectedHint{".y=", "y"},
+                        ExpectedHint{".z=", "z"});
+}
+
 TEST(InlayHints, RestrictRange) {
   Annotations Code(R"cpp(
     auto a = false;

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1733,19 +1733,6 @@ TEST(TypeHints, SubstTemplateParameterAliases) {
 
 TEST(DesignatorHints, Basic) {
   assertDesignatorHints(R"cpp(
-    struct Point {
-      int x;
-      int y;
-    };
-    void bar() {
-      Point p{$x[[41]], $y[[42]]};
-    }
-  )cpp",
-                        ExpectedHint{".x=", "x"}, ExpectedHint{".y=", "y"});
-}
-
-TEST(DesignatorHints, BasicArray) {
-  assertDesignatorHints(R"cpp(
     struct S { int x, y, z; };
     S s {$x[[1]], $y[[2+2]]};
 
@@ -1821,7 +1808,7 @@ TEST(DesignatorHints, NoCrash) {
                         ExpectedHint{".b=", "b"});
 }
 
-TEST(DesignatorHints, BasicParenInit) {
+TEST(DesignatorHints, ParenInit) {
   assertDesignatorHints(R"cpp(
     struct S { 
       int x;
@@ -1834,7 +1821,7 @@ TEST(DesignatorHints, BasicParenInit) {
                         ExpectedHint{".z=", "z"});
 }
 
-TEST(DesignatorHints, BasicParenInitDerived) {
+TEST(DesignatorHints, ParenInitDerived) {
   assertDesignatorHints(R"cpp(
     struct S1 {
       int a;

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1839,7 +1839,7 @@ TEST(DesignatorHints, ParenInitDerived) {
                         ExpectedHint{".c=", "c"}, ExpectedHint{".d=", "d"});
 }
 
-TEST(DesignatorHints, BasicParenInitTemplate) {
+TEST(DesignatorHints, ParenInitTemplate) {
   assertDesignatorHints(R"cpp(
     template <typename T>
     struct S1 {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -92,6 +92,9 @@ Improvements to clangd
 Inlay hints
 ^^^^^^^^^^^
 
+- ``clangd`` now shows designator hints for aggregate initialization of structures 
+  with parentheses-list initialization (``CXXParenListInitExpr``) syntax. 
+
 Diagnostics
 ^^^^^^^^^^^
 


### PR DESCRIPTION
Enabled hints for `CXXParenListInitExpr`, 

```cpp
struct Point {
  int x;
  int y;
};

int main() {
  Point p1{1, 2};  // brace syntax  <-- already present
  Point p2(1, 2);  // parens syntax <-- added in this commit
}
```

<img width="434" height="413" alt="image" src="https://github.com/user-attachments/assets/710d7168-30f7-494d-8b2c-6413fa4152a7" />

Fixes clangd/clangd#2540