### PR TITLE
[lldb-dap] Detect if we can automatically attach to targets.

### DIFF
--- a/lldb/tools/lldb-dap/DAPSessionManager.h
+++ b/lldb/tools/lldb-dap/DAPSessionManager.h
@@ -59,6 +59,9 @@ public:
   /// Get the singleton instance of the DAP session manager.
   static DAPSessionManager &GetInstance();
 
+  void SetServerMode() { m_server_mode = true; }
+  bool GetServerMode() { return m_server_mode; }
+
   /// Register a DAP session.
   void RegisterSession(lldb_private::MainLoop *loop, DAP *dap);
 
@@ -103,6 +106,7 @@ private:
   DAPSessionManager(DAPSessionManager &&) = delete;
   DAPSessionManager &operator=(DAPSessionManager &&) = delete;
 
+  bool m_server_mode = false;
   bool m_client_failed = false;
   std::mutex m_sessions_mutex;
   std::condition_variable m_sessions_condition;

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -449,6 +449,13 @@ void HandleTargetEvent(const lldb::SBEvent &event, Log *log) {
       }
     }
   } else if (event_mask & lldb::SBTarget::eBroadcastBitNewTargetCreated) {
+    if (!DAPSessionManager::GetInstance().GetServerMode()) {
+      dap->SendOutput(OutputType::Console,
+                      "lldb-dap: Enable server mode for automatically "
+                      "attaching to new debugger targets.");
+      return;
+    }
+
     // For NewTargetCreated events, GetTargetFromEvent returns the parent
     // target, and GetCreatedTargetFromEvent returns the newly created target.
     lldb::SBTarget created_target =

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -28,6 +28,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Threading.h"
+#include "llvm/Support/WithColor.h"
+#include "llvm/Support/raw_ostream.h"
 #include <mutex>
 #include <utility>
 
@@ -449,10 +451,15 @@ void HandleTargetEvent(const lldb::SBEvent &event, Log *log) {
       }
     }
   } else if (event_mask & lldb::SBTarget::eBroadcastBitNewTargetCreated) {
+    // This feature is only supported if lldb-dap is running in server mode,
+    // otherwise multiple clients cannot connect over stdio.
     if (!DAPSessionManager::GetInstance().GetServerMode()) {
-      dap->SendOutput(OutputType::Console,
-                      "lldb-dap: Enable server mode for automatically "
-                      "attaching to new debugger targets.");
+      std::string message;
+      raw_string_ostream OS(message);
+      llvm::WithColor::remark(OS)
+          << "lldb-dap: Enable server mode for automatically attaching to new "
+             "debugger targets.";
+      dap->SendOutput(OutputType::Console, message);
       return;
     }
 

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -425,6 +425,8 @@ static llvm::Error serveConnection(
     return status.takeError();
   }
 
+  DAPSessionManager::GetInstance().SetServerMode();
+
   std::string address = llvm::join(listener->GetListeningConnectionURI(), ", ");
   DAP_LOG(log, "started with connection listeners {0}", address);
 


### PR DESCRIPTION
The new support for automatically attaching to targets during a debug session is not guarded on how lldb-dap is running. If its running over stdio then this feature will not work.

Instead, I added a message to the console and skip attempting to attach.