### PR TITLE
Revert "[lldb] improve the heuristics for checking if a terminal supports Unicode (#168603)

### DIFF
--- a/lldb/include/lldb/Host/Terminal.h
+++ b/lldb/include/lldb/Host/Terminal.h
@@ -68,18 +68,6 @@ public:
 
   llvm::Error SetHardwareFlowControl(bool enabled);
 
-  /// Returns whether or not the current terminal supports Unicode rendering.
-  ///
-  /// The value is cached after the first computation.
-  ///
-  /// On POSIX systems, we check if the LANG environment variable contains the
-  /// substring "UTF-8", case insensitive.
-  ///
-  /// On Windows, we always return true since we use the `WriteConsoleW` API
-  /// internally. Note that the default Windows codepage (437) does not support
-  /// all Unicode characters. This function does not check the codepage.
-  static bool SupportsUnicode();
-
 protected:
   struct Data;
 

--- a/lldb/source/Host/common/DiagnosticsRendering.cpp
+++ b/lldb/source/Host/common/DiagnosticsRendering.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/common/DiagnosticsRendering.h"
-#include "lldb/Host/Terminal.h"
-
 #include <cstdint>
 
 using namespace lldb_private;
@@ -99,8 +97,12 @@ void RenderDiagnosticDetails(Stream &stream,
     return;
   }
 
+  // Since there is no other way to find this out, use the color
+  // attribute as a proxy for whether the terminal supports Unicode
+  // characters.  In the future it might make sense to move this into
+  // Host so it can be customized for a specific platform.
   llvm::StringRef cursor, underline, vbar, joint, hbar, spacer;
-  if (Terminal::SupportsUnicode()) {
+  if (stream.AsRawOstream().colors_enabled()) {
     cursor = "˄";
     underline = "˜";
     vbar = "│";

--- a/lldb/source/Host/common/Terminal.cpp
+++ b/lldb/source/Host/common/Terminal.cpp
@@ -400,21 +400,6 @@ llvm::Error Terminal::SetHardwareFlowControl(bool enabled) {
 #endif // LLDB_ENABLE_TERMIOS
 }
 
-bool Terminal::SupportsUnicode() {
-  static std::optional<bool> result;
-  if (result)
-    return result.value();
-#ifdef _WIN32
-  return true;
-#else
-  const char *lang_var = std::getenv("LANG");
-  if (!lang_var)
-    return false;
-  result = llvm::StringRef(lang_var).lower().find("utf-8") != std::string::npos;
-#endif
-  return result.value();
-}
-
 TerminalState::TerminalState(Terminal term, bool save_process_group)
     : m_tty(term) {
   Save(term, save_process_group);


### PR DESCRIPTION
This reverts commit 64e19916f9518709562ef41e236c1dba6c421782.

https://github.com/llvm/llvm-project/pull/168603 breaks the CI because the bots support Unicode but the tests expect non Unicode characters.