### PR TITLE
[Flang-RT] Set LD_LIBRARY_PATH for unittests

### DIFF
--- a/flang-rt/test/NonGtestUnit/lit.cfg.py
+++ b/flang-rt/test/NonGtestUnit/lit.cfg.py
@@ -1,6 +1,7 @@
 # -*- Python -*-
 
 import os
+import platform
 
 import lit.formats
 
@@ -19,3 +20,23 @@ config.test_exec_root = config.flang_rt_binary_test_dir
 
 # testFormat: The test format to use to interpret tests.
 config.test_format = lit.formats.ExecutableTest()
+
+
+def find_shlibpath_var():
+    if platform.system() in ["Linux", "FreeBSD", "NetBSD", "OpenBSD", "SunOS"]:
+        yield "LD_LIBRARY_PATH"
+    elif platform.system() == "Darwin":
+        yield "DYLD_LIBRARY_PATH"
+    elif platform.system() == "Windows" or sys.platform == "cygwin":
+        yield "PATH"
+    elif platform.system() == "AIX":
+        yield "LIBPATH"
+
+
+for shlibpath_var in find_shlibpath_var():
+    config.environment[shlibpath_var] = os.path.pathsep.join(
+        (
+            config.flang_rt_output_resource_lib_dir,
+            config.environment.get(shlibpath_var, ""),
+        )
+    )

--- a/flang-rt/test/NonGtestUnit/lit.site.cfg.py.in
+++ b/flang-rt/test/NonGtestUnit/lit.site.cfg.py.in
@@ -6,6 +6,7 @@ config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
 config.flang_rt_source_dir = "@FLANG_RT_SOURCE_DIR@"
 config.flangrt_binary_dir = "@FLANG_RT_BINARY_DIR@"
 config.flang_rt_binary_test_dir = os.path.dirname(__file__)
+config.flang_rt_output_resource_lib_dir = "@FLANG_RT_OUTPUT_RESOURCE_LIB_DIR@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/flang-rt/test/Unit/lit.cfg.py
+++ b/flang-rt/test/Unit/lit.cfg.py
@@ -1,6 +1,7 @@
 # -*- Python -*-
 
 import os
+import platform
 
 import lit.formats
 
@@ -19,3 +20,23 @@ config.test_exec_root = config.flang_rt_binary_test_dir
 
 # testFormat: The test format to use to interpret tests.
 config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, "Tests")
+
+
+def find_shlibpath_var():
+    if platform.system() in ["Linux", "FreeBSD", "NetBSD", "OpenBSD", "SunOS"]:
+        yield "LD_LIBRARY_PATH"
+    elif platform.system() == "Darwin":
+        yield "DYLD_LIBRARY_PATH"
+    elif platform.system() == "Windows" or sys.platform == "cygwin":
+        yield "PATH"
+    elif platform.system() == "AIX":
+        yield "LIBPATH"
+
+
+for shlibpath_var in find_shlibpath_var():
+    config.environment[shlibpath_var] = os.path.pathsep.join(
+        (
+            config.flang_rt_output_resource_lib_dir,
+            config.environment.get(shlibpath_var, ""),
+        )
+    )

--- a/flang-rt/test/Unit/lit.site.cfg.py.in
+++ b/flang-rt/test/Unit/lit.site.cfg.py.in
@@ -7,6 +7,7 @@ config.llvm_build_mode = "@LLVM_BUILD_MODE@"
 config.flang_rt_source_dir = "@FLANG_RT_SOURCE_DIR@"
 config.flangrt_binary_dir = "@FLANG_RT_BINARY_DIR@"
 config.flang_rt_binary_test_dir = os.path.dirname(__file__)
+config.flang_rt_output_resource_lib_dir = "@FLANG_RT_OUTPUT_RESOURCE_LIB_DIR@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
In case that the unittests have to link to the dynamic library with `FLANG_RT_ENABLE_SHARED=ON` and the static library unavailable with `FLANG_RT_ENABLE_SHARED=OFF` or the shared library is prefered with `BUILD_SHARED_LIBS=ON`.

Code to set enviornment variables adapted from Clang's unittest's code at https://github.com/llvm/llvm-project/blob/main/clang/test/Unit/lit.cfg.py#L49-L71. The `lit.formats.ExecutableTest` does not recognize `config.enviornment`, hence using `os.environ`.


