### PR TITLE
[NFC] Add missing analysis to `DirectX/llc-pipeline`

### DIFF
--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -5,6 +5,7 @@
 
 ; CHECK-LABEL: Pass Arguments:
 ; CHECK-NEXT: Target Library Information
+; CHECK-NEXT: Runtime Library Function Analysis
 ; CHECK-NEXT: DXIL Resource Type Analysis
 ; CHECK-NEXT: Target Transform Information
 ; CHECK-NEXT: Assumption Cache Tracker


### PR DESCRIPTION
The Runtime Library Function Analysis pass was added in https://github.com/llvm/llvm-project/pull/168622 but the backend test case was not updating accordingly.