### PR TITLE
Add commas for riscv and arm configs.

### DIFF
--- a/libc/config/linux/arm/config.json
+++ b/libc/config/linux/arm/config.json
@@ -2,7 +2,7 @@
   "string": {
     "LIBC_CONF_STRING_LENGTH_IMPL": {
       "value": "element"
-    }
+    },
     "LIBC_CONF_FIND_FIRST_CHARACTER_IMPL": {
       "value": "element"
     }

--- a/libc/config/linux/riscv/config.json
+++ b/libc/config/linux/riscv/config.json
@@ -2,7 +2,7 @@
   "string": {
     "LIBC_CONF_STRING_LENGTH_IMPL": {
       "value": "element"
-    }
+    },
     "LIBC_CONF_FIND_FIRST_CHARACTER_IMPL": {
       "value": "element"
     }


### PR DESCRIPTION
Fix for breakage introduced by pr170738