### PR TITLE
[InstCombine] Fix profile metadata when folding implied conditionals

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -3067,14 +3067,10 @@ Instruction *InstCombinerImpl::foldAndOrOfSelectUsingImpliedCond(Value *Op,
          "Op must be either i1 or vector of i1.");
   if (SI.getCondition()->getType() != Op->getType())
     return nullptr;
-  if (Value *V = simplifyNestedSelectsUsingImpliedCond(SI, Op, IsAnd, DL)) {
-    Instruction *MDFrom = nullptr;
-    if (!ProfcheckDisableMetadataFixes)
-      MDFrom = &SI;
-    return SelectInst::Create(
+  if (Value *V = simplifyNestedSelectsUsingImpliedCond(SI, Op, IsAnd, DL))
+    return createSelectInstWithUnknownProfile(
         Op, IsAnd ? V : ConstantInt::getTrue(Op->getType()),
-        IsAnd ? ConstantInt::getFalse(Op->getType()) : V, "", nullptr, MDFrom);
-  }
+        IsAnd ? ConstantInt::getFalse(Op->getType()) : V);
   return nullptr;
 }
 

--- a/llvm/test/Transforms/InstCombine/select-safe-impliedcond-transforms.ll
+++ b/llvm/test/Transforms/InstCombine/select-safe-impliedcond-transforms.ll
@@ -263,5 +263,5 @@ define i1 @neg_icmp_eq_implies_trunc(i8 %x, i1 %c) {
 !1 = !{!"branch_weights", i32 2, i32 3}
 ;.
 ; CHECK: [[META0:![0-9]+]] = !{!"function_entry_count", i64 1000}
-; CHECK: [[PROF1]] = !{!"branch_weights", i32 2, i32 3}
+; CHECK: [[PROF1]] = !{!"unknown", !"instcombine"}
 ;.


### PR DESCRIPTION
\#163412 touched this last and directly propagated the profile information. This was not correct for the motivating example:

  %a = icmp eq i32 %z, 0
  %b = icmp eq i32 %z, 1
  %v2 = select i1 %b, i1 true, i1 %pred, !prof !18
  %v3 = and i1 %a, %v2

to

  %a = icmp eq i32 %z, 0
  %v3 = select i1 %a, i1 %pred, i1 false

z == 1 does not imply that z == 0 for i8. In general for the and case, we need a => b, which means that b must be equivalent or more restrictive than a, which means we cannot propagate profile information without additional information on the value distribution of z. For the or case we need !a => b. We again cannot derive profile information for a/!a without additional value distribution information.