### PR TITLE
[flang][OpenMP] Add explicit return type to visitor function

### DIFF
--- a/flang/lib/Parser/openmp-utils.cpp
+++ b/flang/lib/Parser/openmp-utils.cpp
@@ -123,7 +123,7 @@ const OmpObjectList *GetOmpObjectList(const OmpClause &clause) {
 const OmpObjectList *GetOmpObjectList(const OmpClause::Depend &clause) {
   return common::visit(
       common::visitors{
-          [](const OmpDoacross &) { return nullptr; },
+          [](const OmpDoacross &) -> const OmpObjectList * { return nullptr; },
           [](const OmpDependClause::TaskDep &x) { return GetOmpObjectList(x); },
       },
       clause.v.u);


### PR DESCRIPTION
This fixes a build break with older compilers after PR170351.