### PR TITLE
[lldb][windows] fix copying instead of using a reference of STARTUPINFOW

### DIFF
--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -198,7 +198,7 @@ llvm::ErrorOr<std::vector<HANDLE>> ProcessLauncherWindows::GetInheritedHandles(
     const ProcessLaunchInfo &launch_info, STARTUPINFOEXW &startupinfoex,
     HANDLE stdout_handle, HANDLE stderr_handle, HANDLE stdin_handle) {
   std::vector<HANDLE> inherited_handles;
-  STARTUPINFOW startupinfo = startupinfoex.StartupInfo;
+  STARTUPINFOW &startupinfo = startupinfoex.StartupInfo;
 
   startupinfo.hStdError =
       stderr_handle ? stderr_handle : GetStdHandle(STD_ERROR_HANDLE);


### PR DESCRIPTION
This patch fixes a implicit copy instead of using a reference to a STARTUPINFOW instance.

This is a followup to https://github.com/llvm/llvm-project/pull/170301.