### PR TITLE
[Hexagon] Fix assignment

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonGenWideningVecInstr.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonGenWideningVecInstr.cpp
@@ -839,9 +839,9 @@ bool HexagonGenWideningVecInstr::replaceWithVmpaIntrinsic(Instruction *Inst,
   NewVOP2 = IRB.CreateBitCast(NewVOP2, InType);
   Value *VecOP = IRB.CreateCall(ExtF, {NewVOP1, NewVOP2});
 
-  Intrinsic::ID VmpaIntID =
-      (NewResEltSize == 16) ? VmpaIntID = Intrinsic::hexagon_V6_vmpabus_128B
-                            : VmpaIntID = Intrinsic::hexagon_V6_vmpauhb_128B;
+  Intrinsic::ID VmpaIntID = (NewResEltSize == 16)
+                                ? Intrinsic::hexagon_V6_vmpabus_128B
+                                : Intrinsic::hexagon_V6_vmpauhb_128B;
   ExtF = Intrinsic::getOrInsertDeclaration(M, VmpaIntID);
   auto *ResType =
       FixedVectorType::get(getElementTy(NewResEltSize, IRB), NumElts);


### PR DESCRIPTION
`VmpaIntID` was used in variable definition of `VmpaIntID`.

```
/home/fedora/src/llvm-project/main/llvm/lib/Target/Hexagon/HexagonGenWideningVecInstr.cpp: In member function ‘bool {anonymous}::HexagonGenWideningVecInstr::replaceWithVmpaIntrinsic(llvm::Instruction*, OPInfo*)’:
/home/fedora/src/llvm-project/main/llvm/lib/Target/Hexagon/HexagonGenWideningVecInstr.cpp:843:41: warning: operation on ‘VmpaIntID’ may be undefined [-Wsequence-point]
  843 |       (NewResEltSize == 16) ? VmpaIntID = Intrinsic::hexagon_V6_vmpabus_128B
      |                               ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```