### PR TITLE
[lldb][NFC] Replace const std::vector& with ArrayRef in APIs

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -298,29 +298,12 @@ public:
   ///     matches.
   void FindCompileUnits(const FileSpec &path, SymbolContextList &sc_list);
 
-  /// Find functions by lookup info.
-  ///
-  /// If the function is an inlined function, it will have a block,
-  /// representing the inlined function, and the function will be the
-  /// containing function.  If it is not inlined, then the block will be NULL.
-  ///
-  /// \param[in] lookup_info
-  ///     The lookup info of the function we are looking for.
-  ///
-  /// \param[out] sc_list
-  ///     A symbol context list that gets filled in with all of the
-  ///     matches.
-  void FindFunctions(const LookupInfo &lookup_info,
-                     const CompilerDeclContext &parent_decl_ctx,
-                     const ModuleFunctionSearchOptions &options,
-                     SymbolContextList &sc_list);
-
   /// Find functions by a vector of lookup infos.
   ///
   /// If the function is an inlined function, it will have a block,
   /// representing the inlined function, and the function will be the
   /// containing function.  If it is not inlined, then the block will be NULL.
-  void FindFunctions(const std::vector<LookupInfo> &lookup_infos,
+  void FindFunctions(llvm::ArrayRef<LookupInfo> lookup_infos,
                      const CompilerDeclContext &parent_decl_ctx,
                      const ModuleFunctionSearchOptions &options,
                      SymbolContextList &sc_list);

--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -309,10 +309,9 @@ public:
   virtual void FindFunctions(const Module::LookupInfo &lookup_info,
                              const CompilerDeclContext &parent_decl_ctx,
                              bool include_inlines, SymbolContextList &sc_list);
-  virtual void
-  FindFunctions(const std::vector<Module::LookupInfo> &lookup_infos,
-                const CompilerDeclContext &parent_decl_ctx,
-                bool include_inlines, SymbolContextList &sc_list);
+  virtual void FindFunctions(llvm::ArrayRef<Module::LookupInfo> lookup_infos,
+                             const CompilerDeclContext &parent_decl_ctx,
+                             bool include_inlines, SymbolContextList &sc_list);
   virtual void FindFunctions(const RegularExpression &regex,
                              bool include_inlines, SymbolContextList &sc_list);
 

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -820,31 +820,22 @@ void Module::LookupInfo::Prune(SymbolContextList &sc_list,
   }
 }
 
-void Module::FindFunctions(const Module::LookupInfo &lookup_info,
+void Module::FindFunctions(llvm::ArrayRef<Module::LookupInfo> lookup_infos,
                            const CompilerDeclContext &parent_decl_ctx,
                            const ModuleFunctionSearchOptions &options,
                            SymbolContextList &sc_list) {
-  // Find all the functions (not symbols, but debug information functions...
-  if (SymbolFile *symbols = GetSymbolFile()) {
+  for (auto &lookup_info : lookup_infos) {
+    SymbolFile *symbols = GetSymbolFile();
+    if (!symbols)
+      continue;
+
     symbols->FindFunctions(lookup_info, parent_decl_ctx,
                            options.include_inlines, sc_list);
-    // Now check our symbol table for symbols that are code symbols if
-    // requested
-    if (options.include_symbols) {
-      if (Symtab *symtab = symbols->GetSymtab()) {
+    if (options.include_symbols)
+      if (Symtab *symtab = symbols->GetSymtab())
         symtab->FindFunctionSymbols(lookup_info.GetLookupName(),
                                     lookup_info.GetNameTypeMask(), sc_list);
-      }
-    }
   }
-}
-
-void Module::FindFunctions(const std::vector<Module::LookupInfo> &lookup_infos,
-                           const CompilerDeclContext &parent_decl_ctx,
-                           const ModuleFunctionSearchOptions &options,
-                           SymbolContextList &sc_list) {
-  for (auto &lookup_info : lookup_infos)
-    FindFunctions(lookup_info, parent_decl_ctx, options, sc_list);
 }
 
 void Module::FindFunctions(ConstString name,

--- a/lldb/source/Symbol/SymbolFile.cpp
+++ b/lldb/source/Symbol/SymbolFile.cpp
@@ -126,10 +126,10 @@ void SymbolFile::FindFunctions(const Module::LookupInfo &lookup_info,
                                bool include_inlines,
                                SymbolContextList &sc_list) {}
 
-void SymbolFile::FindFunctions(
-    const std::vector<Module::LookupInfo> &lookup_infos,
-    const CompilerDeclContext &parent_decl_ctx, bool include_inlines,
-    SymbolContextList &sc_list) {
+void SymbolFile::FindFunctions(llvm::ArrayRef<Module::LookupInfo> lookup_infos,
+                               const CompilerDeclContext &parent_decl_ctx,
+                               bool include_inlines,
+                               SymbolContextList &sc_list) {
   for (const auto &lookup_info : lookup_infos)
     FindFunctions(lookup_info, parent_decl_ctx, include_inlines, sc_list);
 }


### PR DESCRIPTION
Inside the LLVM codebase, const vector& should just be ArrayRef, as this more general API works both with vectors, SmallVectors and SmallVectorImpl, as well as with single elements.

This commit replaces two uses introduced in
https://github.com/llvm/llvm-project/pull/168797 .