### PR TITLE
[ThreadSafety] Ignore parameter destructors

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -2821,7 +2821,7 @@ void ThreadSafetyAnalyzer::runAnalysis(AnalysisDeclContext &AC) {
         case CFGElement::AutomaticObjectDtor: {
           CFGAutomaticObjDtor AD = BI.castAs<CFGAutomaticObjDtor>();
           const auto *DD = AD.getDestructorDecl(AC.getASTContext());
-          // Function parameters as they are constructed in callee's context and
+          // Function parameters as they are constructed in caller's context and
           // the CFG does not contain the ctors. Ignore them as their
           // capabilities cannot be analysed because of this missing
           // information.

--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -2821,7 +2821,8 @@ void ThreadSafetyAnalyzer::runAnalysis(AnalysisDeclContext &AC) {
         case CFGElement::AutomaticObjectDtor: {
           CFGAutomaticObjDtor AD = BI.castAs<CFGAutomaticObjDtor>();
           const auto *DD = AD.getDestructorDecl(AC.getASTContext());
-          // Ignore parameter dtors: their ctors happen in caller context.
+          // Ignore parameter dtors: their ctors happen in caller context, so
+          // we can't match lock/unlock pairs for thread safety analysis.
           if (isa_and_nonnull<ParmVarDecl>(AD.getVarDecl()))
             break;
           if (!DD || !DD->hasAttrs())

--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -2821,10 +2821,7 @@ void ThreadSafetyAnalyzer::runAnalysis(AnalysisDeclContext &AC) {
         case CFGElement::AutomaticObjectDtor: {
           CFGAutomaticObjDtor AD = BI.castAs<CFGAutomaticObjDtor>();
           const auto *DD = AD.getDestructorDecl(AC.getASTContext());
-          // Ignore dtor for parameters as the corresponding constructor does
-          // not happen in the callee context but in the caller context. It is
-          // not possible to know which constuctor was used for its construction
-          // so avoid reading the destructor as well.
+          // Ignore parameter dtors: their ctors happen in caller context.
           if (isa_and_nonnull<ParmVarDecl>(AD.getVarDecl()))
             break;
           if (!DD || !DD->hasAttrs())

--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -2821,8 +2821,10 @@ void ThreadSafetyAnalyzer::runAnalysis(AnalysisDeclContext &AC) {
         case CFGElement::AutomaticObjectDtor: {
           CFGAutomaticObjDtor AD = BI.castAs<CFGAutomaticObjDtor>();
           const auto *DD = AD.getDestructorDecl(AC.getASTContext());
-          // Ignore parameter dtors: their ctors happen in caller context, so
-          // we can't match lock/unlock pairs for thread safety analysis.
+          // Function parameters as they are constructed in callee's context and
+          // the CFG does not contain the ctors. Ignore them as their
+          // capabilities cannot be analysed because of this missing
+          // information.
           if (isa_and_nonnull<ParmVarDecl>(AD.getVarDecl()))
             break;
           if (!DD || !DD->hasAttrs())

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -7622,3 +7622,19 @@ void testLoopConditionalReassignment(Foo *f1, Foo *f2, bool cond) {
   ptr->mu.Unlock(); // expected-warning{{releasing mutex 'ptr->mu' that was not held}}
 } // expected-warning{{mutex 'f1->mu' is still held at the end of function}}
 }  // namespace CapabilityAliases
+
+namespace test_function_param_lock_unlock {
+class A {
+ public:
+  A() EXCLUSIVE_LOCK_FUNCTION(mu_) {
+    mu_.Lock();
+  }
+  ~A() UNLOCK_FUNCTION(mu_) { mu_.Unlock(); }
+ private:
+  Mutex mu_;
+};
+
+int do_something(A a) {
+  return 0;
+}
+} // namespace test_function_param_lock_unlock

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -1881,7 +1881,7 @@ public:
 };
 // FIXME: This is a false-positive as the lock is released by the dtor.
 void do_something(MutexWrapper mw) {
-  mw.Lock(); // expectred-note {{mutex acquired here}}
+  mw.Lock(); // expected-note {{mutex acquired here}}
 }            // expected-warning {{mutex 'mw.mu_' is still held at the end of function}}
 
 } // namespace test_function_param_lock_unlock


### PR DESCRIPTION
Fixes a false positive in thread safety analysis when function parameters have lock/unlock annotations in their constructor/destructor.

PR #169320 added destructors to the CFG, which introduced false positives in thread safety analysis for function parameters. According to [expr.call#6](https://eel.is/c++draft/expr.call#6), parameter initialization occurs in the caller's context while destruction occurs in the callee's context.

```cpp
class A {
 public:
  A() EXCLUSIVE_LOCK_FUNCTION(mu_) { mu_.Lock(); }
  ~A() UNLOCK_FUNCTION(mu_) { mu_.Unlock(); }
 private:
  Mutex mu_;
};

int do_something(A a) {  // Previously: false positive warning
  return 0;
}
```

Previously, thread safety analysis would see the destructor (unlock) in `do_something` but not the corresponding constructor (lock) that happened in the caller's context, causing a false positive.