### PR TITLE
[sanitizer_common] [Darwin] Add inline frame support for AtosSymbolizer

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_mac.cpp
@@ -216,8 +216,7 @@ bool AtosSymbolizer::SymbolizePC(uptr addr, SymbolizedStack *stack) {
     // Upon failure, ParseCommandOutput returns NULL.
     if (!buf) {
       Report("WARNING: atos failed to symbolize buf address \"0x%zx\"\n", addr);
-      break;
-      // return false;
+      return NULL;
     }
     cur->info.line = (int)line;
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/print-stack-trace-in-code-loaded-after-fork.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/print-stack-trace-in-code-loaded-after-fork.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
   PrintStackFnPtrTy PrintStackFnPtr = (PrintStackFnPtrTy)dlsym(handle, "PrintStack");
   assert(PrintStackFnPtr);
   // Check that the symbolizer is told examine the child process.
-  // CHECK: Launching Symbolizer process: {{.+}}atos -p [[CHILD_PID]]
+  // CHECK: Launching Symbolizer process: {{.+}}atos -i -p [[CHILD_PID]]
   // CHECK-STACKTRACE: #2{{( *0x.* *in *)?}} main {{.*}}print-stack-trace-in-code-loaded-after-fork.cpp:[[@LINE+1]]
   PrintStackFnPtr();
   return 0;

--- a/compiler-rt/test/sanitizer_common/TestCases/symbolize_pc_inline.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/symbolize_pc_inline.cpp
@@ -1,9 +1,7 @@
 // RUN: %clangxx -O3  %s -o %t
-// RUN: %env_tool_opts=strip_path_prefix=/TestCases/ %run %t 2>&1 | FileCheck %s
-// RUN: %env_tool_opts=strip_path_prefix=/TestCases/:symbolize_inline_frames=0 %run %t 2>&1 | FileCheck %s --check-prefixes=NOINLINE
+// RUN: %env_tool_opts=strip_path_prefix=/TestCases/:verbosity=3 %run %t 2>&1 | FileCheck %s
+// RUN: %env_tool_opts=strip_path_prefix=/TestCases/:symbolize_inline_frames=0 %run %t 2>&1 | FileCheck %s --check-prefixes=%if darwin %{NOINLINE-ATOS%} %else %{NOINLINE%}
 // RUN: %env_tool_opts=strip_path_prefix=/TestCases/:symbolize_inline_frames=1 %run %t 2>&1 | FileCheck %s
-
-// XFAIL: darwin
 
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>
@@ -19,14 +17,15 @@ __attribute__((noinline)) static void Symbolize() {
 }
 
 // NOINLINE: {{0x[0-9a-f]+}} in main symbolize_pc_inline.cpp:[[@LINE+2]]
-// CHECK: [[ADDR:0x[0-9a-f]+]] in C2 symbolize_pc_inline.cpp:[[@LINE+1]]
+// CHECK: [[ADDR:0x[0-9a-f]+]] in C2{{(\(\))?}} symbolize_pc_inline.cpp:[[@LINE+1]]
 static inline void C2() { Symbolize(); }
 
-// CHECK: [[ADDR]] in C3 symbolize_pc_inline.cpp:[[@LINE+1]]
+// CHECK: [[ADDR]] in C3{{(\(\))?}} symbolize_pc_inline.cpp:[[@LINE+1]]
 static inline void C3() { C2(); }
 
-// CHECK: [[ADDR]] in C4 symbolize_pc_inline.cpp:[[@LINE+1]]
+// CHECK: [[ADDR]] in C4{{(\(\))?}} symbolize_pc_inline.cpp:[[@LINE+1]]
 static inline void C4() { C3(); }
 
+// NOINLINE-ATOS: {{0x[0-9a-f]+}} in main symbolize_pc_inline.cpp:[[@LINE+2]]
 // CHECK: [[ADDR]] in main symbolize_pc_inline.cpp:[[@LINE+1]]
 int main() { C4(); }


### PR DESCRIPTION
When the `symbolize_inline_frames` option is set, we should use the `-i` atos option and show inline frames.

The implementation is modeled after `ParseSymbolizePCOutput` and is now quite close to that, but there are some subtle differences which I think make it difficult to merge the implementations.

rdar://165894291