### PR TITLE
[InstCombine] Fix bail-out in `PHIsEqualValue()`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -1005,7 +1005,7 @@ static bool PHIsEqualValue(PHINode *PN, Value *&NonPhiInVal,
     return true;
 
   // Don't scan crazily complex things.
-  if (ValueEqualPHIs.size() == 16)
+  if (ValueEqualPHIs.size() >= 16)
     return false;
 
   // Scan the operands to see if they are either phi nodes or are equal to


### PR DESCRIPTION
We encountered a such case: `PHIsEqualValue()` is called with a PHI node `PN` whose incoming values are all PHI nodes, and `NonPhiInVal` is nullptr. When the size of `ValueEqualPHIs` reaches 16, `NonPhiInVal` is still nullptr, then we keep scanning PHI node operands, this time the recursion won't bail out even if we have visited too many PHI nodes.

In our case, the recursion ends with ~1700 PHI nodes visited, causes InstCombine time-consuming.