### PR TITLE
[TLI] Handle f[min/max]imum_num in hasOptimizedCodegen

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -410,6 +410,10 @@ public:
     case LibFunc_floor:        case LibFunc_floorf:     case LibFunc_floorl:
     case LibFunc_fmax:         case LibFunc_fmaxf:      case LibFunc_fmaxl:
     case LibFunc_fmin:         case LibFunc_fminf:      case LibFunc_fminl:
+    case LibFunc_fmaximum_num: case LibFunc_fmaximum_numf:
+                                                  case LibFunc_fmaximum_numl:
+    case LibFunc_fminimum_num: case LibFunc_fminimum_numf:
+                                                  case LibFunc_fminimum_numl:
     case LibFunc_ldexp:        case LibFunc_ldexpf:     case LibFunc_ldexpl:
     case LibFunc_log2:         case LibFunc_log2f:      case LibFunc_log2l:
     case LibFunc_memcmp:       case LibFunc_bcmp:       case LibFunc_strcmp:


### PR DESCRIPTION
This is a prerequisite to lowering them to intrinsics later.
