### PR TITLE
[RISCV] Use GPRNoX0 instead of AVL for Xsfmm pseudos. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXSfmm.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXSfmm.td
@@ -278,7 +278,7 @@ let Uses = [FRM], mayRaiseFPException = true in {
 } // DecoderNamespace = "XSfvector"
 
 class VPseudoSF_VTileLoad
-    : RISCVVPseudo<(outs), (ins GPR:$rs2, GPR:$rs1, AVL:$atn, ixlenimm:$sew,
+    : RISCVVPseudo<(outs), (ins GPR:$rs2, GPR:$rs1, GPRNoX0:$atn, ixlenimm:$sew,
                                 ixlenimm:$twiden)> {
   let mayLoad = 1;
   let mayStore = 0;
@@ -289,7 +289,7 @@ class VPseudoSF_VTileLoad
 }
 
 class VPseudoSF_VTileStore
-    : RISCVVPseudo<(outs), (ins GPR:$rs2, GPR:$rs1, AVL:$atn, ixlenimm:$sew,
+    : RISCVVPseudo<(outs), (ins GPR:$rs2, GPR:$rs1, GPRNoX0:$atn, ixlenimm:$sew,
                                 ixlenimm:$twiden)> {
   let mayLoad = 0;
   let mayStore = 1;
@@ -300,7 +300,7 @@ class VPseudoSF_VTileStore
 }
 
 class VPseudoSF_VTileMove_V_T
-    : RISCVVPseudo<(outs VRM8:$vd), (ins GPR:$rs1, AVL:$atn, ixlenimm:$sew,
+    : RISCVVPseudo<(outs VRM8:$vd), (ins GPR:$rs1, GPRNoX0:$atn, ixlenimm:$sew,
                                          ixlenimm:$twiden)> {
   let mayLoad = 0;
   let mayStore = 0;
@@ -311,7 +311,7 @@ class VPseudoSF_VTileMove_V_T
 }
 
 class VPseudoSF_VTileMove_T_V
-    : RISCVVPseudo<(outs), (ins GPR:$rs1, VRM8:$vs2, AVL:$atn, ixlenimm:$sew,
+    : RISCVVPseudo<(outs), (ins GPR:$rs1, VRM8:$vs2, GPRNoX0:$atn, ixlenimm:$sew,
                                 ixlenimm:$twiden)> {
   let mayLoad = 0;
   let mayStore = 0;
@@ -323,8 +323,9 @@ class VPseudoSF_VTileMove_T_V
 
 class VPseudoSF_MatMul<RegisterClass mtd_class>
     : RISCVVPseudo<(outs),
-                   (ins mtd_class:$rd, VRM8:$vs2, VRM8:$vs1, AVL:$atm, AVL:$atn,
-                        AVL:$atk, ixlenimm:$sew, ixlenimm:$twiden)> {
+                   (ins mtd_class:$rd, VRM8:$vs2, VRM8:$vs1, GPRNoX0:$atm,
+                        GPRNoX0:$atn, GPRNoX0:$atk, ixlenimm:$sew,
+                        ixlenimm:$twiden)> {
   let mayLoad = 0;
   let mayStore = 0;
   let HasTmOp = 1;
@@ -338,7 +339,7 @@ class VPseudoSF_MatMul<RegisterClass mtd_class>
 class VPseudoSF_MatMul_FRM<RegisterClass mtd_class>
     : RISCVVPseudo<(outs),
                    (ins mtd_class:$rd, VRM8:$vs2, VRM8:$vs1, ixlenimm:$frm,
-                        AVL:$atm, AVL:$atn, AVL:$atk, ixlenimm:$sew,
+                        GPRNoX0:$atm, GPRNoX0:$atn, GPRNoX0:$atk, ixlenimm:$sew,
                         ixlenimm:$twiden), []> {
   let mayLoad = 0;
   let mayStore = 0;
@@ -413,7 +414,7 @@ let hasSideEffects = 1, mayLoad = 0, mayStore = 0 in {
   let HasVLOp = 1, HasTmOp = 1, HasTWidenOp = 1, HasSEWOp = 1 in
     def PseudoSF_VTZERO_T
         : RISCVVPseudo<(outs),
-                       (ins TR:$rd, AVL:$atm, AVL:$atn, ixlenimm:$sew,
+                       (ins TR:$rd, GPRNoX0:$atm, GPRNoX0:$atn, ixlenimm:$sew,
                             ixlenimm:$twiden)>;
   def PseudoSF_VTDISCARD : RISCVVPseudo<(outs), (ins), []>;
 }
@@ -424,7 +425,7 @@ class VPatXSfmmTileStore<string intrinsic_name,
   Pat<(!cast<Intrinsic>(intrinsic_name)
        (XLenVT GPR:$rs2),
        (XLenVT GPR:$rs1),
-       (XLenVT AVL:$tn)),
+       (XLenVT GPRNoX0:$tn)),
       (!cast<Instruction>(inst_name)
        (XLenVT GPR:$rs2),
        (XLenVT GPR:$rs1),
@@ -437,7 +438,7 @@ class VPatXSfmmTileMove_T_V<string intrinsic_name,
   Pat<(!cast<Intrinsic>(intrinsic_name)
                     (XLenVT GPR:$rs1),
                     (reg_type VRM8:$vs2),
-                    (XLenVT AVL:$atn)),
+                    (XLenVT GPRNoX0:$atn)),
       (!cast<Instruction>(inst_name)
        (XLenVT GPR:$rs1),
        (reg_type VRM8:$vs2),
@@ -449,7 +450,7 @@ class VPatXSfmmTileMove_V_T<string intrinsic_name,
                             int log2sew> :
   Pat<(result_type (!cast<Intrinsic>(intrinsic_name)
                     (XLenVT GPR:$rs1),
-                    (XLenVT AVL:$atn))),
+                    (XLenVT GPRNoX0:$atn))),
       (!cast<Instruction>(inst_name)
        (XLenVT GPR:$rs1),
        GPR:$atn, log2sew, 1)>;


### PR DESCRIPTION
AVL allows immediates, but we don't have an equivalent of vsetivli for XSfmm.