### PR TITLE
[lldb][test] Add basic API tests for DW_TAG_template_alias

### DIFF
--- a/lldb/test/API/lang/cpp/template-alias/Makefile
+++ b/lldb/test/API/lang/cpp/template-alias/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/template-alias/TestTemplateAlias.py
+++ b/lldb/test/API/lang/cpp/template-alias/TestTemplateAlias.py
@@ -1,0 +1,50 @@
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class TestTemplateAlias(TestBase):
+    def do_test(self, extra_flags):
+        self.build(dictionary=extra_flags)
+        self.main_source_file = lldb.SBFileSpec("main.cpp")
+        lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))
+
+        self.expect_expr("f1", result_type="Foo<int>")
+        self.expect_expr("f2", result_type="Foo<double>")
+        self.expect_expr("b1", result_type="Bar<int>")
+        self.expect_expr("b2", result_type="Bar<double>")
+        self.expect_expr("bf1", result_type="Bar<int>")
+        self.expect_expr("bf2", result_type="Bar<double>")
+        self.expect_expr("bf1", result_type="Bar<int>")
+        self.expect_expr("bf2", result_type="Bar<double>")
+        self.expect_expr("cbf1", result_type="Container<int>")
+
+    @expectedFailureAll(
+        bugnumber="LLDB doesn't reconstruct template alias names from template parameters"
+    )
+    def test_tag_alias_simple(self):
+        self.do_test(
+            dict(CXXFLAGS_EXTRAS="-gdwarf-5 -gtemplate-alias -gsimple-template-names")
+        )
+
+    def test_tag_alias_no_simple(self):
+        self.do_test(
+            dict(
+                CXXFLAGS_EXTRAS="-gdwarf-5 -gtemplate-alias -gno-simple-template-names"
+            )
+        )
+
+    def test_no_tag_alias_simple(self):
+        self.do_test(
+            dict(
+                CXXFLAGS_EXTRAS="-gdwarf-5 -gno-template-alias -gsimple-template-names"
+            )
+        )
+
+    def test_no_tag_alias_no_simple(self):
+        self.do_test(
+            dict(
+                CXXFLAGS_EXTRAS="-gdwarf-5 -gno-template-alias -gno-simple-template-names"
+            )
+        )

--- a/lldb/test/API/lang/cpp/template-alias/main.cpp
+++ b/lldb/test/API/lang/cpp/template-alias/main.cpp
@@ -1,19 +1,16 @@
-template<typename T>
-using Foo = T;
+template <typename T> using Foo = T;
 
-template<typename T>
-using Bar = Foo<T>;
+template <typename T> using Bar = Foo<T>;
 
-template<typename T>
-struct Container {};
+template <typename T> struct Container {};
 
 int main() {
-    Foo<int> f1;
-    Foo<double> f2;
-    Bar<int> b1;
-    Bar<double> b2;
-    Bar<Foo<int>> bf1;
-    Bar<Foo<double>> bf2;
-    Container<Bar<Foo<int>>> cbf1;
-    return 0;
+  Foo<int> f1;
+  Foo<double> f2;
+  Bar<int> b1;
+  Bar<double> b2;
+  Bar<Foo<int>> bf1;
+  Bar<Foo<double>> bf2;
+  Container<Bar<Foo<int>>> cbf1;
+  return 0;
 }

--- a/lldb/test/API/lang/cpp/template-alias/main.cpp
+++ b/lldb/test/API/lang/cpp/template-alias/main.cpp
@@ -1,0 +1,19 @@
+template<typename T>
+using Foo = T;
+
+template<typename T>
+using Bar = Foo<T>;
+
+template<typename T>
+struct Container {};
+
+int main() {
+    Foo<int> f1;
+    Foo<double> f2;
+    Bar<int> b1;
+    Bar<double> b2;
+    Bar<Foo<int>> bf1;
+    Bar<Foo<double>> bf2;
+    Container<Bar<Foo<int>>> cbf1;
+    return 0;
+}


### PR DESCRIPTION
Basic API tests to check how template aliases are rendered by LLDB (using both `DW_TAG_template_alias` and `DW_TAG_typedef`, with and without `-gsimple-template-names`).