### PR TITLE
[RISCV] Inserting indirect jumps with X7 for Zicfilp

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -1372,8 +1372,11 @@ void RISCVInstrInfo::insertIndirectBranch(MachineBasicBlock &MBB,
                           .addMBB(&DestBB, RISCVII::MO_CALL);
 
   RS->enterBasicBlockEnd(MBB);
+  const TargetRegisterClass *RC = &RISCV::GPRRegClass;
+  if (STI.hasStdExtZicfilp())
+    RC = &RISCV::GPRX7RegClass;
   Register TmpGPR =
-      RS->scavengeRegisterBackwards(RISCV::GPRRegClass, MI.getIterator(),
+      RS->scavengeRegisterBackwards(*RC, MI.getIterator(),
                                     /*RestoreAfter=*/false, /*SpAdj=*/0,
                                     /*AllowSpill=*/false);
   if (TmpGPR.isValid())
@@ -1383,6 +1386,9 @@ void RISCVInstrInfo::insertIndirectBranch(MachineBasicBlock &MBB,
 
     // Pick s11(or s1 for rve) because it doesn't make a difference.
     TmpGPR = STI.hasStdExtE() ? RISCV::X9 : RISCV::X27;
+    // Force t2 if Zicfilp is on
+    if (STI.hasStdExtZicfilp())
+      TmpGPR = RISCV::X7;
 
     int FrameIndex = RVFI->getBranchRelaxationScratchFrameIndex();
     if (FrameIndex == -1)

--- a/llvm/test/CodeGen/RISCV/branch-relaxation-rv64.ll
+++ b/llvm/test/CodeGen/RISCV/branch-relaxation-rv64.ll
@@ -7,6 +7,8 @@
 ; RUN:   | FileCheck %s
 ; RUN: llc -mtriple=riscv64 -relocation-model=pic -verify-machineinstrs < %s \
 ; RUN:   | FileCheck %s
+; RUN: llc -mtriple=riscv64 -verify-machineinstrs -mattr=+experimental-zicfilp < %s \
+; RUN:   | FileCheck %s --check-prefixes=CHECK-ZICFILP
 
 define void @relax_bcc(i1 %a) nounwind {
 ; CHECK-LABEL: relax_bcc:
@@ -20,6 +22,19 @@ define void @relax_bcc(i1 %a) nounwind {
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:  .LBB0_2: # %tail
 ; CHECK-NEXT:    ret
+;
+; CHECK-ZICFILP-LABEL: relax_bcc:
+; CHECK-ZICFILP:       # %bb.0:
+; CHECK-ZICFILP-NEXT:    lpad 0
+; CHECK-ZICFILP-NEXT:    andi a0, a0, 1
+; CHECK-ZICFILP-NEXT:    bnez a0, .LBB0_1
+; CHECK-ZICFILP-NEXT:    j .LBB0_2
+; CHECK-ZICFILP-NEXT:  .LBB0_1: # %iftrue
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    .zero 4096
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:  .LBB0_2: # %tail
+; CHECK-ZICFILP-NEXT:    ret
   br i1 %a, label %iftrue, label %tail
 
 iftrue:
@@ -52,6 +67,29 @@ define i32 @relax_jal(i1 %a) nounwind {
 ; CHECK-NEXT:    li a0, 1
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
+;
+; CHECK-ZICFILP-LABEL: relax_jal:
+; CHECK-ZICFILP:       # %bb.0:
+; CHECK-ZICFILP-NEXT:    lpad 0
+; CHECK-ZICFILP-NEXT:    addi sp, sp, -16
+; CHECK-ZICFILP-NEXT:    andi a0, a0, 1
+; CHECK-ZICFILP-NEXT:    bnez a0, .LBB1_1
+; CHECK-ZICFILP-NEXT:  # %bb.4:
+; CHECK-ZICFILP-NEXT:    jump .LBB1_2, t2
+; CHECK-ZICFILP-NEXT:  .LBB1_1: # %iftrue
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    .zero 1048576
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    j .LBB1_3
+; CHECK-ZICFILP-NEXT:  .LBB1_2: # %jmp
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:  .LBB1_3: # %tail
+; CHECK-ZICFILP-NEXT:    li a0, 1
+; CHECK-ZICFILP-NEXT:    addi sp, sp, 16
+; CHECK-ZICFILP-NEXT:    ret
   br i1 %a, label %iftrue, label %jmp
 
 jmp:
@@ -312,6 +350,247 @@ define void @relax_jal_spill_64() {
 ; CHECK-NEXT:    addi sp, sp, 112
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
+;
+; CHECK-ZICFILP-LABEL: relax_jal_spill_64:
+; CHECK-ZICFILP:       # %bb.0:
+; CHECK-ZICFILP-NEXT:    lpad 0
+; CHECK-ZICFILP-NEXT:    addi sp, sp, -112
+; CHECK-ZICFILP-NEXT:    .cfi_def_cfa_offset 112
+; CHECK-ZICFILP-NEXT:    sd ra, 104(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s0, 96(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s1, 88(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s2, 80(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s3, 72(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s4, 64(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s5, 56(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s6, 48(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s7, 40(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s8, 32(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s9, 24(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s10, 16(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s11, 8(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    .cfi_offset ra, -8
+; CHECK-ZICFILP-NEXT:    .cfi_offset s0, -16
+; CHECK-ZICFILP-NEXT:    .cfi_offset s1, -24
+; CHECK-ZICFILP-NEXT:    .cfi_offset s2, -32
+; CHECK-ZICFILP-NEXT:    .cfi_offset s3, -40
+; CHECK-ZICFILP-NEXT:    .cfi_offset s4, -48
+; CHECK-ZICFILP-NEXT:    .cfi_offset s5, -56
+; CHECK-ZICFILP-NEXT:    .cfi_offset s6, -64
+; CHECK-ZICFILP-NEXT:    .cfi_offset s7, -72
+; CHECK-ZICFILP-NEXT:    .cfi_offset s8, -80
+; CHECK-ZICFILP-NEXT:    .cfi_offset s9, -88
+; CHECK-ZICFILP-NEXT:    .cfi_offset s10, -96
+; CHECK-ZICFILP-NEXT:    .cfi_offset s11, -104
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li ra, 1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t0, 5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t1, 6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t2, 7
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s0, 8
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s1, 9
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a0, 10
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a1, 11
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a2, 12
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a3, 13
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a4, 14
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a5, 15
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a6, 16
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a7, 17
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s2, 18
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s3, 19
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s4, 20
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s5, 21
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s6, 22
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s7, 23
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s8, 24
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s9, 25
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s10, 26
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s11, 27
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t3, 28
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t4, 29
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t5, 30
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t6, 31
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    beq t5, t6, .LBB2_1
+; CHECK-ZICFILP-NEXT:  # %bb.3:
+; CHECK-ZICFILP-NEXT:    sd t2, 0(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    jump .LBB2_4, t2
+; CHECK-ZICFILP-NEXT:  .LBB2_1: # %branch_1
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    .zero 1048576
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    j .LBB2_2
+; CHECK-ZICFILP-NEXT:  .LBB2_4: # %branch_2
+; CHECK-ZICFILP-NEXT:    ld t2, 0(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:  .LBB2_2: # %branch_2
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use ra
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t0
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s0
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a0
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a4
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a7
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s4
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s7
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s8
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s9
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s10
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s11
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t4
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    ld ra, 104(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s0, 96(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s1, 88(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s2, 80(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s3, 72(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s4, 64(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s5, 56(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s6, 48(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s7, 40(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s8, 32(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s9, 24(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s10, 16(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s11, 8(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    .cfi_restore ra
+; CHECK-ZICFILP-NEXT:    .cfi_restore s0
+; CHECK-ZICFILP-NEXT:    .cfi_restore s1
+; CHECK-ZICFILP-NEXT:    .cfi_restore s2
+; CHECK-ZICFILP-NEXT:    .cfi_restore s3
+; CHECK-ZICFILP-NEXT:    .cfi_restore s4
+; CHECK-ZICFILP-NEXT:    .cfi_restore s5
+; CHECK-ZICFILP-NEXT:    .cfi_restore s6
+; CHECK-ZICFILP-NEXT:    .cfi_restore s7
+; CHECK-ZICFILP-NEXT:    .cfi_restore s8
+; CHECK-ZICFILP-NEXT:    .cfi_restore s9
+; CHECK-ZICFILP-NEXT:    .cfi_restore s10
+; CHECK-ZICFILP-NEXT:    .cfi_restore s11
+; CHECK-ZICFILP-NEXT:    addi sp, sp, 112
+; CHECK-ZICFILP-NEXT:    .cfi_def_cfa_offset 0
+; CHECK-ZICFILP-NEXT:    ret
   %ra = call i64 asm sideeffect "addi ra, x0, 1", "={ra}"()
   %t0 = call i64 asm sideeffect "addi t0, x0, 5", "={t0}"()
   %t1 = call i64 asm sideeffect "addi t1, x0, 6", "={t1}"()
@@ -634,6 +913,256 @@ define void @relax_jal_spill_64_adjust_spill_slot() {
 ; CHECK-NEXT:    addi sp, sp, 2032
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
+;
+; CHECK-ZICFILP-LABEL: relax_jal_spill_64_adjust_spill_slot:
+; CHECK-ZICFILP:       # %bb.0:
+; CHECK-ZICFILP-NEXT:    lpad 0
+; CHECK-ZICFILP-NEXT:    addi sp, sp, -2032
+; CHECK-ZICFILP-NEXT:    .cfi_def_cfa_offset 2032
+; CHECK-ZICFILP-NEXT:    sd ra, 2024(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s0, 2016(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s1, 2008(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s2, 2000(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s3, 1992(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s4, 1984(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s5, 1976(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s6, 1968(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s7, 1960(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s8, 1952(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s9, 1944(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s10, 1936(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s11, 1928(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    .cfi_offset ra, -8
+; CHECK-ZICFILP-NEXT:    .cfi_offset s0, -16
+; CHECK-ZICFILP-NEXT:    .cfi_offset s1, -24
+; CHECK-ZICFILP-NEXT:    .cfi_offset s2, -32
+; CHECK-ZICFILP-NEXT:    .cfi_offset s3, -40
+; CHECK-ZICFILP-NEXT:    .cfi_offset s4, -48
+; CHECK-ZICFILP-NEXT:    .cfi_offset s5, -56
+; CHECK-ZICFILP-NEXT:    .cfi_offset s6, -64
+; CHECK-ZICFILP-NEXT:    .cfi_offset s7, -72
+; CHECK-ZICFILP-NEXT:    .cfi_offset s8, -80
+; CHECK-ZICFILP-NEXT:    .cfi_offset s9, -88
+; CHECK-ZICFILP-NEXT:    .cfi_offset s10, -96
+; CHECK-ZICFILP-NEXT:    .cfi_offset s11, -104
+; CHECK-ZICFILP-NEXT:    addi s0, sp, 2032
+; CHECK-ZICFILP-NEXT:    .cfi_def_cfa s0, 0
+; CHECK-ZICFILP-NEXT:    lui a0, 2
+; CHECK-ZICFILP-NEXT:    addi a0, a0, -2032
+; CHECK-ZICFILP-NEXT:    sub sp, sp, a0
+; CHECK-ZICFILP-NEXT:    srli a0, sp, 12
+; CHECK-ZICFILP-NEXT:    slli sp, a0, 12
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li ra, 1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t0, 5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t1, 6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t2, 7
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s0, 8
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s1, 9
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a0, 10
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a1, 11
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a2, 12
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a3, 13
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a4, 14
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a5, 15
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a6, 16
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a7, 17
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s2, 18
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s3, 19
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s4, 20
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s5, 21
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s6, 22
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s7, 23
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s8, 24
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s9, 25
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s10, 26
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s11, 27
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t3, 28
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t4, 29
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t5, 30
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t6, 31
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    beq t5, t6, .LBB3_1
+; CHECK-ZICFILP-NEXT:  # %bb.3:
+; CHECK-ZICFILP-NEXT:    sd t2, 0(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    jump .LBB3_4, t2
+; CHECK-ZICFILP-NEXT:  .LBB3_1: # %branch_1
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    .zero 1048576
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    j .LBB3_2
+; CHECK-ZICFILP-NEXT:  .LBB3_4: # %branch_2
+; CHECK-ZICFILP-NEXT:    ld t2, 0(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:  .LBB3_2: # %branch_2
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use ra
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t0
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s0
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a0
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a4
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a7
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s4
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s7
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s8
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s9
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s10
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s11
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t4
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    addi sp, s0, -2032
+; CHECK-ZICFILP-NEXT:    .cfi_def_cfa sp, 2032
+; CHECK-ZICFILP-NEXT:    ld ra, 2024(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s0, 2016(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s1, 2008(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s2, 2000(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s3, 1992(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s4, 1984(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s5, 1976(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s6, 1968(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s7, 1960(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s8, 1952(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s9, 1944(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s10, 1936(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s11, 1928(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    .cfi_restore ra
+; CHECK-ZICFILP-NEXT:    .cfi_restore s0
+; CHECK-ZICFILP-NEXT:    .cfi_restore s1
+; CHECK-ZICFILP-NEXT:    .cfi_restore s2
+; CHECK-ZICFILP-NEXT:    .cfi_restore s3
+; CHECK-ZICFILP-NEXT:    .cfi_restore s4
+; CHECK-ZICFILP-NEXT:    .cfi_restore s5
+; CHECK-ZICFILP-NEXT:    .cfi_restore s6
+; CHECK-ZICFILP-NEXT:    .cfi_restore s7
+; CHECK-ZICFILP-NEXT:    .cfi_restore s8
+; CHECK-ZICFILP-NEXT:    .cfi_restore s9
+; CHECK-ZICFILP-NEXT:    .cfi_restore s10
+; CHECK-ZICFILP-NEXT:    .cfi_restore s11
+; CHECK-ZICFILP-NEXT:    addi sp, sp, 2032
+; CHECK-ZICFILP-NEXT:    .cfi_def_cfa_offset 0
+; CHECK-ZICFILP-NEXT:    ret
   %stack_obj = alloca i64, align 4096
 
   %ra = call i64 asm sideeffect "addi ra, x0, 1", "={ra}"()
@@ -964,6 +1493,265 @@ define void @relax_jal_spill_64_restore_block_correspondence() {
 ; CHECK-NEXT:  # %bb.7: # %space
 ; CHECK-NEXT:    sd s11, 0(sp) # 8-byte Folded Spill
 ; CHECK-NEXT:    jump .LBB4_8, s11
+;
+; CHECK-ZICFILP-LABEL: relax_jal_spill_64_restore_block_correspondence:
+; CHECK-ZICFILP:       # %bb.0: # %entry
+; CHECK-ZICFILP-NEXT:    lpad 0
+; CHECK-ZICFILP-NEXT:    addi sp, sp, -112
+; CHECK-ZICFILP-NEXT:    .cfi_def_cfa_offset 112
+; CHECK-ZICFILP-NEXT:    sd ra, 104(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s0, 96(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s1, 88(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s2, 80(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s3, 72(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s4, 64(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s5, 56(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s6, 48(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s7, 40(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s8, 32(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s9, 24(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s10, 16(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    sd s11, 8(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    .cfi_offset ra, -8
+; CHECK-ZICFILP-NEXT:    .cfi_offset s0, -16
+; CHECK-ZICFILP-NEXT:    .cfi_offset s1, -24
+; CHECK-ZICFILP-NEXT:    .cfi_offset s2, -32
+; CHECK-ZICFILP-NEXT:    .cfi_offset s3, -40
+; CHECK-ZICFILP-NEXT:    .cfi_offset s4, -48
+; CHECK-ZICFILP-NEXT:    .cfi_offset s5, -56
+; CHECK-ZICFILP-NEXT:    .cfi_offset s6, -64
+; CHECK-ZICFILP-NEXT:    .cfi_offset s7, -72
+; CHECK-ZICFILP-NEXT:    .cfi_offset s8, -80
+; CHECK-ZICFILP-NEXT:    .cfi_offset s9, -88
+; CHECK-ZICFILP-NEXT:    .cfi_offset s10, -96
+; CHECK-ZICFILP-NEXT:    .cfi_offset s11, -104
+; CHECK-ZICFILP-NEXT:    .cfi_remember_state
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li ra, 1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t0, 5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t1, 6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t2, 7
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s0, 8
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s1, 9
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a0, 10
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a1, 11
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a2, 12
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a3, 13
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a4, 14
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a5, 15
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a6, 16
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li a7, 17
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s2, 18
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s3, 19
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s4, 20
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s5, 21
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s6, 22
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s7, 23
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s8, 24
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s9, 25
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s10, 26
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li s11, 27
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t3, 28
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t4, 29
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t5, 30
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    li t6, 31
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    bne t5, t6, .LBB4_2
+; CHECK-ZICFILP-NEXT:    j .LBB4_1
+; CHECK-ZICFILP-NEXT:  .LBB4_8: # %dest_1
+; CHECK-ZICFILP-NEXT:    ld t2, 0(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:  .LBB4_1: # %dest_1
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # dest 1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    j .LBB4_3
+; CHECK-ZICFILP-NEXT:  .LBB4_2: # %cond_2
+; CHECK-ZICFILP-NEXT:    bne t3, t4, .LBB4_5
+; CHECK-ZICFILP-NEXT:  .LBB4_3: # %dest_2
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # dest 2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:  .LBB4_4: # %dest_3
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # dest 3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use ra
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t0
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s0
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a0
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a1
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a4
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use a7
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s2
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s4
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s7
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s8
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s9
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s10
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use s11
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t3
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t4
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t5
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    # reg use t6
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:    ld ra, 104(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s0, 96(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s1, 88(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s2, 80(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s3, 72(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s4, 64(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s5, 56(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s6, 48(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s7, 40(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s8, 32(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s9, 24(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s10, 16(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    ld s11, 8(sp) # 8-byte Folded Reload
+; CHECK-ZICFILP-NEXT:    .cfi_restore ra
+; CHECK-ZICFILP-NEXT:    .cfi_restore s0
+; CHECK-ZICFILP-NEXT:    .cfi_restore s1
+; CHECK-ZICFILP-NEXT:    .cfi_restore s2
+; CHECK-ZICFILP-NEXT:    .cfi_restore s3
+; CHECK-ZICFILP-NEXT:    .cfi_restore s4
+; CHECK-ZICFILP-NEXT:    .cfi_restore s5
+; CHECK-ZICFILP-NEXT:    .cfi_restore s6
+; CHECK-ZICFILP-NEXT:    .cfi_restore s7
+; CHECK-ZICFILP-NEXT:    .cfi_restore s8
+; CHECK-ZICFILP-NEXT:    .cfi_restore s9
+; CHECK-ZICFILP-NEXT:    .cfi_restore s10
+; CHECK-ZICFILP-NEXT:    .cfi_restore s11
+; CHECK-ZICFILP-NEXT:    addi sp, sp, 112
+; CHECK-ZICFILP-NEXT:    .cfi_def_cfa_offset 0
+; CHECK-ZICFILP-NEXT:    ret
+; CHECK-ZICFILP-NEXT:  .LBB4_5: # %cond_3
+; CHECK-ZICFILP-NEXT:    .cfi_restore_state
+; CHECK-ZICFILP-NEXT:    beq t1, t2, .LBB4_4
+; CHECK-ZICFILP-NEXT:  # %bb.6: # %space
+; CHECK-ZICFILP-NEXT:    #APP
+; CHECK-ZICFILP-NEXT:    .zero 1048576
+; CHECK-ZICFILP-NEXT:    #NO_APP
+; CHECK-ZICFILP-NEXT:  # %bb.7: # %space
+; CHECK-ZICFILP-NEXT:    sd t2, 0(sp) # 8-byte Folded Spill
+; CHECK-ZICFILP-NEXT:    jump .LBB4_8, t2
 entry:
   %ra = call i64 asm sideeffect "addi ra, x0, 1", "={ra}"()
   %t0 = call i64 asm sideeffect "addi t0, x0, 5", "={t0}"()


### PR DESCRIPTION
`BranchRelxation` uses `RISCVInstrInfo::insertIndirectBranch` to insert an indirect branch if the jump target is out of range. Currently it uses register scavenging to find a free register to use for the indirect target. If Zicfilp is enabled, we need to use X7 so that the jump will be treated as a software guarded branch.