### PR TITLE
Add parentheses around '&&' within '||'

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -3353,10 +3353,11 @@ bool SPIRVInstructionSelector::selectGEP(Register ResVReg,
                  .addUse(GR.getSPIRVTypeID(ResType))
                  // Object to get a pointer to.
                  .addUse(I.getOperand(3).getReg());
-  assert(Opcode == SPIRV::OpPtrAccessChain ||
-         Opcode == SPIRV::OpInBoundsPtrAccessChain ||
-         (getImm(I.getOperand(4), MRI) && foldImm(I.getOperand(4), MRI) == 0) &&
-             "Cannot translate GEP to OpAccessChain. First index must be 0.");
+  assert(
+      (Opcode == SPIRV::OpPtrAccessChain ||
+       Opcode == SPIRV::OpInBoundsPtrAccessChain ||
+       (getImm(I.getOperand(4), MRI) && foldImm(I.getOperand(4), MRI) == 0)) &&
+      "Cannot translate GEP to OpAccessChain. First index must be 0.");
 
   // Adding indices.
   const unsigned StartingIndex =


### PR DESCRIPTION
Addresses this warning:

```
/home/fedora/src/llvm-project/main/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp:3358
79: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
 3358 |          (getImm(I.getOperand(4), MRI) && foldImm(I.getOperand(4), MRI) == 0) &&
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
 3359 |              "Cannot translate GEP to OpAccessChain. First index must be 0.");
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```