### PR TITLE
[CI] Parse preceeding lines in mismatched failure messages

### DIFF
--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -62,6 +62,18 @@ def _parse_ninja_log(ninja_log: list[str]) -> list[tuple[str, str]]:
         # aligned with the failure.
         failing_action = ninja_log[index].split("FAILED: ")[1]
         failure_log = []
+
+        # Parse the lines above the FAILED: string if the line does not come
+        # immediately after a progress indicator to ensure that we capture the
+        # entire failure message.
+        if not ninja_log[index - 1].startswith("["):
+            before_index = index - 1
+            while before_index > 0 and not ninja_log[before_index].startswith("["):
+                failure_log.append(ninja_log[before_index])
+                before_index = before_index - 1
+            failure_log.reverse()
+
+        # Parse the failure information, which comes after the FAILED: tag.
         while (
             index < len(ninja_log)
             and not ninja_log[index].startswith("[")

--- a/.ci/generate_test_report_lib_test.py
+++ b/.ci/generate_test_report_lib_test.py
@@ -181,6 +181,7 @@ class TestReports(unittest.TestCase):
                 "tools/check-langley",
                 dedent(
                     """\
+                    ModuleNotFoundError: No module named 'mount_langley'
                     FAILED: tools/check-langley
                     Wow! This system is really broken!"""
                 ),


### PR DESCRIPTION
In some cases ninja will emit FAILED: lines that are not immediately after a progress indicator. In these cases we also want to capture the preceeding context up to the last progress indicator as it is also part of the error message in the cases that we have seen.

This fixes the rest of #165131.