### PR TITLE
[OpenACC] Adjust rules of 'routine' required clauses

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13537,21 +13537,19 @@ def err_acc_clause_after_device_type
 def err_acc_clause_cannot_combine
     : Error<"OpenACC clause '%0' may not appear on the same construct as a "
             "'%1' clause on a '%2' construct">;
-def err_acc_clause_routine_cannot_combine_before_device_type
-    : Error<"OpenACC clause '%0' after 'device_type' clause on a 'routine' "
-              "conflicts with the '%1' clause before the first 'device_type'">;
-def err_acc_clause_routine_cannot_combine_same_device_type
-    : Error<"OpenACC clause '%0' on a 'routine' directive conflicts with the "
-            "'%1' clause applying to the same 'device_type'">;
+def err_acc_clause_cannot_combine_before_device_type
+    : Error<
+          "OpenACC clause '%1' after 'device_type' clause on a '%0' construct "
+          "conflicts with the '%2' clause before the first 'device_type'">;
+def err_acc_clause_cannot_combine_same_device_type
+    : Error<"OpenACC clause '%1' cannot combine with previous '%2' clause"
+            "%select{| in the same 'device_type' region}3 on a '%0' directive">;
+def err_acc_clause_conflicts_prev_dev_type
+    : Error<"OpenACC '%0' clause applies to 'device_type' '%1', which "
+            "conflicts with previous '%2' clause">;
 def err_acc_clause_routine_one_of_in_region
     : Error<"OpenACC 'routine' construct must have at least one 'gang', 'seq', "
             "'vector', or 'worker' clause that applies to each 'device_type'">;
-def err_acc_clause_since_last_device_type
-    : Error<"OpenACC '%0' clause cannot appear more than once%select{| in a "
-            "'device_type' region}2 on a '%1' directive">;
-def err_acc_clause_conflicts_prev_dev_type
-    : Error<"OpenACC '%0' clause applies to 'device_type' '%1', which "
-            "conflicts with previous '%0' clause">;
 
 def err_acc_reduction_num_gangs_conflict
     : Error<"OpenACC '%1' clause %select{|with more than 1 argument }0may not "

--- a/clang/lib/Sema/SemaOpenACCClause.cpp
+++ b/clang/lib/Sema/SemaOpenACCClause.cpp
@@ -246,97 +246,172 @@ class SemaOpenACCClauseVisitor {
     llvm_unreachable("didn't return from switch above?");
   }
 
-  // Helper for the 'routine' checks during 'new' clause addition. Precondition
-  // is that we already know the new clause is one of the prohbiited ones.
+  // Certain clauses are not allowed within the same 'device_type' region, or in
+  // a 'device_type' region if there is one 'outside' of a 'device_type' region,
+  // or within a conflicting 'device_type' region.  This helper checks these
+  // cases.
+  // DTOverrides is whether the 'before a device type' value is allowed to be
+  // 'overridden' by each individual device type.
   template <typename Pred>
-  bool
-  CheckValidRoutineNewClauseHelper(Pred HasPredicate,
-                                   SemaOpenACC::OpenACCParsedClause &Clause) {
-    if (Clause.getDirectiveKind() != OpenACCDirectiveKind::Routine)
-      return false;
+  bool DisallowSinceLastDeviceType(Pred HasPredicate,
+                                   SemaOpenACC::OpenACCParsedClause &Clause,
+                                   bool DTOverrides = true) {
+    using ItrTy = decltype(ExistingClauses.begin());
+    llvm::SmallVector<ItrTy> DeviceTypeClauses;
 
-    auto *FirstDeviceType =
+    ItrTy DevTypeItr =
         llvm::find_if(ExistingClauses, llvm::IsaPred<OpenACCDeviceTypeClause>);
+    while (DevTypeItr != ExistingClauses.end()) {
+      DeviceTypeClauses.push_back(DevTypeItr);
+      DevTypeItr = std::find_if(std::next(DevTypeItr), ExistingClauses.end(),
+                                llvm::IsaPred<OpenACCDeviceTypeClause>);
+    }
 
-    if (FirstDeviceType == ExistingClauses.end()) {
-      // If there isn't a device type yet, ANY duplicate is wrong.
+    auto SinceLastDevType =
+        std::find_if(DeviceTypeClauses.empty() ? ExistingClauses.begin()
+                                               : DeviceTypeClauses.back(),
+                     ExistingClauses.end(), HasPredicate);
 
-      auto *ExistingProhibitedClause =
-          llvm::find_if(ExistingClauses, HasPredicate);
+    // At this point, any duplicates since the 'last' device type are an error,
+    // so diagnose that.
+    if (SinceLastDevType != ExistingClauses.end()) {
+      SemaRef.Diag(Clause.getBeginLoc(),
+                   diag::err_acc_clause_cannot_combine_same_device_type)
+          << Clause.getDirectiveKind() << Clause.getClauseKind()
+          << (*SinceLastDevType)->getClauseKind() << !DeviceTypeClauses.empty();
 
-      if (ExistingProhibitedClause == ExistingClauses.end())
-        return false;
-
-      SemaRef.Diag(Clause.getBeginLoc(), diag::err_acc_clause_cannot_combine)
-          << Clause.getClauseKind()
-          << (*ExistingProhibitedClause)->getClauseKind()
-          << Clause.getDirectiveKind();
-      SemaRef.Diag((*ExistingProhibitedClause)->getBeginLoc(),
+      SemaRef.Diag((*SinceLastDevType)->getBeginLoc(),
                    diag::note_acc_previous_clause_here)
-          << (*ExistingProhibitedClause)->getClauseKind();
+          << (*SinceLastDevType)->getClauseKind();
+
+      if (!DeviceTypeClauses.empty()) {
+        SemaRef.Diag((*DeviceTypeClauses.back())->getBeginLoc(),
+                     diag::note_acc_active_applies_clause_here)
+            << diag::ACCDeviceTypeApp::Active
+            << (*DeviceTypeClauses.back())->getClauseKind();
+      }
+
       return true;
     }
 
-    // At this point we know that this is 'after' a device type. So this is an
-    // error if: 1- there is one BEFORE the 'device_type' 2- there is one
-    // between this and the previous 'device_type'.
-
-    auto *BeforeDeviceType =
-        std::find_if(ExistingClauses.begin(), FirstDeviceType, HasPredicate);
-    // If there is one before the device_type (and we know we are after a
-    // device_type), than this is ill-formed.
-    if (BeforeDeviceType != FirstDeviceType) {
-      SemaRef.Diag(
-          Clause.getBeginLoc(),
-          diag::err_acc_clause_routine_cannot_combine_before_device_type)
-          << Clause.getClauseKind() << (*BeforeDeviceType)->getClauseKind();
-      SemaRef.Diag((*BeforeDeviceType)->getBeginLoc(),
-                   diag::note_acc_previous_clause_here)
-          << (*BeforeDeviceType)->getClauseKind();
-      SemaRef.Diag((*FirstDeviceType)->getBeginLoc(),
-                   diag::note_acc_active_applies_clause_here)
-          << diag::ACCDeviceTypeApp::Active
-          << (*FirstDeviceType)->getClauseKind();
-      return true;
-    }
-
-    auto LastDeviceTypeItr =
-        std::find_if(ExistingClauses.rbegin(), ExistingClauses.rend(),
-                     llvm::IsaPred<OpenACCDeviceTypeClause>);
-
-    // We already know there is one in the list, so it is nonsensical to not
-    // have one.
-    assert(LastDeviceTypeItr != ExistingClauses.rend());
-
-    // Get the device-type from-the-front (not reverse) iterator from the
-    // reverse iterator.
-    auto *LastDeviceType = LastDeviceTypeItr.base() - 1;
-
-    auto *ExistingProhibitedSinceLastDevice =
-        std::find_if(LastDeviceType, ExistingClauses.end(), HasPredicate);
-
-    // No prohibited ones since the last device-type.
-    if (ExistingProhibitedSinceLastDevice == ExistingClauses.end())
+    // The only other diagnostics are relationships between the current clause
+    // and ones in OTHER device_type regions, so if we have no other ones, we
+    // can exit early.
+    if (DeviceTypeClauses.empty())
       return false;
 
-    SemaRef.Diag(Clause.getBeginLoc(),
-                 diag::err_acc_clause_routine_cannot_combine_same_device_type)
-        << Clause.getClauseKind()
-        << (*ExistingProhibitedSinceLastDevice)->getClauseKind();
-    SemaRef.Diag((*ExistingProhibitedSinceLastDevice)->getBeginLoc(),
-                 diag::note_acc_previous_clause_here)
-        << (*ExistingProhibitedSinceLastDevice)->getClauseKind();
-    SemaRef.Diag((*LastDeviceType)->getBeginLoc(),
-                 diag::note_acc_active_applies_clause_here)
-        << diag::ACCDeviceTypeApp::Active << (*LastDeviceType)->getClauseKind();
-    return true;
+    if (!DTOverrides) {
+      // At this point we know we are after 1 of the device_type clauses, AND
+      // that one exists, so see if we conflict with anything BEFORE the first
+      // device_type clause.
+      auto BeforeFirstDevType = std::find_if(
+          ExistingClauses.begin(), DeviceTypeClauses.front(), HasPredicate);
+
+      if (BeforeFirstDevType != DeviceTypeClauses.front()) {
+        SemaRef.Diag(Clause.getBeginLoc(),
+                     diag::err_acc_clause_cannot_combine_before_device_type)
+            << Clause.getDirectiveKind() << Clause.getClauseKind()
+            << (*BeforeFirstDevType)->getClauseKind();
+
+        SemaRef.Diag((*BeforeFirstDevType)->getBeginLoc(),
+                     diag::note_acc_previous_clause_here)
+            << (*BeforeFirstDevType)->getClauseKind();
+
+        SemaRef.Diag((*DeviceTypeClauses.back())->getBeginLoc(),
+                     diag::note_acc_active_applies_clause_here)
+            << diag::ACCDeviceTypeApp::Active
+            << (*DeviceTypeClauses.back())->getClauseKind();
+        return true;
+      }
+    }
+
+    // This catches duplicates, * regions, duplicate-same-text (thanks to
+    // identifier equiv), and case-insensitive dupes, in addition to the
+    // acc_device_nvidia/nvidia equivilence.
+    auto areSameArch = [](const DeviceTypeArgument &LHS,
+                          const DeviceTypeArgument &RHS) {
+      // If they are the same identifier, they are the same. This includes both
+      // nulls.
+      if (LHS.getIdentifierInfo() == RHS.getIdentifierInfo())
+        return true;
+      // If only 1 is null, they obviously aren't the same.
+      if (!LHS.getIdentifierInfo() || !RHS.getIdentifierInfo())
+        return false;
+      StringRef LHSName = LHS.getIdentifierInfo()->getName();
+      StringRef RHSName = RHS.getIdentifierInfo()->getName();
+      if (LHSName.equals_insensitive(RHSName))
+        return true;
+
+      // acc_device_nvidia is used in NVC++ as an alias for nvidia, so include
+      // a check here.
+      return (LHSName.equals_insensitive("acc_device_nvidia") &&
+              RHSName.equals_insensitive("nvidia")) ||
+             (RHSName.equals_insensitive("acc_device_nvidia") &&
+              LHSName.equals_insensitive("nvidia"));
+    };
+    const OpenACCDeviceTypeClause *ActiveDTClause =
+        cast<OpenACCDeviceTypeClause>(*DeviceTypeClauses.back());
+
+    // Loop through each of the device types to figure out if they have a
+    // conflicting clause.
+    for (unsigned Idx = 0; Idx < DeviceTypeClauses.size() - 1; ++Idx) {
+      ItrTy ProhibitedClause = std::find_if(
+          DeviceTypeClauses[Idx], DeviceTypeClauses[Idx + 1], HasPredicate);
+
+      // If there no prohibited clause between this and the next, we don't have
+      // to check this region.
+      if (ProhibitedClause == DeviceTypeClauses[Idx + 1])
+        continue;
+
+      const OpenACCDeviceTypeClause *CurDTClause =
+          cast<OpenACCDeviceTypeClause>(*DeviceTypeClauses[Idx]);
+
+      for (const DeviceTypeArgument &ActiveArch :
+           ActiveDTClause->getArchitectures()) {
+        for (const DeviceTypeArgument &CurArch :
+             CurDTClause->getArchitectures()) {
+          if (areSameArch(CurArch, ActiveArch)) {
+            SemaRef.Diag(Clause.getBeginLoc(),
+                         diag::err_acc_clause_conflicts_prev_dev_type)
+                << Clause.getClauseKind()
+                << (ActiveArch.getIdentifierInfo()
+                        ? ActiveArch.getIdentifierInfo()->getName()
+                        : "*")
+                << (*ProhibitedClause)->getClauseKind();
+
+            SemaRef.Diag(ActiveDTClause->getBeginLoc(),
+                         diag::note_acc_active_applies_clause_here)
+                << diag::ACCDeviceTypeApp::Active
+                << ActiveDTClause->getClauseKind();
+
+            SemaRef.Diag((*ProhibitedClause)->getBeginLoc(),
+                         diag::note_acc_previous_clause_here)
+                << (*ProhibitedClause)->getClauseKind();
+
+            SemaRef.Diag(CurDTClause->getBeginLoc(),
+                         diag::note_acc_active_applies_clause_here)
+                << diag::ACCDeviceTypeApp::Applies
+                << CurDTClause->getClauseKind();
+
+            return true;
+          }
+        }
+      }
+
+      // At this point we know we have a potentially prohibited clause, but only
+      // if the device_type clauses try to do the 'same' thing.
+    }
+
+    // If we haven't found anything by now, this is valid.
+    return false;
   }
 
   // Routine has a pretty complicated set of rules for how device_type and the
   // gang, worker, vector, and seq clauses work.  So diagnose some of it here.
   bool CheckValidRoutineGangWorkerVectorSeqNewClause(
       SemaOpenACC::OpenACCParsedClause &Clause) {
-
+    if (Clause.getDirectiveKind() != OpenACCDirectiveKind::Routine)
+      return false;
     if (Clause.getClauseKind() != OpenACCClauseKind::Gang &&
         Clause.getClauseKind() != OpenACCClauseKind::Vector &&
         Clause.getClauseKind() != OpenACCClauseKind::Worker &&
@@ -345,7 +420,8 @@ class SemaOpenACCClauseVisitor {
     auto ProhibitedPred = llvm::IsaPred<OpenACCGangClause, OpenACCWorkerClause,
                                         OpenACCVectorClause, OpenACCSeqClause>;
 
-    return CheckValidRoutineNewClauseHelper(ProhibitedPred, Clause);
+    return DisallowSinceLastDeviceType(ProhibitedPred, Clause,
+                                       /*DTOverrides=*/false);
   }
 
   // Bind should have similar rules on a routine as gang/worker/vector/seq,
@@ -353,124 +429,14 @@ class SemaOpenACCClauseVisitor {
   // here.
   bool
   CheckValidRoutineBindNewClause(SemaOpenACC::OpenACCParsedClause &Clause) {
-
+    if (Clause.getDirectiveKind() != OpenACCDirectiveKind::Routine)
+      return false;
     if (Clause.getClauseKind() != OpenACCClauseKind::Bind)
       return false;
 
     auto HasBindPred = llvm::IsaPred<OpenACCBindClause>;
-    return CheckValidRoutineNewClauseHelper(HasBindPred, Clause);
-  }
-
-  // For 'tile' and 'collapse', only allow 1 per 'device_type'.
-  // Also applies to num_worker, num_gangs, vector_length, and async.
-  // This does introspection into the actual device-types to prevent duplicates
-  // across device types as well.
-  template <typename TheClauseTy>
-  bool DisallowSinceLastDeviceType(SemaOpenACC::OpenACCParsedClause &Clause) {
-    auto LastDeviceTypeItr =
-        std::find_if(ExistingClauses.rbegin(), ExistingClauses.rend(),
-                     llvm::IsaPred<OpenACCDeviceTypeClause>);
-
-    auto LastSinceDevTy =
-        std::find_if(ExistingClauses.rbegin(), LastDeviceTypeItr,
-                     llvm::IsaPred<TheClauseTy>);
-
-    // In this case there is a duplicate since the last device_type/lack of a
-    // device_type.  Diagnose these as duplicates.
-    if (LastSinceDevTy != LastDeviceTypeItr) {
-      SemaRef.Diag(Clause.getBeginLoc(),
-                   diag::err_acc_clause_since_last_device_type)
-          << Clause.getClauseKind() << Clause.getDirectiveKind()
-          << (LastDeviceTypeItr != ExistingClauses.rend());
-
-      SemaRef.Diag((*LastSinceDevTy)->getBeginLoc(),
-                   diag::note_acc_previous_clause_here)
-          << (*LastSinceDevTy)->getClauseKind();
-
-      // Mention the last device_type as well.
-      if (LastDeviceTypeItr != ExistingClauses.rend())
-        SemaRef.Diag((*LastDeviceTypeItr)->getBeginLoc(),
-                     diag::note_acc_active_applies_clause_here)
-            << diag::ACCDeviceTypeApp::Active
-            << (*LastDeviceTypeItr)->getClauseKind();
-      return true;
-    }
-
-    // If this isn't in a device_type, and we didn't diagnose that there are
-    // dupes above, just give up, no sense in searching for previous device_type
-    // regions as they don't exist.
-    if (LastDeviceTypeItr == ExistingClauses.rend())
-      return false;
-
-    // The device-type that is active for us, so we can compare to the previous
-    // ones.
-    const auto &ActiveDeviceTypeClause =
-        cast<OpenACCDeviceTypeClause>(**LastDeviceTypeItr);
-
-    auto PrevDeviceTypeItr = LastDeviceTypeItr;
-    auto CurDevTypeItr = LastDeviceTypeItr;
-
-    while ((CurDevTypeItr = std::find_if(
-                std::next(PrevDeviceTypeItr), ExistingClauses.rend(),
-                llvm::IsaPred<OpenACCDeviceTypeClause>)) !=
-           ExistingClauses.rend()) {
-      // At this point, we know that we have a region between two device_types,
-      // as specified by CurDevTypeItr and PrevDeviceTypeItr.
-
-      auto CurClauseKindItr = std::find_if(PrevDeviceTypeItr, CurDevTypeItr,
-                                           llvm::IsaPred<TheClauseTy>);
-
-      // There are no clauses of the current kind between these device_types, so
-      // continue.
-      if (CurClauseKindItr == CurDevTypeItr) {
-        PrevDeviceTypeItr = CurDevTypeItr;
-        continue;
-      }
-
-      // At this point, we know that this device_type region has a collapse.  So
-      // diagnose if the two device_types have any overlap in their
-      // architectures.
-      const auto &CurDeviceTypeClause =
-          cast<OpenACCDeviceTypeClause>(**CurDevTypeItr);
-
-      for (const DeviceTypeArgument &arg :
-           ActiveDeviceTypeClause.getArchitectures()) {
-        for (const DeviceTypeArgument &prevArg :
-             CurDeviceTypeClause.getArchitectures()) {
-
-          // This should catch duplicates * regions, duplicate same-text (thanks
-          // to identifier equiv.) and case insensitive dupes.
-          if (arg.getIdentifierInfo() == prevArg.getIdentifierInfo() ||
-              (arg.getIdentifierInfo() && prevArg.getIdentifierInfo() &&
-               StringRef{arg.getIdentifierInfo()->getName()}.equals_insensitive(
-                   prevArg.getIdentifierInfo()->getName()))) {
-            SemaRef.Diag(Clause.getBeginLoc(),
-                         diag::err_acc_clause_conflicts_prev_dev_type)
-                << Clause.getClauseKind()
-                << (arg.getIdentifierInfo() ? arg.getIdentifierInfo()->getName()
-                                            : "*");
-            // mention the active device type.
-            SemaRef.Diag(ActiveDeviceTypeClause.getBeginLoc(),
-                         diag::note_acc_active_applies_clause_here)
-                << diag::ACCDeviceTypeApp::Active
-                << ActiveDeviceTypeClause.getClauseKind();
-            // mention the previous clause.
-            SemaRef.Diag((*CurClauseKindItr)->getBeginLoc(),
-                         diag::note_acc_previous_clause_here)
-                << (*CurClauseKindItr)->getClauseKind();
-            // mention the previous device type.
-            SemaRef.Diag(CurDeviceTypeClause.getBeginLoc(),
-                         diag::note_acc_active_applies_clause_here)
-                << diag::ACCDeviceTypeApp::Applies
-                << CurDeviceTypeClause.getClauseKind();
-            return true;
-          }
-        }
-      }
-
-      PrevDeviceTypeItr = CurDevTypeItr;
-    }
-    return false;
+    return DisallowSinceLastDeviceType(HasBindPred, Clause,
+                                       /*DTOverrides=*/false);
   }
 
 public:
@@ -530,7 +496,7 @@ OpenACCClause *SemaOpenACCClauseVisitor::VisitDefaultClause(
 OpenACCClause *SemaOpenACCClauseVisitor::VisitTileClause(
     SemaOpenACC::OpenACCParsedClause &Clause) {
 
-  if (DisallowSinceLastDeviceType<OpenACCTileClause>(Clause))
+  if (DisallowSinceLastDeviceType(llvm::IsaPred<OpenACCTileClause>, Clause))
     return nullptr;
 
   llvm::SmallVector<Expr *> NewSizeExprs;
@@ -598,7 +564,7 @@ OpenACCClause *SemaOpenACCClauseVisitor::VisitSelfClause(
 OpenACCClause *SemaOpenACCClauseVisitor::VisitNumGangsClause(
     SemaOpenACC::OpenACCParsedClause &Clause) {
 
-  if (DisallowSinceLastDeviceType<OpenACCNumGangsClause>(Clause))
+  if (DisallowSinceLastDeviceType(llvm::IsaPred<OpenACCNumGangsClause>, Clause))
     return nullptr;
 
   // num_gangs requires at least 1 int expr in all forms.  Diagnose here, but
@@ -695,7 +661,8 @@ OpenACCClause *SemaOpenACCClauseVisitor::VisitNumGangsClause(
 OpenACCClause *SemaOpenACCClauseVisitor::VisitNumWorkersClause(
     SemaOpenACC::OpenACCParsedClause &Clause) {
 
-  if (DisallowSinceLastDeviceType<OpenACCNumWorkersClause>(Clause))
+  if (DisallowSinceLastDeviceType(llvm::IsaPred<OpenACCNumWorkersClause>,
+                                  Clause))
     return nullptr;
 
   // OpenACC 3.3 Section 2.9.2:
@@ -728,7 +695,8 @@ OpenACCClause *SemaOpenACCClauseVisitor::VisitNumWorkersClause(
 OpenACCClause *SemaOpenACCClauseVisitor::VisitVectorLengthClause(
     SemaOpenACC::OpenACCParsedClause &Clause) {
 
-  if (DisallowSinceLastDeviceType<OpenACCVectorLengthClause>(Clause))
+  if (DisallowSinceLastDeviceType(llvm::IsaPred<OpenACCVectorLengthClause>,
+                                  Clause))
     return nullptr;
 
   // OpenACC 3.3 Section 2.9.4:
@@ -760,7 +728,7 @@ OpenACCClause *SemaOpenACCClauseVisitor::VisitVectorLengthClause(
 
 OpenACCClause *SemaOpenACCClauseVisitor::VisitAsyncClause(
     SemaOpenACC::OpenACCParsedClause &Clause) {
-  if (DisallowSinceLastDeviceType<OpenACCAsyncClause>(Clause))
+  if (DisallowSinceLastDeviceType(llvm::IsaPred<OpenACCAsyncClause>, Clause))
     return nullptr;
 
   assert(Clause.getNumIntExprs() < 2 &&
@@ -1796,7 +1764,7 @@ OpenACCClause *SemaOpenACCClauseVisitor::VisitReductionClause(
 OpenACCClause *SemaOpenACCClauseVisitor::VisitCollapseClause(
     SemaOpenACC::OpenACCParsedClause &Clause) {
 
-  if (DisallowSinceLastDeviceType<OpenACCCollapseClause>(Clause))
+  if (DisallowSinceLastDeviceType(llvm::IsaPred<OpenACCCollapseClause>, Clause))
     return nullptr;
 
   ExprResult LoopCount = SemaRef.CheckCollapseLoopCount(Clause.getLoopCount());

--- a/clang/test/ParserOpenACC/parse-clauses.c
+++ b/clang/test/ParserOpenACC/parse-clauses.c
@@ -1315,16 +1315,16 @@ void Gang() {
 
 }
 
-  // expected-error@+4{{OpenACC clause 'seq' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+4{{OpenACC clause 'seq' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+3{{previous 'worker' clause is here}}
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine worker, vector, seq, nohost
 void bar();
 
-  // expected-error@+4{{OpenACC clause 'seq' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+4{{OpenACC clause 'seq' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+3{{previous 'worker' clause is here}}
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine(bar) worker, vector, seq, nohost
 

--- a/clang/test/SemaOpenACC/combined-construct-num_gangs-clause.c
+++ b/clang/test/SemaOpenACC/combined-construct-num_gangs-clause.c
@@ -13,23 +13,23 @@ void Test() {
 #pragma acc parallel loop num_gangs(1)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+2{{OpenACC 'num_gangs' clause cannot appear more than once on a 'kernels loop' directive}}
+  // expected-error@+2{{OpenACC clause 'num_gangs' cannot combine with previous 'num_gangs' clause on a 'kernels loop' directive}}
   // expected-note@+1{{previous 'num_gangs' clause is here}}
 #pragma acc kernels loop num_gangs(1) num_gangs(2)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+2{{OpenACC 'num_gangs' clause cannot appear more than once on a 'parallel loop' directive}}
+  // expected-error@+2{{OpenACC clause 'num_gangs' cannot combine with previous 'num_gangs' clause on a 'parallel loop' directive}}
   // expected-note@+1{{previous 'num_gangs' clause is here}}
 #pragma acc parallel loop num_gangs(1) num_gangs(2)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+3{{OpenACC 'num_gangs' clause cannot appear more than once in a 'device_type' region on a 'kernels loop' directive}}
+  // expected-error@+3{{OpenACC clause 'num_gangs' cannot combine with previous 'num_gangs' clause in the same 'device_type' region on a 'kernels loop' directive}}
   // expected-note@+2{{previous 'num_gangs' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc kernels loop num_gangs(1) device_type(*) num_gangs(1) num_gangs(2)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+3{{OpenACC 'num_gangs' clause cannot appear more than once in a 'device_type' region on a 'parallel loop' directive}}
+  // expected-error@+3{{OpenACC clause 'num_gangs' cannot combine with previous 'num_gangs' clause in the same 'device_type' region on a 'parallel loop' directive}}
   // expected-note@+2{{previous 'num_gangs' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc parallel loop device_type(*) num_gangs(1) num_gangs(2)

--- a/clang/test/SemaOpenACC/combined-construct-num_workers-clause.c
+++ b/clang/test/SemaOpenACC/combined-construct-num_workers-clause.c
@@ -13,23 +13,23 @@ void Test() {
 #pragma acc parallel loop num_workers(1)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+2{{OpenACC 'num_workers' clause cannot appear more than once on a 'kernels loop' directive}}
+  // expected-error@+2{{OpenACC clause 'num_workers' cannot combine with previous 'num_workers' clause on a 'kernels loop' directive}}
   // expected-note@+1{{previous 'num_workers' clause is here}}
 #pragma acc kernels loop num_workers(1) num_workers(2)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+2{{OpenACC 'num_workers' clause cannot appear more than once on a 'parallel loop' directive}}
+  // expected-error@+2{{OpenACC clause 'num_workers' cannot combine with previous 'num_workers' clause on a 'parallel loop' directive}}
   // expected-note@+1{{previous 'num_workers' clause is here}}
 #pragma acc parallel loop num_workers(1) num_workers(2)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+3{{OpenACC 'num_workers' clause cannot appear more than once in a 'device_type' region on a 'kernels loop' directive}}
+  // expected-error@+3{{OpenACC clause 'num_workers' cannot combine with previous 'num_workers' clause in the same 'device_type' region on a 'kernels loop' directive}}
   // expected-note@+2{{previous 'num_workers' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc kernels loop num_workers(1) device_type(*) num_workers(1) num_workers(2)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+3{{OpenACC 'num_workers' clause cannot appear more than once in a 'device_type' region on a 'parallel loop' directive}}
+  // expected-error@+3{{OpenACC clause 'num_workers' cannot combine with previous 'num_workers' clause in the same 'device_type' region on a 'parallel loop' directive}}
   // expected-note@+2{{previous 'num_workers' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc parallel loop device_type(*) num_workers(1) num_workers(2)

--- a/clang/test/SemaOpenACC/combined-construct-vector_length-clause.c
+++ b/clang/test/SemaOpenACC/combined-construct-vector_length-clause.c
@@ -13,23 +13,23 @@ void Test() {
 #pragma acc parallel loop vector_length(1)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+2{{OpenACC 'vector_length' clause cannot appear more than once on a 'kernels loop' directive}}
+  // expected-error@+2{{OpenACC clause 'vector_length' cannot combine with previous 'vector_length' clause on a 'kernels loop' directive}}
   // expected-note@+1{{previous 'vector_length' clause is here}}
 #pragma acc kernels loop vector_length(1) vector_length(2)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+2{{OpenACC 'vector_length' clause cannot appear more than once on a 'parallel loop' directive}}
+  // expected-error@+2{{OpenACC clause 'vector_length' cannot combine with previous 'vector_length' clause on a 'parallel loop' directive}}
   // expected-note@+1{{previous 'vector_length' clause is here}}
 #pragma acc parallel loop vector_length(1) vector_length(2)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+3{{OpenACC 'vector_length' clause cannot appear more than once in a 'device_type' region on a 'kernels loop' directive}}
+  // expected-error@+3{{OpenACC clause 'vector_length' cannot combine with previous 'vector_length' clause in the same 'device_type' region on a 'kernels loop' directive}}
   // expected-note@+2{{previous 'vector_length' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc kernels loop vector_length(1) device_type(*) vector_length(1) vector_length(2)
   for(int i = 5; i < 10;++i);
 
-  // expected-error@+3{{OpenACC 'vector_length' clause cannot appear more than once in a 'device_type' region on a 'parallel loop' directive}}
+  // expected-error@+3{{OpenACC clause 'vector_length' cannot combine with previous 'vector_length' clause in the same 'device_type' region on a 'parallel loop' directive}}
   // expected-note@+2{{previous 'vector_length' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc parallel loop device_type(*) vector_length(1) vector_length(2)

--- a/clang/test/SemaOpenACC/compute-construct-async-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-async-clause.c
@@ -20,43 +20,43 @@ void Test() {
 #pragma acc serial async(1, 2)
   while(1);
 
-  // expected-error@+2{{OpenACC 'async' clause cannot appear more than once on a 'kernels' directive}}
+  // expected-error@+2{{OpenACC clause 'async' cannot combine with previous 'async' clause on a 'kernels' directive}}
   // expected-note@+1{{previous 'async' clause is here}}
 #pragma acc kernels async async
   while(1);
 
-  // expected-error@+2{{OpenACC 'async' clause cannot appear more than once on a 'kernels' directive}}
+  // expected-error@+2{{OpenACC clause 'async' cannot combine with previous 'async' clause on a 'kernels' directive}}
   // expected-note@+1{{previous 'async' clause is here}}
 #pragma acc kernels async(1) async(2)
   while(1);
 
-  // expected-error@+2{{OpenACC 'async' clause cannot appear more than once on a 'parallel' directive}}
+  // expected-error@+2{{OpenACC clause 'async' cannot combine with previous 'async' clause on a 'parallel' directive}}
   // expected-note@+1{{previous 'async' clause is here}}
 #pragma acc parallel async(1) async(2)
   while(1);
 
-  // expected-error@+2{{OpenACC 'async' clause cannot appear more than once on a 'serial' directive}}
+  // expected-error@+2{{OpenACC clause 'async' cannot combine with previous 'async' clause on a 'serial' directive}}
   // expected-note@+1{{previous 'async' clause is here}}
 #pragma acc serial async(1) async(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'async' clause cannot appear more than once in a 'device_type' region on a 'kernels' directive}}
+  // expected-error@+3{{OpenACC clause 'async' cannot combine with previous 'async' clause in the same 'device_type' region on a 'kernels' directive}}
   // expected-note@+2{{previous 'async' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc kernels async(1) device_type(*) async(1) async(2)
   while(1);
-  // expected-error@+3{{OpenACC 'async' clause cannot appear more than once in a 'device_type' region on a 'parallel' directive}}
+  // expected-error@+3{{OpenACC clause 'async' cannot combine with previous 'async' clause in the same 'device_type' region on a 'parallel' directive}}
   // expected-note@+2{{previous 'async' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc parallel async device_type(*) async async
   while(1);
-  // expected-error@+3{{OpenACC 'async' clause cannot appear more than once in a 'device_type' region on a 'serial' directive}}
+  // expected-error@+3{{OpenACC clause 'async' cannot combine with previous 'async' clause in the same 'device_type' region on a 'serial' directive}}
   // expected-note@+2{{previous 'async' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc serial async(1) device_type(*) async async(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'async' clause cannot appear more than once in a 'device_type' region on a 'parallel' directive}}
+  // expected-error@+3{{OpenACC clause 'async' cannot combine with previous 'async' clause in the same 'device_type' region on a 'parallel' directive}}
   // expected-note@+2{{previous 'async' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc parallel device_type(*) async async

--- a/clang/test/SemaOpenACC/compute-construct-num_gangs-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-num_gangs-clause.c
@@ -12,23 +12,23 @@ void Test() {
 #pragma acc parallel num_gangs(1)
   while(1);
 
-  // expected-error@+2{{OpenACC 'num_gangs' clause cannot appear more than once on a 'kernels' directive}}
+  // expected-error@+2{{OpenACC clause 'num_gangs' cannot combine with previous 'num_gangs' clause on a 'kernels' directive}}
   // expected-note@+1{{previous 'num_gangs' clause is here}}
 #pragma acc kernels num_gangs(1) num_gangs(2)
   while(1);
 
-  // expected-error@+2{{OpenACC 'num_gangs' clause cannot appear more than once on a 'parallel' directive}}
+  // expected-error@+2{{OpenACC clause 'num_gangs' cannot combine with previous 'num_gangs' clause on a 'parallel' directive}}
   // expected-note@+1{{previous 'num_gangs' clause is here}}
 #pragma acc parallel num_gangs(1) num_gangs(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'num_gangs' clause cannot appear more than once in a 'device_type' region on a 'kernels' directive}}
+  // expected-error@+3{{OpenACC clause 'num_gangs' cannot combine with previous 'num_gangs' clause in the same 'device_type' region on a 'kernels' directive}}
   // expected-note@+2{{previous 'num_gangs' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc kernels num_gangs(1) device_type(*) num_gangs(1) num_gangs(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'num_gangs' clause cannot appear more than once in a 'device_type' region on a 'parallel' directive}}
+  // expected-error@+3{{OpenACC clause 'num_gangs' cannot combine with previous 'num_gangs' clause in the same 'device_type' region on a 'parallel' directive}}
   // expected-note@+2{{previous 'num_gangs' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc parallel device_type(*) num_gangs(1) num_gangs(2)

--- a/clang/test/SemaOpenACC/compute-construct-num_workers-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-num_workers-clause.c
@@ -8,23 +8,23 @@ void Test() {
 #pragma acc kernels num_workers(1)
   while(1);
 
-  // expected-error@+2{{OpenACC 'num_workers' clause cannot appear more than once on a 'kernels' directive}}
+  // expected-error@+2{{OpenACC clause 'num_workers' cannot combine with previous 'num_workers' clause on a 'kernels' directive}}
   // expected-note@+1{{previous 'num_workers' clause is here}}
 #pragma acc kernels num_workers(1) num_workers(2)
   while(1);
 
-  // expected-error@+2{{OpenACC 'num_workers' clause cannot appear more than once on a 'parallel' directive}}
+  // expected-error@+2{{OpenACC clause 'num_workers' cannot combine with previous 'num_workers' clause on a 'parallel' directive}}
   // expected-note@+1{{previous 'num_workers' clause is here}}
 #pragma acc parallel num_workers(1) num_workers(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'num_workers' clause cannot appear more than once in a 'device_type' region on a 'kernels' directive}}
+  // expected-error@+3{{OpenACC clause 'num_workers' cannot combine with previous 'num_workers' clause in the same 'device_type' region on a 'kernels' directive}}
   // expected-note@+2{{previous 'num_workers' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc kernels num_workers(1) device_type(*) num_workers(1) num_workers(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'num_workers' clause cannot appear more than once in a 'device_type' region on a 'parallel' directive}}
+  // expected-error@+3{{OpenACC clause 'num_workers' cannot combine with previous 'num_workers' clause in the same 'device_type' region on a 'parallel' directive}}
   // expected-note@+2{{previous 'num_workers' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc parallel device_type(*) num_workers(1) num_workers(2)

--- a/clang/test/SemaOpenACC/compute-construct-vector_length-clause.c
+++ b/clang/test/SemaOpenACC/compute-construct-vector_length-clause.c
@@ -8,23 +8,23 @@ void Test() {
 #pragma acc kernels vector_length(1)
   while(1);
 
-  // expected-error@+2{{OpenACC 'vector_length' clause cannot appear more than once on a 'kernels' directive}}
+  // expected-error@+2{{OpenACC clause 'vector_length' cannot combine with previous 'vector_length' clause on a 'kernels' directive}}
   // expected-note@+1{{previous 'vector_length' clause is here}}
 #pragma acc kernels vector_length(1) vector_length(2)
   while(1);
 
-  // expected-error@+2{{OpenACC 'vector_length' clause cannot appear more than once on a 'parallel' directive}}
+  // expected-error@+2{{OpenACC clause 'vector_length' cannot combine with previous 'vector_length' clause on a 'parallel' directive}}
   // expected-note@+1{{previous 'vector_length' clause is here}}
 #pragma acc parallel vector_length(1) vector_length(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'vector_length' clause cannot appear more than once in a 'device_type' region on a 'kernels' directive}}
+  // expected-error@+3{{OpenACC clause 'vector_length' cannot combine with previous 'vector_length' clause in the same 'device_type' region on a 'kernels' directive}}
   // expected-note@+2{{previous 'vector_length' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc kernels vector_length(1) device_type(*) vector_length(1) vector_length(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'vector_length' clause cannot appear more than once in a 'device_type' region on a 'parallel' directive}}
+  // expected-error@+3{{OpenACC clause 'vector_length' cannot combine with previous 'vector_length' clause in the same 'device_type' region on a 'parallel' directive}}
   // expected-note@+2{{previous 'vector_length' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc parallel device_type(*) vector_length(1) vector_length(2)

--- a/clang/test/SemaOpenACC/data-construct-async-clause.c
+++ b/clang/test/SemaOpenACC/data-construct-async-clause.c
@@ -24,7 +24,7 @@ void Test() {
 #pragma acc host_data use_device(NC) async(NC)
   ;
 
-  // expected-error@+2{{OpenACC 'async' clause cannot appear more than once on a 'data' directive}}
+  // expected-error@+2{{OpenACC clause 'async' cannot combine with previous 'async' clause on a 'data' directive}}
   // expected-note@+1{{previous 'async' clause is here}}
 #pragma acc data copyin(I) async(I) async(I)
   ;
@@ -32,38 +32,38 @@ void Test() {
   // expected-note@+1{{to match this '('}}
 #pragma acc enter data copyin(I) async(I, I)
   //
-  // expected-error@+2{{OpenACC 'async' clause cannot appear more than once on a 'data' directive}}
+  // expected-error@+2{{OpenACC clause 'async' cannot combine with previous 'async' clause on a 'data' directive}}
   // expected-note@+1{{previous 'async' clause is here}}
 #pragma acc data default(none) async async
   while(1);
 
-  // expected-error@+2{{OpenACC 'async' clause cannot appear more than once on a 'data' directive}}
+  // expected-error@+2{{OpenACC clause 'async' cannot combine with previous 'async' clause on a 'data' directive}}
   // expected-note@+1{{previous 'async' clause is here}}
 #pragma acc data default(none) async(1) async(2)
   while(1);
 
-  // expected-error@+2{{OpenACC 'async' clause cannot appear more than once on a 'data' directive}}
+  // expected-error@+2{{OpenACC clause 'async' cannot combine with previous 'async' clause on a 'data' directive}}
   // expected-note@+1{{previous 'async' clause is here}}
 #pragma acc data default(none) async(1) async(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'async' clause cannot appear more than once in a 'device_type' region on a 'data' directive}}
+  // expected-error@+3{{OpenACC clause 'async' cannot combine with previous 'async' clause in the same 'device_type' region on a 'data' directive}}
   // expected-note@+2{{previous 'async' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc data default(none) async(1) device_type(*) async(1) async(2)
   while(1);
-  // expected-error@+3{{OpenACC 'async' clause cannot appear more than once in a 'device_type' region on a 'data' directive}}
+  // expected-error@+3{{OpenACC clause 'async' cannot combine with previous 'async' clause in the same 'device_type' region on a 'data' directive}}
   // expected-note@+2{{previous 'async' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc data default(none) async device_type(*) async async
   while(1);
-  // expected-error@+3{{OpenACC 'async' clause cannot appear more than once in a 'device_type' region on a 'data' directive}}
+  // expected-error@+3{{OpenACC clause 'async' cannot combine with previous 'async' clause in the same 'device_type' region on a 'data' directive}}
   // expected-note@+2{{previous 'async' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc data default(none) async(1) device_type(*) async async(2)
   while(1);
 
-  // expected-error@+3{{OpenACC 'async' clause cannot appear more than once in a 'device_type' region on a 'data' directive}}
+  // expected-error@+3{{OpenACC clause 'async' cannot combine with previous 'async' clause in the same 'device_type' region on a 'data' directive}}
   // expected-note@+2{{previous 'async' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc data default(none) device_type(*) async async

--- a/clang/test/SemaOpenACC/loop-construct-collapse-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-collapse-clause.cpp
@@ -15,7 +15,7 @@ void only_for_loops() {
 }
 
 void only_one_on_loop() {
-  // expected-error@+2{{OpenACC 'collapse' clause cannot appear more than once on a 'loop' directive}}
+  // expected-error@+2{{OpenACC clause 'collapse' cannot combine with previous 'collapse' clause on a 'loop' directive}}
   // expected-note@+1{{previous 'collapse' clause is here}}
 #pragma acc loop collapse(1) collapse(1)
   for(int i = 0; i < 5; ++i);
@@ -529,13 +529,14 @@ void allow_multiple_collapse() {
 }
 
 void no_dupes_since_last_device_type() {
-  // expected-error@+3{{OpenACC 'collapse' clause cannot appear more than once in a 'device_type' region on a 'loop' directive}}
+
+  // expected-error@+3{{OpenACC clause 'collapse' cannot combine with previous 'collapse' clause in the same 'device_type' region on a 'loop' directive}}
   // expected-note@+2{{previous 'collapse' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc loop collapse(1) device_type(*) collapse(1) collapse(2)
   for(unsigned i = 0; i < 5; ++i)
     for(unsigned j = 0; j < 5; ++j);
- 
+
 #pragma acc loop collapse(1) device_type(*) collapse(1) device_type(nvidia) collapse(2)
   for(unsigned i = 0; i < 5; ++i)
     for(unsigned j = 0; j < 5; ++j);
@@ -548,7 +549,7 @@ void no_dupes_since_last_device_type() {
 #pragma acc loop device_type(nvidia) collapse(1) device_type(*) collapse(2)
   for(unsigned i = 0; i < 5; ++i)
     for(unsigned j = 0; j < 5; ++j);
-  
+
   // expected-error@+4{{OpenACC 'collapse' clause applies to 'device_type' '*', which conflicts with previous 'collapse' clause}}
   // expected-note@+3{{active 'device_type' clause here}}
   // expected-note@+2{{previous 'collapse' clause is here}}
@@ -570,6 +571,21 @@ void no_dupes_since_last_device_type() {
   // expected-note@+2{{previous 'collapse' clause is here}}
   // expected-note@+1{{which applies to 'device_type' clause here}}
 #pragma acc loop device_type(radeon) collapse(1) device_type(nvidia, radeon) collapse(2)
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
+
+  // expected-error@+4{{OpenACC 'collapse' clause applies to 'device_type' 'acc_device_nvidia', which conflicts with previous 'collapse' clause}}
+  // expected-note@+3{{active 'device_type' clause here}}
+  // expected-note@+2{{previous 'collapse' clause is here}}
+  // expected-note@+1{{which applies to 'device_type' clause here}}
+#pragma acc loop device_type(nvidia) collapse(1) device_type(acc_device_nvidia) collapse(2)
+  for(unsigned i = 0; i < 5; ++i)
+    for(unsigned j = 0; j < 5; ++j);
+  // expected-error@+4{{OpenACC 'collapse' clause applies to 'device_type' 'nvidia', which conflicts with previous 'collapse' clause}}
+  // expected-note@+3{{active 'device_type' clause here}}
+  // expected-note@+2{{previous 'collapse' clause is here}}
+  // expected-note@+1{{which applies to 'device_type' clause here}}
+#pragma acc loop device_type(acc_device_nvidia) collapse(1) device_type(nvidia) collapse(2)
   for(unsigned i = 0; i < 5; ++i)
     for(unsigned j = 0; j < 5; ++j);
 

--- a/clang/test/SemaOpenACC/loop-construct-tile-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-tile-clause.cpp
@@ -144,7 +144,7 @@ void only_for_loops() {
 }
 
 void only_one_on_loop() {
-  // expected-error@+2{{OpenACC 'tile' clause cannot appear more than once on a 'loop' directive}}
+  // expected-error@+2{{OpenACC clause 'tile' cannot combine with previous 'tile' clause on a 'loop' directive}}
   // expected-note@+1{{previous 'tile' clause is here}}
 #pragma acc loop tile(1) tile(1)
   for(int i = 0; i < 5; ++i);
@@ -409,7 +409,7 @@ void collapse_tile_depth() {
   }
 }
 void no_dupes_since_last_device_type() {
-  // expected-error@+3{{OpenACC 'tile' clause cannot appear more than once in a 'device_type' region on a 'loop' directive}}
+  // expected-error@+3{{OpenACC clause 'tile' cannot combine with previous 'tile' clause in the same 'device_type' region on a 'loop' directive}}
   // expected-note@+2{{previous 'tile' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc loop tile(1) device_type(*) tile(1) tile(2)

--- a/clang/test/SemaOpenACC/routine-construct-clauses.cpp
+++ b/clang/test/SemaOpenACC/routine-construct-clauses.cpp
@@ -7,62 +7,63 @@ void Func2();
 #pragma acc routine(Func) vector nohost
 #pragma acc routine(Func) nohost seq
 #pragma acc routine(Func) gang
-// expected-error@+2{{OpenACC clause 'bind' may not appear on the same construct as a 'bind' clause on a 'routine' construct}}
+
+// expected-error@+2{{OpenACC clause 'bind' cannot combine with previous 'bind' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'bind' clause is here}}
 #pragma acc routine(Func) gang bind(a) bind(a)
 
-// expected-error@+2{{OpenACC clause 'bind' may not appear on the same construct as a 'bind' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'bind' cannot combine with previous 'bind' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'bind' clause is here}}
 #pragma acc routine gang bind(a) bind(a)
 void DupeImplName();
 
 // Only 1 of worker, vector, seq, gang.
-// expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'worker' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine(Func) worker vector
-// expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'worker' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine(Func) worker seq
-// expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'worker' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine(Func) worker gang
-// expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'worker' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine(Func) worker worker
-// expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'vector' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine(Func) vector worker
-// expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'vector' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine(Func) vector seq
-// expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'vector' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine(Func) vector gang
-// expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'vector' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine(Func) vector vector
-// expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'seq' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine(Func) seq worker
-// expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'seq' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine(Func) seq vector
-// expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'seq' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine(Func) seq gang
-// expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'seq' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine(Func) seq seq
-// expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'gang' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine(Func) gang worker
-// expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'gang' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine(Func) gang vector
-// expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'gang' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine(Func) gang seq
-// expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+// expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'gang' clause on a 'routine' directive}}
 // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine(Func) gang gang
 // expected-error@+1{{OpenACC 'routine' construct must have at least one 'gang', 'seq', 'vector', or 'worker' clause}}
@@ -233,67 +234,67 @@ void DupeBinds6();
 // The ones before any 'device_type' apply to all.
 namespace FigureDupesAllowedAroundDeviceType {
   // Test conflicts without a device type
-  // expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'gang' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine gang gang
   void Func1();
-  // expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'gang' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine gang worker
   void Func2();
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'gang' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine gang vector
   void Func3();
-  // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'gang' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine gang seq
   void Func4();
-  // expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine worker gang
   void Func5();
-  // expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine worker worker
   void Func6();
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine worker vector
   void Func7();
-  // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine worker seq
   void Func8();
-  // expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'vector' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine vector gang
   void Func9();
-  // expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'vector' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine vector worker
   void Func10();
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'vector' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine vector vector
   void Func11();
-  // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'vector' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine vector seq
   void Func12();
-  // expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'seq' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine seq gang
   void Func13();
-  // expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'seq' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine seq worker
   void Func14();
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'seq' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine seq vector
   void Func15();
-  // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'seq' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine seq seq
   void Func16();
@@ -303,67 +304,67 @@ namespace FigureDupesAllowedAroundDeviceType {
   void Func16();
 
   // Check same conflicts for 'before' the device_type
-  // expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'gang' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine gang gang device_type(*)
   void Func17();
-  // expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'gang' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine gang worker device_type(*)
   void Func18();
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'gang' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine gang vector device_type(*)
   void Func19();
-  // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'gang' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'gang' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'gang' clause is here}}
 #pragma acc routine gang seq device_type(*)
   void Func20();
-  // expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine worker gang device_type(*)
   void Func21();
-  // expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine worker worker device_type(*)
   void Func22();
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine worker vector device_type(*)
   void Func23();
-  // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'worker' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'worker' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'worker' clause is here}}
 #pragma acc routine worker seq device_type(*)
   void Func24();
-  // expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'vector' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine vector gang device_type(*)
   void Func25();
-  // expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'vector' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine vector worker device_type(*)
   void Func26();
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'vector' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine vector vector device_type(*)
   void Func27();
-  // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'vector' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'vector' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'vector' clause is here}}
 #pragma acc routine vector seq device_type(*)
   void Func28();
-  // expected-error@+2{{OpenACC clause 'gang' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'gang' cannot combine with previous 'seq' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine seq gang device_type(*)
   void Func29();
-  // expected-error@+2{{OpenACC clause 'worker' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'worker' cannot combine with previous 'seq' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine seq worker device_type(*)
   void Func30();
-  // expected-error@+2{{OpenACC clause 'vector' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'vector' cannot combine with previous 'seq' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine seq vector device_type(*)
   void Func31();
-  // expected-error@+2{{OpenACC clause 'seq' may not appear on the same construct as a 'seq' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'seq' cannot combine with previous 'seq' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'seq' clause is here}}
 #pragma acc routine seq seq device_type(*)
   void Func32();
@@ -373,326 +374,326 @@ namespace FigureDupesAllowedAroundDeviceType {
   void Func33();
 
   // Conflicts between 'global' and 'device_type'
-  // expected-error@+3{{OpenACC clause 'gang' after 'device_type' clause on a 'routine' conflicts with the 'gang' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' after 'device_type' clause on a 'routine' construct conflicts with the 'gang' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine gang device_type(*) gang
   void Func34();
-  // expected-error@+3{{OpenACC clause 'worker' after 'device_type' clause on a 'routine' conflicts with the 'gang' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' after 'device_type' clause on a 'routine' construct conflicts with the 'gang' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine gang device_type(*) worker
   void Func35();
-  // expected-error@+3{{OpenACC clause 'vector' after 'device_type' clause on a 'routine' conflicts with the 'gang' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' after 'device_type' clause on a 'routine' construct conflicts with the 'gang' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine gang device_type(*) vector
   void Func36();
-  // expected-error@+3{{OpenACC clause 'seq' after 'device_type' clause on a 'routine' conflicts with the 'gang' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' after 'device_type' clause on a 'routine' construct conflicts with the 'gang' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine gang device_type(*) seq
   void Func37();
-  // expected-error@+3{{OpenACC clause 'gang' after 'device_type' clause on a 'routine' conflicts with the 'worker' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' after 'device_type' clause on a 'routine' construct conflicts with the 'worker' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine worker device_type(*) gang
   void Func38();
-  // expected-error@+3{{OpenACC clause 'worker' after 'device_type' clause on a 'routine' conflicts with the 'worker' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' after 'device_type' clause on a 'routine' construct conflicts with the 'worker' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine worker device_type(*) worker
   void Func39();
-  // expected-error@+3{{OpenACC clause 'vector' after 'device_type' clause on a 'routine' conflicts with the 'worker' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' after 'device_type' clause on a 'routine' construct conflicts with the 'worker' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine worker device_type(*) vector
   void Func40();
-  // expected-error@+3{{OpenACC clause 'seq' after 'device_type' clause on a 'routine' conflicts with the 'worker' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' after 'device_type' clause on a 'routine' construct conflicts with the 'worker' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine worker device_type(*) seq
   void Func41();
-  // expected-error@+3{{OpenACC clause 'gang' after 'device_type' clause on a 'routine' conflicts with the 'vector' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' after 'device_type' clause on a 'routine' construct conflicts with the 'vector' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine vector device_type(*) gang
   void Func42();
-  // expected-error@+3{{OpenACC clause 'worker' after 'device_type' clause on a 'routine' conflicts with the 'vector' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' after 'device_type' clause on a 'routine' construct conflicts with the 'vector' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine vector device_type(*) worker
   void Func43();
-  // expected-error@+3{{OpenACC clause 'vector' after 'device_type' clause on a 'routine' conflicts with the 'vector' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' after 'device_type' clause on a 'routine' construct conflicts with the 'vector' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine vector device_type(*) vector
   void Func44();
-  // expected-error@+3{{OpenACC clause 'seq' after 'device_type' clause on a 'routine' conflicts with the 'vector' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' after 'device_type' clause on a 'routine' construct conflicts with the 'vector' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine vector device_type(*) seq
   void Func45();
-  // expected-error@+3{{OpenACC clause 'gang' after 'device_type' clause on a 'routine' conflicts with the 'seq' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' after 'device_type' clause on a 'routine' construct conflicts with the 'seq' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine seq device_type(*) gang
   void Func46();
-  // expected-error@+3{{OpenACC clause 'worker' after 'device_type' clause on a 'routine' conflicts with the 'seq' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' after 'device_type' clause on a 'routine' construct conflicts with the 'seq' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine seq device_type(*) worker
   void Func47();
-  // expected-error@+3{{OpenACC clause 'vector' after 'device_type' clause on a 'routine' conflicts with the 'seq' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' after 'device_type' clause on a 'routine' construct conflicts with the 'seq' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine seq device_type(*) vector
   void Func48();
-  // expected-error@+3{{OpenACC clause 'seq' after 'device_type' clause on a 'routine' conflicts with the 'seq' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' after 'device_type' clause on a 'routine' construct conflicts with the 'seq' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine seq device_type(*) seq
   void Func49();
 
   // Conflicts within same device_type
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) gang gang
   void Func50();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) gang worker
   void Func51();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) gang vector
   void Func52();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) gang seq
   void Func53();
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) worker gang
   void Func54();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) worker worker
   void Func55();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) worker vector
   void Func56();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) worker seq
   void Func57();
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) vector gang
   void Func58();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) vector worker
   void Func59();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) vector vector
   void Func60();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) vector seq
   void Func61();
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) seq gang
   void Func62();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) seq worker
   void Func63();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) seq vector
   void Func64();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) seq seq
   void Func65();
 
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) gang gang device_type(nvidia) seq
   void Func66();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) gang worker device_type(nvidia) seq
   void Func67();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) gang vector device_type(nvidia) seq
   void Func68();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) gang seq device_type(nvidia) seq
   void Func69();
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) worker gang device_type(nvidia) seq
   void Func70();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) worker worker device_type(nvidia) seq
   void Func71();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) worker vector device_type(nvidia) seq
   void Func72();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) worker seq device_type(nvidia) seq
   void Func73();
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) vector gang device_type(nvidia) seq
   void Func74();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) vector worker device_type(nvidia) seq
   void Func75();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) vector vector device_type(nvidia) seq
   void Func76();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) vector seq device_type(nvidia) seq
   void Func77();
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) seq gang device_type(nvidia) seq
   void Func78();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) seq worker device_type(nvidia) seq
   void Func79();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) seq vector device_type(nvidia) seq
   void Func80();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(*) seq seq device_type(nvidia) seq
   void Func81();
 
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) gang gang
   void Func82();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) gang worker
   void Func83();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) gang vector
   void Func84();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'gang' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'gang' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'gang' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) gang seq
   void Func85();
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) worker gang
   void Func86();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) worker worker
   void Func87();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) worker vector
   void Func88();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'worker' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'worker' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'worker' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) worker seq
   void Func89();
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) vector gang
   void Func90();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) vector worker
   void Func91();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) vector vector
   void Func92();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'vector' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'vector' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'vector' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) vector seq
   void Func93();
-  // expected-error@+3{{OpenACC clause 'gang' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'gang' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) seq gang
   void Func94();
-  // expected-error@+3{{OpenACC clause 'worker' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'worker' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) seq worker
   void Func95();
-  // expected-error@+3{{OpenACC clause 'vector' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'vector' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) seq vector
   void Func96();
-  // expected-error@+3{{OpenACC clause 'seq' on a 'routine' directive conflicts with the 'seq' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'seq' cannot combine with previous 'seq' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'seq' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine device_type(nvidia) seq device_type(*) seq seq
@@ -735,40 +736,70 @@ namespace FigureDupesAllowedAroundDeviceType {
 }
 
 namespace BindDupes {
-  // expected-error@+2{{OpenACC clause 'bind' may not appear on the same construct as a 'bind' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'bind' cannot combine with previous 'bind' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'bind' clause is here}}
 #pragma acc routine seq bind(asdf) bind(asdf)
   void Func1();
-  // expected-error@+2{{OpenACC clause 'bind' may not appear on the same construct as a 'bind' clause on a 'routine' construct}}
+  // expected-error@+2{{OpenACC clause 'bind' cannot combine with previous 'bind' clause on a 'routine' directive}}
   // expected-note@+1{{previous 'bind' clause is here}}
 #pragma acc routine seq bind(asdf) bind(asdf) device_type(*)
   void Func2();
-  // expected-error@+3{{OpenACC clause 'bind' after 'device_type' clause on a 'routine' conflicts with the 'bind' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'bind' after 'device_type' clause on a 'routine' construct conflicts with the 'bind' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'bind' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine seq bind(asdf) device_type(*) bind(asdf)
   void Func3();
-  // expected-error@+3{{OpenACC clause 'bind' after 'device_type' clause on a 'routine' conflicts with the 'bind' clause before the first 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'bind' after 'device_type' clause on a 'routine' construct conflicts with the 'bind' clause before the first 'device_type'}}
   // expected-note@+2{{previous 'bind' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine seq bind(asdf) device_type(*) bind(asdf) device_type(*)
   void Func4();
-  // expected-error@+3{{OpenACC clause 'bind' on a 'routine' directive conflicts with the 'bind' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'bind' cannot combine with previous 'bind' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'bind' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine seq device_type(*) bind(asdf) bind(asdf)
   void Func5();
-  // expected-error@+3{{OpenACC clause 'bind' on a 'routine' directive conflicts with the 'bind' clause applying to the same 'device_type'}}
+  // expected-error@+3{{OpenACC clause 'bind' cannot combine with previous 'bind' clause in the same 'device_type' region on a 'routine' directive}}
   // expected-note@+2{{previous 'bind' clause is here}}
   // expected-note@+1{{active 'device_type' clause here}}
 #pragma acc routine seq device_type(*) bind(asdf) bind(asdf) device_type(*)
+
   void Func6();
-  // expected-error@+3{{OpenACC clause 'bind' on a 'routine' directive conflicts with the 'bind' clause applying to the same 'device_type'}}
-  // expected-note@+2{{previous 'bind' clause is here}}
-  // expected-note@+1{{active 'device_type' clause here}}
+  // expected-error@+8{{OpenACC 'bind' clause applies to 'device_type' '*', which conflicts with previous 'bind' clause}}
+  // expected-note@+7{{previous 'bind' clause is here}}
+  // expected-note@+6{{active 'device_type' clause here}}
+  // expected-note@+5{{which applies to 'device_type' clause here}}
+  // expected-error@+4{{OpenACC 'bind' clause applies to 'device_type' '*', which conflicts with previous 'bind' clause}}
+  // expected-note@+3{{previous 'bind' clause is here}}
+  // expected-note@+2{{active 'device_type' clause here}}
+  // expected-note@+1{{which applies to 'device_type' clause here}}
 #pragma acc routine seq device_type(*) bind(asdf) device_type(*) bind(asdf) bind(asdf)
   void Func7();
 
+  // expected-error@+4{{OpenACC 'bind' clause applies to 'device_type' '*', which conflicts with previous 'bind' clause}}
+  // expected-note@+3{{active 'device_type' clause here}}
+  // expected-note@+2{{previous 'bind' clause is here}}
+  // expected-note@+1{{which applies to 'device_type' clause here}}
 #pragma acc routine seq device_type(*) bind(asdf) device_type(*) bind(asdf)
   void Func8();
+}
+
+namespace OtherDupes {
+  // expected-error@+5{{OpenACC 'seq' clause applies to 'device_type' 'nvidia', which conflicts with previous 'worker' clause}}
+  // expected-note@+4{{active 'device_type' clause here}}
+  // expected-note@+3{{previous 'worker' clause is here}}
+  // expected-note@+2{{which applies to 'device_type' clause here}}
+  // expected-error@+1{{OpenACC 'routine' construct must have at least one 'gang', 'seq', 'vector', or 'worker' clause that applies to each 'device_type'}}
+#pragma acc routine device_type(nvidia) worker device_type(nvidia) seq
+  void Func1();
+  // expected-error@+5{{OpenACC 'gang' clause applies to 'device_type' 'acc_device_nvidia', which conflicts with previous 'vector' clause}}
+  // expected-note@+4{{active 'device_type' clause here}}
+  // expected-note@+3{{previous 'vector' clause is here}}
+  // expected-note@+2{{which applies to 'device_type' clause here}}
+  // expected-error@+1{{OpenACC 'routine' construct must have at least one 'gang', 'seq', 'vector', or 'worker' clause that applies to each 'device_type'}}
+#pragma acc routine device_type(nvidia) vector device_type(acc_device_nvidia) gang
+  void Func2();
+  // expected-error@+1{{OpenACC 'routine' construct must have at least one 'gang', 'seq', 'vector', or 'worker' clause that applies to each 'device_type'}}
+#pragma acc routine device_type(nvidia) vector device_type(acc_device_nvidia)
+  void Func3();
 }


### PR DESCRIPTION
The interaction between various clauses on 'routine' was not implemented QUITE right, as I discovered when looking into the implementation of the ACC dialect.  This patch fixes it up so that there can only be 1 of the special clauses per device_type VALUE (including nvidia ==
    acc_device_nvidia).

This patch also does a refactor/unification of this with the rules of other clauses, as we now know they are effectively the same.