### PR TITLE
[Flang][OpenMP] Only allow implicit mappers for Allocatables.

### DIFF
--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -189,7 +189,7 @@ bool requiresImplicitDefaultDeclareMapper(
 
     semantics::DirectComponentIterator directComponents{spec};
     for (const semantics::Symbol &component : directComponents) {
-      if (semantics::IsAllocatableOrPointer(component))
+      if (component.attrs().test(semantics::Attr::ALLOCATABLE))
         return true;
 
       if (const semantics::DeclTypeSpec *declType = component.GetType())


### PR DESCRIPTION
Generate implicit declare mappers only for Allocatables.

Fixes #169382 introduced by #140562.