### PR TITLE
[RISCV] Use a valid AVL immediate in allone-masked-to-unmasked.mir. NFC

### DIFF
--- a/llvm/test/CodeGen/RISCV/rvv/allone-masked-to-unmasked.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/allone-masked-to-unmasked.mir
@@ -9,8 +9,8 @@ body: |
     ; CHECK-LABEL: name: vcpop.m
     ; CHECK: %allones:vr = PseudoVMSET_M_B64 $noreg, 0 /* e8 */
     ; CHECK-NEXT: $v0 = COPY %allones
-    ; CHECK-NEXT: [[PseudoVCPOP_M_B64_:%[0-9]+]]:gpr = PseudoVCPOP_M_B64 $noreg, 42, 0 /* e8 */
+    ; CHECK-NEXT: [[PseudoVCPOP_M_B64_:%[0-9]+]]:gpr = PseudoVCPOP_M_B64 $noreg, 21, 0 /* e8 */
     %allones:vr = PseudoVMSET_M_B64 $noreg, 0
     $v0 = COPY %allones
-    %2:gpr = PseudoVCPOP_M_B64_MASK $noreg, $v0, 42, 0
+    %2:gpr = PseudoVCPOP_M_B64_MASK $noreg, $v0, 21, 0
 ...


### PR DESCRIPTION
AVL operands should be a register, a uimm5, or -1.