### PR TITLE
[sanitizer_common] Fix missing `check-sanitizer` deps under LLVM_ENABLE_RUNTIMES

### DIFF
--- a/compiler-rt/test/sanitizer_common/CMakeLists.txt
+++ b/compiler-rt/test/sanitizer_common/CMakeLists.txt
@@ -51,7 +51,7 @@ message(
 # Create a separate config for each tool we support.
 foreach(tool ${SUPPORTED_TOOLS})
   string(TOUPPER ${tool} tool_toupper)
-  if(${tool_toupper}_SUPPORTED_ARCH AND NOT COMPILER_RT_STANDALONE_BUILD)
+  if(${tool_toupper}_SUPPORTED_ARCH AND (NOT COMPILER_RT_STANDALONE_BUILD OR LLVM_RUNTIMES_BUILD))
     list(APPEND SANITIZER_COMMON_TEST_DEPS ${tool})
   endif()
   set(TEST_ARCH ${${tool_toupper}_SUPPORTED_ARCH})


### PR DESCRIPTION
`COMPILER_RT_STANDALONE_BUILD` is set when doing a `LLVM_ENABLE_RUNTIMES` build. This prevents the sanitizer runtimes from being added as dependencies to `check-sanitizer`. Currently, if you make runtime changes and then run `check-sanitizer` you won't actually be testing a rebuilt runtime.

I don't follow why `COMPILER_RT_STANDALONE_BUILD` is even relevant here (was it ever?), so the right thing to do may be to remove the check entirely instead of adding `OR LLVM_RUNTIMES_BUILD` like I'm doing here..

rdar://165894534