### PR TITLE
[DA] runtime predicates for delinearization bounds checks

### DIFF
--- a/llvm/include/llvm/Analysis/Delinearization.h
+++ b/llvm/include/llvm/Analysis/Delinearization.h
@@ -26,6 +26,7 @@ class GetElementPtrInst;
 class Instruction;
 class ScalarEvolution;
 class SCEV;
+class SCEVPredicate;
 
 /// Compute the array dimensions Sizes from the set of Terms extracted from
 /// the memory access function of this SCEVAddRecExpr (second step of
@@ -144,11 +145,13 @@ bool delinearizeFixedSizeArray(ScalarEvolution &SE, const SCEV *Expr,
 /// Check that each subscript in \p Subscripts is within the corresponding size
 /// in \p Sizes. For the outermost dimension, the subscript being negative is
 /// allowed. If \p Ptr is not nullptr, it may be used to get information from
-/// the IR pointer value, which may help in the validation.
-bool validateDelinearizationResult(ScalarEvolution &SE,
-                                   ArrayRef<const SCEV *> Sizes,
-                                   ArrayRef<const SCEV *> Subscripts,
-                                   const Value *Ptr = nullptr);
+/// the IR pointer value, which may help in the validation. If \p Assume is not
+/// nullptr and a compile-time check fails, runtime predicates are added to
+/// \p Assume instead of returning false.
+bool validateDelinearizationResult(
+    ScalarEvolution &SE, ArrayRef<const SCEV *> Sizes,
+    ArrayRef<const SCEV *> Subscripts, const Value *Ptr = nullptr,
+    SmallVectorImpl<const SCEVPredicate *> *Assume = nullptr);
 
 /// Gathers the individual index expressions from a GEP instruction.
 ///

--- a/llvm/include/llvm/Analysis/DependenceAnalysis.h
+++ b/llvm/include/llvm/Analysis/DependenceAnalysis.h
@@ -754,7 +754,8 @@ private:
   /// Given a linear access function, tries to recover subscripts
   /// for each dimension of the array element access.
   bool tryDelinearize(Instruction *Src, Instruction *Dst,
-                      SmallVectorImpl<Subscript> &Pair);
+                      SmallVectorImpl<Subscript> &Pair,
+                      SmallVectorImpl<const SCEVPredicate *> &Assume);
 
   /// Tries to delinearize \p Src and \p Dst access functions for a fixed size
   /// multi-dimensional array. Calls delinearizeFixedSizeArray() to delinearize
@@ -762,7 +763,8 @@ private:
   bool tryDelinearizeFixedSize(Instruction *Src, Instruction *Dst,
                                const SCEV *SrcAccessFn, const SCEV *DstAccessFn,
                                SmallVectorImpl<const SCEV *> &SrcSubscripts,
-                               SmallVectorImpl<const SCEV *> &DstSubscripts);
+                               SmallVectorImpl<const SCEV *> &DstSubscripts,
+                               SmallVectorImpl<const SCEVPredicate *> &Assume);
 
   /// Tries to delinearize access function for a multi-dimensional array with
   /// symbolic runtime sizes.
@@ -771,7 +773,8 @@ private:
   tryDelinearizeParametricSize(Instruction *Src, Instruction *Dst,
                                const SCEV *SrcAccessFn, const SCEV *DstAccessFn,
                                SmallVectorImpl<const SCEV *> &SrcSubscripts,
-                               SmallVectorImpl<const SCEV *> &DstSubscripts);
+                               SmallVectorImpl<const SCEV *> &DstSubscripts,
+                               SmallVectorImpl<const SCEVPredicate *> &Assume);
 
   /// checkSubscript - Helper function for checkSrcSubscript and
   /// checkDstSubscript to avoid duplicate code

--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -544,6 +544,14 @@ public:
                                 const SCEV *LHS, const SCEV *RHS,
                                 const Instruction *CtxI = nullptr);
 
+  /// Get the predicate that, if true at runtime, proves that the binary
+  /// operation \p BinOp between \p LHS and \p RHS does not have
+  /// signed/unsigned overflow (depending on \p Signed). Returns the
+  /// predicate, or nullptr if no-overflow is already provable at compile time.
+  LLVM_ABI const SCEVPredicate *
+  getNoOverflowPredicate(Instruction::BinaryOps BinOp, bool Signed,
+                         const SCEV *LHS, const SCEV *RHS);
+
   /// Parse NSW/NUW flags from add/sub/mul IR binary operation \p Op into
   /// SCEV no-wrap flags, and deduce flag[s] that aren't known yet.
   /// Does not mutate the original instruction. Returns std::nullopt if it could

--- a/llvm/test/Analysis/DependenceAnalysis/Banerjee.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Banerjee.ll
@@ -46,9 +46,14 @@ define void @banerjee0(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ;
 ; DELIN-LABEL: 'banerjee0'
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 0, ptr %arrayidx, align 8
-; DELIN-NEXT:    da analyze - none!
+; DELIN-NEXT:    da analyze - consistent output [0 0]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
+; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %0 = load i64, ptr %arrayidx6, align 8
-; DELIN-NEXT:    da analyze - flow [<= <>]!
+; DELIN-NEXT:    da analyze - consistent flow [0 1]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: %0 = load i64, ptr %arrayidx6, align 8
@@ -132,12 +137,18 @@ define void @banerjee1(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-LABEL: 'banerjee1'
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 0, ptr %arrayidx, align 8
 ; DELIN-NEXT:    da analyze - output [* *]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %2 = load i64, ptr %arrayidx6, align 8
 ; DELIN-NEXT:    da analyze - flow [* <>]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %2, ptr %B.addr.12, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %2 = load i64, ptr %arrayidx6, align 8 --> Dst: %2 = load i64, ptr %arrayidx6, align 8
 ; DELIN-NEXT:    da analyze - input [* *]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %2 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %2, ptr %B.addr.12, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %2, ptr %B.addr.12, align 8 --> Dst: store i64 %2, ptr %B.addr.12, align 8
@@ -320,11 +331,16 @@ define void @banerjee3(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 0, ptr %arrayidx, align 8
 ; DELIN-NEXT:    da analyze - none!
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %0 = load i64, ptr %arrayidx7, align 8
-; DELIN-NEXT:    da analyze - flow [> >]!
+; DELIN-NEXT:    da analyze - consistent flow [-9 -9]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: %0 = load i64, ptr %arrayidx7, align 8
-; DELIN-NEXT:    da analyze - none!
+; DELIN-NEXT:    da analyze - consistent input [0 0]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
+; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
@@ -490,11 +506,16 @@ define void @banerjee5(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 0, ptr %arrayidx, align 8
 ; DELIN-NEXT:    da analyze - none!
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %0 = load i64, ptr %arrayidx6, align 8
-; DELIN-NEXT:    da analyze - flow [< <]!
+; DELIN-NEXT:    da analyze - consistent flow [9 9]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {-9,+,1}<nsw><%for.body3> sge) 0
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: %0 = load i64, ptr %arrayidx6, align 8
-; DELIN-NEXT:    da analyze - none!
+; DELIN-NEXT:    da analyze - consistent input [0 0]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {-9,+,1}<nsw><%for.body3> sge) 0
+; DELIN-NEXT:    Compare predicate: {-9,+,1}<nsw><%for.body3> sge) 0
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
@@ -575,11 +596,16 @@ define void @banerjee6(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 0, ptr %arrayidx, align 8
 ; DELIN-NEXT:    da analyze - none!
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %0 = load i64, ptr %arrayidx7, align 8
-; DELIN-NEXT:    da analyze - flow [=> <>]!
+; DELIN-NEXT:    da analyze - consistent flow [0 -9]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: %0 = load i64, ptr %arrayidx7, align 8
-; DELIN-NEXT:    da analyze - none!
+; DELIN-NEXT:    da analyze - consistent input [0 0]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
+; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
@@ -745,11 +771,16 @@ define void @banerjee8(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 0, ptr %arrayidx, align 8
 ; DELIN-NEXT:    da analyze - none!
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %0 = load i64, ptr %arrayidx7, align 8
-; DELIN-NEXT:    da analyze - flow [> <>]!
+; DELIN-NEXT:    da analyze - consistent flow [-1 -1]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: %0 = load i64, ptr %arrayidx7, align 8
-; DELIN-NEXT:    da analyze - none!
+; DELIN-NEXT:    da analyze - consistent input [0 0]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
+; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
@@ -828,9 +859,14 @@ define void @banerjee9(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ;
 ; DELIN-LABEL: 'banerjee9'
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 0, ptr %arrayidx, align 8
-; DELIN-NEXT:    da analyze - output [* *]!
+; DELIN-NEXT:    da analyze - consistent output [0 0]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {0,+,30}<nuw><nsw><%for.cond1.preheader> slt) 500
+; DELIN-NEXT:    Compare predicate: {0,+,30}<nuw><nsw><%for.cond1.preheader> slt) 500
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %1 = load i64, ptr %arrayidx7, align 8
-; DELIN-NEXT:    da analyze - flow [<= 0|<]!
+; DELIN-NEXT:    da analyze - flow [< 0]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {0,+,30}<nuw><nsw><%for.cond1.preheader> slt) 500
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %1, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %1 = load i64, ptr %arrayidx7, align 8 --> Dst: %1 = load i64, ptr %arrayidx7, align 8
@@ -1005,7 +1041,10 @@ define void @banerjee11(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: %0 = load i64, ptr %arrayidx6, align 8
-; DELIN-NEXT:    da analyze - none!
+; DELIN-NEXT:    da analyze - consistent input [0 0]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {11,+,-1}<nsw><%for.body3> sge) 0
+; DELIN-NEXT:    Compare predicate: {11,+,-1}<nsw><%for.body3> sge) 0
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
@@ -1087,10 +1126,15 @@ define void @banerjee12(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    da analyze - none!
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %0 = load i64, ptr %arrayidx6, align 8
 ; DELIN-NEXT:    da analyze - flow [0 <>]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {11,+,-1}<nsw><%for.body3> sge) 0
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: %0 = load i64, ptr %arrayidx6, align 8
-; DELIN-NEXT:    da analyze - none!
+; DELIN-NEXT:    da analyze - consistent input [0 0]!
+; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {11,+,-1}<nsw><%for.body3> sge) 0
+; DELIN-NEXT:    Compare predicate: {11,+,-1}<nsw><%for.body3> sge) 0
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8

--- a/llvm/test/Analysis/DependenceAnalysis/Banerjee.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Banerjee.ll
@@ -49,7 +49,6 @@ define void @banerjee0(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    da analyze - consistent output [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
 ; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
-; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %0 = load i64, ptr %arrayidx6, align 8
 ; DELIN-NEXT:    da analyze - consistent flow [0 1]!
 ; DELIN-NEXT:    Runtime Assumptions:
@@ -142,7 +141,6 @@ define void @banerjee1(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    Equal predicate: (sext i64 {80,+,80}<%for.cond1.preheader> to i128) == {80,+,80}<nuw><nsw><%for.cond1.preheader>
 ; DELIN-NEXT:    Equal predicate: (sext i64 {160,+,80}<%for.cond1.preheader> to i128) == (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw>
 ; DELIN-NEXT:    Equal predicate: (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw>
-; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %2 = load i64, ptr %arrayidx6, align 8
 ; DELIN-NEXT:    da analyze - consistent flow [0 1]!
 ; DELIN-NEXT:    Runtime Assumptions:
@@ -160,7 +158,6 @@ define void @banerjee1(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    Equal predicate: (sext i64 {80,+,80}<%for.cond1.preheader> to i128) == {80,+,80}<nuw><nsw><%for.cond1.preheader>
 ; DELIN-NEXT:    Equal predicate: (sext i64 {160,+,80}<%for.cond1.preheader> to i128) == (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw>
 ; DELIN-NEXT:    Equal predicate: (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw>
-; DELIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %2 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %2, ptr %B.addr.12, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %2, ptr %B.addr.12, align 8 --> Dst: store i64 %2, ptr %B.addr.12, align 8
@@ -352,7 +349,6 @@ define void @banerjee3(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    da analyze - consistent input [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
 ; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
-; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
@@ -527,7 +523,6 @@ define void @banerjee5(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    da analyze - consistent input [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
 ; DELIN-NEXT:    Compare predicate: {-9,+,1}<nsw><%for.body3> sge) 0
-; DELIN-NEXT:    Compare predicate: {-9,+,1}<nsw><%for.body3> sge) 0
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
@@ -616,7 +611,6 @@ define void @banerjee6(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: %0 = load i64, ptr %arrayidx7, align 8
 ; DELIN-NEXT:    da analyze - consistent input [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
-; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
@@ -792,7 +786,6 @@ define void @banerjee8(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    da analyze - consistent input [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
 ; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
-; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx7, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
@@ -873,7 +866,6 @@ define void @banerjee9(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 0, ptr %arrayidx, align 8
 ; DELIN-NEXT:    da analyze - consistent output [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
-; DELIN-NEXT:    Compare predicate: {0,+,30}<nuw><nsw><%for.cond1.preheader> slt) 500
 ; DELIN-NEXT:    Compare predicate: {0,+,30}<nuw><nsw><%for.cond1.preheader> slt) 500
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %1 = load i64, ptr %arrayidx7, align 8
 ; DELIN-NEXT:    da analyze - flow [< 0]!
@@ -1056,7 +1048,6 @@ define void @banerjee11(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    da analyze - consistent input [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
 ; DELIN-NEXT:    Compare predicate: {11,+,-1}<nsw><%for.body3> sge) 0
-; DELIN-NEXT:    Compare predicate: {11,+,-1}<nsw><%for.body3> sge) 0
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: store i64 %0, ptr %B.addr.11, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
@@ -1145,7 +1136,6 @@ define void @banerjee12(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: %0 = load i64, ptr %arrayidx6, align 8
 ; DELIN-NEXT:    da analyze - consistent input [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
-; DELIN-NEXT:    Compare predicate: {11,+,-1}<nsw><%for.body3> sge) 0
 ; DELIN-NEXT:    Compare predicate: {11,+,-1}<nsw><%for.body3> sge) 0
 ; DELIN-NEXT:  Src: %0 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %0, ptr %B.addr.11, align 8
 ; DELIN-NEXT:    da analyze - confused!

--- a/llvm/test/Analysis/DependenceAnalysis/Banerjee.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Banerjee.ll
@@ -136,18 +136,30 @@ define void @banerjee1(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ;
 ; DELIN-LABEL: 'banerjee1'
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 0, ptr %arrayidx, align 8
-; DELIN-NEXT:    da analyze - output [* *]!
+; DELIN-NEXT:    da analyze - consistent output [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
+; DELIN-NEXT:    Equal predicate: {80,+,80}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80,+,80}<%for.cond1.preheader> to i128)
+; DELIN-NEXT:    Equal predicate: (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {160,+,80}<%for.cond1.preheader> to i128)
+; DELIN-NEXT:    Equal predicate: (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw> == (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw>
 ; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %2 = load i64, ptr %arrayidx6, align 8
-; DELIN-NEXT:    da analyze - flow [* <>]!
+; DELIN-NEXT:    da analyze - consistent flow [0 1]!
 ; DELIN-NEXT:    Runtime Assumptions:
 ; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
+; DELIN-NEXT:    Equal predicate: {80,+,80}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80,+,80}<%for.cond1.preheader> to i128)
+; DELIN-NEXT:    Equal predicate: (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {160,+,80}<%for.cond1.preheader> to i128)
+; DELIN-NEXT:    Equal predicate: (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw> == (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw>
+; DELIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %2, ptr %B.addr.12, align 8
 ; DELIN-NEXT:    da analyze - confused!
 ; DELIN-NEXT:  Src: %2 = load i64, ptr %arrayidx6, align 8 --> Dst: %2 = load i64, ptr %arrayidx6, align 8
-; DELIN-NEXT:    da analyze - input [* *]!
+; DELIN-NEXT:    da analyze - consistent input [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
+; DELIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body3> slt) 10
+; DELIN-NEXT:    Equal predicate: {80,+,80}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80,+,80}<%for.cond1.preheader> to i128)
+; DELIN-NEXT:    Equal predicate: (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {160,+,80}<%for.cond1.preheader> to i128)
+; DELIN-NEXT:    Equal predicate: (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw> == (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw>
 ; DELIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %2 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %2, ptr %B.addr.12, align 8
 ; DELIN-NEXT:    da analyze - confused!

--- a/llvm/test/Analysis/DependenceAnalysis/Banerjee.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Banerjee.ll
@@ -139,17 +139,17 @@ define void @banerjee1(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    da analyze - consistent output [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
 ; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
-; DELIN-NEXT:    Equal predicate: {80,+,80}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80,+,80}<%for.cond1.preheader> to i128)
-; DELIN-NEXT:    Equal predicate: (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {160,+,80}<%for.cond1.preheader> to i128)
-; DELIN-NEXT:    Equal predicate: (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw> == (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw>
+; DELIN-NEXT:    Equal predicate: (sext i64 {80,+,80}<%for.cond1.preheader> to i128) == {80,+,80}<nuw><nsw><%for.cond1.preheader>
+; DELIN-NEXT:    Equal predicate: (sext i64 {160,+,80}<%for.cond1.preheader> to i128) == (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw>
+; DELIN-NEXT:    Equal predicate: (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw>
 ; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: %2 = load i64, ptr %arrayidx6, align 8
 ; DELIN-NEXT:    da analyze - consistent flow [0 1]!
 ; DELIN-NEXT:    Runtime Assumptions:
 ; DELIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body3> slt) 10
-; DELIN-NEXT:    Equal predicate: {80,+,80}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80,+,80}<%for.cond1.preheader> to i128)
-; DELIN-NEXT:    Equal predicate: (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {160,+,80}<%for.cond1.preheader> to i128)
-; DELIN-NEXT:    Equal predicate: (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw> == (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw>
+; DELIN-NEXT:    Equal predicate: (sext i64 {80,+,80}<%for.cond1.preheader> to i128) == {80,+,80}<nuw><nsw><%for.cond1.preheader>
+; DELIN-NEXT:    Equal predicate: (sext i64 {160,+,80}<%for.cond1.preheader> to i128) == (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw>
+; DELIN-NEXT:    Equal predicate: (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw>
 ; DELIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: store i64 0, ptr %arrayidx, align 8 --> Dst: store i64 %2, ptr %B.addr.12, align 8
 ; DELIN-NEXT:    da analyze - confused!
@@ -157,9 +157,9 @@ define void @banerjee1(ptr %A, ptr %B, i64 %m, i64 %n) nounwind uwtable ssp {
 ; DELIN-NEXT:    da analyze - consistent input [0 0]!
 ; DELIN-NEXT:    Runtime Assumptions:
 ; DELIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body3> slt) 10
-; DELIN-NEXT:    Equal predicate: {80,+,80}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80,+,80}<%for.cond1.preheader> to i128)
-; DELIN-NEXT:    Equal predicate: (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {160,+,80}<%for.cond1.preheader> to i128)
-; DELIN-NEXT:    Equal predicate: (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw> == (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw>
+; DELIN-NEXT:    Equal predicate: (sext i64 {80,+,80}<%for.cond1.preheader> to i128) == {80,+,80}<nuw><nsw><%for.cond1.preheader>
+; DELIN-NEXT:    Equal predicate: (sext i64 {160,+,80}<%for.cond1.preheader> to i128) == (80 + (sext i64 {80,+,80}<%for.cond1.preheader> to i128))<nsw>
+; DELIN-NEXT:    Equal predicate: (15 + (sext i64 {144,+,80}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {160,+,80}<%for.cond1.preheader> to i128))<nsw>
 ; DELIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body3> slt) 10
 ; DELIN-NEXT:  Src: %2 = load i64, ptr %arrayidx6, align 8 --> Dst: store i64 %2, ptr %B.addr.12, align 8
 ; DELIN-NEXT:    da analyze - confused!

--- a/llvm/test/Analysis/DependenceAnalysis/Constraints.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Constraints.ll
@@ -40,7 +40,6 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:    da analyze - consistent output [S 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {10,+,10}<nuw><nsw><%.lr.ph4> slt) 111
-; CHECK-NEXT:    Compare predicate: {10,+,10}<nuw><nsw><%.lr.ph4> slt) 111
 ; CHECK-NEXT:  Src: store i32 0, ptr %13, align 4 --> Dst: %18 = load i32, ptr %17, align 4
 ; CHECK-NEXT:    da analyze - flow [S * *|<]!
 ; CHECK-NEXT:  Src: store i32 0, ptr %13, align 4 --> Dst: %20 = load i32, ptr %19, align 4
@@ -83,7 +82,6 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:  Src: %20 = load i32, ptr %19, align 4 --> Dst: %20 = load i32, ptr %19, align 4
 ; CHECK-NEXT:    da analyze - consistent input [S 0 S 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%.lr.ph> slt) 11
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%.lr.ph> slt) 11
 ; CHECK-NEXT:  Src: %20 = load i32, ptr %19, align 4 --> Dst: %23 = load i32, ptr %22, align 4
 ; CHECK-NEXT:    da analyze - input [S * * *|<]!
@@ -132,7 +130,6 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:    da analyze - consistent input [S 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {10,+,11}<%.lr.ph4> slt) 111
-; CHECK-NEXT:    Compare predicate: {10,+,11}<%.lr.ph4> slt) 111
 ; CHECK-NEXT:  Src: %27 = load i32, ptr %26, align 4 --> Dst: %29 = load i32, ptr %28, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: %27 = load i32, ptr %26, align 4 --> Dst: store i32 %30, ptr %31, align 4
@@ -145,7 +142,6 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:    da analyze - consistent input [S 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nw><%.lr.ph4> slt) 11
-; CHECK-NEXT:    Compare predicate: {1,+,1}<nw><%.lr.ph4> slt) 11
 ; CHECK-NEXT:  Src: %29 = load i32, ptr %28, align 4 --> Dst: store i32 %30, ptr %31, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: %29 = load i32, ptr %28, align 4 --> Dst: %32 = load i32, ptr %6, align 4
@@ -155,7 +151,6 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:  Src: store i32 %30, ptr %31, align 4 --> Dst: store i32 %30, ptr %31, align 4
 ; CHECK-NEXT:    da analyze - consistent output [S 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {1,+,1}<nw><%.lr.ph4> slt) 11
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nw><%.lr.ph4> slt) 11
 ; CHECK-NEXT:  Src: store i32 %30, ptr %31, align 4 --> Dst: %32 = load i32, ptr %6, align 4
 ; CHECK-NEXT:    da analyze - flow [S|<]!

--- a/llvm/test/Analysis/DependenceAnalysis/Constraints.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Constraints.ll
@@ -37,7 +37,10 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:  Src: %out_l.promoted = load i32, ptr @out_l, align 4 --> Dst: store i32 %33, ptr @out_l, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [|<]!
 ; CHECK-NEXT:  Src: store i32 0, ptr %13, align 4 --> Dst: store i32 0, ptr %13, align 4
-; CHECK-NEXT:    da analyze - output [S * *]!
+; CHECK-NEXT:    da analyze - consistent output [S 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {10,+,10}<nuw><nsw><%.lr.ph4> slt) 111
+; CHECK-NEXT:    Compare predicate: {10,+,10}<nuw><nsw><%.lr.ph4> slt) 111
 ; CHECK-NEXT:  Src: store i32 0, ptr %13, align 4 --> Dst: %18 = load i32, ptr %17, align 4
 ; CHECK-NEXT:    da analyze - flow [S * *|<]!
 ; CHECK-NEXT:  Src: store i32 0, ptr %13, align 4 --> Dst: %20 = load i32, ptr %19, align 4
@@ -47,7 +50,10 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:  Src: store i32 0, ptr %13, align 4 --> Dst: store i32 %24, ptr %25, align 4
 ; CHECK-NEXT:    da analyze - output [S * *|<]!
 ; CHECK-NEXT:  Src: store i32 0, ptr %13, align 4 --> Dst: %27 = load i32, ptr %26, align 4
-; CHECK-NEXT:    da analyze - flow [S * *|<]!
+; CHECK-NEXT:    da analyze - flow [S 0 *|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {10,+,10}<nuw><nsw><%.lr.ph4> slt) 111
+; CHECK-NEXT:    Compare predicate: {10,+,11}<%.lr.ph4> slt) 111
 ; CHECK-NEXT:  Src: store i32 0, ptr %13, align 4 --> Dst: %29 = load i32, ptr %28, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 0, ptr %13, align 4 --> Dst: store i32 %30, ptr %31, align 4
@@ -75,7 +81,10 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:  Src: %18 = load i32, ptr %17, align 4 --> Dst: store i32 %33, ptr @out_l, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: %20 = load i32, ptr %19, align 4 --> Dst: %20 = load i32, ptr %19, align 4
-; CHECK-NEXT:    da analyze - input [S * S *]!
+; CHECK-NEXT:    da analyze - consistent input [S 0 S 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%.lr.ph> slt) 11
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%.lr.ph> slt) 11
 ; CHECK-NEXT:  Src: %20 = load i32, ptr %19, align 4 --> Dst: %23 = load i32, ptr %22, align 4
 ; CHECK-NEXT:    da analyze - input [S * * *|<]!
 ; CHECK-NEXT:  Src: %20 = load i32, ptr %19, align 4 --> Dst: store i32 %24, ptr %25, align 4
@@ -85,7 +94,10 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:  Src: %20 = load i32, ptr %19, align 4 --> Dst: %29 = load i32, ptr %28, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: %20 = load i32, ptr %19, align 4 --> Dst: store i32 %30, ptr %31, align 4
-; CHECK-NEXT:    da analyze - anti [S * *|<]!
+; CHECK-NEXT:    da analyze - anti [S 0 *|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%.lr.ph> slt) 11
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nw><%.lr.ph4> slt) 11
 ; CHECK-NEXT:  Src: %20 = load i32, ptr %19, align 4 --> Dst: %32 = load i32, ptr %6, align 4
 ; CHECK-NEXT:    da analyze - input [S|<]!
 ; CHECK-NEXT:  Src: %20 = load i32, ptr %19, align 4 --> Dst: store i32 %33, ptr @out_l, align 4
@@ -117,7 +129,10 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:  Src: store i32 %24, ptr %25, align 4 --> Dst: store i32 %33, ptr @out_l, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: %27 = load i32, ptr %26, align 4 --> Dst: %27 = load i32, ptr %26, align 4
-; CHECK-NEXT:    da analyze - input [S * *]!
+; CHECK-NEXT:    da analyze - consistent input [S 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {10,+,11}<%.lr.ph4> slt) 111
+; CHECK-NEXT:    Compare predicate: {10,+,11}<%.lr.ph4> slt) 111
 ; CHECK-NEXT:  Src: %27 = load i32, ptr %26, align 4 --> Dst: %29 = load i32, ptr %28, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: %27 = load i32, ptr %26, align 4 --> Dst: store i32 %30, ptr %31, align 4
@@ -127,7 +142,10 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:  Src: %27 = load i32, ptr %26, align 4 --> Dst: store i32 %33, ptr @out_l, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: %29 = load i32, ptr %28, align 4 --> Dst: %29 = load i32, ptr %28, align 4
-; CHECK-NEXT:    da analyze - input [S * *]!
+; CHECK-NEXT:    da analyze - consistent input [S 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nw><%.lr.ph4> slt) 11
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nw><%.lr.ph4> slt) 11
 ; CHECK-NEXT:  Src: %29 = load i32, ptr %28, align 4 --> Dst: store i32 %30, ptr %31, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: %29 = load i32, ptr %28, align 4 --> Dst: %32 = load i32, ptr %6, align 4
@@ -135,7 +153,10 @@ define void @dep_constraint_crash_test(i32 %M, i32 %N) {
 ; CHECK-NEXT:  Src: %29 = load i32, ptr %28, align 4 --> Dst: store i32 %33, ptr @out_l, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %30, ptr %31, align 4 --> Dst: store i32 %30, ptr %31, align 4
-; CHECK-NEXT:    da analyze - output [S * *]!
+; CHECK-NEXT:    da analyze - consistent output [S 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nw><%.lr.ph4> slt) 11
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nw><%.lr.ph4> slt) 11
 ; CHECK-NEXT:  Src: store i32 %30, ptr %31, align 4 --> Dst: %32 = load i32, ptr %6, align 4
 ; CHECK-NEXT:    da analyze - flow [S|<]!
 ; CHECK-NEXT:  Src: store i32 %30, ptr %31, align 4 --> Dst: store i32 %33, ptr @out_l, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/DADelin.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/DADelin.ll
@@ -122,7 +122,6 @@ define void @t2(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body8> slt) %o
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -211,7 +210,6 @@ define void @t3(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.body8> sge) 0
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -300,7 +298,6 @@ define void @t4(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.cond5.preheader> slt) %m
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -390,8 +387,6 @@ define void @t5(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> sge) 0
-; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> slt) %m
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -727,8 +722,6 @@ define double @test_sizes(i16 %h, i16 %N, ptr nocapture %array) {
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> sge) 0
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> slt) (sext i16 %h to i32)
 ; CHECK-NEXT:    Equal predicate: (sext i32 (2 * (sext i16 %h to i32))<nsw> to i64) == (2 * (sext i16 %h to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> sge) 0
-; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> slt) (sext i16 %h to i32)
 ;
 entry:
   %cmp28 = icmp sgt i16 %N, 1
@@ -784,7 +777,6 @@ define void @nonnegative(ptr nocapture %A, i32 %N) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64) == (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
 ; CHECK-NEXT:  Src: store i32 1, ptr %arrayidx, align 4 --> Dst: store i32 2, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -793,7 +785,6 @@ define void @nonnegative(ptr nocapture %A, i32 %N) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64) == (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
 ; CHECK-NEXT:  Src: store i32 2, ptr %arrayidx, align 4 --> Dst: store i32 2, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -802,7 +793,6 @@ define void @nonnegative(ptr nocapture %A, i32 %N) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64) == (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
 ;
 entry:
   %cmp44 = icmp eq i32 %N, 0
@@ -852,7 +842,6 @@ define void @coeff_may_negative(ptr %a, i32 %k) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,%k}<%loop> to i64) == ((sext i32 {0,+,1}<nuw><%loop> to i64) * (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + %k),+,%k}<%loop> to i64) == (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.0, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [-1]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -860,7 +849,6 @@ define void @coeff_may_negative(ptr %a, i32 %k) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,%k}<%loop> to i64) == ((sext i32 {0,+,1}<nuw><%loop> to i64) * (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + %k),+,%k}<%loop> to i64) == (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {1,+,1}<%loop> to i64) * (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(2 * %k),+,%k}<%loop> to i64) == ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64) == (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw>
@@ -871,7 +859,6 @@ define void @coeff_may_negative(ptr %a, i32 %k) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {1,+,1}<%loop> to i64) * (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(2 * %k),+,%k}<%loop> to i64) == ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64) == (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ;
 entry:
   br label %loop
@@ -912,7 +899,6 @@ define void @coeff_positive(ptr %a, i32 %k) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,%k}<%loop> to i64) == {0,+,(sext i32 %k to i64)}<%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + %k),+,%k}<%loop> to i64) == (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.0, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [-1]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -920,7 +906,6 @@ define void @coeff_positive(ptr %a, i32 %k) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,%k}<%loop> to i64) == {0,+,(sext i32 %k to i64)}<%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + %k),+,%k}<%loop> to i64) == (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == {(sext i32 %k to i64),+,(sext i32 %k to i64)}<%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(2 * %k),+,%k}<%loop> to i64) == ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64) == (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw>
@@ -931,7 +916,6 @@ define void @coeff_positive(ptr %a, i32 %k) {
 ; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == {(sext i32 %k to i64),+,(sext i32 %k to i64)}<%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(2 * %k),+,%k}<%loop> to i64) == ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64))
 ; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64) == (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw>
-; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ;
 entry:
   br label %loop

--- a/llvm/test/Analysis/DependenceAnalysis/DADelin.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/DADelin.ll
@@ -13,11 +13,29 @@ target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 define void @t1(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-LABEL: 't1'
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - input [* * *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - anti [* * *|<]!
+; CHECK-NEXT:    da analyze - consistent anti [0 0 0|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -79,12 +97,31 @@ for.cond.cleanup:                                 ; preds = %for.cond.cleanup3, 
 define void @t2(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-LABEL: 't2'
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - input [* * *]!
-; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - anti [* * *|<]!
-; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
+; CHECK-NEXT:    da analyze - consistent anti [0 0 -1]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body8> slt) %o
+; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body8> slt) %o
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body8> slt) %o
 ;
 entry:
@@ -149,12 +186,31 @@ for.cond.cleanup:                                 ; preds = %for.cond.cleanup3, 
 define void @t3(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-LABEL: 't3'
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - input [* * *]!
-; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - anti [* * *|<]!
-; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
+; CHECK-NEXT:    da analyze - consistent anti [0 0 1]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.body8> sge) 0
+; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.body8> sge) 0
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.body8> sge) 0
 ;
 entry:
@@ -219,12 +275,31 @@ for.cond.cleanup:                                 ; preds = %for.cond.cleanup3, 
 define void @t4(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-LABEL: 't4'
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - input [* * *]!
-; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - anti [* * *|<]!
-; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
+; CHECK-NEXT:    da analyze - consistent anti [0 -1 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.cond5.preheader> slt) %m
+; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.cond5.preheader> slt) %m
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.cond5.preheader> slt) %m
 ;
 entry:
@@ -288,12 +363,33 @@ for.cond.cleanup:                                 ; preds = %for.cond.cleanup3, 
 define void @t5(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-LABEL: 't5'
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - input [* * *]!
-; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - anti [* * *|<]!
-; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
+; CHECK-NEXT:    da analyze - consistent anti [0 1 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> sge) 0
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> slt) %m
+; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> sge) 0
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> slt) %m
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> sge) 0
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> slt) %m
 ;
@@ -358,11 +454,32 @@ for.cond.cleanup:                                 ; preds = %for.cond.cleanup3, 
 define void @t6(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-LABEL: 't6'
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - input [* * *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - anti [* * *|<]!
+; CHECK-NEXT:    da analyze - consistent anti [-1 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: {(sext i32 (4 * %m * %o) to i64),+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (8 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {(sext i32 (4 * %m * %o) to i64),+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (8 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -426,11 +543,32 @@ for.cond.cleanup:                                 ; preds = %for.cond.cleanup3, 
 define void @t7(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-LABEL: 't7'
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - input [* * *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - anti [* * *|<]!
+; CHECK-NEXT:    da analyze - consistent anti [1 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: {(-1 * (sext i32 (4 * %m * %o) to i64))<nsw>,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (3 + (sext i32 {-4,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nuw><nsw>
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {(-1 * (sext i32 (4 * %m * %o) to i64))<nsw>,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (3 + (sext i32 {-4,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nuw><nsw>
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -494,11 +632,29 @@ for.cond.cleanup:                                 ; preds = %for.cond.cleanup3, 
 define void @t8(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-LABEL: 't8'
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - input [* * *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - anti [* * *|<]!
+; CHECK-NEXT:    da analyze - consistent anti [0 0 1]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -562,9 +718,15 @@ define double @test_sizes(i16 %h, i16 %N, ptr nocapture %array) {
 ; CHECK-NEXT:    da analyze - anti [* *|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body> slt) (sext i16 %h to i32)
+; CHECK-NEXT:    Equal predicate: (2 * (sext i16 %h to i64))<nsw> == (sext i32 (2 * (sext i16 %h to i32))<nsw> to i64)
+; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> sge) 0
+; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> slt) (sext i16 %h to i32)
 ; CHECK-NEXT:  Src: store i16 %add6, ptr %arrayidx8, align 4 --> Dst: store i16 %add6, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - output [* *]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> sge) 0
+; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> slt) (sext i16 %h to i32)
+; CHECK-NEXT:    Equal predicate: (2 * (sext i16 %h to i64))<nsw> == (sext i32 (2 * (sext i16 %h to i32))<nsw> to i64)
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> sge) 0
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> slt) (sext i16 %h to i32)
 ;
@@ -615,16 +777,31 @@ for.end12:                                        ; preds = %for.inc10, %entry
 define void @nonnegative(ptr nocapture %A, i32 %N) {
 ; CHECK-LABEL: 'nonnegative'
 ; CHECK-NEXT:  Src: store i32 1, ptr %arrayidx, align 4 --> Dst: store i32 1, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 %N to i64))<nsw> == (sext i32 (4 * %N) to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64)) == (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)) == (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw> == (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64)
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
 ; CHECK-NEXT:  Src: store i32 1, ptr %arrayidx, align 4 --> Dst: store i32 2, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* *|<]!
+; CHECK-NEXT:    da analyze - consistent output [0 0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 %N to i64))<nsw> == (sext i32 (4 * %N) to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64)) == (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)) == (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw> == (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
 ; CHECK-NEXT:  Src: store i32 2, ptr %arrayidx, align 4 --> Dst: store i32 2, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
+; CHECK-NEXT:    Equal predicate: (4 * (sext i32 %N to i64))<nsw> == (sext i32 (4 * %N) to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64)) == (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)) == (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw> == (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64)
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
 ;
 entry:
@@ -672,16 +849,29 @@ define void @coeff_may_negative(ptr %a, i32 %k) {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Compare predicate: %k ne) 0
+; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,1}<nuw><%loop> to i64) * (sext i32 %k to i64)) == (sext i32 {0,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.0, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
-; CHECK-NEXT:    da analyze - output [*|<]!
+; CHECK-NEXT:    da analyze - consistent output [-1]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
+; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,1}<nuw><%loop> to i64) * (sext i32 %k to i64)) == (sext i32 {0,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
+; CHECK-NEXT:    Equal predicate: ((sext i32 {1,+,1}<nw><%loop> to i64) * (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {(2 * %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64)
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.1, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Compare predicate: %k ne) 0
+; CHECK-NEXT:    Equal predicate: ((sext i32 {1,+,1}<nw><%loop> to i64) * (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {(2 * %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ;
 entry:
   br label %loop
@@ -719,16 +909,29 @@ define void @coeff_positive(ptr %a, i32 %k) {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Compare predicate: %k ne) 0
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 %k to i64)}<%loop> == (sext i32 {0,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.0, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
-; CHECK-NEXT:    da analyze - output [*|<]!
+; CHECK-NEXT:    da analyze - consistent output [-1]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 %k to i64)}<%loop> == (sext i32 {0,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
+; CHECK-NEXT:    Equal predicate: {(sext i32 %k to i64),+,(sext i32 %k to i64)}<%loop> == (sext i32 {%k,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {(2 * %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64)
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.1, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Compare predicate: %k ne) 0
+; CHECK-NEXT:    Equal predicate: {(sext i32 %k to i64),+,(sext i32 %k to i64)}<%loop> == (sext i32 {%k,+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {(2 * %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ;
 entry:
   br label %loop

--- a/llvm/test/Analysis/DependenceAnalysis/DADelin.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/DADelin.ll
@@ -15,27 +15,27 @@ define void @t1(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [0 0 0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -99,29 +99,29 @@ define void @t2(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [0 0 -1]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body8> slt) %o
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body8> slt) %o
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body8> slt) %o
 ;
 entry:
@@ -188,29 +188,29 @@ define void @t3(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [0 0 1]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.body8> sge) 0
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.body8> sge) 0
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.body8> sge) 0
 ;
 entry:
@@ -277,29 +277,29 @@ define void @t4(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [0 -1 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.cond5.preheader> slt) %m
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.cond5.preheader> slt) %m
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.cond5.preheader> slt) %m
 ;
 entry:
@@ -365,19 +365,19 @@ define void @t5(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [0 1 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> sge) 0
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> slt) %m
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
@@ -385,11 +385,11 @@ define void @t5(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> sge) 0
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> slt) %m
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> sge) 0
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<%for.cond5.preheader> slt) %m
 ;
@@ -456,30 +456,30 @@ define void @t6(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [-1 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: {(sext i32 (4 * %m * %o) to i64),+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (8 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {(sext i32 (4 * %m * %o) to i64),+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (8 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {(sext i32 (4 * %m * %o) to i64),+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (8 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {(sext i32 (4 * %m * %o) to i64),+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (8 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(8 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -545,30 +545,30 @@ define void @t7(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [1 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: {(-1 * (sext i32 (4 * %m * %o) to i64))<nsw>,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (3 + (sext i32 {-4,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {(-1 * (sext i32 (4 * %m * %o) to i64))<nsw>,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (3 + (sext i32 {-4,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nuw><nsw> == (-1 + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {(-1 * (sext i32 (4 * %m * %o) to i64))<nsw>,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (3 + (sext i32 {-4,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {(-1 * (sext i32 (4 * %m * %o) to i64))<nsw>,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {(-4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (3 + (sext i32 {-4,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nuw><nsw> == (-1 + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -634,27 +634,27 @@ define void @t8(i32 %n, i32 %m, i32 %o, ptr nocapture %A) {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [0 0 1]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ; CHECK-NEXT:  Src: store i32 %add12, ptr %arrayidx2, align 4 --> Dst: store i32 %add12, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i32 %m to i64) * (sext i32 %o to i64)) == (sext i32 (%m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 (%m * %o) to i64))<nsw> == (sext i32 (4 * %m * %o) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader> == (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64)) == (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw> == (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (%m * %o) to i64) == ((sext i32 %m to i64) * (sext i32 %o to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %m * %o) to i64) == (4 * (sext i32 (%m * %o) to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == {0,+,(sext i32 (4 * %m * %o) to i64)}<%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == ((sext i32 (4 * %m * %o) to i64) + (sext i32 {0,+,(4 * %m * %o)}<%for.cond1.preheader> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.cond1.preheader> to i64) == (-1 + (sext i32 {(4 * %m * %o),+,(4 * %m * %o)}<%for.cond1.preheader> to i64))<nsw>
 ;
 entry:
   %cmp49 = icmp sgt i32 %n, 0
@@ -718,7 +718,7 @@ define double @test_sizes(i16 %h, i16 %N, ptr nocapture %array) {
 ; CHECK-NEXT:    da analyze - anti [* *|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body> slt) (sext i16 %h to i32)
-; CHECK-NEXT:    Equal predicate: (2 * (sext i16 %h to i64))<nsw> == (sext i32 (2 * (sext i16 %h to i32))<nsw> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (2 * (sext i16 %h to i32))<nsw> to i64) == (2 * (sext i16 %h to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> sge) 0
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> slt) (sext i16 %h to i32)
 ; CHECK-NEXT:  Src: store i16 %add6, ptr %arrayidx8, align 4 --> Dst: store i16 %add6, ptr %arrayidx8, align 4
@@ -726,7 +726,7 @@ define double @test_sizes(i16 %h, i16 %N, ptr nocapture %array) {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> sge) 0
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> slt) (sext i16 %h to i32)
-; CHECK-NEXT:    Equal predicate: (2 * (sext i16 %h to i64))<nsw> == (sext i32 (2 * (sext i16 %h to i32))<nsw> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (2 * (sext i16 %h to i32))<nsw> to i64) == (2 * (sext i16 %h to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> sge) 0
 ; CHECK-NEXT:    Compare predicate: {(sext i16 {2,+,(1 + %h)}<%for.body> to i32),+,1}<nsw><%for.body5> slt) (sext i16 %h to i32)
 ;
@@ -780,28 +780,28 @@ define void @nonnegative(ptr nocapture %A, i32 %N) {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 %N to i64))<nsw> == (sext i32 (4 * %N) to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64)) == (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)) == (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw> == (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %N) to i64) == (4 * (sext i32 %N to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64) == (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
 ; CHECK-NEXT:  Src: store i32 1, ptr %arrayidx, align 4 --> Dst: store i32 2, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 %N to i64))<nsw> == (sext i32 (4 * %N) to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64)) == (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)) == (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw> == (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %N) to i64) == (4 * (sext i32 %N to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64) == (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
 ; CHECK-NEXT:  Src: store i32 2, ptr %arrayidx, align 4 --> Dst: store i32 2, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
-; CHECK-NEXT:    Equal predicate: (4 * (sext i32 %N to i64))<nsw> == (sext i32 (4 * %N) to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64)) == (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64)) == (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw> == (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 (4 * %N) to i64) == (4 * (sext i32 %N to i64))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) * (sext i32 {0,+,1}<nuw><%for.outer> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64) == ((sext i32 (4 * %N) to i64) + (sext i32 {0,+,(4 * %N)}<%for.outer> to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (4 * %N)),+,(4 * %N)}<%for.outer> to i64) == (-1 + (sext i32 {(4 * %N),+,(4 * %N)}<%for.outer> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><%for.inner> slt) %N
 ;
 entry:
@@ -849,28 +849,28 @@ define void @coeff_may_negative(ptr %a, i32 %k) {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,1}<nuw><%loop> to i64) * (sext i32 %k to i64)) == (sext i32 {0,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,%k}<%loop> to i64) == ((sext i32 {0,+,1}<nuw><%loop> to i64) * (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + %k),+,%k}<%loop> to i64) == (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.0, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [-1]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,1}<nuw><%loop> to i64) * (sext i32 %k to i64)) == (sext i32 {0,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,%k}<%loop> to i64) == ((sext i32 {0,+,1}<nuw><%loop> to i64) * (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + %k),+,%k}<%loop> to i64) == (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: ((sext i32 {1,+,1}<nw><%loop> to i64) * (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {(2 * %k),+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {1,+,1}<%loop> to i64) * (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(2 * %k),+,%k}<%loop> to i64) == ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64) == (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw>
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.1, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: ((sext i32 {1,+,1}<nw><%loop> to i64) * (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {(2 * %k),+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {1,+,1}<%loop> to i64) * (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(2 * %k),+,%k}<%loop> to i64) == ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64) == (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ;
 entry:
@@ -909,28 +909,28 @@ define void @coeff_positive(ptr %a, i32 %k) {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 %k to i64)}<%loop> == (sext i32 {0,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,%k}<%loop> to i64) == {0,+,(sext i32 %k to i64)}<%loop>
+; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + %k),+,%k}<%loop> to i64) == (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.0, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [-1]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i32 %k to i64)}<%loop> == (sext i32 {0,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {%k,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + %k),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 {0,+,%k}<%loop> to i64) == {0,+,(sext i32 %k to i64)}<%loop>
+; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == ((sext i32 {0,+,%k}<%loop> to i64) + (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + %k),+,%k}<%loop> to i64) == (-1 + (sext i32 {%k,+,%k}<%loop> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: {(sext i32 %k to i64),+,(sext i32 %k to i64)}<%loop> == (sext i32 {%k,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {(2 * %k),+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == {(sext i32 %k to i64),+,(sext i32 %k to i64)}<%loop>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(2 * %k),+,%k}<%loop> to i64) == ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64) == (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw>
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx.1, align 1 --> Dst: store i8 42, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: {(sext i32 %k to i64),+,(sext i32 %k to i64)}<%loop> == (sext i32 {%k,+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64)) == (sext i32 {(2 * %k),+,%k}<%loop> to i64)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw> == (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64)
+; CHECK-NEXT:    Equal predicate: (sext i32 {%k,+,%k}<%loop> to i64) == {(sext i32 %k to i64),+,(sext i32 %k to i64)}<%loop>
+; CHECK-NEXT:    Equal predicate: (sext i32 {(2 * %k),+,%k}<%loop> to i64) == ((sext i32 {%k,+,%k}<%loop> to i64) + (sext i32 %k to i64))
+; CHECK-NEXT:    Equal predicate: (sext i32 {(-1 + (2 * %k)),+,%k}<%loop> to i64) == (-1 + (sext i32 {(2 * %k),+,%k}<%loop> to i64))<nsw>
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ;
 entry:

--- a/llvm/test/Analysis/DependenceAnalysis/DifferentOffsets.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/DifferentOffsets.ll
@@ -106,8 +106,6 @@ define void @linearized_accesses(i64 %n, i64 %m, i64 %o, ptr %A) {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128) == ((sext i64 (4 * %m * %o) to i128) * (sext i64 {0,+,2}<%for.i> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128) == ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %m * %o)),+,(8 * %m * %o)}<%for.i> to i128) == (-1 + (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.j> slt) %m
-; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.k> slt) %o
 ; CHECK-NEXT:  Src: store i32 1, ptr %idx0, align 4 --> Dst: store i32 1, ptr %idx1, align 4
 ; CHECK-NEXT:    da analyze - output [* * *|<]!
 ; CHECK-NEXT:    Runtime Assumptions:

--- a/llvm/test/Analysis/DependenceAnalysis/DifferentOffsets.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/DifferentOffsets.ll
@@ -98,8 +98,14 @@ define void @linearized_accesses(i64 %n, i64 %m, i64 %o, ptr %A) {
 ; CHECK-LABEL: 'linearized_accesses'
 ; CHECK-NEXT:  Src: store i32 1, ptr %idx0, align 4 --> Dst: store i32 1, ptr %idx0, align 4
 ; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.j> slt) %m
+; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.k> slt) %o
 ; CHECK-NEXT:  Src: store i32 1, ptr %idx0, align 4 --> Dst: store i32 1, ptr %idx1, align 4
 ; CHECK-NEXT:    da analyze - output [* * *|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.j> slt) %m
+; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.k> slt) %o
 ; CHECK-NEXT:  Src: store i32 1, ptr %idx1, align 4 --> Dst: store i32 1, ptr %idx1, align 4
 ; CHECK-NEXT:    da analyze - output [* * *]!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/DifferentOffsets.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/DifferentOffsets.ll
@@ -97,8 +97,15 @@ entry:
 define void @linearized_accesses(i64 %n, i64 %m, i64 %o, ptr %A) {
 ; CHECK-LABEL: 'linearized_accesses'
 ; CHECK-NEXT:  Src: store i32 1, ptr %idx0, align 4 --> Dst: store i32 1, ptr %idx0, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.j> slt) %m
+; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.k> slt) %o
+; CHECK-NEXT:    Equal predicate: ((sext i64 %m to i128) * (sext i64 %o to i128)) == (sext i64 (%m * %o) to i128)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 (%m * %o) to i128))<nsw> == (sext i64 (4 * %m * %o) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) * (sext i64 {0,+,2}<%for.i> to i128)) == (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128)) == (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * %m * %o)),+,(8 * %m * %o)}<%for.i> to i128)
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.j> slt) %m
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.k> slt) %o
 ; CHECK-NEXT:  Src: store i32 1, ptr %idx0, align 4 --> Dst: store i32 1, ptr %idx1, align 4
@@ -106,8 +113,22 @@ define void @linearized_accesses(i64 %n, i64 %m, i64 %o, ptr %A) {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.j> slt) %m
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.k> slt) %o
+; CHECK-NEXT:    Equal predicate: ((sext i64 %m to i128) * (sext i64 %o to i128)) == (sext i64 (%m * %o) to i128)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 (%m * %o) to i128))<nsw> == (sext i64 (4 * %m * %o) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) * (sext i64 {0,+,2}<%for.i> to i128)) == (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128)) == (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * %m * %o)),+,(8 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %m * %o) to i128)}<%for.i> == (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128)) == (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.i> to i128)
 ; CHECK-NEXT:  Src: store i32 1, ptr %idx1, align 4 --> Dst: store i32 1, ptr %idx1, align 4
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: ((sext i64 %m to i128) * (sext i64 %o to i128)) == (sext i64 (%m * %o) to i128)
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 (%m * %o) to i128))<nsw> == (sext i64 (4 * %m * %o) to i128)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %m * %o) to i128)}<%for.i> == (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128)) == (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.i> to i128)
 ;
 entry:
   br label %for.i

--- a/llvm/test/Analysis/DependenceAnalysis/DifferentOffsets.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/DifferentOffsets.ll
@@ -101,11 +101,11 @@ define void @linearized_accesses(i64 %n, i64 %m, i64 %o, ptr %A) {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.j> slt) %m
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.k> slt) %o
-; CHECK-NEXT:    Equal predicate: ((sext i64 %m to i128) * (sext i64 %o to i128)) == (sext i64 (%m * %o) to i128)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 (%m * %o) to i128))<nsw> == (sext i64 (4 * %m * %o) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) * (sext i64 {0,+,2}<%for.i> to i128)) == (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128)) == (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * %m * %o)),+,(8 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (%m * %o) to i128) == ((sext i64 %m to i128) * (sext i64 %o to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %m * %o) to i128) == (4 * (sext i64 (%m * %o) to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128) == ((sext i64 (4 * %m * %o) to i128) * (sext i64 {0,+,2}<%for.i> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128) == ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %m * %o)),+,(8 * %m * %o)}<%for.i> to i128) == (-1 + (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.j> slt) %m
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.k> slt) %o
 ; CHECK-NEXT:  Src: store i32 1, ptr %idx0, align 4 --> Dst: store i32 1, ptr %idx1, align 4
@@ -113,22 +113,22 @@ define void @linearized_accesses(i64 %n, i64 %m, i64 %o, ptr %A) {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.j> slt) %m
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<%for.k> slt) %o
-; CHECK-NEXT:    Equal predicate: ((sext i64 %m to i128) * (sext i64 %o to i128)) == (sext i64 (%m * %o) to i128)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 (%m * %o) to i128))<nsw> == (sext i64 (4 * %m * %o) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) * (sext i64 {0,+,2}<%for.i> to i128)) == (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128)) == (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * %m * %o)),+,(8 * %m * %o)}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %m * %o) to i128)}<%for.i> == (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128)) == (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (%m * %o) to i128) == ((sext i64 %m to i128) * (sext i64 %o to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %m * %o) to i128) == (4 * (sext i64 (%m * %o) to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128) == ((sext i64 (4 * %m * %o) to i128) * (sext i64 {0,+,2}<%for.i> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128) == ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(8 * %m * %o)}<%for.i> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %m * %o)),+,(8 * %m * %o)}<%for.i> to i128) == (-1 + (sext i64 {(4 * %m * %o),+,(8 * %m * %o)}<%for.i> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128) == {0,+,(sext i64 (4 * %m * %o) to i128)}<%for.i>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128) == ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.i> to i128) == (-1 + (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 1, ptr %idx1, align 4 --> Dst: store i32 1, ptr %idx1, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: ((sext i64 %m to i128) * (sext i64 %o to i128)) == (sext i64 (%m * %o) to i128)
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 (%m * %o) to i128))<nsw> == (sext i64 (4 * %m * %o) to i128)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %m * %o) to i128)}<%for.i> == (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128)) == (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (%m * %o) to i128) == ((sext i64 %m to i128) * (sext i64 %o to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %m * %o) to i128) == (4 * (sext i64 (%m * %o) to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128) == {0,+,(sext i64 (4 * %m * %o) to i128)}<%for.i>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128) == ((sext i64 (4 * %m * %o) to i128) + (sext i64 {0,+,(4 * %m * %o)}<%for.i> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %m * %o)),+,(4 * %m * %o)}<%for.i> to i128) == (-1 + (sext i64 {(4 * %m * %o),+,(4 * %m * %o)}<%for.i> to i128))<nsw>
 ;
 entry:
   br label %for.i

--- a/llvm/test/Analysis/DependenceAnalysis/ExactRDIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/ExactRDIV.ll
@@ -501,7 +501,6 @@ define void @rdiv9(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
-; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -560,7 +559,6 @@ define void @rdiv10(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
-; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -618,7 +616,6 @@ define void @rdiv11(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
-; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -675,7 +672,6 @@ define void @rdiv12(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
 ; CHECK-NEXT:    da analyze - flow [* *|<]!

--- a/llvm/test/Analysis/DependenceAnalysis/ExactRDIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/ExactRDIV.ll
@@ -498,7 +498,10 @@ for.end8:                                         ; preds = %for.body4
 define void @rdiv9(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'rdiv9'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
+; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -554,7 +557,10 @@ for.end7:                                         ; preds = %for.inc5
 define void @rdiv10(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'rdiv10'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
+; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -609,7 +615,10 @@ for.end7:                                         ; preds = %for.inc5
 define void @rdiv11(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'rdiv11'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
+; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -664,7 +673,10 @@ for.end7:                                         ; preds = %for.inc5
 define void @rdiv12(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'rdiv12'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
+; CHECK-NEXT:    Compare predicate: {0,+,-1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx4, align 4
 ; CHECK-NEXT:    da analyze - flow [* *|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/GCD.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/GCD.ll
@@ -282,18 +282,26 @@ for.end9:                                         ; preds = %for.inc7
 define void @gcd4(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd4'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128)) == (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128)
 ; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
-; CHECK-NEXT:    da analyze - flow [* *|<]!
-; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
+; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
-; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {4,+,15}<nw><%for.cond1.preheader> slt) %M
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128)) == (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128)
 ; CHECK-NEXT:    Compare predicate: {4,+,15}<nw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -356,18 +364,36 @@ for.end19:                                        ; preds = %for.inc17
 define void @gcd5(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd5'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128)) == (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128)
 ; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
-; CHECK-NEXT:    da analyze - flow [* *|<]!
+; CHECK-NEXT:    da analyze - flow [> *]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128)) == (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Compare predicate: {5,+,15}<nw><%for.cond1.preheader> slt) %M
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128)) == (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128)
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
-; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {5,+,15}<nw><%for.cond1.preheader> slt) %M
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128)) == (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128)
 ; CHECK-NEXT:    Compare predicate: {5,+,15}<nw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -430,18 +456,26 @@ for.end19:                                        ; preds = %for.inc17
 define void @gcd6(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd6'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: store i32 %conv, ptr %arrayidx5, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,4}<nuw><nsw><%for.body3> slt) %n
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,2}<nuw><%for.cond1.preheader> to i128)) == (sext i64 {0,+,(8 * %n)}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(8 * %n)}<%for.cond1.preheader> to i128)) == (sext i64 {(4 * %n),+,(8 * %n)}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(8 * %n)}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(8 * %n)}<%for.cond1.preheader> to i128)
 ; CHECK-NEXT:    Compare predicate: {0,+,4}<nuw><nsw><%for.body3> slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: %2 = load i32, ptr %arrayidx9, align 4
-; CHECK-NEXT:    da analyze - flow [* *|<]!
-; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {0,+,4}<nuw><nsw><%for.body3> slt) %n
+; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: store i32 %2, ptr %B.addr.12, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx9, align 4 --> Dst: %2 = load i32, ptr %arrayidx9, align 4
-; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.body3> slt) %n
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,8}<%for.cond1.preheader> to i128)) == (sext i64 {0,+,(32 * %n)}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(32 * %n)}<%for.cond1.preheader> to i128)) == (sext i64 {(4 * %n),+,(32 * %n)}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(32 * %n)}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(32 * %n)}<%for.cond1.preheader> to i128)
 ; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.body3> slt) %n
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx9, align 4 --> Dst: store i32 %2, ptr %B.addr.12, align 4
 ; CHECK-NEXT:    da analyze - confused!

--- a/llvm/test/Analysis/DependenceAnalysis/GCD.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/GCD.ll
@@ -18,7 +18,6 @@ define void @gcd0(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
-; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
 ; CHECK-NEXT:    da analyze - flow [=> *|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -26,7 +25,6 @@ define void @gcd0(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {0,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
 ; CHECK-NEXT:    Compare predicate: {0,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -83,7 +81,6 @@ define void @gcd1(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
-; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -91,7 +88,6 @@ define void @gcd1(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
 ; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -149,7 +145,6 @@ define void @gcd2(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {1,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
-; CHECK-NEXT:    Compare predicate: {1,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -157,7 +152,6 @@ define void @gcd2(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {0,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
 ; CHECK-NEXT:    Compare predicate: {0,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -215,7 +209,6 @@ define void @gcd3(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond1.preheader> slt) 2
-; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond1.preheader> slt) 2
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx6, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [1 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -227,8 +220,6 @@ define void @gcd3(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx6, align 4 --> Dst: %0 = load i32, ptr %arrayidx6, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> sge) 0
-; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> slt) 2
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> sge) 0
 ; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> slt) 2
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -289,7 +280,6 @@ define void @gcd4(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -302,7 +292,6 @@ define void @gcd4(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {4,+,15}<nw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -371,7 +360,6 @@ define void @gcd5(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
 ; CHECK-NEXT:    da analyze - flow [> *]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -394,7 +382,6 @@ define void @gcd5(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {5,+,15}<nw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -463,7 +450,6 @@ define void @gcd6(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %n)}<%for.cond1.preheader> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,2}<nuw><%for.cond1.preheader> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(8 * %n)}<%for.cond1.preheader> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(8 * %n)}<%for.cond1.preheader> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(8 * %n)}<%for.cond1.preheader> to i128) == (-1 + (sext i64 {(4 * %n),+,(8 * %n)}<%for.cond1.preheader> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,4}<nuw><nsw><%for.body3> slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: %2 = load i32, ptr %arrayidx9, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: store i32 %2, ptr %B.addr.12, align 4
@@ -476,7 +462,6 @@ define void @gcd6(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(32 * %n)}<%for.cond1.preheader> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,8}<%for.cond1.preheader> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(32 * %n)}<%for.cond1.preheader> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(32 * %n)}<%for.cond1.preheader> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(32 * %n)}<%for.cond1.preheader> to i128) == (-1 + (sext i64 {(4 * %n),+,(32 * %n)}<%for.cond1.preheader> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.body3> slt) %n
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx9, align 4 --> Dst: store i32 %2, ptr %B.addr.12, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %2, ptr %B.addr.12, align 4 --> Dst: store i32 %2, ptr %B.addr.12, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/GCD.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/GCD.ll
@@ -15,13 +15,19 @@ target triple = "x86_64-apple-macosx10.6.0"
 define void @gcd0(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd0'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
+; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
 ; CHECK-NEXT:    da analyze - flow [=> *|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
-; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
+; CHECK-NEXT:    Compare predicate: {0,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -74,13 +80,19 @@ for.end10:                                        ; preds = %for.inc8
 define void @gcd1(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd1'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
+; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
-; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
+; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -134,13 +146,19 @@ for.end11:                                        ; preds = %for.inc9
 define void @gcd2(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd2'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
+; CHECK-NEXT:    Compare predicate: {1,+,2}<nuw><nsw><%for.cond1.preheader> slt) 4
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
-; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
+; CHECK-NEXT:    Compare predicate: {0,+,6}<nuw><nsw><%for.cond1.preheader> slt) 8
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -194,13 +212,25 @@ for.end11:                                        ; preds = %for.inc9
 define void @gcd3(ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd3'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond1.preheader> slt) 2
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond1.preheader> slt) 2
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx6, align 4
-; CHECK-NEXT:    da analyze - flow [<> *]!
+; CHECK-NEXT:    da analyze - consistent flow [1 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond1.preheader> slt) 2
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> sge) 0
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> slt) 2
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx6, align 4 --> Dst: %0 = load i32, ptr %arrayidx6, align 4
-; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> sge) 0
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> slt) 2
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> sge) 0
+; CHECK-NEXT:    Compare predicate: {-1,+,1}<nsw><%for.cond1.preheader> slt) 2
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -253,12 +283,18 @@ define void @gcd4(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd4'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
 ; CHECK-NEXT:    da analyze - flow [* *|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
 ; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {4,+,15}<nw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -321,12 +357,18 @@ define void @gcd5(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd5'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
 ; CHECK-NEXT:    da analyze - flow [* *|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
 ; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {5,+,15}<nw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -389,12 +431,18 @@ define void @gcd6(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'gcd6'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: store i32 %conv, ptr %arrayidx5, align 4
 ; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,4}<nuw><nsw><%for.body3> slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: %2 = load i32, ptr %arrayidx9, align 4
 ; CHECK-NEXT:    da analyze - flow [* *|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,4}<nuw><nsw><%for.body3> slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: store i32 %2, ptr %B.addr.12, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx9, align 4 --> Dst: %2 = load i32, ptr %arrayidx9, align 4
 ; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.body3> slt) %n
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx9, align 4 --> Dst: store i32 %2, ptr %B.addr.12, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %2, ptr %B.addr.12, align 4 --> Dst: store i32 %2, ptr %B.addr.12, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/GCD.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/GCD.ll
@@ -285,10 +285,10 @@ define void @gcd4(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128)) == (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %M) to i128) == (4 * (sext i64 %M to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
 ; CHECK-NEXT:    da analyze - none!
@@ -298,10 +298,10 @@ define void @gcd4(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {4,+,15}<nw><%for.cond1.preheader> slt) %M
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128)) == (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %M) to i128) == (4 * (sext i64 %M to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {4,+,15}<nw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -367,33 +367,33 @@ define void @gcd5(ptr %A, ptr %B, i64 %M, i64 %N) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128)) == (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %M) to i128) == (4 * (sext i64 %M to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
 ; CHECK-NEXT:    da analyze - flow [> *]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,5}<nuw><nsw><%for.cond1.preheader> slt) %M
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128)) == (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %M) to i128) == (4 * (sext i64 %M to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(9 * %N),+,10}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(36 * %M * %N),+,(40 * %M)}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (36 * %N)) * %M)),+,(40 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (36 * %N)) * %M),+,(40 * %M)}<%for.body3> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {5,+,15}<nw><%for.cond1.preheader> slt) %M
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128)) == (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: %0 = load i32, ptr %arrayidx16, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {5,+,15}<nw><%for.cond1.preheader> slt) %M
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %M to i128))<nsw> == (sext i64 (4 * %M) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128)) == (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128)) == (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw> == (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %M) to i128) == (4 * (sext i64 %M to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) * (sext i64 {(-21 * %N),+,20}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128) == ((sext i64 (4 * %M) to i128) + (sext i64 {(-84 * %M * %N),+,(80 * %M)}<%for.body3> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + ((4 + (-84 * %N)) * %M)),+,(80 * %M)}<%for.body3> to i128) == (-1 + (sext i64 {((4 + (-84 * %N)) * %M),+,(80 * %M)}<%for.body3> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {5,+,15}<nw><%for.cond1.preheader> slt) %M
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx16, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -459,10 +459,10 @@ define void @gcd6(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,4}<nuw><nsw><%for.body3> slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,2}<nuw><%for.cond1.preheader> to i128)) == (sext i64 {0,+,(8 * %n)}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(8 * %n)}<%for.cond1.preheader> to i128)) == (sext i64 {(4 * %n),+,(8 * %n)}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(8 * %n)}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(8 * %n)}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %n)}<%for.cond1.preheader> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,2}<nuw><%for.cond1.preheader> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(8 * %n)}<%for.cond1.preheader> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(8 * %n)}<%for.cond1.preheader> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(8 * %n)}<%for.cond1.preheader> to i128) == (-1 + (sext i64 {(4 * %n),+,(8 * %n)}<%for.cond1.preheader> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,4}<nuw><nsw><%for.body3> slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: %2 = load i32, ptr %arrayidx9, align 4
 ; CHECK-NEXT:    da analyze - none!
@@ -472,10 +472,10 @@ define void @gcd6(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.body3> slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,8}<%for.cond1.preheader> to i128)) == (sext i64 {0,+,(32 * %n)}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(32 * %n)}<%for.cond1.preheader> to i128)) == (sext i64 {(4 * %n),+,(32 * %n)}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(32 * %n)}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(32 * %n)}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(32 * %n)}<%for.cond1.preheader> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,8}<%for.cond1.preheader> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(32 * %n)}<%for.cond1.preheader> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(32 * %n)}<%for.cond1.preheader> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(32 * %n)}<%for.cond1.preheader> to i128) == (-1 + (sext i64 {(4 * %n),+,(32 * %n)}<%for.cond1.preheader> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {1,+,6}<nuw><nsw><%for.body3> slt) %n
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx9, align 4 --> Dst: store i32 %2, ptr %B.addr.12, align 4
 ; CHECK-NEXT:    da analyze - confused!

--- a/llvm/test/Analysis/DependenceAnalysis/Invariant.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Invariant.ll
@@ -2,7 +2,6 @@
 ; RUN: opt < %s -disable-output "-passes=print<da>" -aa-pipeline=basic-aa 2>&1 \
 ; RUN: | FileCheck %s
 
-; XFAIL: *
 ; Currently fails since delinearization doesn't work as expected, due to the
 ; inconsistency in the estimated array sizes between `rr[i][j]` and `rr[j][j]`.
 ; The latter is now regarded as an access to a 1D array.
@@ -26,7 +25,7 @@ define float @foo(float %g, ptr %rr) nounwind {
 ; CHECK-NEXT:  Src: %0 = load float, ptr %arrayidx4, align 4 --> Dst: %0 = load float, ptr %arrayidx4, align 4
 ; CHECK-NEXT:    da analyze - consistent input [S 0]!
 ; CHECK-NEXT:  Src: %0 = load float, ptr %arrayidx4, align 4 --> Dst: %1 = load float, ptr %arrayidx6, align 4
-; CHECK-NEXT:    da analyze - input [* 0|<]!
+; CHECK-NEXT:    da analyze - input [* *|<]!
 ; CHECK-NEXT:  Src: %1 = load float, ptr %arrayidx6, align 4 --> Dst: %1 = load float, ptr %arrayidx6, align 4
 ; CHECK-NEXT:    da analyze - none!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/MismatchingNestLevels.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/MismatchingNestLevels.ll
@@ -14,21 +14,21 @@ define void @test1(i64 noundef %n, ptr nocapture noundef writeonly %A) {
 ; CHECK-NEXT:  Src: store double %conv, ptr %arrayidx, align 8 --> Dst: store double %conv, ptr %arrayidx, align 8
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {8,+,8}<nuw><%for.body> == (sext i64 {8,+,8}<nuw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw> == {7,+,8}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,8}<nuw><%for.body> to i128) == {8,+,8}<nuw><%for.body>
+; CHECK-NEXT:    Equal predicate: {7,+,8}<nuw><nsw><%for.body> == (-1 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store double %conv, ptr %arrayidx, align 8 --> Dst: store double %conv2, ptr %arrayidx3, align 8
 ; CHECK-NEXT:    da analyze - output [|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {8,+,8}<nuw><%for.body> == (sext i64 {8,+,8}<nuw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw> == {7,+,8}<nuw><nsw><%for.body>
-; CHECK-NEXT:    Equal predicate: (8 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw> == (sext i64 {16,+,8}<nw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {16,+,8}<nw><%for.body> to i128))<nsw> == (7 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,8}<nuw><%for.body> to i128) == {8,+,8}<nuw><%for.body>
+; CHECK-NEXT:    Equal predicate: {7,+,8}<nuw><nsw><%for.body> == (-1 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {16,+,8}<nw><%for.body> to i128) == (8 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (7 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {16,+,8}<nw><%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store double %conv2, ptr %arrayidx3, align 8 --> Dst: store double %conv2, ptr %arrayidx3, align 8
 ; CHECK-NEXT:    da analyze - output []!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {8,+,8}<nuw><%for.body> == (sext i64 {8,+,8}<nuw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (8 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw> == (sext i64 {16,+,8}<nw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {16,+,8}<nw><%for.body> to i128))<nsw> == (7 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,8}<nuw><%for.body> to i128) == {8,+,8}<nuw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {16,+,8}<nw><%for.body> to i128) == (8 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (7 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {16,+,8}<nw><%for.body> to i128))<nsw>
 ;
 entry:
   %mul1 = mul nsw i64 %n, %n
@@ -78,23 +78,23 @@ define dso_local void @test2(i32 noundef zeroext %n, ptr noundef %A, ptr noalias
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: (1 + (zext i32 %n to i64))<nuw><nsw> slt) (zext i32 (1 + %n) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i> == (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>)
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: (1 + (zext i32 %n to i64))<nuw><nsw> slt) (zext i32 (1 + %n) to i64)
 ; CHECK-NEXT:  Src: store float 1.230000e+02, ptr %arrayidx7, align 4 --> Dst: store float %conv13, ptr %arrayidx17, align 4
 ; CHECK-NEXT:    da analyze - output [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: (1 + (zext i32 %n to i64))<nuw><nsw> slt) (zext i32 (1 + %n) to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i> == (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>)
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw>
 ; CHECK-NEXT:  Src: store float %conv13, ptr %arrayidx17, align 4 --> Dst: store float %conv13, ptr %arrayidx17, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i> == (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>)
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw>
 ;
 entry:
   %add = add i32 %n, 1
@@ -167,15 +167,15 @@ define void @test3(i32 noundef %n, ptr noalias noundef %A, ptr noalias noundef %
 ; CHECK-NEXT:  Src: store double 0.000000e+00, ptr %arrayidx, align 8 --> Dst: store double 0.000000e+00, ptr %arrayidx, align 8
 ; CHECK-NEXT:    da analyze - output [* S]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,8}<%for.s> == (sext i64 {0,+,8}<%for.s> to i128)
-; CHECK-NEXT:    Equal predicate: (8 + (sext i64 {0,+,8}<%for.s> to i128))<nsw> == (sext i64 {8,+,8}<%for.s> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,8}<%for.s> to i128))<nsw> == (7 + (sext i64 {0,+,8}<%for.s> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,8}<%for.s> to i128) == {0,+,8}<%for.s>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,8}<%for.s> to i128) == (8 + (sext i64 {0,+,8}<%for.s> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (7 + (sext i64 {0,+,8}<%for.s> to i128))<nuw><nsw> == (-1 + (sext i64 {8,+,8}<%for.s> to i128))<nsw>
 ; CHECK-NEXT:  Src: store double 0.000000e+00, ptr %arrayidx, align 8 --> Dst: store double 1.000000e+00, ptr %arrayidx21, align 8
 ; CHECK-NEXT:    da analyze - output [*|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,8}<%for.s> == (sext i64 {0,+,8}<%for.s> to i128)
-; CHECK-NEXT:    Equal predicate: (8 + (sext i64 {0,+,8}<%for.s> to i128))<nsw> == (sext i64 {8,+,8}<%for.s> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,8}<%for.s> to i128))<nsw> == (7 + (sext i64 {0,+,8}<%for.s> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,8}<%for.s> to i128) == {0,+,8}<%for.s>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,8}<%for.s> to i128) == (8 + (sext i64 {0,+,8}<%for.s> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (7 + (sext i64 {0,+,8}<%for.s> to i128))<nuw><nsw> == (-1 + (sext i64 {8,+,8}<%for.s> to i128))<nsw>
 ; CHECK-NEXT:  Src: store double 1.000000e+00, ptr %arrayidx21, align 8 --> Dst: store double 1.000000e+00, ptr %arrayidx21, align 8
 ; CHECK-NEXT:    da analyze - none!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/MismatchingNestLevels.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/MismatchingNestLevels.ll
@@ -64,8 +64,12 @@ define dso_local void @test2(i32 noundef zeroext %n, ptr noundef %A, ptr noalias
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store float 1.230000e+02, ptr %arrayidx7, align 4 --> Dst: store float 1.230000e+02, ptr %arrayidx7, align 4
 ; CHECK-NEXT:    da analyze - output [*]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: (1 + (zext i32 %n to i64))<nuw><nsw> slt) (zext i32 (1 + %n) to i64)
 ; CHECK-NEXT:  Src: store float 1.230000e+02, ptr %arrayidx7, align 4 --> Dst: store float %conv13, ptr %arrayidx17, align 4
 ; CHECK-NEXT:    da analyze - output [*|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: (1 + (zext i32 %n to i64))<nuw><nsw> slt) (zext i32 (1 + %n) to i64)
 ; CHECK-NEXT:  Src: store float %conv13, ptr %arrayidx17, align 4 --> Dst: store float %conv13, ptr %arrayidx17, align 4
 ; CHECK-NEXT:    da analyze - none!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/MismatchingNestLevels.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/MismatchingNestLevels.ll
@@ -12,11 +12,23 @@
 define void @test1(i64 noundef %n, ptr nocapture noundef writeonly %A) {
 ; CHECK-LABEL: 'test1'
 ; CHECK-NEXT:  Src: store double %conv, ptr %arrayidx, align 8 --> Dst: store double %conv, ptr %arrayidx, align 8
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {8,+,8}<nuw><%for.body> == (sext i64 {8,+,8}<nuw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw> == {7,+,8}<nuw><nsw><%for.body>
 ; CHECK-NEXT:  Src: store double %conv, ptr %arrayidx, align 8 --> Dst: store double %conv2, ptr %arrayidx3, align 8
 ; CHECK-NEXT:    da analyze - output [|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {8,+,8}<nuw><%for.body> == (sext i64 {8,+,8}<nuw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw> == {7,+,8}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (8 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw> == (sext i64 {16,+,8}<nw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {16,+,8}<nw><%for.body> to i128))<nsw> == (7 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: store double %conv2, ptr %arrayidx3, align 8 --> Dst: store double %conv2, ptr %arrayidx3, align 8
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - output []!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {8,+,8}<nuw><%for.body> == (sext i64 {8,+,8}<nuw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (8 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nsw> == (sext i64 {16,+,8}<nw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {16,+,8}<nw><%for.body> to i128))<nsw> == (7 + (sext i64 {8,+,8}<nuw><%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %mul1 = mul nsw i64 %n, %n
@@ -63,15 +75,26 @@ define dso_local void @test2(i32 noundef zeroext %n, ptr noundef %A, ptr noalias
 ; CHECK-NEXT:  Src: store i32 %conv5, ptr %arrayidx, align 4 --> Dst: store float %conv13, ptr %arrayidx17, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store float 1.230000e+02, ptr %arrayidx7, align 4 --> Dst: store float 1.230000e+02, ptr %arrayidx7, align 4
-; CHECK-NEXT:    da analyze - output [*]!
+; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: (1 + (zext i32 %n to i64))<nuw><nsw> slt) (zext i32 (1 + %n) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i> == (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
 ; CHECK-NEXT:    Compare predicate: (1 + (zext i32 %n to i64))<nuw><nsw> slt) (zext i32 (1 + %n) to i64)
 ; CHECK-NEXT:  Src: store float 1.230000e+02, ptr %arrayidx7, align 4 --> Dst: store float %conv13, ptr %arrayidx17, align 4
-; CHECK-NEXT:    da analyze - output [*|<]!
+; CHECK-NEXT:    da analyze - output [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: (1 + (zext i32 %n to i64))<nuw><nsw> slt) (zext i32 (1 + %n) to i64)
+; CHECK-NEXT:    Equal predicate: {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i> == (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
 ; CHECK-NEXT:  Src: store float %conv13, ptr %arrayidx17, align 4 --> Dst: store float %conv13, ptr %arrayidx17, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i> == (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128)
 ;
 entry:
   %add = add i32 %n, 1
@@ -143,8 +166,16 @@ define void @test3(i32 noundef %n, ptr noalias noundef %A, ptr noalias noundef %
 ; CHECK-LABEL: 'test3'
 ; CHECK-NEXT:  Src: store double 0.000000e+00, ptr %arrayidx, align 8 --> Dst: store double 0.000000e+00, ptr %arrayidx, align 8
 ; CHECK-NEXT:    da analyze - output [* S]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,8}<%for.s> == (sext i64 {0,+,8}<%for.s> to i128)
+; CHECK-NEXT:    Equal predicate: (8 + (sext i64 {0,+,8}<%for.s> to i128))<nsw> == (sext i64 {8,+,8}<%for.s> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,8}<%for.s> to i128))<nsw> == (7 + (sext i64 {0,+,8}<%for.s> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: store double 0.000000e+00, ptr %arrayidx, align 8 --> Dst: store double 1.000000e+00, ptr %arrayidx21, align 8
 ; CHECK-NEXT:    da analyze - output [*|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,8}<%for.s> == (sext i64 {0,+,8}<%for.s> to i128)
+; CHECK-NEXT:    Equal predicate: (8 + (sext i64 {0,+,8}<%for.s> to i128))<nsw> == (sext i64 {8,+,8}<%for.s> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,8}<%for.s> to i128))<nsw> == (7 + (sext i64 {0,+,8}<%for.s> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: store double 1.000000e+00, ptr %arrayidx21, align 8 --> Dst: store double 1.000000e+00, ptr %arrayidx21, align 8
 ; CHECK-NEXT:    da analyze - none!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/MismatchingNestLevels.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/MismatchingNestLevels.ll
@@ -81,7 +81,6 @@ define dso_local void @test2(i32 noundef zeroext %n, ptr noundef %A, ptr noalias
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == {0,+,(4 * (zext i32 (1 + %n) to i128))<nuw><nsw>}<%for.i>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == ((sext i64 {0,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) + (4 * (zext i32 (1 + %n) to i128))<nuw><nsw>)
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 (1 + %n) to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128) == (-1 + (sext i64 {(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%for.i> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: (1 + (zext i32 %n to i64))<nuw><nsw> slt) (zext i32 (1 + %n) to i64)
 ; CHECK-NEXT:  Src: store float 1.230000e+02, ptr %arrayidx7, align 4 --> Dst: store float %conv13, ptr %arrayidx17, align 4
 ; CHECK-NEXT:    da analyze - output [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:

--- a/llvm/test/Analysis/DependenceAnalysis/NonCanonicalizedSubscript.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/NonCanonicalizedSubscript.ll
@@ -60,7 +60,6 @@ define void @coupled_miv_type_mismatch(i32 %n) {
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {10003,+,1}<nw><%for.cond1> slt) 10005
-; CHECK-NEXT:    Compare predicate: {10003,+,1}<nw><%for.cond1> slt) 10005
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx5, align 4 --> Dst: store i32 %add6, ptr %arrayidx10, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %add6, ptr %arrayidx10, align 4 --> Dst: store i32 %add6, ptr %arrayidx10, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/NonCanonicalizedSubscript.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/NonCanonicalizedSubscript.ll
@@ -57,9 +57,12 @@ for.end:
 define void @coupled_miv_type_mismatch(i32 %n) {
 ; CHECK-LABEL: 'coupled_miv_type_mismatch'
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx5, align 4 --> Dst: %2 = load i32, ptr %arrayidx5, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {10003,+,1}<nw><%for.cond1> slt) 10005
+; CHECK-NEXT:    Compare predicate: {10003,+,1}<nw><%for.cond1> slt) 10005
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx5, align 4 --> Dst: store i32 %add6, ptr %arrayidx10, align 4
-; CHECK-NEXT:    da analyze - anti [< >]!
+; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %add6, ptr %arrayidx10, align 4 --> Dst: store i32 %add6, ptr %arrayidx10, align 4
 ; CHECK-NEXT:    da analyze - none!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/Preliminary.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Preliminary.ll
@@ -65,8 +65,6 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; CHECK-NEXT:    Equal predicate: (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128) == {80000,+,80000}<nuw><nsw><%for.cond1.preheader>
 ; CHECK-NEXT:    Equal predicate: (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
-; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; CHECK-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
 ; CHECK-NEXT:    da analyze - flow [-3 -2] / assuming 1 loop level(s) fused: [-3 -2 -1]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -89,8 +87,6 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128) == (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128) == (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw>
 ; CHECK-NEXT:    Equal predicate: (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
-; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
 ; CHECK-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i64 %0, ptr %B.addr.24, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8

--- a/llvm/test/Analysis/DependenceAnalysis/Preliminary.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Preliminary.ll
@@ -60,12 +60,21 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'p2'
 ; CHECK-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %i.011, ptr %arrayidx8, align 8
 ; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; CHECK-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
 ; CHECK-NEXT:    da analyze - flow [* *|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; CHECK-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
 ; CHECK-NEXT:    da analyze - input [* * *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
 ; CHECK-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i64 %0, ptr %B.addr.24, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8

--- a/llvm/test/Analysis/DependenceAnalysis/Preliminary.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Preliminary.ll
@@ -63,8 +63,8 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
-; CHECK-NEXT:    Equal predicate: {80000,+,80000}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128) == {80000,+,80000}<nuw><nsw><%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; CHECK-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
@@ -72,13 +72,13 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
-; CHECK-NEXT:    Equal predicate: {80000,+,80000}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128) == {80000,+,80000}<nuw><nsw><%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
-; CHECK-NEXT:    Equal predicate: (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw> == (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128) == (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128) == (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
@@ -86,9 +86,9 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
-; CHECK-NEXT:    Equal predicate: (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw> == (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128) == (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128) == (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
 ; CHECK-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
@@ -475,9 +475,9 @@ define void @p4(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp sgt i64 %n, 0
@@ -532,9 +532,9 @@ define void @p5(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp sgt i64 %n, 0
@@ -579,21 +579,29 @@ define void @p6(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: store i32 %1, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {12,+,4}<nuw><nsw><%for.body> == (sext i64 {12,+,4}<nuw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw> == {11,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {12,+,4}<nuw><%for.body> to i128) == {12,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {11,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: %2 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [2]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {12,+,4}<nuw><nsw><%for.body> == (sext i64 {12,+,4}<nuw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw> == {11,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {12,+,4}<nuw><%for.body> to i128) == {12,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {11,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<nuw><%for.body> to i128) == {4,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {3,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {4,+,4}<nuw><%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: store i32 %2, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx3, align 4 --> Dst: %2 = load i32, ptr %arrayidx3, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<nuw><%for.body> to i128) == {4,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {3,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {4,+,4}<nuw><%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx3, align 4 --> Dst: store i32 %2, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %2, ptr %B.addr.02, align 4 --> Dst: store i32 %2, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<nuw><%for.body> to i128) == {4,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {3,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {4,+,4}<nuw><%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp sgt i64 %n, 0
@@ -768,24 +776,24 @@ define void @foo(ptr %s, i32 %size) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %0, align 4 --> Dst: %1 = load i32, ptr %0, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {4,+,4}<nuw><nsw><%while.body> == (sext i64 {4,+,4}<%while.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {4,+,4}<%while.body> to i128))<nsw> == (sext i64 {8,+,4}<%while.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,4}<%while.body> to i128))<nsw> == (3 + (sext i64 {4,+,4}<%while.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%while.body> to i128) == {4,+,4}<nuw><nsw><%while.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,4}<%while.body> to i128) == (4 + (sext i64 {4,+,4}<%while.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {4,+,4}<%while.body> to i128))<nuw><nsw> == (-1 + (sext i64 {8,+,4}<%while.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %0, align 4 --> Dst: store i32 %1, ptr %i.02, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [1]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {4,+,4}<nuw><nsw><%while.body> == (sext i64 {4,+,4}<nw><%while.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nsw> == (sext i64 {8,+,4}<%while.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,4}<%while.body> to i128))<nsw> == (3 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nuw><nsw>
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%while.body> == (sext i64 {0,+,4}<nuw><%while.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nsw> == (sext i64 {4,+,4}<nw><%while.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<nw><%while.body> to i128) == {4,+,4}<nuw><nsw><%while.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,4}<%while.body> to i128) == (4 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nuw><nsw> == (-1 + (sext i64 {8,+,4}<%while.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<nuw><%while.body> to i128) == {0,+,4}<nuw><nsw><%while.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<nw><%while.body> to i128) == (4 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %i.02, align 4 --> Dst: store i32 %1, ptr %i.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%while.body> == (sext i64 {0,+,4}<nuw><%while.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nsw> == (sext i64 {4,+,4}<nw><%while.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<nuw><%while.body> to i128) == {0,+,4}<nuw><nsw><%while.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<nw><%while.body> to i128) == (4 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nsw>
 ;
 entry:
   %idx.ext = zext i32 %size to i64

--- a/llvm/test/Analysis/DependenceAnalysis/Preliminary.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Preliminary.ll
@@ -59,20 +59,36 @@ entry:
 define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; CHECK-LABEL: 'p2'
 ; CHECK-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %i.011, ptr %arrayidx8, align 8
-; CHECK-NEXT:    da analyze - output [* * *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
+; CHECK-NEXT:    Equal predicate: {80000,+,80000}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; CHECK-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
-; CHECK-NEXT:    da analyze - flow [* *|<]!
+; CHECK-NEXT:    da analyze - flow [-3 -2] / assuming 1 loop level(s) fused: [-3 -2 -1]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
+; CHECK-NEXT:    Equal predicate: {80000,+,80000}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw>
+; CHECK-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
+; CHECK-NEXT:    Equal predicate: (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw> == (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
-; CHECK-NEXT:    da analyze - input [* * *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
+; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
+; CHECK-NEXT:    Equal predicate: (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw> == (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw>
 ; CHECK-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
 ; CHECK-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
 ; CHECK-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
@@ -457,7 +473,11 @@ define void @p4(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx5, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp sgt i64 %n, 0
@@ -510,7 +530,11 @@ define void @p5(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx5, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp sgt i64 %n, 0
@@ -553,9 +577,15 @@ for.end:                                          ; preds = %for.end.loopexit, %
 define void @p6(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'p6'
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: store i32 %1, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {12,+,4}<nuw><nsw><%for.body> == (sext i64 {12,+,4}<nuw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw> == {11,+,4}<nuw><nsw><%for.body>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: %2 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [2]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {12,+,4}<nuw><nsw><%for.body> == (sext i64 {12,+,4}<nuw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw> == {11,+,4}<nuw><nsw><%for.body>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: store i32 %2, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx3, align 4 --> Dst: %2 = load i32, ptr %arrayidx3, align 4
@@ -736,11 +766,26 @@ entry:
 define void @foo(ptr %s, i32 %size) nounwind uwtable ssp {
 ; CHECK-LABEL: 'foo'
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %0, align 4 --> Dst: %1 = load i32, ptr %0, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {4,+,4}<nuw><nsw><%while.body> == (sext i64 {4,+,4}<%while.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {4,+,4}<%while.body> to i128))<nsw> == (sext i64 {8,+,4}<%while.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,4}<%while.body> to i128))<nsw> == (3 + (sext i64 {4,+,4}<%while.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %0, align 4 --> Dst: store i32 %1, ptr %i.02, align 4
 ; CHECK-NEXT:    da analyze - consistent anti [1]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {4,+,4}<nuw><nsw><%while.body> == (sext i64 {4,+,4}<nw><%while.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nsw> == (sext i64 {8,+,4}<%while.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,4}<%while.body> to i128))<nsw> == (3 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%while.body> == (sext i64 {0,+,4}<nuw><%while.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nsw> == (sext i64 {4,+,4}<nw><%while.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %i.02, align 4 --> Dst: store i32 %1, ptr %i.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%while.body> == (sext i64 {0,+,4}<nuw><%while.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nsw> == (sext i64 {4,+,4}<nw><%while.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<nw><%while.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<nuw><%while.body> to i128))<nuw><nsw>
 ;
 entry:
   %idx.ext = zext i32 %size to i64

--- a/llvm/test/Analysis/DependenceAnalysis/PreliminaryNoValidityCheckFixedSize.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/PreliminaryNoValidityCheckFixedSize.ll
@@ -32,20 +32,36 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ;
 ; LIN-LABEL: 'p2'
 ; LIN-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %i.011, ptr %arrayidx8, align 8
-; LIN-NEXT:    da analyze - output [* * *]!
+; LIN-NEXT:    da analyze - consistent output [0 0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
+; LIN-NEXT:    Equal predicate: {80000,+,80000}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw>
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; LIN-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
-; LIN-NEXT:    da analyze - flow [* *|<]!
+; LIN-NEXT:    da analyze - flow [-3 -2] / assuming 1 loop level(s) fused: [-3 -2 -1]!
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
+; LIN-NEXT:    Equal predicate: {80000,+,80000}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw>
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
+; LIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
+; LIN-NEXT:    Equal predicate: (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw> == (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128)
+; LIN-NEXT:    Equal predicate: (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw>
 ; LIN-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; LIN-NEXT:    da analyze - confused!
 ; LIN-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
-; LIN-NEXT:    da analyze - input [* * *]!
+; LIN-NEXT:    da analyze - consistent input [0 0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
+; LIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
+; LIN-NEXT:    Equal predicate: (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw> == (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128)
+; LIN-NEXT:    Equal predicate: (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw>
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
 ; LIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
 ; LIN-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8

--- a/llvm/test/Analysis/DependenceAnalysis/PreliminaryNoValidityCheckFixedSize.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/PreliminaryNoValidityCheckFixedSize.ll
@@ -36,8 +36,8 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
-; LIN-NEXT:    Equal predicate: {80000,+,80000}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128) == {80000,+,80000}<nuw><nsw><%for.cond1.preheader>
+; LIN-NEXT:    Equal predicate: (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; LIN-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
@@ -45,13 +45,13 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
-; LIN-NEXT:    Equal predicate: {80000,+,80000}<nuw><nsw><%for.cond1.preheader> == (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128) == {80000,+,80000}<nuw><nsw><%for.cond1.preheader>
+; LIN-NEXT:    Equal predicate: (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
 ; LIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
-; LIN-NEXT:    Equal predicate: (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw> == (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128)
-; LIN-NEXT:    Equal predicate: (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128) == (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128) == (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw>
 ; LIN-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; LIN-NEXT:    da analyze - confused!
 ; LIN-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
@@ -59,9 +59,9 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
 ; LIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
-; LIN-NEXT:    Equal predicate: (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw> == (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128)
-; LIN-NEXT:    Equal predicate: (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw> == (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128) == (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128) == (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
 ; LIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
 ; LIN-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8

--- a/llvm/test/Analysis/DependenceAnalysis/PreliminaryNoValidityCheckFixedSize.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/PreliminaryNoValidityCheckFixedSize.ll
@@ -38,8 +38,6 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; LIN-NEXT:    Equal predicate: (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128) == {80000,+,80000}<nuw><nsw><%for.cond1.preheader>
 ; LIN-NEXT:    Equal predicate: (127 + (sext i64 {79872,+,80000}<nw><%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {80000,+,80000}<nuw><%for.cond1.preheader> to i128))<nsw>
-; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
-; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; LIN-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
 ; LIN-NEXT:    da analyze - flow [-3 -2] / assuming 1 loop level(s) fused: [-3 -2 -1]!
 ; LIN-NEXT:    Runtime Assumptions:
@@ -62,8 +60,6 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; LIN-NEXT:    Equal predicate: (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128) == (80000 * (sext i64 {3,+,1}<nuw><%for.cond1.preheader> to i128))<nsw>
 ; LIN-NEXT:    Equal predicate: (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128) == (80000 + (sext i64 {240000,+,80000}<%for.cond1.preheader> to i128))<nsw>
 ; LIN-NEXT:    Equal predicate: (127 + (sext i64 {319872,+,80000}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {320000,+,80000}<%for.cond1.preheader> to i128))<nsw>
-; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
-; LIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
 ; LIN-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; LIN-NEXT:    da analyze - confused!
 ; LIN-NEXT:  Src: store i64 %0, ptr %B.addr.24, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8

--- a/llvm/test/Analysis/DependenceAnalysis/PreliminaryNoValidityCheckFixedSize.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/PreliminaryNoValidityCheckFixedSize.ll
@@ -33,12 +33,21 @@ define void @p2(i64 %n, ptr %A, ptr %B) nounwind uwtable ssp {
 ; LIN-LABEL: 'p2'
 ; LIN-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %i.011, ptr %arrayidx8, align 8
 ; LIN-NEXT:    da analyze - output [* * *]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; LIN-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
 ; LIN-NEXT:    da analyze - flow [* *|<]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.cond4.preheader> slt) 100
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body6> slt) 100
 ; LIN-NEXT:  Src: store i64 %i.011, ptr %arrayidx8, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; LIN-NEXT:    da analyze - confused!
 ; LIN-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: %0 = load i64, ptr %arrayidx17, align 8
 ; LIN-NEXT:    da analyze - input [* * *]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><%for.cond4.preheader> slt) 100
+; LIN-NEXT:    Compare predicate: {1,+,1}<nuw><nsw><%for.body12> slt) 100
 ; LIN-NEXT:  Src: %0 = load i64, ptr %arrayidx17, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8
 ; LIN-NEXT:    da analyze - confused!
 ; LIN-NEXT:  Src: store i64 %0, ptr %B.addr.24, align 8 --> Dst: store i64 %0, ptr %B.addr.24, align 8

--- a/llvm/test/Analysis/DependenceAnalysis/Propagating.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Propagating.ll
@@ -17,7 +17,6 @@ define void @prop0(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {100,+,1}<nuw><nsw><%for.body3> slt) 101
-; CHECK-NEXT:    Compare predicate: {100,+,1}<nuw><nsw><%for.body3> slt) 101
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -153,7 +152,6 @@ define void @prop2(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 101
-; CHECK-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 101
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -207,7 +205,6 @@ define void @prop3(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.body3> slt) 101
-; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.body3> slt) 101
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx4, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - flow [<> *]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx4, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -215,7 +212,6 @@ define void @prop3(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {5,+,2}<nuw><nsw><%for.body3> slt) 99
 ; CHECK-NEXT:    Compare predicate: {5,+,2}<nuw><nsw><%for.body3> slt) 99
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -270,7 +266,6 @@ define void @prop4(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: store i32 %conv, ptr %arrayidx6, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {99,+,1}<nuw><nsw><%for.body3> slt) 102
 ; CHECK-NEXT:    Compare predicate: {99,+,1}<nuw><nsw><%for.body3> slt) 102
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: %0 = load i32, ptr %arrayidx10, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [1 99]!
@@ -335,7 +330,6 @@ define void @prop5(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {-28290,+,1}<nsw><%for.body3> sge) 0
-; CHECK-NEXT:    Compare predicate: {-28290,+,1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: %0 = load i32, ptr %arrayidx12, align 4
 ; CHECK-NEXT:    da analyze - flow [* *|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -397,7 +391,6 @@ define void @prop6(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: store i32 %conv, ptr %arrayidx6, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {102,+,1}<nuw><nsw><%for.body3> slt) 104
 ; CHECK-NEXT:    Compare predicate: {102,+,1}<nuw><nsw><%for.body3> slt) 104
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: %0 = load i32, ptr %arrayidx11, align 4
 ; CHECK-NEXT:    da analyze - flow [=> <>]!
@@ -580,7 +573,6 @@ define void @prop9(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: store i32 %conv, ptr %arrayidx7, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Compare predicate: {197,+,1}<nuw><nsw><%for.body3> slt) 205
 ; CHECK-NEXT:    Compare predicate: {197,+,1}<nuw><nsw><%for.body3> slt) 205
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: %0 = load i32, ptr %arrayidx9, align 4
 ; CHECK-NEXT:    da analyze - flow [<= <]!

--- a/llvm/test/Analysis/DependenceAnalysis/Propagating.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/Propagating.ll
@@ -14,9 +14,12 @@ target triple = "x86_64-apple-macosx10.6.0"
 define void @prop0(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'prop0'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: store i32 %conv, ptr %arrayidx5, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {100,+,1}<nuw><nsw><%for.body3> slt) 101
+; CHECK-NEXT:    Compare predicate: {100,+,1}<nuw><nsw><%for.body3> slt) 101
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
-; CHECK-NEXT:    da analyze - flow [< >]!
+; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx5, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
@@ -147,7 +150,10 @@ define void @prop2(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx4, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 101
+; CHECK-NEXT:    Compare predicate: {9,+,1}<nuw><nsw><%for.body3> slt) 101
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -198,13 +204,19 @@ for.end10:                                        ; preds = %for.inc8
 define void @prop3(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'prop3'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx4, align 4 --> Dst: store i32 %conv, ptr %arrayidx4, align 4
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.body3> slt) 101
+; CHECK-NEXT:    Compare predicate: {0,+,2}<nuw><nsw><%for.body3> slt) 101
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx4, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
 ; CHECK-NEXT:    da analyze - flow [<> *]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx4, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: %0 = load i32, ptr %arrayidx8, align 4
-; CHECK-NEXT:    da analyze - input [* *]!
+; CHECK-NEXT:    da analyze - consistent input [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {5,+,2}<nuw><nsw><%for.body3> slt) 99
+; CHECK-NEXT:    Compare predicate: {5,+,2}<nuw><nsw><%for.body3> slt) 99
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.11, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -256,9 +268,14 @@ for.end11:                                        ; preds = %for.inc9
 define void @prop4(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'prop4'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: store i32 %conv, ptr %arrayidx6, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {99,+,1}<nuw><nsw><%for.body3> slt) 102
+; CHECK-NEXT:    Compare predicate: {99,+,1}<nuw><nsw><%for.body3> slt) 102
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: %0 = load i32, ptr %arrayidx10, align 4
-; CHECK-NEXT:    da analyze - flow [< <>]!
+; CHECK-NEXT:    da analyze - consistent flow [1 99]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {99,+,1}<nuw><nsw><%for.body3> slt) 102
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx10, align 4 --> Dst: %0 = load i32, ptr %arrayidx10, align 4
@@ -315,7 +332,10 @@ for.end13:                                        ; preds = %for.inc11
 define void @prop5(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'prop5'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: store i32 %conv, ptr %arrayidx7, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {-28290,+,1}<nsw><%for.body3> sge) 0
+; CHECK-NEXT:    Compare predicate: {-28290,+,1}<nsw><%for.body3> sge) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: %0 = load i32, ptr %arrayidx12, align 4
 ; CHECK-NEXT:    da analyze - flow [* *|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -375,7 +395,10 @@ for.end15:                                        ; preds = %for.inc13
 define void @prop6(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'prop6'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: store i32 %conv, ptr %arrayidx6, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {102,+,1}<nuw><nsw><%for.body3> slt) 104
+; CHECK-NEXT:    Compare predicate: {102,+,1}<nuw><nsw><%for.body3> slt) 104
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: %0 = load i32, ptr %arrayidx11, align 4
 ; CHECK-NEXT:    da analyze - flow [=> <>]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx6, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4
@@ -555,7 +578,10 @@ for.end12:                                        ; preds = %for.inc10
 define void @prop9(ptr %A, ptr %B, i32 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'prop9'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: store i32 %conv, ptr %arrayidx7, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {197,+,1}<nuw><nsw><%for.body3> slt) 205
+; CHECK-NEXT:    Compare predicate: {197,+,1}<nuw><nsw><%for.body3> slt) 205
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: %0 = load i32, ptr %arrayidx9, align 4
 ; CHECK-NEXT:    da analyze - flow [<= <]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.11, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/SimpleSIVNoValidityCheck.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SimpleSIVNoValidityCheck.ll
@@ -21,16 +21,31 @@ define void @t1(i32 signext %n, i32 signext %m, ptr %a) {
 ;
 ; LIN-LABEL: 't1'
 ; LIN-NEXT:  Src: %6 = load i32, ptr %arrayidx7, align 4 --> Dst: %6 = load i32, ptr %arrayidx7, align 4
-; LIN-NEXT:    da analyze - input [* *]!
+; LIN-NEXT:    da analyze - consistent input [0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
+; LIN-NEXT:    Equal predicate: {(4 * (zext i32 %m to i128))<nuw><nsw>,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body> == (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>) == (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
 ; LIN-NEXT:  Src: %6 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %6, ptr %arrayidx11, align 4
-; LIN-NEXT:    da analyze - anti [* *|<]!
+; LIN-NEXT:    da analyze - consistent anti [1 -2]!
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
+; LIN-NEXT:    Equal predicate: {(4 * (zext i32 %m to i128))<nuw><nsw>,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body> == (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>) == (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
+; LIN-NEXT:    Equal predicate: {0,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body> == (sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
 ; LIN-NEXT:  Src: store i32 %6, ptr %arrayidx11, align 4 --> Dst: store i32 %6, ptr %arrayidx11, align 4
-; LIN-NEXT:    da analyze - output [* *]!
+; LIN-NEXT:    da analyze - consistent output [0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
+; LIN-NEXT:    Equal predicate: {0,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body> == (sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
 ;
 entry:
@@ -92,20 +107,53 @@ define void @t2(i32 signext %n, i32 signext %m, ptr %a) {
 ;
 ; LIN-LABEL: 't2'
 ; LIN-NEXT:  Src: %21 = load i32, ptr %arrayidx28, align 4 --> Dst: %21 = load i32, ptr %arrayidx28, align 4
-; LIN-NEXT:    da analyze - input [* * * * *]!
+; LIN-NEXT:    da analyze - consistent input [0 0 0 0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {0,+,1}<%for.body12> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
+; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (zext i32 %n to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
+; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
+; LIN-NEXT:    Equal predicate: ((zext i32 %m to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
+; LIN-NEXT:    Equal predicate: (4 * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128))<nsw> == (sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
+; LIN-NEXT:    Equal predicate: {(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128),+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body> == (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)) == (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<%for.body12> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
 ; LIN-NEXT:  Src: %21 = load i32, ptr %arrayidx28, align 4 --> Dst: store i32 %21, ptr %arrayidx38, align 4
-; LIN-NEXT:    da analyze - anti [* * * * *|<]!
+; LIN-NEXT:    da analyze - consistent anti [1 -2 0 -3 2]!
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<%for.body12> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
+; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (zext i32 %n to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
+; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
+; LIN-NEXT:    Equal predicate: ((zext i32 %m to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
+; LIN-NEXT:    Equal predicate: (4 * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128))<nsw> == (sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
+; LIN-NEXT:    Equal predicate: {(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128),+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body> == (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)) == (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {3,+,1}<%for.body12> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
+; LIN-NEXT:    Equal predicate: {0,+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body> == (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)) == (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
 ; LIN-NEXT:  Src: store i32 %21, ptr %arrayidx38, align 4 --> Dst: store i32 %21, ptr %arrayidx38, align 4
-; LIN-NEXT:    da analyze - output [* * * * *]!
+; LIN-NEXT:    da analyze - consistent output [0 0 0 0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {3,+,1}<%for.body12> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
+; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (zext i32 %n to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
+; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
+; LIN-NEXT:    Equal predicate: ((zext i32 %m to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
+; LIN-NEXT:    Equal predicate: (4 * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128))<nsw> == (sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
+; LIN-NEXT:    Equal predicate: {0,+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body> == (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)) == (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {3,+,1}<%for.body12> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
@@ -234,18 +282,39 @@ define void @t3(i64 %n, i64 %m, i64 %lb, ptr %a) {
 ;
 ; LIN-LABEL: 't3'
 ; LIN-NEXT:  Src: %2 = load i32, ptr %arrayidx6, align 4 --> Dst: %2 = load i32, ptr %arrayidx6, align 4
-; LIN-NEXT:    da analyze - input [* *]!
+; LIN-NEXT:    da analyze - consistent input [0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> sge) 0
+; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> slt) %m
+; LIN-NEXT:    Equal predicate: (4 * (sext i64 %m to i128))<nsw> == (sext i64 (4 * %m) to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) * (sext i64 {1,+,1}<nuw><%for.body> to i128)) == (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)) == (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * %m)),+,(4 * %m)}<%for.body> to i128)
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> sge) 0
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> slt) %m
 ; LIN-NEXT:  Src: %2 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %2, ptr %arrayidx8, align 4
-; LIN-NEXT:    da analyze - anti [* *|<]!
+; LIN-NEXT:    da analyze - anti [1 *]!
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> sge) 0
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> slt) %m
+; LIN-NEXT:    Equal predicate: (4 * (sext i64 %m to i128))<nsw> == (sext i64 (4 * %m) to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) * (sext i64 {1,+,1}<nuw><%for.body> to i128)) == (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)) == (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * %m)),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> sge) 0
+; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> slt) %m
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) + (sext i64 {0,+,(4 * %m)}<%for.body> to i128)) == (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %m)),+,(4 * %m)}<%for.body> to i128)
 ; LIN-NEXT:  Src: store i32 %2, ptr %arrayidx8, align 4 --> Dst: store i32 %2, ptr %arrayidx8, align 4
-; LIN-NEXT:    da analyze - output [* *]!
+; LIN-NEXT:    da analyze - consistent output [0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> sge) 0
+; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> slt) %m
+; LIN-NEXT:    Equal predicate: (4 * (sext i64 %m to i128))<nsw> == (sext i64 (4 * %m) to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) + (sext i64 {0,+,(4 * %m)}<%for.body> to i128)) == (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %m)),+,(4 * %m)}<%for.body> to i128)
 ; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> sge) 0
 ; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> slt) %m
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/SimpleSIVNoValidityCheck.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SimpleSIVNoValidityCheck.ll
@@ -24,28 +24,28 @@ define void @t1(i32 signext %n, i32 signext %m, ptr %a) {
 ; LIN-NEXT:    da analyze - consistent input [0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
-; LIN-NEXT:    Equal predicate: {(4 * (zext i32 %m to i128))<nuw><nsw>,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body> == (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>) == (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == {(4 * (zext i32 %m to i128))<nuw><nsw>,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body>
+; LIN-NEXT:    Equal predicate: (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == ((sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>)
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (8 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == (-1 + (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
 ; LIN-NEXT:  Src: %6 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %6, ptr %arrayidx11, align 4
 ; LIN-NEXT:    da analyze - consistent anti [1 -2]!
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
-; LIN-NEXT:    Equal predicate: {(4 * (zext i32 %m to i128))<nuw><nsw>,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body> == (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>) == (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == {(4 * (zext i32 %m to i128))<nuw><nsw>,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body>
+; LIN-NEXT:    Equal predicate: (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == ((sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>)
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (8 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == (-1 + (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
-; LIN-NEXT:    Equal predicate: {0,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body> == (sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == {0,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body>
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == ((sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>)
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == (-1 + (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw>
 ; LIN-NEXT:  Src: store i32 %6, ptr %arrayidx11, align 4 --> Dst: store i32 %6, ptr %arrayidx11, align 4
 ; LIN-NEXT:    da analyze - consistent output [0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
-; LIN-NEXT:    Equal predicate: {0,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body> == (sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>) == (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == {0,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body>
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == ((sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>)
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == (-1 + (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
 ;
 entry:
@@ -112,13 +112,13 @@ define void @t2(i32 signext %n, i32 signext %m, ptr %a) {
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<%for.body12> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
-; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (zext i32 %n to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
-; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
-; LIN-NEXT:    Equal predicate: ((zext i32 %m to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
-; LIN-NEXT:    Equal predicate: (4 * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128))<nsw> == (sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
-; LIN-NEXT:    Equal predicate: {(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128),+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body> == (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)) == (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128) == ((zext i32 %n to i128) * (zext i32 %n to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128) == ((zext i32 %n to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) == ((zext i32 %m to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) == (4 * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == {(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128),+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body>
+; LIN-NEXT:    Equal predicate: (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == (-1 + (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<%for.body12> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
@@ -128,32 +128,32 @@ define void @t2(i32 signext %n, i32 signext %m, ptr %a) {
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<%for.body12> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
-; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (zext i32 %n to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
-; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
-; LIN-NEXT:    Equal predicate: ((zext i32 %m to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
-; LIN-NEXT:    Equal predicate: (4 * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128))<nsw> == (sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
-; LIN-NEXT:    Equal predicate: {(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128),+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body> == (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)) == (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128) == ((zext i32 %n to i128) * (zext i32 %n to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128) == ((zext i32 %n to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) == ((zext i32 %m to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) == (4 * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == {(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128),+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body>
+; LIN-NEXT:    Equal predicate: (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == (-1 + (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {3,+,1}<%for.body12> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
-; LIN-NEXT:    Equal predicate: {0,+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body> == (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)) == (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == {0,+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body>
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == (-1 + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw>
 ; LIN-NEXT:  Src: store i32 %21, ptr %arrayidx38, align 4 --> Dst: store i32 %21, ptr %arrayidx38, align 4
 ; LIN-NEXT:    da analyze - consistent output [0 0 0 0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {3,+,1}<%for.body12> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
-; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (zext i32 %n to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
-; LIN-NEXT:    Equal predicate: ((zext i32 %n to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)
-; LIN-NEXT:    Equal predicate: ((zext i32 %m to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128)) == (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
-; LIN-NEXT:    Equal predicate: (4 * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128))<nsw> == (sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)
-; LIN-NEXT:    Equal predicate: {0,+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body> == (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)) == (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128) == ((zext i32 %n to i128) * (zext i32 %n to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128) == ((zext i32 %n to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64)) to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) == ((zext i32 %m to i128) * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64)) to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) == (4 * (sext i64 ((zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == {0,+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body>
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == (-1 + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {3,+,1}<%for.body12> slt) (zext i32 %n to i64)
 ; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
@@ -286,10 +286,10 @@ define void @t3(i64 %n, i64 %m, i64 %lb, ptr %a) {
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> sge) 0
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> slt) %m
-; LIN-NEXT:    Equal predicate: (4 * (sext i64 %m to i128))<nsw> == (sext i64 (4 * %m) to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) * (sext i64 {1,+,1}<nuw><%for.body> to i128)) == (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)) == (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * %m)),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 (4 * %m) to i128) == (4 * (sext i64 %m to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) * (sext i64 {1,+,1}<nuw><%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (8 * %m)),+,(4 * %m)}<%for.body> to i128) == (-1 + (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> sge) 0
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> slt) %m
 ; LIN-NEXT:  Src: %2 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %2, ptr %arrayidx8, align 4
@@ -297,24 +297,24 @@ define void @t3(i64 %n, i64 %m, i64 %lb, ptr %a) {
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> sge) 0
 ; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> slt) %m
-; LIN-NEXT:    Equal predicate: (4 * (sext i64 %m to i128))<nsw> == (sext i64 (4 * %m) to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) * (sext i64 {1,+,1}<nuw><%for.body> to i128)) == (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)) == (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (8 * %m)),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 (4 * %m) to i128) == (4 * (sext i64 %m to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) * (sext i64 {1,+,1}<nuw><%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (8 * %m)),+,(4 * %m)}<%for.body> to i128) == (-1 + (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> sge) 0
 ; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> slt) %m
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %m)}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) + (sext i64 {0,+,(4 * %m)}<%for.body> to i128)) == (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %m)),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) + (sext i64 {0,+,(4 * %m)}<%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %m)),+,(4 * %m)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))<nsw>
 ; LIN-NEXT:  Src: store i32 %2, ptr %arrayidx8, align 4 --> Dst: store i32 %2, ptr %arrayidx8, align 4
 ; LIN-NEXT:    da analyze - consistent output [0 0]!
 ; LIN-NEXT:    Runtime Assumptions:
 ; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> sge) 0
 ; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> slt) %m
-; LIN-NEXT:    Equal predicate: (4 * (sext i64 %m to i128))<nsw> == (sext i64 (4 * %m) to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %m)}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: ((sext i64 (4 * %m) to i128) + (sext i64 {0,+,(4 * %m)}<%for.body> to i128)) == (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128)
-; LIN-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %m)),+,(4 * %m)}<%for.body> to i128)
+; LIN-NEXT:    Equal predicate: (sext i64 (4 * %m) to i128) == (4 * (sext i64 %m to i128))<nsw>
+; LIN-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) + (sext i64 {0,+,(4 * %m)}<%for.body> to i128))
+; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %m)),+,(4 * %m)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))<nsw>
 ; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> sge) 0
 ; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> slt) %m
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/SimpleSIVNoValidityCheck.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SimpleSIVNoValidityCheck.ll
@@ -22,10 +22,16 @@ define void @t1(i32 signext %n, i32 signext %m, ptr %a) {
 ; LIN-LABEL: 't1'
 ; LIN-NEXT:  Src: %6 = load i32, ptr %arrayidx7, align 4 --> Dst: %6 = load i32, ptr %arrayidx7, align 4
 ; LIN-NEXT:    da analyze - input [* *]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
 ; LIN-NEXT:  Src: %6 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %6, ptr %arrayidx11, align 4
 ; LIN-NEXT:    da analyze - anti [* *|<]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
 ; LIN-NEXT:  Src: store i32 %6, ptr %arrayidx11, align 4 --> Dst: store i32 %6, ptr %arrayidx11, align 4
 ; LIN-NEXT:    da analyze - output [* *]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
 ;
 entry:
   %0 = zext i32 %m to i64
@@ -87,10 +93,22 @@ define void @t2(i32 signext %n, i32 signext %m, ptr %a) {
 ; LIN-LABEL: 't2'
 ; LIN-NEXT:  Src: %21 = load i32, ptr %arrayidx28, align 4 --> Dst: %21 = load i32, ptr %arrayidx28, align 4
 ; LIN-NEXT:    da analyze - input [* * * * *]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {0,+,1}<%for.body12> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
 ; LIN-NEXT:  Src: %21 = load i32, ptr %arrayidx28, align 4 --> Dst: store i32 %21, ptr %arrayidx38, align 4
 ; LIN-NEXT:    da analyze - anti [* * * * *|<]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {0,+,1}<%for.body12> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
 ; LIN-NEXT:  Src: store i32 %21, ptr %arrayidx38, align 4 --> Dst: store i32 %21, ptr %arrayidx38, align 4
 ; LIN-NEXT:    da analyze - output [* * * * *]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {3,+,1}<%for.body12> slt) (zext i32 %n to i64)
+; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
 ;
 entry:
   %0 = zext i32 %n to i64
@@ -217,10 +235,19 @@ define void @t3(i64 %n, i64 %m, i64 %lb, ptr %a) {
 ; LIN-LABEL: 't3'
 ; LIN-NEXT:  Src: %2 = load i32, ptr %arrayidx6, align 4 --> Dst: %2 = load i32, ptr %arrayidx6, align 4
 ; LIN-NEXT:    da analyze - input [* *]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> sge) 0
+; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> slt) %m
 ; LIN-NEXT:  Src: %2 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %2, ptr %arrayidx8, align 4
 ; LIN-NEXT:    da analyze - anti [* *|<]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> sge) 0
+; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> slt) %m
 ; LIN-NEXT:  Src: store i32 %2, ptr %arrayidx8, align 4 --> Dst: store i32 %2, ptr %arrayidx8, align 4
 ; LIN-NEXT:    da analyze - output [* *]!
+; LIN-NEXT:    Runtime Assumptions:
+; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> sge) 0
+; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> slt) %m
 ;
 entry:
   %0 = add i64 %n, -1

--- a/llvm/test/Analysis/DependenceAnalysis/SimpleSIVNoValidityCheck.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SimpleSIVNoValidityCheck.ll
@@ -27,7 +27,6 @@ define void @t1(i32 signext %n, i32 signext %m, ptr %a) {
 ; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == {(4 * (zext i32 %m to i128))<nuw><nsw>,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body>
 ; LIN-NEXT:    Equal predicate: (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == ((sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>)
 ; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (8 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == (-1 + (sext i64 {(8 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw>
-; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
 ; LIN-NEXT:  Src: %6 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %6, ptr %arrayidx11, align 4
 ; LIN-NEXT:    da analyze - consistent anti [1 -2]!
 ; LIN-NEXT:    Runtime Assumptions:
@@ -46,7 +45,6 @@ define void @t1(i32 signext %n, i32 signext %m, ptr %a) {
 ; LIN-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == {0,+,(4 * (zext i32 %m to i128))<nuw><nsw>}<%for.body>
 ; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == ((sext i64 {0,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) + (4 * (zext i32 %m to i128))<nuw><nsw>)
 ; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 %m to i64))<nuw><nsw>)<nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128) == (-1 + (sext i64 {(4 * (zext i32 %m to i64))<nuw><nsw>,+,(4 * (zext i32 %m to i64))<nuw><nsw>}<%for.body> to i128))<nsw>
-; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %m to i64)
 ;
 entry:
   %0 = zext i32 %m to i64
@@ -119,9 +117,6 @@ define void @t2(i32 signext %n, i32 signext %m, ptr %a) {
 ; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == {(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128),+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body>
 ; LIN-NEXT:    Equal predicate: (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))
 ; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == (-1 + (sext i64 {(8 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw>
-; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
-; LIN-NEXT:    Compare predicate: {0,+,1}<%for.body12> slt) (zext i32 %n to i64)
-; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
 ; LIN-NEXT:  Src: %21 = load i32, ptr %arrayidx28, align 4 --> Dst: store i32 %21, ptr %arrayidx38, align 4
 ; LIN-NEXT:    da analyze - consistent anti [1 -2 0 -3 2]!
 ; LIN-NEXT:    Runtime Assumptions:
@@ -154,9 +149,6 @@ define void @t2(i32 signext %n, i32 signext %m, ptr %a) {
 ; LIN-NEXT:    Equal predicate: (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == {0,+,(sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128)}<%for.body>
 ; LIN-NEXT:    Equal predicate: (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == ((sext i64 (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)) to i128) + (sext i64 {0,+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))
 ; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128) == (-1 + (sext i64 {(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64)),+,(4 * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %n to i64) * (zext i32 %m to i64))}<%for.body> to i128))<nsw>
-; LIN-NEXT:    Compare predicate: {2,+,1}<nuw><nsw><%for.body4> slt) (zext i32 %n to i64)
-; LIN-NEXT:    Compare predicate: {3,+,1}<%for.body12> slt) (zext i32 %n to i64)
-; LIN-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%for.body17> slt) (zext i32 %m to i64)
 ;
 entry:
   %0 = zext i32 %n to i64
@@ -290,8 +282,6 @@ define void @t3(i64 %n, i64 %m, i64 %lb, ptr %a) {
 ; LIN-NEXT:    Equal predicate: (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) * (sext i64 {1,+,1}<nuw><%for.body> to i128))
 ; LIN-NEXT:    Equal predicate: (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))
 ; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (8 * %m)),+,(4 * %m)}<%for.body> to i128) == (-1 + (sext i64 {(8 * %m),+,(4 * %m)}<%for.body> to i128))<nsw>
-; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> sge) 0
-; LIN-NEXT:    Compare predicate: {(-2 + %lb),+,1}<%for.body4> slt) %m
 ; LIN-NEXT:  Src: %2 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %2, ptr %arrayidx8, align 4
 ; LIN-NEXT:    da analyze - anti [1 *]!
 ; LIN-NEXT:    Runtime Assumptions:
@@ -315,8 +305,6 @@ define void @t3(i64 %n, i64 %m, i64 %lb, ptr %a) {
 ; LIN-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
 ; LIN-NEXT:    Equal predicate: (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128) == ((sext i64 (4 * %m) to i128) + (sext i64 {0,+,(4 * %m)}<%for.body> to i128))
 ; LIN-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %m)),+,(4 * %m)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %m),+,(4 * %m)}<%for.body> to i128))<nsw>
-; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> sge) 0
-; LIN-NEXT:    Compare predicate: {%lb,+,1}<%for.body4> slt) %m
 ;
 entry:
   %0 = add i64 %n, -1

--- a/llvm/test/Analysis/DependenceAnalysis/StrongSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/StrongSIV.ll
@@ -17,21 +17,29 @@ define void @strong0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: store i32 %1, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {12,+,4}<nuw><nsw><%for.body> == (sext i64 {12,+,4}<nuw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw> == {11,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {12,+,4}<nuw><%for.body> to i128) == {12,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {11,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: %2 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [2]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {12,+,4}<nuw><nsw><%for.body> == (sext i64 {12,+,4}<nuw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw> == {11,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {12,+,4}<nuw><%for.body> to i128) == {12,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {11,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<nuw><%for.body> to i128) == {4,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {3,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {4,+,4}<nuw><%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: store i32 %2, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx3, align 4 --> Dst: %2 = load i32, ptr %arrayidx3, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<nuw><%for.body> to i128) == {4,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {3,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {4,+,4}<nuw><%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx3, align 4 --> Dst: store i32 %2, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %2, ptr %B.addr.02, align 4 --> Dst: store i32 %2, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<nuw><%for.body> to i128) == {4,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {3,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {4,+,4}<nuw><%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp sgt i64 %n, 0
@@ -122,34 +130,34 @@ define void @strong2(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {2,+,1}<nw><%for.body> to i128))<nsw> == (sext i64 {8,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {8,+,4}<%for.body> to i128))<nsw> == (sext i64 {12,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {8,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,4}<%for.body> to i128) == (4 * (sext i64 {2,+,1}<nw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {12,+,4}<%for.body> to i128) == (4 + (sext i64 {8,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {8,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {12,+,4}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [2]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {2,+,1}<nw><%for.body> to i128))<nsw> == (sext i64 {8,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {8,+,4}<%for.body> to i128))<nsw> == (sext i64 {12,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {8,+,4}<%for.body> to i128))<nuw><nsw>
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,4}<%for.body> to i128) == (4 * (sext i64 {2,+,1}<nw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {12,+,4}<%for.body> to i128) == (4 + (sext i64 {8,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {8,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {12,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -464,9 +472,9 @@ define void @strong9(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-ALL-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
 ; CHECK-ALL-NEXT:    Runtime Assumptions:
-; CHECK-ALL-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-ALL-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-ALL-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 ; CHECK-STRONG-SIV-LABEL: 'strong9'
 ; CHECK-STRONG-SIV-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
@@ -482,9 +490,9 @@ define void @strong9(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-STRONG-SIV-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-STRONG-SIV-NEXT:    da analyze - consistent output [0]!
 ; CHECK-STRONG-SIV-NEXT:    Runtime Assumptions:
-; CHECK-STRONG-SIV-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-STRONG-SIV-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-STRONG-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-STRONG-SIV-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-STRONG-SIV-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-STRONG-SIV-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -528,19 +536,19 @@ define void @strong10(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 5 slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %n) to i128)}<%for.body> == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == {0,+,(sext i64 (4 * %n) to i128)}<%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 5 slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %n) to i128)}<%for.body> == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == {0,+,(sext i64 (4 * %n) to i128)}<%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -548,10 +556,10 @@ define void @strong10(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 5 slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %n) to i128)}<%for.body> == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == {0,+,(sext i64 (4 * %n) to i128)}<%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -594,9 +602,9 @@ define void @strong11(ptr %A) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 0, ptr %arrayidx, align 4 --> Dst: store i32 0, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0 S]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.cond1.preheader> == (sext i64 {0,+,4}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {4,+,4}<%for.cond1.preheader> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.cond1.preheader> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.cond1.preheader> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.cond1.preheader> to i128) == {0,+,4}<nuw><nsw><%for.cond1.preheader>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.cond1.preheader> to i128) == (4 + (sext i64 {0,+,4}<%for.cond1.preheader> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.cond1.preheader> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.cond1.preheader> to i128))<nsw>
 ;
 entry:
   br label %for.cond1.preheader

--- a/llvm/test/Analysis/DependenceAnalysis/StrongSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/StrongSIV.ll
@@ -15,9 +15,15 @@ target triple = "x86_64-apple-macosx10.6.0"
 define void @strong0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'strong0'
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: store i32 %1, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {12,+,4}<nuw><nsw><%for.body> == (sext i64 {12,+,4}<nuw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw> == {11,+,4}<nuw><nsw><%for.body>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: %2 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [2]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {12,+,4}<nuw><nsw><%for.body> == (sext i64 {12,+,4}<nuw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<nuw><%for.body> to i128))<nsw> == {11,+,4}<nuw><nsw><%for.body>
 ; CHECK-NEXT:  Src: store i32 %1, ptr %arrayidx, align 4 --> Dst: store i32 %2, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %2 = load i32, ptr %arrayidx3, align 4 --> Dst: %2 = load i32, ptr %arrayidx3, align 4
@@ -114,17 +120,36 @@ for.end:                                          ; preds = %for.end.loopexit, %
 define void @strong2(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'strong2'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {2,+,1}<nw><%for.body> to i128))<nsw> == (sext i64 {8,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {8,+,4}<%for.body> to i128))<nsw> == (sext i64 {12,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {8,+,4}<%for.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [2]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {2,+,1}<nw><%for.body> to i128))<nsw> == (sext i64 {8,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {8,+,4}<%for.body> to i128))<nsw> == (sext i64 {12,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {12,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {8,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -437,7 +462,11 @@ define void @strong9(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-ALL-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-ALL-NEXT:    da analyze - confused!
 ; CHECK-ALL-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-ALL-NEXT:    da analyze - none!
+; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
+; CHECK-ALL-NEXT:    Runtime Assumptions:
+; CHECK-ALL-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-ALL-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 ; CHECK-STRONG-SIV-LABEL: 'strong9'
 ; CHECK-STRONG-SIV-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
@@ -451,7 +480,11 @@ define void @strong9(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-STRONG-SIV-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-STRONG-SIV-NEXT:    da analyze - confused!
 ; CHECK-STRONG-SIV-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-STRONG-SIV-NEXT:    da analyze - none!
+; CHECK-STRONG-SIV-NEXT:    da analyze - consistent output [0]!
+; CHECK-STRONG-SIV-NEXT:    Runtime Assumptions:
+; CHECK-STRONG-SIV-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-STRONG-SIV-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-STRONG-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -495,19 +528,31 @@ define void @strong10(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 5 slt) %n
-; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %n) to i128)}<%for.body> == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 5 slt) %n
-; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %n) to i128)}<%for.body> == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: %0 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 5 slt) %n
-; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %n) to i128)}<%for.body> == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.01, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
@@ -545,13 +590,13 @@ for.end:                                          ; preds = %for.body
 ;;        A[i] = 0;
 
 define void @strong11(ptr %A) nounwind uwtable ssp {
-; CHECK-ALL-LABEL: 'strong11'
-; CHECK-ALL-NEXT:  Src: store i32 0, ptr %arrayidx, align 4 --> Dst: store i32 0, ptr %arrayidx, align 4
-; CHECK-ALL-NEXT:    da analyze - none!
-;
-; CHECK-STRONG-SIV-LABEL: 'strong11'
-; CHECK-STRONG-SIV-NEXT:  Src: store i32 0, ptr %arrayidx, align 4 --> Dst: store i32 0, ptr %arrayidx, align 4
-; CHECK-STRONG-SIV-NEXT:    da analyze - consistent output [0 S]!
+; CHECK-LABEL: 'strong11'
+; CHECK-NEXT:  Src: store i32 0, ptr %arrayidx, align 4 --> Dst: store i32 0, ptr %arrayidx, align 4
+; CHECK-NEXT:    da analyze - consistent output [0 S]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.cond1.preheader> == (sext i64 {0,+,4}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.cond1.preheader> to i128))<nsw> == (sext i64 {4,+,4}<%for.cond1.preheader> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.cond1.preheader> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.cond1.preheader> to i128))<nuw><nsw>
 ;
 entry:
   br label %for.cond1.preheader

--- a/llvm/test/Analysis/DependenceAnalysis/StrongSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/StrongSIV.ll
@@ -540,7 +540,6 @@ define void @strong10(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == {0,+,(sext i64 (4 * %n) to i128)}<%for.body>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -549,7 +548,6 @@ define void @strong10(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == {0,+,(sext i64 (4 * %n) to i128)}<%for.body>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: %0 = load i32, ptr %arrayidx3, align 4
@@ -560,7 +558,6 @@ define void @strong10(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == {0,+,(sext i64 (4 * %n) to i128)}<%for.body>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.01, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/StrongSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/StrongSIV.ll
@@ -494,16 +494,19 @@ define void @strong10(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: %0 = load i32, ptr %arrayidx3, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 5 slt) %n
 ; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: store i32 %0, ptr %B.addr.01, align 4
 ; CHECK-NEXT:    da analyze - confused!

--- a/llvm/test/Analysis/DependenceAnalysis/SymbolicRDIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SymbolicRDIV.ll
@@ -25,7 +25,11 @@ define void @symbolicrdiv0(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx8, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -94,7 +98,11 @@ define void @symbolicrdiv1(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx9, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body5> == (sext i64 {0,+,4}<%for.body5> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body5> to i128))<nsw> == (sext i64 {4,+,4}<%for.body5> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body5> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body5> to i128))<nuw><nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -165,7 +173,11 @@ define void @symbolicrdiv2(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -234,7 +246,11 @@ define void @symbolicrdiv3(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -301,7 +317,11 @@ define void @symbolicrdiv4(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -369,7 +389,11 @@ define void @symbolicrdiv5(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0

--- a/llvm/test/Analysis/DependenceAnalysis/SymbolicRDIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SymbolicRDIV.ll
@@ -27,9 +27,9 @@ define void @symbolicrdiv0(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body4> to i128) == {0,+,4}<nuw><nsw><%for.body4>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body4> to i128) == (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -100,9 +100,9 @@ define void @symbolicrdiv1(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body5> == (sext i64 {0,+,4}<%for.body5> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body5> to i128))<nsw> == (sext i64 {4,+,4}<%for.body5> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body5> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body5> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body5> to i128) == {0,+,4}<nuw><nsw><%for.body5>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body5> to i128) == (4 + (sext i64 {0,+,4}<%for.body5> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body5> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body5> to i128))<nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -175,9 +175,9 @@ define void @symbolicrdiv2(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body4> to i128) == {0,+,4}<nuw><nsw><%for.body4>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body4> to i128) == (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -248,9 +248,9 @@ define void @symbolicrdiv3(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body4> to i128) == {0,+,4}<nuw><nsw><%for.body4>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body4> to i128) == (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -319,9 +319,9 @@ define void @symbolicrdiv4(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body4> to i128) == {0,+,4}<nuw><nsw><%for.body4>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body4> to i128) == (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0
@@ -391,9 +391,9 @@ define void @symbolicrdiv5(ptr %A, ptr %B, i64 %n1, i64 %n2) nounwind uwtable ss
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body4> == (sext i64 {0,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw> == (sext i64 {4,+,4}<%for.body4> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body4> to i128) == {0,+,4}<nuw><nsw><%for.body4>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body4> to i128) == (4 + (sext i64 {0,+,4}<%for.body4> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body4> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body4> to i128))<nsw>
 ;
 entry:
   %cmp4 = icmp eq i64 %n1, 0

--- a/llvm/test/Analysis/DependenceAnalysis/SymbolicSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SymbolicSIV.ll
@@ -383,14 +383,21 @@ define void @symbolicsiv6(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: %M sge) 0
+; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:    Compare predicate: (16 * %N) ne) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
 ; CHECK-NEXT:    da analyze - flow [*|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: %M sge) 0
+; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) sge) 0
+; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) slt) %N
 ; CHECK-NEXT:    Compare predicate: (16 * %N) ne) 0
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
@@ -443,14 +450,21 @@ define void @symbolicsiv7(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: %M sge) 0
+; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:    Compare predicate: (8 * %N) ne) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %1 = load i32, ptr %arrayidx6, align 4
 ; CHECK-NEXT:    da analyze - flow [*|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: %M sge) 0
+; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx6, align 4 --> Dst: %1 = load i32, ptr %arrayidx6, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) sge) 0
+; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) slt) %N
 ; CHECK-NEXT:    Compare predicate: (8 * %N) ne) 0
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!

--- a/llvm/test/Analysis/DependenceAnalysis/SymbolicSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SymbolicSIV.ll
@@ -25,9 +25,9 @@ define void @symbolicsiv0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == {0,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -81,9 +81,9 @@ define void @symbolicsiv1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == {0,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -139,9 +139,9 @@ define void @symbolicsiv2(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == {0,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -195,9 +195,9 @@ define void @symbolicsiv3(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == {0,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -252,9 +252,9 @@ define void @symbolicsiv4(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == {0,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -308,9 +308,9 @@ define void @symbolicsiv5(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == {0,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -362,17 +362,17 @@ define void @weaktest(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,-1}<nw><%for.body> to i128))<nsw> == (sext i64 {0,+,-4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,-4}<%for.body> to i128))<nsw> == (sext i64 {4,+,-4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,-4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,-4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,-4}<%for.body> to i128) == (4 * (sext i64 {0,+,-1}<nw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,-4}<%for.body> to i128) == (4 + (sext i64 {0,+,-4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,-4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,-4}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -417,10 +417,10 @@ define void @symbolicsiv6(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128)) == (sext i64 {0,+,(16 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %N) to i128) == (4 * (sext i64 %N to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
@@ -428,10 +428,10 @@ define void @symbolicsiv6(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128)) == (sext i64 {0,+,(16 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %N) to i128) == (4 * (sext i64 %N to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) sge) 0
 ; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
@@ -441,10 +441,10 @@ define void @symbolicsiv6(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) sge) 0
 ; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) slt) %N
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128)) == (sext i64 {0,+,(16 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %N) to i128) == (4 * (sext i64 %N to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) sge) 0
 ; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
@@ -452,9 +452,9 @@ define void @symbolicsiv6(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == {0,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -504,10 +504,10 @@ define void @symbolicsiv7(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128)) == (sext i64 {0,+,(8 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %N) to i128) == (4 * (sext i64 %N to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %1 = load i32, ptr %arrayidx6, align 4
@@ -515,10 +515,10 @@ define void @symbolicsiv7(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128)) == (sext i64 {0,+,(8 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %N) to i128) == (4 * (sext i64 %N to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) sge) 0
 ; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
@@ -528,10 +528,10 @@ define void @symbolicsiv7(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) sge) 0
 ; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) slt) %N
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128)) == (sext i64 {0,+,(8 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %N) to i128) == (4 * (sext i64 %N to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) sge) 0
 ; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
@@ -539,9 +539,9 @@ define void @symbolicsiv7(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:  Src: store i32 %1, ptr %B.addr.02, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == {0,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/SymbolicSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SymbolicSIV.ll
@@ -421,8 +421,6 @@ define void @symbolicsiv6(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: %M sge) 0
-; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
 ; CHECK-NEXT:    da analyze - flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -445,8 +443,6 @@ define void @symbolicsiv6(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) sge) 0
-; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
@@ -508,8 +504,6 @@ define void @symbolicsiv7(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: %M sge) 0
-; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %1 = load i32, ptr %arrayidx6, align 4
 ; CHECK-NEXT:    da analyze - flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -532,8 +526,6 @@ define void @symbolicsiv7(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128) == ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) sge) 0
-; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %1, ptr %B.addr.02, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/SymbolicSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/SymbolicSIV.ll
@@ -23,7 +23,11 @@ define void @symbolicsiv0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx4, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -75,7 +79,11 @@ define void @symbolicsiv1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx5, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -129,7 +137,11 @@ define void @symbolicsiv2(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -181,7 +193,11 @@ define void @symbolicsiv3(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -234,7 +250,11 @@ define void @symbolicsiv4(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx3, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -286,7 +306,11 @@ define void @symbolicsiv5(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx4, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -336,11 +360,19 @@ define void @weaktest(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,-1}<nw><%for.body> to i128))<nsw> == (sext i64 {0,+,-4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,-4}<%for.body> to i128))<nsw> == (sext i64 {4,+,-4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,-4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,-4}<%for.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -385,12 +417,23 @@ define void @symbolicsiv6(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
-; CHECK-NEXT:    Compare predicate: (16 * %N) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128)) == (sext i64 {0,+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: %M sge) 0
+; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
-; CHECK-NEXT:    da analyze - flow [*|<]!
+; CHECK-NEXT:    da analyze - flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128)) == (sext i64 {0,+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) sge) 0
+; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: %0 = load i32, ptr %arrayidx7, align 4
@@ -398,11 +441,20 @@ define void @symbolicsiv6(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) sge) 0
 ; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) slt) %N
-; CHECK-NEXT:    Compare predicate: (16 * %N) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,4}<%for.body> to i128)) == (sext i64 {0,+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(16 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(16 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(16 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) sge) 0
+; CHECK-NEXT:    Compare predicate: (1 + (3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx7, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -452,12 +504,23 @@ define void @symbolicsiv7(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
-; CHECK-NEXT:    Compare predicate: (8 * %N) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128)) == (sext i64 {0,+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: %M sge) 0
+; CHECK-NEXT:    Compare predicate: %M slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %1 = load i32, ptr %arrayidx6, align 4
-; CHECK-NEXT:    da analyze - flow [*|<]!
+; CHECK-NEXT:    da analyze - flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: %M sge) 0
 ; CHECK-NEXT:    Compare predicate: %M slt) %N
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128)) == (sext i64 {0,+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) sge) 0
+; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx6, align 4 --> Dst: %1 = load i32, ptr %arrayidx6, align 4
@@ -465,11 +528,20 @@ define void @symbolicsiv7(ptr %A, ptr %B, i64 %n, i64 %N, i64 %M) nounwind uwtab
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) sge) 0
 ; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) slt) %N
-; CHECK-NEXT:    Compare predicate: (8 * %N) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %N to i128))<nsw> == (sext i64 (4 * %N) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) * (sext i64 {0,+,2}<%for.body> to i128)) == (sext i64 {0,+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %N) to i128) + (sext i64 {0,+,(8 * %N)}<%for.body> to i128)) == (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %N),+,(8 * %N)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %N)),+,(8 * %N)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) sge) 0
+; CHECK-NEXT:    Compare predicate: (2 + (-3 * %M)) slt) %N
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx6, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %1, ptr %B.addr.02, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,4}<nuw><nsw><%for.body> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
@@ -17,22 +17,42 @@ define void @weakcrossing0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 1 slt) %n
-; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 1 slt) %n
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: 1 slt) %n
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,-1}<%for.body> to i128)) == (sext i64 {0,+,(-4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(-4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(-4 * %n)}<%for.body> to i128)
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 1 slt) %n
-; CHECK-NEXT:    Compare predicate: (-4 * %n) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,-1}<%for.body> to i128)) == (sext i64 {0,+,(-4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(-4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(-4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -84,7 +104,11 @@ define void @weakcrossing1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -251,17 +275,29 @@ for.end:                                          ; preds = %for.body
 define void @weakcrossing5(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'weakcrossing5'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,3}<%for.body> to i128))<nsw> == (sext i64 {0,+,12}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,12}<%for.body> to i128))<nsw> == (sext i64 {4,+,12}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,12}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,12}<%for.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %1 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx2, align 4 --> Dst: %1 = load i32, ptr %arrayidx2, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {5,+,-3}<%for.body> to i128))<nsw> == (sext i64 {20,+,-12}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {20,+,-12}<%for.body> to i128))<nsw> == (sext i64 {24,+,-12}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {24,+,-12}<%for.body> to i128))<nsw> == (3 + (sext i64 {20,+,-12}<%for.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %1, ptr %B.addr.02, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
@@ -17,42 +17,42 @@ define void @weakcrossing0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 1 slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 1 slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 1 slt) %n
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,-1}<%for.body> to i128)) == (sext i64 {0,+,(-4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(-4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(-4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(-4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,-1}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(-4 * %n)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(-4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 1 slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,-1}<%for.body> to i128)) == (sext i64 {0,+,(-4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(-4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(-4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(-4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,-1}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(-4 * %n)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(-4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -106,9 +106,9 @@ define void @weakcrossing1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -277,9 +277,9 @@ define void @weakcrossing5(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,3}<%for.body> to i128))<nsw> == (sext i64 {0,+,12}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,12}<%for.body> to i128))<nsw> == (sext i64 {4,+,12}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,12}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,12}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,12}<%for.body> to i128) == (4 * (sext i64 {0,+,3}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,12}<%for.body> to i128) == (4 + (sext i64 {0,+,12}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,12}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,12}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %1 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
@@ -287,17 +287,17 @@ define void @weakcrossing5(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx2, align 4 --> Dst: %1 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {5,+,-3}<%for.body> to i128))<nsw> == (sext i64 {20,+,-12}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {20,+,-12}<%for.body> to i128))<nsw> == (sext i64 {24,+,-12}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {24,+,-12}<%for.body> to i128))<nsw> == (3 + (sext i64 {20,+,-12}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {20,+,-12}<%for.body> to i128) == (4 * (sext i64 {5,+,-3}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {24,+,-12}<%for.body> to i128) == (4 + (sext i64 {20,+,-12}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {20,+,-12}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {24,+,-12}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: %1 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %1, ptr %B.addr.02, align 4 --> Dst: store i32 %1, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
@@ -21,7 +21,6 @@ define void @weakcrossing0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - flow [0|<]!
 ; CHECK-NEXT:    Runtime Assumptions:
@@ -30,7 +29,6 @@ define void @weakcrossing0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(-4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,-1}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(-4 * %n)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(-4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128))<nsw>
@@ -44,7 +42,6 @@ define void @weakcrossing0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(-4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,-1}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(-4 * %n)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(-4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(-4 * %n)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakCrossingSIV.ll
@@ -16,14 +16,18 @@ define void @weakcrossing0(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - flow [0|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: %0 = load i32, ptr %arrayidx2, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 1 slt) %n
 ; CHECK-NEXT:    Compare predicate: (-4 * %n) ne) 0
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx2, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
@@ -97,7 +97,6 @@ define void @weakzerodst1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 10 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - flow [p<=|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
@@ -92,6 +92,7 @@ define void @weakzerodst1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 10 slt) %n
 ; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - flow [p<=|<]!

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
@@ -93,7 +93,11 @@ define void @weakzerodst1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 10 slt) %n
-; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: 10 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - flow [p<=|<]!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
@@ -103,7 +107,11 @@ define void @weakzerodst1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -311,7 +319,11 @@ for.end:                                          ; preds = %for.body
 define void @weakzerodst6(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-LABEL: 'weakzerodst6'
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,3}<%for.body> to i128))<nsw> == (sext i64 {0,+,12}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,12}<%for.body> to i128))<nsw> == (sext i64 {4,+,12}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,12}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,12}<%for.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
@@ -321,7 +333,11 @@ define void @weakzerodst6(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroDstSIV.ll
@@ -93,10 +93,10 @@ define void @weakzerodst1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 10 slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 10 slt) %n
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - flow [p<=|<]!
@@ -109,9 +109,9 @@ define void @weakzerodst1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -321,9 +321,9 @@ define void @weakzerodst6(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %conv, ptr %arrayidx, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,3}<%for.body> to i128))<nsw> == (sext i64 {0,+,12}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,12}<%for.body> to i128))<nsw> == (sext i64 {4,+,12}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,12}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,12}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,12}<%for.body> to i128) == (4 * (sext i64 {0,+,3}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,12}<%for.body> to i128) == (4 + (sext i64 {0,+,12}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,12}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,12}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
@@ -335,9 +335,9 @@ define void @weakzerodst6(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
@@ -97,11 +97,19 @@ define void @weakzerosrc1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 10 slt) %n
-; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Compare predicate: 10 slt) %n
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -315,11 +323,19 @@ define void @weakzerosrc6(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: store i32 %conv, ptr %arrayidx, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,3}<%for.body> to i128))<nsw> == (sext i64 {0,+,12}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,12}<%for.body> to i128))<nsw> == (sext i64 {4,+,12}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,12}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,12}<%for.body> to i128))<nuw><nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
@@ -101,7 +101,6 @@ define void @weakzerosrc1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 10 slt) %n
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
@@ -97,19 +97,19 @@ define void @weakzerosrc1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 10 slt) %n
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %n to i128))<nsw> == (sext i64 (4 * %n) to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128)) == (sext i64 {0,+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128)) == (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw> == (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %n) to i128) == (4 * (sext i64 %n to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) * (sext i64 {0,+,1}<nuw><%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128) == ((sext i64 (4 * %n) to i128) + (sext i64 {0,+,(4 * %n)}<%for.body> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %n)),+,(4 * %n)}<%for.body> to i128) == (-1 + (sext i64 {(4 * %n),+,(4 * %n)}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 10 slt) %n
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0
@@ -325,17 +325,17 @@ define void @weakzerosrc6(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,3}<%for.body> to i128))<nsw> == (sext i64 {0,+,12}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,12}<%for.body> to i128))<nsw> == (sext i64 {4,+,12}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,12}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,12}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,12}<%for.body> to i128) == (4 * (sext i64 {0,+,3}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,12}<%for.body> to i128) == (4 + (sext i64 {0,+,12}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,12}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,12}<%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!
 ; CHECK-NEXT:  Src: store i32 %0, ptr %B.addr.02, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw> == (sext i64 {0,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw> == (sext i64 {4,+,4}<%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw> == (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,4}<%for.body> to i128) == (4 * (sext i64 {0,+,1}<nuw><%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {4,+,4}<%for.body> to i128) == (4 + (sext i64 {0,+,4}<%for.body> to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (3 + (sext i64 {0,+,4}<%for.body> to i128))<nuw><nsw> == (-1 + (sext i64 {4,+,4}<%for.body> to i128))<nsw>
 ;
 entry:
   %cmp1 = icmp eq i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/WeakZeroSrcSIV.ll
@@ -96,6 +96,7 @@ define void @weakzerosrc1(ptr %A, ptr %B, i64 %n) nounwind uwtable ssp {
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: %0 = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 10 slt) %n
 ; CHECK-NEXT:    Compare predicate: (4 * %n) ne) 0
 ; CHECK-NEXT:  Src: %0 = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %0, ptr %B.addr.02, align 4
 ; CHECK-NEXT:    da analyze - confused!

--- a/llvm/test/Analysis/DependenceAnalysis/becount-couldnotcompute.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/becount-couldnotcompute.ll
@@ -14,7 +14,6 @@ define void @test(i64 %conv, ptr %a) {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %conv)}<%loop> to i128) == {0,+,(sext i64 (4 * %conv) to i128)}<%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %conv),+,(4 * %conv)}<%loop> to i128) == ((sext i64 (4 * %conv) to i128) + (sext i64 {0,+,(4 * %conv)}<%loop> to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %conv)),+,(4 * %conv)}<%loop> to i128) == (-1 + (sext i64 {(4 * %conv),+,(4 * %conv)}<%loop> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop> slt) %conv
 ;
 entry:
   %sub = add i64 %conv, 1

--- a/llvm/test/Analysis/DependenceAnalysis/becount-couldnotcompute.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/becount-couldnotcompute.ll
@@ -10,10 +10,10 @@ define void @test(i64 %conv, ptr %a) {
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop> slt) %conv
-; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %conv to i128))<nsw> == (sext i64 (4 * %conv) to i128)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %conv) to i128)}<%loop> == (sext i64 {0,+,(4 * %conv)}<%loop> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %conv) to i128) + (sext i64 {0,+,(4 * %conv)}<%loop> to i128)) == (sext i64 {(4 * %conv),+,(4 * %conv)}<%loop> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %conv),+,(4 * %conv)}<%loop> to i128))<nsw> == (sext i64 {(-1 + (4 * %conv)),+,(4 * %conv)}<%loop> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 (4 * %conv) to i128) == (4 * (sext i64 %conv to i128))<nsw>
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(4 * %conv)}<%loop> to i128) == {0,+,(sext i64 (4 * %conv) to i128)}<%loop>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(4 * %conv),+,(4 * %conv)}<%loop> to i128) == ((sext i64 (4 * %conv) to i128) + (sext i64 {0,+,(4 * %conv)}<%loop> to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (4 * %conv)),+,(4 * %conv)}<%loop> to i128) == (-1 + (sext i64 {(4 * %conv),+,(4 * %conv)}<%loop> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop> slt) %conv
 ;
 entry:

--- a/llvm/test/Analysis/DependenceAnalysis/becount-couldnotcompute.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/becount-couldnotcompute.ll
@@ -10,7 +10,11 @@ define void @test(i64 %conv, ptr %a) {
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop> slt) %conv
-; CHECK-NEXT:    Compare predicate: (4 + (4 * %conv)) ne) 0
+; CHECK-NEXT:    Equal predicate: (4 * (sext i64 %conv to i128))<nsw> == (sext i64 (4 * %conv) to i128)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (4 * %conv) to i128)}<%loop> == (sext i64 {0,+,(4 * %conv)}<%loop> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 (4 * %conv) to i128) + (sext i64 {0,+,(4 * %conv)}<%loop> to i128)) == (sext i64 {(4 * %conv),+,(4 * %conv)}<%loop> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(4 * %conv),+,(4 * %conv)}<%loop> to i128))<nsw> == (sext i64 {(-1 + (4 * %conv)),+,(4 * %conv)}<%loop> to i128)
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop> slt) %conv
 ;
 entry:
   %sub = add i64 %conv, 1

--- a/llvm/test/Analysis/DependenceAnalysis/becount-couldnotcompute.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/becount-couldnotcompute.ll
@@ -9,6 +9,7 @@ define void @test(i64 %conv, ptr %a) {
 ; CHECK-NEXT:  Src: %ld = load i32, ptr %arrayidx12, align 4 --> Dst: %ld = load i32, ptr %arrayidx12, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop> slt) %conv
 ; CHECK-NEXT:    Compare predicate: (4 + (4 * %conv)) ne) 0
 ;
 entry:

--- a/llvm/test/Analysis/DependenceAnalysis/compute-absolute-value.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/compute-absolute-value.ll
@@ -19,16 +19,20 @@ define void @unknown_sign(ptr %a, i64 %k) {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Compare predicate: (-1 * %k) ne) 0
-; CHECK-NEXT:  Src: store i8 1, ptr %idx.0, align 1 --> Dst: store i8 2, ptr %idx.1, align 1
-; CHECK-NEXT:    da analyze - output [*|<]!
-; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {0,+,(-1 * (sext i64 %k to i128))<nsw>}<%loop> == {0,+,(sext i64 (-1 * %k) to i128)}<nsw><%loop>
+; CHECK-NEXT:    Equal predicate: {(sext i64 %k to i128),+,(sext i64 (-1 * %k) to i128)}<nw><%loop> == (sext i64 {%k,+,(-1 * %k)}<nw><%loop> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {%k,+,(-1 * %k)}<nw><%loop> to i128))<nsw> == (sext i64 {(-1 + %k),+,(-1 * %k)}<nw><%loop> to i128)
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
+; CHECK-NEXT:  Src: store i8 1, ptr %idx.0, align 1 --> Dst: store i8 2, ptr %idx.1, align 1
+; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i8 2, ptr %idx.1, align 1 --> Dst: store i8 2, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 1 slt) %k
-; CHECK-NEXT:    Compare predicate: (-1 * %k) ne) 0
+; CHECK-NEXT:    Equal predicate: {(2 * (sext i64 %k to i128))<nsw>,+,(-1 * (sext i64 %k to i128))<nsw>}<%loop> == (sext i64 {(2 * %k),+,(-1 * %k)}<%loop> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 {(2 * %k),+,(-1 * %k)}<%loop> to i128) + (sext i64 %k to i128)) == (sext i64 {(3 * %k),+,(-1 * %k)}<%loop> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(3 * %k),+,(-1 * %k)}<%loop> to i128))<nsw> == (sext i64 {(-1 + (3 * %k)),+,(-1 * %k)}<%loop> to i128)
+; CHECK-NEXT:    Compare predicate: 1 slt) %k
 ;
 entry:
   %k.neg = sub nsw i64 0, %k

--- a/llvm/test/Analysis/DependenceAnalysis/compute-absolute-value.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/compute-absolute-value.ll
@@ -19,9 +19,9 @@ define void @unknown_sign(ptr %a, i64 %k) {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: {0,+,(-1 * (sext i64 %k to i128))<nsw>}<%loop> == {0,+,(sext i64 (-1 * %k) to i128)}<nsw><%loop>
-; CHECK-NEXT:    Equal predicate: {(sext i64 %k to i128),+,(sext i64 (-1 * %k) to i128)}<nw><%loop> == (sext i64 {%k,+,(-1 * %k)}<nw><%loop> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {%k,+,(-1 * %k)}<nw><%loop> to i128))<nsw> == (sext i64 {(-1 + %k),+,(-1 * %k)}<nw><%loop> to i128)
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (-1 * %k) to i128)}<nsw><%loop> == {0,+,(-1 * (sext i64 %k to i128))<nsw>}<%loop>
+; CHECK-NEXT:    Equal predicate: (sext i64 {%k,+,(-1 * %k)}<nw><%loop> to i128) == {(sext i64 %k to i128),+,(sext i64 (-1 * %k) to i128)}<nw><%loop>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + %k),+,(-1 * %k)}<nw><%loop> to i128) == (-1 + (sext i64 {%k,+,(-1 * %k)}<nw><%loop> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:  Src: store i8 1, ptr %idx.0, align 1 --> Dst: store i8 2, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - none!
@@ -29,9 +29,9 @@ define void @unknown_sign(ptr %a, i64 %k) {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 1 slt) %k
-; CHECK-NEXT:    Equal predicate: {(2 * (sext i64 %k to i128))<nsw>,+,(-1 * (sext i64 %k to i128))<nsw>}<%loop> == (sext i64 {(2 * %k),+,(-1 * %k)}<%loop> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 {(2 * %k),+,(-1 * %k)}<%loop> to i128) + (sext i64 %k to i128)) == (sext i64 {(3 * %k),+,(-1 * %k)}<%loop> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(3 * %k),+,(-1 * %k)}<%loop> to i128))<nsw> == (sext i64 {(-1 + (3 * %k)),+,(-1 * %k)}<%loop> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 {(2 * %k),+,(-1 * %k)}<%loop> to i128) == {(2 * (sext i64 %k to i128))<nsw>,+,(-1 * (sext i64 %k to i128))<nsw>}<%loop>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(3 * %k),+,(-1 * %k)}<%loop> to i128) == ((sext i64 {(2 * %k),+,(-1 * %k)}<%loop> to i128) + (sext i64 %k to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (3 * %k)),+,(-1 * %k)}<%loop> to i128) == (-1 + (sext i64 {(3 * %k),+,(-1 * %k)}<%loop> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 1 slt) %k
 ;
 entry:

--- a/llvm/test/Analysis/DependenceAnalysis/compute-absolute-value.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/compute-absolute-value.ll
@@ -22,7 +22,6 @@ define void @unknown_sign(ptr %a, i64 %k) {
 ; CHECK-NEXT:    Equal predicate: {0,+,(sext i64 (-1 * %k) to i128)}<nsw><%loop> == {0,+,(-1 * (sext i64 %k to i128))<nsw>}<%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {%k,+,(-1 * %k)}<nw><%loop> to i128) == {(sext i64 %k to i128),+,(sext i64 (-1 * %k) to i128)}<nw><%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + %k),+,(-1 * %k)}<nw><%loop> to i128) == (-1 + (sext i64 {%k,+,(-1 * %k)}<nw><%loop> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:  Src: store i8 1, ptr %idx.0, align 1 --> Dst: store i8 2, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i8 2, ptr %idx.1, align 1 --> Dst: store i8 2, ptr %idx.1, align 1
@@ -32,7 +31,6 @@ define void @unknown_sign(ptr %a, i64 %k) {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(2 * %k),+,(-1 * %k)}<%loop> to i128) == {(2 * (sext i64 %k to i128))<nsw>,+,(-1 * (sext i64 %k to i128))<nsw>}<%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(3 * %k),+,(-1 * %k)}<%loop> to i128) == ((sext i64 {(2 * %k),+,(-1 * %k)}<%loop> to i128) + (sext i64 %k to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (3 * %k)),+,(-1 * %k)}<%loop> to i128) == (-1 + (sext i64 {(3 * %k),+,(-1 * %k)}<%loop> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 1 slt) %k
 ;
 entry:
   %k.neg = sub nsw i64 0, %k

--- a/llvm/test/Analysis/DependenceAnalysis/compute-absolute-value.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/compute-absolute-value.ll
@@ -18,12 +18,16 @@ define void @unknown_sign(ptr %a, i64 %k) {
 ; CHECK-NEXT:  Src: store i8 1, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.0, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:    Compare predicate: (-1 * %k) ne) 0
 ; CHECK-NEXT:  Src: store i8 1, ptr %idx.0, align 1 --> Dst: store i8 2, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - output [*|<]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:  Src: store i8 2, ptr %idx.1, align 1 --> Dst: store i8 2, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 1 slt) %k
 ; CHECK-NEXT:    Compare predicate: (-1 * %k) ne) 0
 ;
 entry:

--- a/llvm/test/Analysis/DependenceAnalysis/exact-siv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/exact-siv-overflow.ll
@@ -26,7 +26,10 @@
 define void @exactsiv_const_ovfl(ptr %A) {
 ; CHECK-LABEL: 'exactsiv_const_ovfl'
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent output [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
@@ -35,8 +38,14 @@ define void @exactsiv_const_ovfl(ptr %A) {
 ; CHECK-EXACT-SIV-LABEL: 'exactsiv_const_ovfl'
 ; CHECK-EXACT-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-EXACT-SIV-NEXT:    da analyze - consistent output [*]!
+; CHECK-EXACT-SIV-NEXT:    Runtime Assumptions:
+; CHECK-EXACT-SIV-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
+; CHECK-EXACT-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
 ; CHECK-EXACT-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-EXACT-SIV-NEXT:    da analyze - output [*|<]!
+; CHECK-EXACT-SIV-NEXT:    Runtime Assumptions:
+; CHECK-EXACT-SIV-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
+; CHECK-EXACT-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
 ; CHECK-EXACT-SIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-EXACT-SIV-NEXT:    da analyze - consistent output [*]!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/exact-siv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/exact-siv-overflow.ll
@@ -28,8 +28,8 @@ define void @exactsiv_const_ovfl(ptr %A) {
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
+; CHECK-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128) == {9223372036854775808,+,-6}<nsw><%loop.header>
+; CHECK-NEXT:    Equal predicate: {9223372036854775807,+,-6}<nsw><%loop.header> == (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw>
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
@@ -39,13 +39,13 @@ define void @exactsiv_const_ovfl(ptr %A) {
 ; CHECK-EXACT-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-EXACT-SIV-NEXT:    da analyze - consistent output [*]!
 ; CHECK-EXACT-SIV-NEXT:    Runtime Assumptions:
-; CHECK-EXACT-SIV-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
-; CHECK-EXACT-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
+; CHECK-EXACT-SIV-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128) == {9223372036854775808,+,-6}<nsw><%loop.header>
+; CHECK-EXACT-SIV-NEXT:    Equal predicate: {9223372036854775807,+,-6}<nsw><%loop.header> == (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw>
 ; CHECK-EXACT-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-EXACT-SIV-NEXT:    da analyze - output [*|<]!
 ; CHECK-EXACT-SIV-NEXT:    Runtime Assumptions:
-; CHECK-EXACT-SIV-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
-; CHECK-EXACT-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
+; CHECK-EXACT-SIV-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128) == {9223372036854775808,+,-6}<nsw><%loop.header>
+; CHECK-EXACT-SIV-NEXT:    Equal predicate: {9223372036854775807,+,-6}<nsw><%loop.header> == (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw>
 ; CHECK-EXACT-SIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-EXACT-SIV-NEXT:    da analyze - consistent output [*]!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/gcd-miv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/gcd-miv-overflow.ll
@@ -26,17 +26,24 @@ define void @gcdmiv_coef_ovfl(ptr %A, i64 %m) {
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 1, ptr %gep.0, align 1
 ; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
 ; CHECK-ALL-NEXT:    Runtime Assumptions:
+; CHECK-ALL-NEXT:    Compare predicate: 4 slt) %m
 ; CHECK-ALL-NEXT:    Compare predicate: (3 * %m) ne) 0
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - output [*|<]!
+; CHECK-ALL-NEXT:    Runtime Assumptions:
+; CHECK-ALL-NEXT:    Compare predicate: 4 slt) %m
 ; CHECK-ALL-NEXT:  Src: store i8 2, ptr %gep.1, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ;
 ; CHECK-GCD-MIV-LABEL: 'gcdmiv_coef_ovfl'
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 1, ptr %gep.0, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*]!
+; CHECK-GCD-MIV-NEXT:    Runtime Assumptions:
+; CHECK-GCD-MIV-NEXT:    Compare predicate: 4 slt) %m
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*|<]!
+; CHECK-GCD-MIV-NEXT:    Runtime Assumptions:
+; CHECK-GCD-MIV-NEXT:    Compare predicate: 4 slt) %m
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 2, ptr %gep.1, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*]!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/gcd-miv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/gcd-miv-overflow.ll
@@ -30,7 +30,6 @@ define void @gcdmiv_coef_ovfl(ptr %A, i64 %m) {
 ; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {0,+,(3 * %m)}<%loop> to i128) == {0,+,(3 * (sext i64 %m to i128))<nsw>}<%loop>
 ; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {%m,+,(3 * %m)}<%loop> to i128) == ((sext i64 {0,+,(3 * %m)}<%loop> to i128) + (sext i64 %m to i128))
 ; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {(-1 + %m),+,(3 * %m)}<%loop> to i128) == (-1 + (sext i64 {%m,+,(3 * %m)}<%loop> to i128))<nsw>
-; CHECK-ALL-NEXT:    Compare predicate: 4 slt) %m
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 2, ptr %gep.1, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
@@ -44,7 +43,6 @@ define void @gcdmiv_coef_ovfl(ptr %A, i64 %m) {
 ; CHECK-GCD-MIV-NEXT:    Equal predicate: (sext i64 {0,+,(3 * %m)}<%loop> to i128) == {0,+,(3 * (sext i64 %m to i128))<nsw>}<%loop>
 ; CHECK-GCD-MIV-NEXT:    Equal predicate: (sext i64 {%m,+,(3 * %m)}<%loop> to i128) == ((sext i64 {0,+,(3 * %m)}<%loop> to i128) + (sext i64 %m to i128))
 ; CHECK-GCD-MIV-NEXT:    Equal predicate: (sext i64 {(-1 + %m),+,(3 * %m)}<%loop> to i128) == (-1 + (sext i64 {%m,+,(3 * %m)}<%loop> to i128))<nsw>
-; CHECK-GCD-MIV-NEXT:    Compare predicate: 4 slt) %m
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - none!
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 2, ptr %gep.1, align 1 --> Dst: store i8 2, ptr %gep.1, align 1

--- a/llvm/test/Analysis/DependenceAnalysis/gcd-miv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/gcd-miv-overflow.ll
@@ -27,11 +27,12 @@ define void @gcdmiv_coef_ovfl(ptr %A, i64 %m) {
 ; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
 ; CHECK-ALL-NEXT:    Runtime Assumptions:
 ; CHECK-ALL-NEXT:    Compare predicate: 4 slt) %m
-; CHECK-ALL-NEXT:    Compare predicate: (3 * %m) ne) 0
-; CHECK-ALL-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
-; CHECK-ALL-NEXT:    da analyze - output [*|<]!
-; CHECK-ALL-NEXT:    Runtime Assumptions:
+; CHECK-ALL-NEXT:    Equal predicate: {0,+,(3 * (sext i64 %m to i128))<nsw>}<%loop> == (sext i64 {0,+,(3 * %m)}<%loop> to i128)
+; CHECK-ALL-NEXT:    Equal predicate: ((sext i64 {0,+,(3 * %m)}<%loop> to i128) + (sext i64 %m to i128)) == (sext i64 {%m,+,(3 * %m)}<%loop> to i128)
+; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {%m,+,(3 * %m)}<%loop> to i128))<nsw> == (sext i64 {(-1 + %m),+,(3 * %m)}<%loop> to i128)
 ; CHECK-ALL-NEXT:    Compare predicate: 4 slt) %m
+; CHECK-ALL-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
+; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 2, ptr %gep.1, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ;
@@ -40,10 +41,12 @@ define void @gcdmiv_coef_ovfl(ptr %A, i64 %m) {
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*]!
 ; CHECK-GCD-MIV-NEXT:    Runtime Assumptions:
 ; CHECK-GCD-MIV-NEXT:    Compare predicate: 4 slt) %m
-; CHECK-GCD-MIV-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
-; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*|<]!
-; CHECK-GCD-MIV-NEXT:    Runtime Assumptions:
+; CHECK-GCD-MIV-NEXT:    Equal predicate: {0,+,(3 * (sext i64 %m to i128))<nsw>}<%loop> == (sext i64 {0,+,(3 * %m)}<%loop> to i128)
+; CHECK-GCD-MIV-NEXT:    Equal predicate: ((sext i64 {0,+,(3 * %m)}<%loop> to i128) + (sext i64 %m to i128)) == (sext i64 {%m,+,(3 * %m)}<%loop> to i128)
+; CHECK-GCD-MIV-NEXT:    Equal predicate: (-1 + (sext i64 {%m,+,(3 * %m)}<%loop> to i128))<nsw> == (sext i64 {(-1 + %m),+,(3 * %m)}<%loop> to i128)
 ; CHECK-GCD-MIV-NEXT:    Compare predicate: 4 slt) %m
+; CHECK-GCD-MIV-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
+; CHECK-GCD-MIV-NEXT:    da analyze - none!
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 2, ptr %gep.1, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*]!
 ;
@@ -88,7 +91,10 @@ exit:
 define void @gcdmiv_delta_ovfl(ptr %A) {
 ; CHECK-ALL-LABEL: 'gcdmiv_delta_ovfl'
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
-; CHECK-ALL-NEXT:    da analyze - none!
+; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
+; CHECK-ALL-NEXT:    Runtime Assumptions:
+; CHECK-ALL-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
+; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
@@ -97,8 +103,14 @@ define void @gcdmiv_delta_ovfl(ptr %A) {
 ; CHECK-GCD-MIV-LABEL: 'gcdmiv_delta_ovfl'
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*]!
+; CHECK-GCD-MIV-NEXT:    Runtime Assumptions:
+; CHECK-GCD-MIV-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
+; CHECK-GCD-MIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*|<]!
+; CHECK-GCD-MIV-NEXT:    Runtime Assumptions:
+; CHECK-GCD-MIV-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
+; CHECK-GCD-MIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*]!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/gcd-miv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/gcd-miv-overflow.ll
@@ -27,9 +27,9 @@ define void @gcdmiv_coef_ovfl(ptr %A, i64 %m) {
 ; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
 ; CHECK-ALL-NEXT:    Runtime Assumptions:
 ; CHECK-ALL-NEXT:    Compare predicate: 4 slt) %m
-; CHECK-ALL-NEXT:    Equal predicate: {0,+,(3 * (sext i64 %m to i128))<nsw>}<%loop> == (sext i64 {0,+,(3 * %m)}<%loop> to i128)
-; CHECK-ALL-NEXT:    Equal predicate: ((sext i64 {0,+,(3 * %m)}<%loop> to i128) + (sext i64 %m to i128)) == (sext i64 {%m,+,(3 * %m)}<%loop> to i128)
-; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {%m,+,(3 * %m)}<%loop> to i128))<nsw> == (sext i64 {(-1 + %m),+,(3 * %m)}<%loop> to i128)
+; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {0,+,(3 * %m)}<%loop> to i128) == {0,+,(3 * (sext i64 %m to i128))<nsw>}<%loop>
+; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {%m,+,(3 * %m)}<%loop> to i128) == ((sext i64 {0,+,(3 * %m)}<%loop> to i128) + (sext i64 %m to i128))
+; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {(-1 + %m),+,(3 * %m)}<%loop> to i128) == (-1 + (sext i64 {%m,+,(3 * %m)}<%loop> to i128))<nsw>
 ; CHECK-ALL-NEXT:    Compare predicate: 4 slt) %m
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
@@ -41,9 +41,9 @@ define void @gcdmiv_coef_ovfl(ptr %A, i64 %m) {
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*]!
 ; CHECK-GCD-MIV-NEXT:    Runtime Assumptions:
 ; CHECK-GCD-MIV-NEXT:    Compare predicate: 4 slt) %m
-; CHECK-GCD-MIV-NEXT:    Equal predicate: {0,+,(3 * (sext i64 %m to i128))<nsw>}<%loop> == (sext i64 {0,+,(3 * %m)}<%loop> to i128)
-; CHECK-GCD-MIV-NEXT:    Equal predicate: ((sext i64 {0,+,(3 * %m)}<%loop> to i128) + (sext i64 %m to i128)) == (sext i64 {%m,+,(3 * %m)}<%loop> to i128)
-; CHECK-GCD-MIV-NEXT:    Equal predicate: (-1 + (sext i64 {%m,+,(3 * %m)}<%loop> to i128))<nsw> == (sext i64 {(-1 + %m),+,(3 * %m)}<%loop> to i128)
+; CHECK-GCD-MIV-NEXT:    Equal predicate: (sext i64 {0,+,(3 * %m)}<%loop> to i128) == {0,+,(3 * (sext i64 %m to i128))<nsw>}<%loop>
+; CHECK-GCD-MIV-NEXT:    Equal predicate: (sext i64 {%m,+,(3 * %m)}<%loop> to i128) == ((sext i64 {0,+,(3 * %m)}<%loop> to i128) + (sext i64 %m to i128))
+; CHECK-GCD-MIV-NEXT:    Equal predicate: (sext i64 {(-1 + %m),+,(3 * %m)}<%loop> to i128) == (-1 + (sext i64 {%m,+,(3 * %m)}<%loop> to i128))<nsw>
 ; CHECK-GCD-MIV-NEXT:    Compare predicate: 4 slt) %m
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 1, ptr %gep.0, align 1 --> Dst: store i8 2, ptr %gep.1, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - none!
@@ -93,8 +93,8 @@ define void @gcdmiv_delta_ovfl(ptr %A) {
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
 ; CHECK-ALL-NEXT:    Runtime Assumptions:
-; CHECK-ALL-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
-; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
+; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128) == {9223372036854775808,+,-6}<nsw><%loop.header>
+; CHECK-ALL-NEXT:    Equal predicate: {9223372036854775807,+,-6}<nsw><%loop.header> == (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw>
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
@@ -104,13 +104,13 @@ define void @gcdmiv_delta_ovfl(ptr %A) {
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*]!
 ; CHECK-GCD-MIV-NEXT:    Runtime Assumptions:
-; CHECK-GCD-MIV-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
-; CHECK-GCD-MIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
+; CHECK-GCD-MIV-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128) == {9223372036854775808,+,-6}<nsw><%loop.header>
+; CHECK-GCD-MIV-NEXT:    Equal predicate: {9223372036854775807,+,-6}<nsw><%loop.header> == (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw>
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*|<]!
 ; CHECK-GCD-MIV-NEXT:    Runtime Assumptions:
-; CHECK-GCD-MIV-NEXT:    Equal predicate: {9223372036854775808,+,-6}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128)
-; CHECK-GCD-MIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-6}<nsw><%loop.header>
+; CHECK-GCD-MIV-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128) == {9223372036854775808,+,-6}<nsw><%loop.header>
+; CHECK-GCD-MIV-NEXT:    Equal predicate: {9223372036854775807,+,-6}<nsw><%loop.header> == (-1 + (sext i64 {-9223372036854775808,+,-6}<nw><%loop.header> to i128))<nsw>
 ; CHECK-GCD-MIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-GCD-MIV-NEXT:    da analyze - consistent output [*]!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/lcssa.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/lcssa.ll
@@ -5,7 +5,10 @@
 define void @f(ptr %a, i32 %n, i64 %n2) {
 ; CHECK-LABEL: 'f'
 ; CHECK-NEXT:  Src: %v = load i32, ptr %arrayidx1, align 4 --> Dst: %v = load i32, ptr %arrayidx1, align 4
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - consistent input [0]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {8,+,4}<nuw><nsw><%for.body> == (sext i64 {8,+,4}<nuw><%for.body> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,4}<nuw><%for.body> to i128))<nsw> == {7,+,4}<nuw><nsw><%for.body>
 ; CHECK-NEXT:  Src: %v = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %add, ptr %a.lcssa, align 4
 ; CHECK-NEXT:    da analyze - anti [*|<]!
 ; CHECK-NEXT:  Src: store i32 %add, ptr %a.lcssa, align 4 --> Dst: store i32 %add, ptr %a.lcssa, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/lcssa.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/lcssa.ll
@@ -7,8 +7,8 @@ define void @f(ptr %a, i32 %n, i64 %n2) {
 ; CHECK-NEXT:  Src: %v = load i32, ptr %arrayidx1, align 4 --> Dst: %v = load i32, ptr %arrayidx1, align 4
 ; CHECK-NEXT:    da analyze - consistent input [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {8,+,4}<nuw><nsw><%for.body> == (sext i64 {8,+,4}<nuw><%for.body> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {8,+,4}<nuw><%for.body> to i128))<nsw> == {7,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: (sext i64 {8,+,4}<nuw><%for.body> to i128) == {8,+,4}<nuw><nsw><%for.body>
+; CHECK-NEXT:    Equal predicate: {7,+,4}<nuw><nsw><%for.body> == (-1 + (sext i64 {8,+,4}<nuw><%for.body> to i128))<nsw>
 ; CHECK-NEXT:  Src: %v = load i32, ptr %arrayidx1, align 4 --> Dst: store i32 %add, ptr %a.lcssa, align 4
 ; CHECK-NEXT:    da analyze - anti [*|<]!
 ; CHECK-NEXT:  Src: store i32 %add, ptr %a.lcssa, align 4 --> Dst: store i32 %add, ptr %a.lcssa, align 4

--- a/llvm/test/Analysis/DependenceAnalysis/monotonicity-cast.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/monotonicity-cast.ll
@@ -16,6 +16,8 @@ define void @sext_nsw(ptr %a, i8 %start, i8 %step) {
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx, align 1 --> Dst: store i8 0, ptr %idx, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) sge) 0
+; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) slt) (sext i8 %step to i64)
 ; CHECK-NEXT:    Compare predicate: (sext i8 %step to i64) ne) 0
 ;
 entry:

--- a/llvm/test/Analysis/DependenceAnalysis/monotonicity-cast.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/monotonicity-cast.ll
@@ -21,8 +21,6 @@ define void @sext_nsw(ptr %a, i8 %start, i8 %step) {
 ; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(sext i8 %step to i64)}<%loop> to i128) == {0,+,(sext i8 %step to i128)}<%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(sext i8 %step to i64),+,(sext i8 %step to i64)}<%loop> to i128) == ((sext i64 {0,+,(sext i8 %step to i64)}<%loop> to i128) + (sext i8 %step to i128))
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (sext i8 %step to i64))<nsw>,+,(sext i8 %step to i64)}<%loop> to i128) == (-1 + (sext i64 {(sext i8 %step to i64),+,(sext i8 %step to i64)}<%loop> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) sge) 0
-; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) slt) (sext i8 %step to i64)
 ;
 entry:
   br label %loop

--- a/llvm/test/Analysis/DependenceAnalysis/monotonicity-cast.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/monotonicity-cast.ll
@@ -18,7 +18,11 @@ define void @sext_nsw(ptr %a, i8 %start, i8 %step) {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) sge) 0
 ; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) slt) (sext i8 %step to i64)
-; CHECK-NEXT:    Compare predicate: (sext i8 %step to i64) ne) 0
+; CHECK-NEXT:    Equal predicate: {0,+,(sext i8 %step to i128)}<%loop> == (sext i64 {0,+,(sext i8 %step to i64)}<%loop> to i128)
+; CHECK-NEXT:    Equal predicate: ((sext i64 {0,+,(sext i8 %step to i64)}<%loop> to i128) + (sext i8 %step to i128)) == (sext i64 {(sext i8 %step to i64),+,(sext i8 %step to i64)}<%loop> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(sext i8 %step to i64),+,(sext i8 %step to i64)}<%loop> to i128))<nsw> == (sext i64 {(-1 + (sext i8 %step to i64))<nsw>,+,(sext i8 %step to i64)}<%loop> to i128)
+; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) sge) 0
+; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) slt) (sext i8 %step to i64)
 ;
 entry:
   br label %loop

--- a/llvm/test/Analysis/DependenceAnalysis/monotonicity-cast.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/monotonicity-cast.ll
@@ -18,9 +18,9 @@ define void @sext_nsw(ptr %a, i8 %start, i8 %step) {
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) sge) 0
 ; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) slt) (sext i8 %step to i64)
-; CHECK-NEXT:    Equal predicate: {0,+,(sext i8 %step to i128)}<%loop> == (sext i64 {0,+,(sext i8 %step to i64)}<%loop> to i128)
-; CHECK-NEXT:    Equal predicate: ((sext i64 {0,+,(sext i8 %step to i64)}<%loop> to i128) + (sext i8 %step to i128)) == (sext i64 {(sext i8 %step to i64),+,(sext i8 %step to i64)}<%loop> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {(sext i8 %step to i64),+,(sext i8 %step to i64)}<%loop> to i128))<nsw> == (sext i64 {(-1 + (sext i8 %step to i64))<nsw>,+,(sext i8 %step to i64)}<%loop> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 {0,+,(sext i8 %step to i64)}<%loop> to i128) == {0,+,(sext i8 %step to i128)}<%loop>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(sext i8 %step to i64),+,(sext i8 %step to i64)}<%loop> to i128) == ((sext i64 {0,+,(sext i8 %step to i64)}<%loop> to i128) + (sext i8 %step to i128))
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + (sext i8 %step to i64))<nsw>,+,(sext i8 %step to i64)}<%loop> to i128) == (-1 + (sext i64 {(sext i8 %step to i64),+,(sext i8 %step to i64)}<%loop> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) sge) 0
 ; CHECK-NEXT:    Compare predicate: (sext i8 %start to i64) slt) (sext i8 %step to i64)
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/monotonicity-no-wrap-flags.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/monotonicity-no-wrap-flags.ll
@@ -271,7 +271,6 @@ define void @nested_loop_step(ptr %a, i64 %n, i64 %m, i64 %step) {
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop.i.header> slt) %step
 ; CHECK-NEXT:    Equal predicate: (sext i64 {%step,+,%step}<nw><%loop.j> to i128) == {(sext i64 %step to i128),+,(sext i64 %step to i128)}<nw><%loop.j>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + %step),+,%step}<nw><%loop.j> to i128) == (-1 + (sext i64 {%step,+,%step}<nw><%loop.j> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop.i.header> slt) %step
 ;
 entry:
   %guard.i = icmp sgt i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/monotonicity-no-wrap-flags.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/monotonicity-no-wrap-flags.ll
@@ -78,8 +78,8 @@ define void @nested_loop_nsw0(ptr %a, i64 %n, i64 %m) {
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx, align 1 --> Dst: store i8 0, ptr %idx, align 1
 ; CHECK-NEXT:    da analyze - output [* *]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j> == (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j> to i128))<nsw> == {{\{\{}}0,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j>
+; CHECK-NEXT:    Equal predicate: (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j> to i128) == {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j>
+; CHECK-NEXT:    Equal predicate: {{\{\{}}0,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j> == (-1 + (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j> to i128))<nsw>
 ;
 entry:
   %guard.i = icmp sgt i64 %n, 0
@@ -269,8 +269,8 @@ define void @nested_loop_step(ptr %a, i64 %n, i64 %m, i64 %step) {
 ; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop.i.header> slt) %step
-; CHECK-NEXT:    Equal predicate: {(sext i64 %step to i128),+,(sext i64 %step to i128)}<nw><%loop.j> == (sext i64 {%step,+,%step}<nw><%loop.j> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {%step,+,%step}<nw><%loop.j> to i128))<nsw> == (sext i64 {(-1 + %step),+,%step}<nw><%loop.j> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 {%step,+,%step}<nw><%loop.j> to i128) == {(sext i64 %step to i128),+,(sext i64 %step to i128)}<nw><%loop.j>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + %step),+,%step}<nw><%loop.j> to i128) == (-1 + (sext i64 {%step,+,%step}<nw><%loop.j> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop.i.header> slt) %step
 ;
 entry:
@@ -480,8 +480,8 @@ define void @conditional_store1(ptr %a, i64 %n, i64 %m) {
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx, align 1 --> Dst: store i8 0, ptr %idx, align 1
 ; CHECK-NEXT:    da analyze - output [* *]!
 ; CHECK-NEXT:    Runtime Assumptions:
-; CHECK-NEXT:    Equal predicate: {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j.header> == (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j.header> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j.header> to i128))<nsw> == {{\{\{}}0,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j.header>
+; CHECK-NEXT:    Equal predicate: (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j.header> to i128) == {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j.header>
+; CHECK-NEXT:    Equal predicate: {{\{\{}}0,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j.header> == (-1 + (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j.header> to i128))<nsw>
 ;
 entry:
   %guard.i = icmp sgt i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/monotonicity-no-wrap-flags.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/monotonicity-no-wrap-flags.ll
@@ -77,6 +77,9 @@ define void @nested_loop_nsw0(ptr %a, i64 %n, i64 %m) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx, align 1 --> Dst: store i8 0, ptr %idx, align 1
 ; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j> == (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j> to i128))<nsw> == {{\{\{}}0,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j>
 ;
 entry:
   %guard.i = icmp sgt i64 %n, 0
@@ -263,8 +266,11 @@ define void @nested_loop_step(ptr %a, i64 %n, i64 %m, i64 %step) {
 ; CHECK-NEXT:      Monotonicity: MultivariateSignedMonotonic
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx, align 1 --> Dst: store i8 0, ptr %idx, align 1
-; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    da analyze - consistent output [0 0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop.i.header> slt) %step
+; CHECK-NEXT:    Equal predicate: {(sext i64 %step to i128),+,(sext i64 %step to i128)}<nw><%loop.j> == (sext i64 {%step,+,%step}<nw><%loop.j> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {%step,+,%step}<nw><%loop.j> to i128))<nsw> == (sext i64 {(-1 + %step),+,%step}<nw><%loop.j> to i128)
 ; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop.i.header> slt) %step
 ;
 entry:
@@ -473,6 +479,9 @@ define void @conditional_store1(ptr %a, i64 %n, i64 %m) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx, align 1 --> Dst: store i8 0, ptr %idx, align 1
 ; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Equal predicate: {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j.header> == (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j.header> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {{\{\{}}1,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><%loop.j.header> to i128))<nsw> == {{\{\{}}0,+,1}<nuw><nsw><%loop.i.header>,+,1}<nuw><nsw><%loop.j.header>
 ;
 entry:
   %guard.i = icmp sgt i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/monotonicity-no-wrap-flags.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/monotonicity-no-wrap-flags.ll
@@ -264,6 +264,8 @@ define void @nested_loop_step(ptr %a, i64 %n, i64 %m, i64 %step) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  Src: store i8 0, ptr %idx, align 1 --> Dst: store i8 0, ptr %idx, align 1
 ; CHECK-NEXT:    da analyze - output [* *]!
+; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: {0,+,1}<nuw><nsw><%loop.i.header> slt) %step
 ;
 entry:
   %guard.i = icmp sgt i64 %n, 0

--- a/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-overflow.ll
@@ -27,8 +27,8 @@ define void @weakcorssing_delta_ovfl(ptr %A) {
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
 ; CHECK-ALL-NEXT:    Runtime Assumptions:
-; CHECK-ALL-NEXT:    Equal predicate: {9223372036854775808,+,-3}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128)
-; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-3}<nsw><%loop.header>
+; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128) == {9223372036854775808,+,-3}<nsw><%loop.header>
+; CHECK-ALL-NEXT:    Equal predicate: {9223372036854775807,+,-3}<nsw><%loop.header> == (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128))<nsw>
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
@@ -38,8 +38,8 @@ define void @weakcorssing_delta_ovfl(ptr %A) {
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - consistent output [*]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    Runtime Assumptions:
-; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: {9223372036854775808,+,-3}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128)
-; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-3}<nsw><%loop.header>
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128) == {9223372036854775808,+,-3}<nsw><%loop.header>
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: {9223372036854775807,+,-3}<nsw><%loop.header> == (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128))<nsw>
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - none!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
@@ -95,29 +95,29 @@ define void @weakcorssing_prod_ovfl(ptr %A) {
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
 ; CHECK-ALL-NEXT:    Runtime Assumptions:
-; CHECK-ALL-NEXT:    Equal predicate: {9223372036854775808,+,-3}<nsw><%loop> == (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128)
-; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128))<nsw> == {9223372036854775807,+,-3}<nsw><%loop>
+; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128) == {9223372036854775808,+,-3}<nsw><%loop>
+; CHECK-ALL-NEXT:    Equal predicate: {9223372036854775807,+,-3}<nsw><%loop> == (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128))<nsw>
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
 ; CHECK-ALL-NEXT:    Runtime Assumptions:
-; CHECK-ALL-NEXT:    Equal predicate: {2,+,3}<nuw><nsw><%loop> == (sext i64 {2,+,3}<nuw><%loop> to i128)
-; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {2,+,3}<nuw><%loop> to i128))<nsw> == {1,+,3}<nuw><nsw><%loop>
+; CHECK-ALL-NEXT:    Equal predicate: (sext i64 {2,+,3}<nuw><%loop> to i128) == {2,+,3}<nuw><nsw><%loop>
+; CHECK-ALL-NEXT:    Equal predicate: {1,+,3}<nuw><nsw><%loop> == (-1 + (sext i64 {2,+,3}<nuw><%loop> to i128))<nsw>
 ;
 ; CHECK-WEAK-CROSSING-SIV-LABEL: 'weakcorssing_prod_ovfl'
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - consistent output [*]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    Runtime Assumptions:
-; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: {9223372036854775808,+,-3}<nsw><%loop> == (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128)
-; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128))<nsw> == {9223372036854775807,+,-3}<nsw><%loop>
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128) == {9223372036854775808,+,-3}<nsw><%loop>
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: {9223372036854775807,+,-3}<nsw><%loop> == (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128))<nsw>
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - none!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - consistent output [*]!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    Runtime Assumptions:
-; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: {2,+,3}<nuw><nsw><%loop> == (sext i64 {2,+,3}<nuw><%loop> to i128)
-; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {2,+,3}<nuw><%loop> to i128))<nsw> == {1,+,3}<nuw><nsw><%loop>
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: (sext i64 {2,+,3}<nuw><%loop> to i128) == {2,+,3}<nuw><nsw><%loop>
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: {1,+,3}<nuw><nsw><%loop> == (-1 + (sext i64 {2,+,3}<nuw><%loop> to i128))<nsw>
 ;
 entry:
   br label %loop

--- a/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-overflow.ll
@@ -25,7 +25,10 @@
 define void @weakcorssing_delta_ovfl(ptr %A) {
 ; CHECK-ALL-LABEL: 'weakcorssing_delta_ovfl'
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
-; CHECK-ALL-NEXT:    da analyze - none!
+; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
+; CHECK-ALL-NEXT:    Runtime Assumptions:
+; CHECK-ALL-NEXT:    Equal predicate: {9223372036854775808,+,-3}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128)
+; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-3}<nsw><%loop.header>
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
@@ -34,6 +37,9 @@ define void @weakcorssing_delta_ovfl(ptr %A) {
 ; CHECK-WEAK-CROSSING-SIV-LABEL: 'weakcorssing_delta_ovfl'
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - consistent output [*]!
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Runtime Assumptions:
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: {9223372036854775808,+,-3}<nsw><%loop.header> == (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128)
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop.header> to i128))<nsw> == {9223372036854775807,+,-3}<nsw><%loop.header>
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - none!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
@@ -87,19 +93,31 @@ exit:
 define void @weakcorssing_prod_ovfl(ptr %A) {
 ; CHECK-ALL-LABEL: 'weakcorssing_prod_ovfl'
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
-; CHECK-ALL-NEXT:    da analyze - none!
+; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
+; CHECK-ALL-NEXT:    Runtime Assumptions:
+; CHECK-ALL-NEXT:    Equal predicate: {9223372036854775808,+,-3}<nsw><%loop> == (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128)
+; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128))<nsw> == {9223372036854775807,+,-3}<nsw><%loop>
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-ALL-NEXT:    da analyze - none!
 ; CHECK-ALL-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
-; CHECK-ALL-NEXT:    da analyze - none!
+; CHECK-ALL-NEXT:    da analyze - consistent output [0]!
+; CHECK-ALL-NEXT:    Runtime Assumptions:
+; CHECK-ALL-NEXT:    Equal predicate: {2,+,3}<nuw><nsw><%loop> == (sext i64 {2,+,3}<nuw><%loop> to i128)
+; CHECK-ALL-NEXT:    Equal predicate: (-1 + (sext i64 {2,+,3}<nuw><%loop> to i128))<nsw> == {1,+,3}<nuw><nsw><%loop>
 ;
 ; CHECK-WEAK-CROSSING-SIV-LABEL: 'weakcorssing_prod_ovfl'
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - consistent output [*]!
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Runtime Assumptions:
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: {9223372036854775808,+,-3}<nsw><%loop> == (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128)
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {-9223372036854775808,+,-3}<nw><%loop> to i128))<nsw> == {9223372036854775807,+,-3}<nsw><%loop>
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - none!
 ; CHECK-WEAK-CROSSING-SIV-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-WEAK-CROSSING-SIV-NEXT:    da analyze - consistent output [*]!
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Runtime Assumptions:
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: {2,+,3}<nuw><nsw><%loop> == (sext i64 {2,+,3}<nuw><%loop> to i128)
+; CHECK-WEAK-CROSSING-SIV-NEXT:    Equal predicate: (-1 + (sext i64 {2,+,3}<nuw><%loop> to i128))<nsw> == {1,+,3}<nuw><nsw><%loop>
 ;
 entry:
   br label %loop

--- a/llvm/test/Analysis/DependenceAnalysis/zero-coefficient.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/zero-coefficient.ll
@@ -15,6 +15,7 @@ define void @test_zero_coefficient(ptr noalias %A, i64 %k) {
 ; CHECK-NEXT:  Src: store i8 42, ptr %idx, align 1 --> Dst: store i8 42, ptr %idx, align 1
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:    Compare predicate: %k ne) 0
 ;
 entry:

--- a/llvm/test/Analysis/DependenceAnalysis/zero-coefficient.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/zero-coefficient.ll
@@ -18,7 +18,6 @@ define void @test_zero_coefficient(ptr noalias %A, i64 %k) {
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ; CHECK-NEXT:    Equal predicate: (sext i64 {%k,+,%k}<nw><%loop> to i128) == {(sext i64 %k to i128),+,(sext i64 %k to i128)}<nw><%loop>
 ; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + %k),+,%k}<nw><%loop> to i128) == (-1 + (sext i64 {%k,+,%k}<nw><%loop> to i128))<nsw>
-; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ;
 entry:
   br label %loop

--- a/llvm/test/Analysis/DependenceAnalysis/zero-coefficient.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/zero-coefficient.ll
@@ -16,8 +16,8 @@ define void @test_zero_coefficient(ptr noalias %A, i64 %k) {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Equal predicate: {(sext i64 %k to i128),+,(sext i64 %k to i128)}<nw><%loop> == (sext i64 {%k,+,%k}<nw><%loop> to i128)
-; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {%k,+,%k}<nw><%loop> to i128))<nsw> == (sext i64 {(-1 + %k),+,%k}<nw><%loop> to i128)
+; CHECK-NEXT:    Equal predicate: (sext i64 {%k,+,%k}<nw><%loop> to i128) == {(sext i64 %k to i128),+,(sext i64 %k to i128)}<nw><%loop>
+; CHECK-NEXT:    Equal predicate: (sext i64 {(-1 + %k),+,%k}<nw><%loop> to i128) == (-1 + (sext i64 {%k,+,%k}<nw><%loop> to i128))<nsw>
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ;
 entry:

--- a/llvm/test/Analysis/DependenceAnalysis/zero-coefficient.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/zero-coefficient.ll
@@ -16,7 +16,9 @@ define void @test_zero_coefficient(ptr noalias %A, i64 %k) {
 ; CHECK-NEXT:    da analyze - consistent output [0]!
 ; CHECK-NEXT:    Runtime Assumptions:
 ; CHECK-NEXT:    Compare predicate: 0 slt) %k
-; CHECK-NEXT:    Compare predicate: %k ne) 0
+; CHECK-NEXT:    Equal predicate: {(sext i64 %k to i128),+,(sext i64 %k to i128)}<nw><%loop> == (sext i64 {%k,+,%k}<nw><%loop> to i128)
+; CHECK-NEXT:    Equal predicate: (-1 + (sext i64 {%k,+,%k}<nw><%loop> to i128))<nsw> == (sext i64 {(-1 + %k),+,%k}<nw><%loop> to i128)
+; CHECK-NEXT:    Compare predicate: 0 slt) %k
 ;
 entry:
   br label %loop

--- a/llvm/test/Transforms/LoopInterchange/loop-interchange-optimization-remarks.ll
+++ b/llvm/test/Transforms/LoopInterchange/loop-interchange-optimization-remarks.ll
@@ -68,10 +68,10 @@ for.end19:
 
 ; CHECK: --- !Missed
 ; CHECK-NEXT: Pass:            loop-interchange
-; CHECK-NEXT: Name:            Dependence
+; CHECK-NEXT: Name:            InterchangeNotProfitable
 ; CHECK-NEXT: Function:        test01
 ; CHECK-NEXT: Args:
-; CHECK-NEXT:   - String:          All loops have dependencies in all directions.
+; CHECK-NEXT:   - String:          Interchanging loops is not considered to improve cache locality nor vectorization.
 ; CHECK-NEXT: ...
 
 ; DELIN: --- !Analysis
@@ -142,12 +142,12 @@ define void @test02(i32 %k, i32 %N) {
 ; CHECK-NEXT:   - String:          Computed dependence info, invoking the transform.
 ; CHECK-NEXT: ...
 
-; CHECK: --- !Missed
+; CHECK: --- !Passed
 ; CHECK-NEXT: Pass:            loop-interchange
-; CHECK-NEXT: Name:            Dependence
+; CHECK-NEXT: Name:            Interchanged
 ; CHECK-NEXT: Function:        test02
 ; CHECK-NEXT: Args:
-; CHECK-NEXT:   - String:          All loops have dependencies in all directions.
+; CHECK-NEXT:   - String:          Loop interchanged with enclosing loop.
 ; CHECK-NEXT: ...
 
 ; DELIN: --- !Analysis
@@ -287,10 +287,10 @@ for.end17:
 
 ; CHECK: --- !Missed
 ; CHECK-NEXT: Pass:            loop-interchange
-; CHECK-NEXT: Name:            Dependence
+; CHECK-NEXT: Name:            NotTightlyNested
 ; CHECK-NEXT: Function:        test04
 ; CHECK-NEXT: Args:
-; CHECK-NEXT:   - String:          All loops have dependencies in all directions.
+; CHECK-NEXT:   - String:          Cannot interchange loops because they are not tightly nested.
 ; CHECK-NEXT: ...
 
 ; DELIN: --- !Missed


### PR DESCRIPTION
When compile-time checks fail, rely on runtime SCEV predicates, instead of failing delinearization entirely.  This allows delinearization to succeed in more cases where compile-time proofs are not possible, enabling more precise dependence analysis under runtime assumptions.