### PR TITLE
[TableGen] CodeGenInstAlias: reduce calls to isSubClassOf. NFCI

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
@@ -44,11 +44,7 @@ static Expected<ResultOperand> matchSimpleOperand(const Init *Arg,
                                                   const StringInit *ArgName,
                                                   const Record *Op,
                                                   const CodeGenTarget &T) {
-  if (Op->isSubClassOf("RegisterClass") ||
-      Op->isSubClassOf("RegisterOperand")) {
-    const Record *OpRC =
-        Op->isSubClassOf("RegisterClass") ? Op : Op->getValueAsDef("RegClass");
-
+  if (const Record *OpRC = T.getAsRegClassLike(Op)) {
     if (const auto *ArgDef = dyn_cast<DefInit>(Arg)) {
       const Record *ArgRec = ArgDef->getDef();
 
@@ -111,11 +107,9 @@ static Expected<ResultOperand> matchSimpleOperand(const Init *Arg,
       return ResultOperand::createRecord(ArgName->getAsUnquotedString(),
                                          ArgDef->getDef());
     }
-
-    return createStringError("argument must be a subclass of Operand");
   }
-
-  llvm_unreachable("Unknown operand kind");
+  return createStringError("argument must be a subclass of 'Operand' but got " +
+                           Op->getName() + " instead");
 }
 
 static Expected<ResultOperand> matchComplexOperand(const Init *Arg,

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -227,12 +227,14 @@ const Record *CodeGenTarget::getInitValueAsRegClassLike(const Init *V) const {
   const DefInit *VDefInit = dyn_cast<DefInit>(V);
   if (!VDefInit)
     return nullptr;
+  return getAsRegClassLike(VDefInit->getDef());
+}
 
-  const Record *RegClass = VDefInit->getDef();
-  if (RegClass->isSubClassOf("RegisterOperand"))
-    return RegClass->getValueAsDef("RegClass");
+const Record *CodeGenTarget::getAsRegClassLike(const Record *Rec) const {
+  if (Rec->isSubClassOf("RegisterOperand"))
+    return Rec->getValueAsDef("RegClass");
 
-  return RegClass->isSubClassOf("RegisterClassLike") ? RegClass : nullptr;
+  return Rec->isSubClassOf("RegisterClassLike") ? Rec : nullptr;
 }
 
 CodeGenSchedModels &CodeGenTarget::getSchedModels() const {

--- a/llvm/utils/TableGen/Common/CodeGenTarget.h
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.h
@@ -165,6 +165,7 @@ public:
   /// return the Record. This is used as a convenience function to handle direct
   /// RegisterClass references, or those wrapped in a RegisterOperand.
   const Record *getInitValueAsRegClassLike(const Init *V) const;
+  const Record *getAsRegClassLike(const Record *V) const;
 
   CodeGenSchedModels &getSchedModels() const;
 


### PR DESCRIPTION
Add a `getAsRegClassLike()` helper to CodeGenTarget that handles the
`isSubClassOf` calls internally. This slightly reduces duplicated code
since it can be shared with `getInitValueAsRegClassLike()`.
Also change the llvm_unreachable at the end of this function to an
actual error since it could be reachable with bad inputs.
