### PR TITLE
[bazel][NFC] Avoid set for older bazel versions

### DIFF
--- a/utils/bazel/configure.bzl
+++ b/utils/bazel/configure.bzl
@@ -27,7 +27,6 @@ DEFAULT_TARGETS = [
     "XCore",
 ]
 
-
 MAX_TRAVERSAL_STEPS = 1000000  # "big number" upper bound on total visited dirs
 
 def _overlay_directories(repository_ctx):
@@ -44,7 +43,9 @@ def _overlay_directories(repository_ctx):
     for _ in range(MAX_TRAVERSAL_STEPS):
         rel_dir = stack.pop()
 
-        overlay_dirs = set()
+        # TODO: `set()` is only available in bazel 8.1.
+        # Use `set()` after downstream users are on more recent versions.
+        overlay_dirs = {}
 
         # Symlink overlay files, overlay dirs will be handled in future iterations.
         for entry in overlay_root.get_child(rel_dir).readdir():
@@ -53,7 +54,7 @@ def _overlay_directories(repository_ctx):
 
             if entry.is_dir:
                 stack.append(full_rel_path)
-                overlay_dirs.add(name)
+                overlay_dirs[name] = None
             else:
                 src_path = overlay_root.get_child(full_rel_path)
                 dst_path = target_root.get_child(full_rel_path)
@@ -62,7 +63,7 @@ def _overlay_directories(repository_ctx):
         # Symlink source dirs (if not themselves overlaid) and files.
         for src_entry in src_root.get_child(rel_dir).readdir():
             name = src_entry.basename
-            if name in overlay_dirs:
+            if name in overlay_dirs.keys():
                 # Skip: overlay has a directory with this name
                 continue
 


### PR DESCRIPTION
The `set` type is only available on Bazel 8.1, which is newer than some projects. This gives some time for downstream users of LLVM to migrate to Bazel 8.1 or newer.

e.g. https://github.com/openxla/xla/actions/runs/19943322161/job/57186478292