### PR TITLE
[lldb-dap] Add clipboard context support

### DIFF
--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -12,7 +12,6 @@
 #include "lldb/API/SBData.h"
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBType.h"
-#include "lldb/lldb-enumerations.h"
 
 class ValueImpl;
 class ValueLocker;
@@ -319,9 +318,10 @@ public:
 
   lldb::SBValue Persist();
 
-  bool GetDescription(
-      lldb::SBStream &description,
-      lldb::DescriptionLevel description_level = eDescriptionLevelFull);
+  bool GetDescription(lldb::SBStream &description);
+
+  bool GetDescription(lldb::SBStream &description,
+                      lldb::DescriptionLevel description_level);
 
   bool GetExpressionPath(lldb::SBStream &description);
 

--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -318,7 +318,7 @@ public:
 
   lldb::SBValue Persist();
 
-  bool GetDescription(lldb::SBStream &description);
+  bool GetDescription(lldb::SBStream &description, bool short_mode = false);
 
   bool GetExpressionPath(lldb::SBStream &description);
 

--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -12,6 +12,7 @@
 #include "lldb/API/SBData.h"
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBType.h"
+#include "lldb/lldb-enumerations.h"
 
 class ValueImpl;
 class ValueLocker;
@@ -318,7 +319,9 @@ public:
 
   lldb::SBValue Persist();
 
-  bool GetDescription(lldb::SBStream &description, bool short_mode = false);
+  bool GetDescription(
+      lldb::SBStream &description,
+      lldb::DescriptionLevel description_level = eDescriptionLevelFull);
 
   bool GetExpressionPath(lldb::SBStream &description);
 

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -1259,7 +1259,7 @@ lldb::SBValue SBValue::EvaluateExpression(const char *expr,
   return result;
 }
 
-bool SBValue::GetDescription(SBStream &description) {
+bool SBValue::GetDescription(SBStream &description, bool short_mode) {
   LLDB_INSTRUMENT_VA(this, description);
 
   Stream &strm = description.ref();
@@ -1270,6 +1270,11 @@ bool SBValue::GetDescription(SBStream &description) {
     DumpValueObjectOptions options;
     options.SetUseDynamicType(m_opaque_sp->GetUseDynamic());
     options.SetUseSyntheticValue(m_opaque_sp->GetUseSynthetic());
+    if (short_mode) {
+      options.SetAllowOnelinerMode(true);
+      options.SetHideRootName(true);
+      options.SetHideRootType(true);
+    }
     if (llvm::Error error = value_sp->Dump(strm, options)) {
       strm << "error: " << toString(std::move(error));
       return false;

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -1260,6 +1260,11 @@ lldb::SBValue SBValue::EvaluateExpression(const char *expr,
   return result;
 }
 
+bool SBValue::GetDescription(SBStream &description) {
+  LLDB_INSTRUMENT_VA(this, description);
+  return GetDescription(description, eDescriptionLevelFull);
+}
+
 bool SBValue::GetDescription(SBStream &description,
                              lldb::DescriptionLevel description_level) {
   LLDB_INSTRUMENT_VA(this, description, description_level);

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -333,17 +333,91 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
 
         # Now we check that values are updated after stepping
         self.continue_to_breakpoint(breakpoint_4)
-        self.assertEvaluate("my_vec", "size=2", want_varref=True)
+        if self.isResultExpandedDescription():
+            self.assertEvaluate(
+                "my_vec",
+                r"\(std::vector<int>\) \$\d+ = size=2 {\n  \[0\] = 1\n  \[1\] = 2\n}",
+                want_varref=True,
+            )
+        elif self.isResultShortDescription():
+            self.assertEvaluate(
+                "my_vec", r"size=2 {\n  \[0\] = 1\n  \[1\] = 2\n}", want_varref=True
+            )
+        else:
+            self.assertEvaluate("my_vec", "size=2", want_varref=True)
         self.continue_to_breakpoint(breakpoint_5)
-        self.assertEvaluate("my_vec", "size=3", want_varref=True)
+        if self.isResultExpandedDescription():
+            self.assertEvaluate(
+                "my_vec",
+                r"\(std::vector<int>\) \$\d+ = size=3 {\n  \[0\] = 1\n  \[1\] = 2\n  \[2\] = 3\n}",
+                want_varref=True,
+            )
+        elif self.isResultShortDescription():
+            self.assertEvaluate(
+                "my_vec",
+                r"size=3 {\n  \[0\] = 1\n  \[1\] = 2\n  \[2\] = 3\n}",
+                want_varref=True,
+            )
+        else:
+            self.assertEvaluate("my_vec", "size=3", want_varref=True)
 
-        self.assertEvaluate("my_map", "size=2", want_varref=True)
+        if self.isResultExpandedDescription():
+            self.assertEvaluate(
+                "my_map",
+                r"\(std::map<int, int>\) \$\d+ = size=2 {\n  \[0\] = \(first = 1, second = 2\)\n  \[1\] = \(first = 2, second = 3\)\n}",
+                want_varref=True,
+            )
+        elif self.isResultShortDescription():
+            self.assertEvaluate(
+                "my_map",
+                r"size=2 {\n  \[0\] = \(first = 1, second = 2\)\n  \[1\] = \(first = 2, second = 3\)\n}",
+                want_varref=True,
+            )
+        else:
+            self.assertEvaluate("my_map", "size=2", want_varref=True)
         self.continue_to_breakpoint(breakpoint_6)
-        self.assertEvaluate("my_map", "size=3", want_varref=True)
+        if self.isResultExpandedDescription():
+            self.assertEvaluate(
+                "my_map",
+                r"\(std::map<int, int>\) \$\d+ = size=3 {\n  \[0\] = \(first = 1, second = 2\)\n  \[1\] = \(first = 2, second = 3\)\n  \[2\] = \(first = 3, second = 4\)\n}",
+                want_varref=True,
+            )
+        elif self.isResultShortDescription():
+            self.assertEvaluate(
+                "my_map",
+                r"size=3 {\n  \[0\] = \(first = 1, second = 2\)\n  \[1\] = \(first = 2, second = 3\)\n  \[2\] = \(first = 3, second = 4\)\n}",
+                want_varref=True,
+            )
+        else:
+            self.assertEvaluate("my_map", "size=3", want_varref=True)
 
-        self.assertEvaluate("my_bool_vec", "size=1", want_varref=True)
+        if self.isResultExpandedDescription():
+            self.assertEvaluate(
+                "my_bool_vec",
+                r"\(std::vector<bool>\) \$\d+ = size=1 {\n  \[0\] = true\n}",
+                want_varref=True,
+            )
+        elif self.isResultShortDescription():
+            self.assertEvaluate(
+                "my_bool_vec", r"size=1 {\n  \[0\] = true\n}", want_varref=True
+            )
+        else:
+            self.assertEvaluate("my_bool_vec", "size=1", want_varref=True)
         self.continue_to_breakpoint(breakpoint_7)
-        self.assertEvaluate("my_bool_vec", "size=2", want_varref=True)
+        if self.isResultExpandedDescription():
+            self.assertEvaluate(
+                "my_bool_vec",
+                r"\(std::vector<bool>\) \$\d+ = size=2 {\n  \[0\] = true\n  \[1\] = false\n}",
+                want_varref=True,
+            )
+        elif self.isResultShortDescription():
+            self.assertEvaluate(
+                "my_bool_vec",
+                r"size=2 {\n  \[0\] = true\n  \[1\] = false\n}",
+                want_varref=True,
+            )
+        else:
+            self.assertEvaluate("my_bool_vec", "size=2", want_varref=True)
 
         self.continue_to_breakpoint(breakpoint_8)
         # Test memory read, especially with 'empty' repeat commands.
@@ -386,7 +460,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         )
 
     @skipIfWindows
-    def test_variable_evaluate_expressions(self):
+    def test_clipboard_evaluate_expressions(self):
         # Tests expression evaluations that are triggered when value copied in editor
         self.run_test_evaluate_expressions(
             "clipboard", enableAutoVariableSummaries=False

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -430,6 +430,25 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
             self.assertEvaluate("", ".* 14 .*\n", want_memref=False)
             self.assertEvaluate("", ".* 19 .*\n", want_memref=False)
 
+        if self.isResultExpandedDescription():
+            self.assertEvaluate(
+                "my_longs",
+                r"\(long\[3\]\) \$\d+ = \(\[0\] = 5, \[1\] = 6, \[2\] = 7\)",
+                want_varref=True,
+            )
+        elif self.isResultShortDescription():
+            self.assertEvaluate(
+                "my_longs",
+                r"\(\[0\] = 5, \[1\] = 6, \[2\] = 7\)",
+                want_varref=True,
+            )
+        else:
+            self.assertEvaluate(
+                "my_longs",
+                "{5, 6, 7}" if enableAutoVariableSummaries else r"long\[3\] @ 0x",
+                want_varref=True,
+            )
+
         self.continue_to_exit()
 
     @skipIfWindows

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -81,6 +81,9 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
     def isResultExpandedDescription(self):
         return self.context == "repl"
 
+    def isResultShortDescription(self):
+        return self.context == "clipboard"
+
     def isExpressionParsedExpected(self):
         return self.context != "hover"
 
@@ -165,6 +168,25 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
                 want_type="my_struct *",
                 want_varref=True,
             )
+        elif self.isResultShortDescription():
+            self.assertEvaluate(
+                "struct1",
+                "(foo = 15)",
+                want_type="my_struct",
+                want_varref=True,
+            )
+            self.assertEvaluate(
+                "struct2",
+                r"0x.*",
+                want_type="my_struct *",
+                want_varref=True,
+            )
+            self.assertEvaluate(
+                "struct3",
+                "nullptr",
+                want_type="my_struct *",
+                want_varref=True,
+            )
         else:
             self.assertEvaluate(
                 "struct1",
@@ -233,6 +255,13 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
             self.assertEvaluate(
                 "struct1",
                 r"\(my_struct\) (struct1|\$\d+) = \(foo = 15\)",
+                want_type="my_struct",
+                want_varref=True,
+            )
+        elif self.isResultShortDescription():
+            self.assertEvaluate(
+                "struct1",
+                "(foo = 15)",
                 want_type="my_struct",
                 want_varref=True,
             )
@@ -354,4 +383,11 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         # Tests expression evaluations that are triggered in the variable explorer
         self.run_test_evaluate_expressions(
             "variables", enableAutoVariableSummaries=True
+        )
+
+    @skipIfWindows
+    def test_variable_evaluate_expressions(self):
+        # Tests expression evaluations that are triggered when value copied in editor
+        self.run_test_evaluate_expressions(
+            "clipboard", enableAutoVariableSummaries=False
         )

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -376,20 +376,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         else:
             self.assertEvaluate("my_map", "size=2", want_varref=True)
         self.continue_to_breakpoint(breakpoint_6)
-        if self.isResultExpandedDescription():
-            self.assertEvaluate(
-                "my_map",
-                r"\(std::map<int, int>\) \$\d+ = size=3 {\n  \[0\] = \(first = 1, second = 2\)\n  \[1\] = \(first = 2, second = 3\)\n  \[2\] = \(first = 3, second = 4\)\n}",
-                want_varref=True,
-            )
-        elif self.isResultShortDescription():
-            self.assertEvaluate(
-                "my_map",
-                r"size=3 {\n  \[0\] = \(first = 1, second = 2\)\n  \[1\] = \(first = 2, second = 3\)\n  \[2\] = \(first = 3, second = 4\)\n}",
-                want_varref=True,
-            )
-        else:
-            self.assertEvaluate("my_map", "size=3", want_varref=True)
+        self.assertEvaluate("my_map", "size=3", want_varref=True)
 
         if self.isResultExpandedDescription():
             self.assertEvaluate(

--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -432,7 +432,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         else:
             self.assertEvaluate(
                 "my_longs",
-                "{5, 6, 7}" if enableAutoVariableSummaries else r"long\[3\] @ 0x",
+                "{5, 6, 7}" if enableAutoVariableSummaries else r"long\[3\]",
                 want_varref=True,
             )
 

--- a/lldb/test/API/tools/lldb-dap/evaluate/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/evaluate/main.cpp
@@ -47,5 +47,6 @@ int main(int argc, char const *argv[]) {
   my_bool_vec.push_back(true);  // breakpoint 7
 
   uint8_t my_ints[] = {5, 10, 15, 20, 25, 30};
+  long my_longs[] = {5, 6, 7};
   return 0; // breakpoint 8
 }

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -293,7 +293,8 @@ public:
   llvm::Expected<protocol::EvaluateResponseBody>
   Run(const protocol::EvaluateArguments &) const override;
   FeatureSet GetSupportedFeatures() const override {
-    return {protocol::eAdapterFeatureEvaluateForHovers};
+    return {protocol::eAdapterFeatureEvaluateForHovers,
+            protocol::eAdapterFeatureClipboardContext};
   }
 };
 

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -674,7 +674,10 @@ std::string VariableDescription::GetResult(protocol::EvaluateContext context) {
   // Try the SBValue::GetDescription(), which may call into language runtime
   // specific formatters (see ValueObjectPrinter).
   lldb::SBStream stream;
-  val.GetDescription(stream, context == protocol::eEvaluateContextClipboard);
+  if (context == protocol::eEvaluateContextRepl)
+    val.GetDescription(stream, lldb::eDescriptionLevelFull);
+  else
+    val.GetDescription(stream, lldb::eDescriptionLevelBrief);
   llvm::StringRef description = stream.GetData();
   return description.trim().str();
 }

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -662,9 +662,10 @@ VariableDescription::VariableDescription(
 }
 
 std::string VariableDescription::GetResult(protocol::EvaluateContext context) {
-  // In repl context, the results can be displayed as multiple lines so more
-  // detailed descriptions can be returned.
-  if (context != protocol::eEvaluateContextRepl)
+  // In repl and clipboard contexts, the results can be displayed as multiple
+  // lines so more detailed descriptions can be returned.
+  if (context != protocol::eEvaluateContextRepl &&
+      context != protocol::eEvaluateContextClipboard)
     return display_value;
 
   if (!val.IsValid())
@@ -673,7 +674,7 @@ std::string VariableDescription::GetResult(protocol::EvaluateContext context) {
   // Try the SBValue::GetDescription(), which may call into language runtime
   // specific formatters (see ValueObjectPrinter).
   lldb::SBStream stream;
-  val.GetDescription(stream);
+  val.GetDescription(stream, context == protocol::eEvaluateContextClipboard);
   llvm::StringRef description = stream.GetData();
   return description.trim().str();
 }


### PR DESCRIPTION
This patch introduces support for `clipboard` context from [DAP](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Capabilities). This feature is very useful when you want to copy all nested values from a structure or a container instead of a summary (e.g. `size = 3` for vector). I added new short mode for description generation to reduce output verbosity, which is particularly useful for primitive types.