### PR TITLE
[profcheck] Remove the expected failed test cases.

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -143,9 +143,6 @@ Transforms/ExpandLargeFpConvert/X86/expand-large-fp-convert-fptosi129.ll
 Transforms/ExpandLargeFpConvert/X86/expand-large-fp-convert-fptoui129.ll
 Transforms/ExpandLargeFpConvert/X86/expand-large-fp-convert-si129tofp.ll
 Transforms/ExpandLargeFpConvert/X86/expand-large-fp-convert-ui129tofp.ll
-Transforms/ExpandVariadics/expand-va-intrinsic-split-linkage.ll
-Transforms/ExpandVariadics/expand-va-intrinsic-split-simple.ll
-Transforms/ExpandVariadics/intrinsics.ll
 Transforms/FixIrreducible/basic.ll
 Transforms/FixIrreducible/bug45623.ll
 Transforms/FixIrreducible/callbr.ll


### PR DESCRIPTION
The expected failed test cases 
```
  Transforms/ExpandVariadics/expand-va-intrinsic-split-linkage.ll
  Transforms/ExpandVariadics/expand-va-intrinsic-split-simple.ll
  Transforms/ExpandVariadics/intrinsics.ll
```
have been fixed by https://github.com/llvm/llvm-project/pull/168161.