### PR TITLE
AMDGPU: Use correct chain when emitting error on a call

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -1412,7 +1412,7 @@ SDValue AMDGPUTargetLowering::lowerUnhandledCall(CallLoweringInfo &CLI,
       InVals.push_back(DAG.getPOISON(Arg.VT));
   }
 
-  return DAG.getEntryNode();
+  return CLI.Chain;
 }
 
 SDValue AMDGPUTargetLowering::LowerCall(CallLoweringInfo &CLI,


### PR DESCRIPTION
Return the input chain at the callsite, not the entry node
chain. Presumably this could cause issues somewhere.