### PR TITLE
Add the support for recognizing WTF::move like std::move

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -132,17 +132,17 @@ bool tryToFindPtrOrigin(
         }
       }
 
-      if (call->isCallToStdMove() && call->getNumArgs() == 1) {
-        E = call->getArg(0)->IgnoreParenCasts();
-        continue;
-      }
-
       if (auto *callee = call->getDirectCallee()) {
         if (isCtorOfSafePtr(callee)) {
           if (StopAtFirstRefCountedObj)
             return callback(E, true);
 
           E = call->getArg(0);
+          continue;
+        }
+
+        if (isStdOrWTFMove(callee) && call->getNumArgs() == 1) {
+          E = call->getArg(0)->IgnoreParenCasts();
           continue;
         }
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
@@ -267,8 +267,7 @@ public:
       ArgExpr = ArgExpr->IgnoreParenCasts();
       if (auto *InnerCE = dyn_cast<CallExpr>(ArgExpr)) {
         auto *InnerCallee = InnerCE->getDirectCallee();
-        if (InnerCallee && InnerCallee->isInStdNamespace() &&
-            safeGetName(InnerCallee) == "move" && InnerCE->getNumArgs() == 1) {
+        if (isStdOrWTFMove(InnerCallee) && InnerCE->getNumArgs() == 1) {
           ArgExpr = InnerCE->getArg(0);
           continue;
         }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -190,6 +190,9 @@ bool isStdOrWTFMove(const clang::FunctionDecl *F) {
   auto *Namespace = F->getParent();
   if (!Namespace)
     return false;
+  auto* TUDeck = Namespace->getParent();
+  if (!TUDeck || !isa<TranslationUnitDecl>(TUDeck))
+    return false;
   auto NsName = safeGetName(Namespace);
   return (NsName == "WTF" || NsName == "std") && FnName == "move";
 }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -190,8 +190,8 @@ bool isStdOrWTFMove(const clang::FunctionDecl *F) {
   auto *Namespace = F->getParent();
   if (!Namespace)
     return false;
-  auto* TUDeck = Namespace->getParent();
-  if (!TUDeck || !isa<TranslationUnitDecl>(TUDeck))
+  auto *TUDeck = Namespace->getParent();
+  if (!isa_and_nonnull<TranslationUnitDecl>(TUDeck))
     return false;
   auto NsName = safeGetName(Namespace);
   return (NsName == "WTF" || NsName == "std") && FnName == "move";

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -185,6 +185,15 @@ bool isCtorOfSafePtr(const clang::FunctionDecl *F) {
          isCtorOfRetainPtrOrOSPtr(F);
 }
 
+bool isStdOrWTFMove(const clang::FunctionDecl *F) {
+  auto FnName = safeGetName(F);
+  auto *Namespace = F->getParent();
+  if (!Namespace)
+    return false;
+  auto NsName = safeGetName(Namespace);
+  return (NsName == "WTF" || NsName == "std") && FnName == "move";
+}
+
 template <typename Predicate>
 static bool isPtrOfType(const clang::QualType T, Predicate Pred) {
   QualType type = T;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -134,6 +134,9 @@ bool isCtorOfCheckedPtr(const clang::FunctionDecl *F);
 /// uncounted parameter, false if not.
 bool isCtorOfSafePtr(const clang::FunctionDecl *F);
 
+/// \returns true if \p F is std::move or WTF::move.
+bool isStdOrWTFMove(const clang::FunctionDecl *F);
+
 /// \returns true if \p Name is RefPtr, Ref, or its variant, false if not.
 bool isRefType(const std::string &Name);
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
@@ -416,12 +416,9 @@ public:
             return false;
           }
           if (auto *CE = dyn_cast<CallExpr>(Arg)) {
-            if (CE->isCallToStdMove() && CE->getNumArgs() == 1) {
-              Arg = CE->getArg(0)->IgnoreParenCasts();
-              continue;
-            }
             if (auto *Callee = CE->getDirectCallee()) {
-              if (isCtorOfSafePtr(Callee) && CE->getNumArgs() == 1) {
+              if ((isStdOrWTFMove(Callee) || isCtorOfSafePtr(Callee)) &&
+                  CE->getNumArgs() == 1) {
                 Arg = CE->getArg(0)->IgnoreParenCasts();
                 continue;
               }

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
@@ -80,6 +80,7 @@ namespace call_with_std_move {
 void consume(CheckedObj&&);
 void foo(CheckedObj&& obj) {
   consume(std::move(obj));
+  consume(WTF::move(obj));
 }
 
 }

--- a/clang/test/Analysis/Checkers/WebKit/forward-decl-checker.mm
+++ b/clang/test/Analysis/Checkers/WebKit/forward-decl-checker.mm
@@ -44,6 +44,7 @@ void opaque_call_arg(Obj* obj, Obj&& otherObj, const RefPtr<Obj>& safeObj, WeakP
   receive_obj_ref(*obj);
   receive_obj_ptr(&*obj);
   receive_obj_rref(std::move(otherObj));
+  receive_obj_rref(WTF::move(otherObj));
   receive_obj_ref(*safeObj.get());
   receive_obj_ptr(weakObj.get());
   // expected-warning@-1{{Call argument for parameter 'p' uses a forward declared type 'Obj *'}}
@@ -59,6 +60,7 @@ void rval(Obj&& arg) {
   auto &&obj = provide_obj_rval();
   // expected-warning@-1{{Local variable 'obj' uses a forward declared type 'Obj &&'}}
   receive_obj_rval(std::move(arg));
+  receive_obj_rval(WTF::move(arg));
 }
 
 ObjCObj *provide_objcobj();
@@ -84,6 +86,7 @@ void construct_ptr(Obj&& arg) {
   WrapperObj wrapper2(provide_obj_ref());
   // expected-warning@-1{{Call argument for parameter 'obj' uses a forward declared type 'Obj &'}}
   WrapperObj wrapper3(std::move(arg));
+  WrapperObj wrapper4(WTF::move(arg));
 }
 
 JSStringRef provide_opaque_ptr();

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -17,6 +17,12 @@ template<typename T> typename remove_reference<T>::type&& move(T&& t);
 
 #endif
 
+namespace WTF {
+
+template<typename T> typename std::remove_reference<T>::type&& move(T&& t);
+
+}
+
 #ifndef mock_types_1103988513531
 #define mock_types_1103988513531
 

--- a/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
@@ -17,6 +17,12 @@ template<typename T> typename remove_reference<T>::type&& move(T&& t);
 
 #endif
 
+namespace WTF {
+
+template<typename T> typename std::remove_reference<T>::type&& move(T&& t);
+
+}
+
 namespace std {
 
 template <bool, typename U = void> struct enable_if {
@@ -453,7 +459,7 @@ public:
     }
 
     OSObjectPtr(T ptr)
-        : m_ptr(std::move(ptr))
+        : m_ptr(WTF::move(ptr))
     {
         if (m_ptr)
             retainOSObject(m_ptr);
@@ -483,7 +489,7 @@ public:
 
     OSObjectPtr& operator=(T other)
     {
-        OSObjectPtr ptr = std::move(other);
+        OSObjectPtr ptr = WTF::move(other);
         swap(ptr);
         return *this;
     }

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -437,6 +437,14 @@ struct RefCountableWithLambdaCapturingThis {
       });
     });
   }
+
+  void method_nested_lambda4() {
+    callAsync([this, protectedThis = RefPtr { this }] {
+      callAsync([this, protectedThis = WTF::move(*protectedThis)] {
+        nonTrivial();
+      });
+    });
+  }
 };
 
 struct NonRefCountableWithLambdaCapturingThis {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -387,6 +387,7 @@ public:
   unsigned trivial69() { return offsetof(OtherObj, children); }
   DerivedNumber* trivial70() { [[clang::suppress]] return static_cast<DerivedNumber*>(number); }
   unsigned trivial71() { return std::bit_cast<unsigned>(nullptr); }
+  unsigned trivial72() { Number n { 5 }; return WTF::move(n).value(); }
 
   static RefCounted& singleton() {
     static RefCounted s_RefCounted;


### PR DESCRIPTION
This PR adds support for treating WTF::move like std::move in various WebKit checkers.