### PR TITLE
[NFC][clang] Remove extra `To` in method name

### DIFF
--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -2607,7 +2607,7 @@ public:
   bool isAnyPointerType() const;   // Any C pointer or ObjC object pointer
   bool isCountAttributedType() const;
   bool isCFIUncheckedCalleeFunctionType() const;
-  bool hasPointeeToToCFIUncheckedCalleeFunctionType() const;
+  bool hasPointeeToCFIUncheckedCalleeFunctionType() const;
   bool isBlockPointerType() const;
   bool isVoidPointerType() const;
   bool isReferenceType() const;
@@ -8564,7 +8564,7 @@ inline bool Type::isCFIUncheckedCalleeFunctionType() const {
   return false;
 }
 
-inline bool Type::hasPointeeToToCFIUncheckedCalleeFunctionType() const {
+inline bool Type::hasPointeeToCFIUncheckedCalleeFunctionType() const {
   QualType Pointee;
   if (const auto *PT = getAs<PointerType>())
     Pointee = PT->getPointeeType();

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -6601,8 +6601,7 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType,
       FD && DeviceKernelAttr::isOpenCLSpelling(FD->getAttr<DeviceKernelAttr>()))
     CGM.getTargetCodeGenInfo().setOCLKernelStubCallingConvention(FnType);
 
-  bool CFIUnchecked =
-      CalleeType->hasPointeeToToCFIUncheckedCalleeFunctionType();
+  bool CFIUnchecked = CalleeType->hasPointeeToCFIUncheckedCalleeFunctionType();
 
   // If we are checking indirect calls and this call is indirect, check that the
   // function pointer is a member of the bit set for the function type.

--- a/clang/lib/CodeGen/CGPointerAuth.cpp
+++ b/clang/lib/CodeGen/CGPointerAuth.cpp
@@ -530,7 +530,7 @@ llvm::Constant *CodeGenModule::getMemberFunctionPointer(llvm::Constant *Pointer,
         cast_or_null<llvm::ConstantInt>(PointerAuth.getDiscriminator()));
 
   if (const auto *MFT = dyn_cast<MemberPointerType>(FT.getTypePtr())) {
-    if (MFT->hasPointeeToToCFIUncheckedCalleeFunctionType())
+    if (MFT->hasPointeeToCFIUncheckedCalleeFunctionType())
       Pointer = llvm::NoCFIValue::get(cast<llvm::GlobalValue>(Pointer));
   }
 

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -709,7 +709,7 @@ CGCallee ItaniumCXXABI::EmitLoadOfMemberFunctionPointer(
       if (BinOp->isPtrMemOp() &&
           BinOp->getRHS()
               ->getType()
-              ->hasPointeeToToCFIUncheckedCalleeFunctionType())
+              ->hasPointeeToCFIUncheckedCalleeFunctionType())
         ShouldEmitCFICheck = false;
     }
   }


### PR DESCRIPTION
`hasPointeeToToCFIUncheckedCalleeFunctionType` ->
`hasPointeeToCFIUncheckedCalleeFunctionType`