### PR TITLE
[OpenMP] Fix libarcher tests on Ubuntu 22.04

### DIFF
--- a/openmp/tools/archer/tests/lit.cfg
+++ b/openmp/tools/archer/tests/lit.cfg
@@ -14,12 +14,6 @@ if 'PYLINT_IMPORT' in os.environ:
 def get_path_separator():
     return ';' if config.operating_system == 'Windows' else ':'
 
-def append_env_var(name, value, sep):
-    if name in config.environment:
-        config.environment[name] = value + sep + config.environment[name]
-    else:
-        config.environment[name] = value
-
 def append_dynamic_library_path(path):
     if config.operating_system == 'Windows':
         name = 'PATH'
@@ -27,10 +21,19 @@ def append_dynamic_library_path(path):
         name = 'DYLD_LIBRARY_PATH'
     else:
         name = 'LD_LIBRARY_PATH'
-    append_env_var(name, path, get_path_separator())
+    sep = get_path_separator()
+    if name in config.environment:
+        config.environment[name] = path + sep + config.environment[name]
+    else:
+        config.environment[name] = path
 
 def append_path(path):
-    append_env_var('PATH', path, get_path_separator())
+    name = 'PATH'
+    sep = get_path_separator()
+    if name in config.environment:
+        config.environment[name] = config.environment[name] + sep + path
+    else:
+        config.environment[name] = path
 
 # name: The name of this test suite.
 config.name = 'libarcher'

--- a/openmp/tools/archer/tests/lit.cfg
+++ b/openmp/tools/archer/tests/lit.cfg
@@ -11,20 +11,26 @@ if 'PYLINT_IMPORT' in os.environ:
     config = object()
     lit_config = object()
 
+def get_path_separator():
+    return ';' if config.operating_system == 'Windows' else ':'
+
+def append_env_var(name, value, sep):
+    if name in config.environment:
+        config.environment[name] = value + sep + config.environment[name]
+    else:
+        config.environment[name] = value
+
 def append_dynamic_library_path(path):
     if config.operating_system == 'Windows':
         name = 'PATH'
-        sep = ';'
     elif config.operating_system == 'Darwin':
         name = 'DYLD_LIBRARY_PATH'
-        sep = ':'
     else:
         name = 'LD_LIBRARY_PATH'
-        sep = ':'
-    if name in config.environment:
-        config.environment[name] = path + sep + config.environment[name]
-    else:
-        config.environment[name] = path
+    append_env_var(name, path, get_path_separator())
+
+def append_path(path):
+    append_env_var('PATH', path, get_path_separator())
 
 # name: The name of this test suite.
 config.name = 'libarcher'
@@ -64,6 +70,11 @@ for feature in config.test_compiler_features:
 # Setup environment to find dynamic library at runtime
 append_dynamic_library_path(config.omp_library_dir)
 append_dynamic_library_path(config.libarcher_obj_root+"/..")
+
+# Add LLVM bin dir to PATH.
+# llvm-symbolizer is needed to correctly resolve addresses, without relying on
+# system's addr2line.
+append_path(os.path.dirname(config.test_c_compiler))
 
 # Rpath modifications for Darwin
 if config.operating_system == 'Darwin':

--- a/openmp/tools/archer/tests/races/task-taskgroup-unrelated.c
+++ b/openmp/tools/archer/tests/races/task-taskgroup-unrelated.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-int main(int argc, char *argv[]) {
+int test(void) {
   int var = 0, a = 0;
 
 #pragma omp parallel num_threads(8) shared(var, a)
@@ -48,6 +48,18 @@ int main(int argc, char *argv[]) {
   }
 
   int error = (var != 2);
+  return error;
+}
+
+int main(int argc, char *argv[]) {
+  int i, error;
+
+  for (i = 0; i < 10; ++i) {
+    error = test();
+    if (error)
+      return error;
+  }
+
   fprintf(stderr, "DONE\n");
   return error;
 }


### PR DESCRIPTION
When llvm-symbolizer is not found on PATH TSan uses system's addr2line
instead. On Ubuntu 22.04 addr2line can't handle DWARF v5, which results
in failures in some libarcher tests.

This PR adds the directory of the just built LLVM binaries to PATH, to
make llvm-symbolizer available to TSan.

The changes were tested on an AArch64 machine, on which
task-taskgroup-unrelated.c was flaky. Moving the test code to a separate
function, executed 10 times, solved the issue.

Fixes #170138
