### PR TITLE
Reapply "[clangd] Enable lit internal shell by default"

### DIFF
--- a/clang-tools-extra/clangd/test/lit.cfg.py
+++ b/clang-tools-extra/clangd/test/lit.cfg.py
@@ -1,3 +1,5 @@
+import os
+
 import lit.llvm
 import lit.util
 
@@ -5,10 +7,21 @@ lit.llvm.initialize(lit_config, config)
 lit.llvm.llvm_config.clang_setup()
 lit.llvm.llvm_config.use_default_substitutions()
 
+# TODO: Consolidate the logic for turning on the internal shell by default for all LLVM test suites.
+# See https://github.com/llvm/llvm-project/issues/106636 for more details.
+#
+# We prefer the lit internal shell which provides a better user experience on failures
+# and is faster unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0
+# env var.
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+
 config.name = "Clangd"
 config.suffixes = [".test"]
 config.excludes = ["Inputs"]
-config.test_format = lit.formats.ShTest(not lit.llvm.llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest(not use_lit_shell)
 config.test_source_root = config.clangd_source_dir + "/test"
 config.test_exec_root = config.clangd_binary_dir + "/test"
 

--- a/clang-tools-extra/clangd/test/system-include-extractor.test
+++ b/clang-tools-extra/clangd/test/system-include-extractor.test
@@ -5,7 +5,7 @@
 
 # Create a bin directory to store the mock-driver and add it to the path
 # RUN: mkdir -p %t.dir/bin
-# RUN: %python -c "print(__import__('os').environ['PATH'])" > %t.path
+# RUN: %python -c "print(__import__('os').environ['PATH'])" | tr -d '\n' > %t.path
 # RUN: export PATH=%t.dir/bin:%{readfile:%t.path}
 # Generate a mock-driver that will print %temp_dir%/my/dir and
 # %temp_dir%/my/dir2 as include search paths.


### PR DESCRIPTION
This reverts commit 4cfbc44ebe26692c209655c37aeb0b6cbf1d479b.

There was an issue setting up the PATH variable in system-include-extractor.test which prevented chmod from being resolved. Ubuntu 18.04 puts all the standard Linux utilities in `/bin` which sits at the end of `$PATH` on that system. We were not removing the newline after python's print of `$PATH`, which caused lit to not be able to properly resolve the path.