### PR TITLE
[ASan] Disable test that sets call stack on Darwin

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
@@ -1,5 +1,9 @@
 // Check that UAR mode can handle very deep recursion.
 // REQUIRES: shell
+// TODO(boomanaiden154): This test currently fails with the internal
+// shell because python is not able to set RLIMIT_STACK. We should
+// reenable this when the behavior is fixed.
+// UNSUPPORTED: system-darwin
 // RUN: %clangxx_asan -O2 %s -o %t
 // RUN: ulimit -s 4096
 // RUN: %env_asan_opts=detect_stack_use_after_return=1 %run %t 2>&1 | FileCheck %s


### PR DESCRIPTION
This test fails with the internal shell as we implement ulimit with a python wrapper. This python wrapper fails on recent versions of MacOS to set the stack size limit lower, or even to the current values. More discussion is in https://github.com/python/cpython/issues/78783 towards the bottom (it seems like a new issue should be opened).

It does not seem like we lose significant test coverage by disabling this on MacOS as the test running on Linux should catch any major regressions. We can also simply reenable once the issue is fixed (although writing a simple c program with calls setrlimit directly also fails in the smae manner).