### PR TITLE
[AArch64] Disable cortex-a53-835769 when compiling for armv8.1-a or later

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
@@ -453,13 +453,18 @@ void aarch64::getAArch64TargetFeatures(const Driver &D,
       Features.push_back("+fix-cortex-a53-835769");
     else
       Features.push_back("-fix-cortex-a53-835769");
-  } else if (Triple.isAndroid() || Triple.isOHOSFamily()) {
-    // Enabled A53 errata (835769) workaround by default on android
-    Features.push_back("+fix-cortex-a53-835769");
-  } else if (Triple.isOSFuchsia()) {
-    std::string CPU = getCPUName(D, Args, Triple);
-    if (CPU.empty() || CPU == "generic" || CPU == "cortex-a53")
+  } else if (Extensions.BaseArch &&
+             Extensions.BaseArch->Version.getMajor() == 8 &&
+             Extensions.BaseArch->Version.getMinor() == 0) {
+    if (Triple.isAndroid() || Triple.isOHOSFamily()) {
+      // Enabled A53 errata (835769) workaround by default on android, providing
+      // that the architecture allows running on a cortex-a53.
       Features.push_back("+fix-cortex-a53-835769");
+    } else if (Triple.isOSFuchsia()) {
+      std::string CPU = getCPUName(D, Args, Triple);
+      if (CPU.empty() || CPU == "generic" || CPU == "cortex-a53")
+        Features.push_back("+fix-cortex-a53-835769");
+    }
   }
 
   if (Args.getLastArg(options::OPT_mno_bti_at_return_twice))

--- a/clang/test/CodeGen/AArch64/fix-cortex-a53-835769.c
+++ b/clang/test/CodeGen/AArch64/fix-cortex-a53-835769.c
@@ -9,6 +9,14 @@
 // RUN:   | FileCheck --check-prefix=CHECK-YES --check-prefix=CHECK %s
 // RUN: %clang -O3 -target aarch64-linux-ohos %s -S -o- \
 // RUN:   | FileCheck --check-prefix=CHECK-YES --check-prefix=CHECK %s
+// RUN: %clang -O3 --target=aarch64-linux-androideabi -march=armv8.1-a %s -S -o- \
+// RUN:   | FileCheck --check-prefix=CHECK-NO --check-prefix=CHECK %s
+// RUN: %clang -O3 -target aarch64-linux-ohos -march=armv8.1-a %s -S -o- \
+// RUN:   | FileCheck --check-prefix=CHECK-NO --check-prefix=CHECK %s
+// RUN: %clang -O3 --target=aarch64-linux-androideabi -mcpu=cortex-a55 %s -S -o- \
+// RUN:   | FileCheck --check-prefix=CHECK-NO --check-prefix=CHECK %s
+// RUN: %clang -O3 -target aarch64-linux-ohos -mcpu=cortex-a55 %s -S -o- \
+// RUN:   | FileCheck --check-prefix=CHECK-NO --check-prefix=CHECK %s
 // RUN: %clang -O3 --target=aarch64-linux-androideabi -mfix-cortex-a53-835769 %s -S -o- \
 // RUN:   | FileCheck --check-prefix=CHECK-YES --check-prefix=CHECK %s
 // RUN: %clang -O3 --target=aarch64-linux-androideabi -mno-fix-cortex-a53-835769 %s -S -o- \

--- a/clang/test/Driver/aarch64-fix-cortex-a53-835769.c
+++ b/clang/test/Driver/aarch64-fix-cortex-a53-835769.c
@@ -7,9 +7,13 @@
 
 // RUN: %clang --target=aarch64-linux-androideabi %s -### 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-YES %s
+// RUN: %clang --target=aarch64-linux-androideabi -march=armv8.1-a %s -### 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-DEF %s
 
 // RUN: %clang --target=aarch64-fuchsia %s -### 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-YES %s
+// RUN: %clang --target=aarch64-fuchsia -march=armv8.1-a %s -### 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-DEF %s
 
 // RUN: %clang --target=aarch64-fuchsia -mcpu=cortex-a73 %s -### 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-DEF %s


### PR DESCRIPTION
Any code compiled with armv8.1-a or later cannot run on a cortex-a53, so does not need to enable the 835769 errata fix. This patch disables the +fix-cortex-a53-835769 feature when the architecture is later than armv8.0-a. The command line flag -mfix_cortex_a53_835769 will still enable it.