### PR TITLE
Remove LLVM_ABI from members of RuntimeLibraryAnalysis (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/RuntimeLibcallInfo.h
+++ b/llvm/include/llvm/Analysis/RuntimeLibcallInfo.h
@@ -29,12 +29,11 @@ public:
       EABI EABIVersion = EABI::Default, StringRef ABIName = "",
       VectorLibrary VecLib = VectorLibrary::NoLibrary);
 
-  LLVM_ABI RTLIB::RuntimeLibcallsInfo run(const Module &M,
-                                          ModuleAnalysisManager &);
+  RTLIB::RuntimeLibcallsInfo run(const Module &M, ModuleAnalysisManager &);
 
 private:
   friend AnalysisInfoMixin<RuntimeLibraryAnalysis>;
-  LLVM_ABI static AnalysisKey Key;
+  static AnalysisKey Key;
 
   std::optional<RTLIB::RuntimeLibcallsInfo> LibcallsInfo;
 };


### PR DESCRIPTION
The Windows build has been failing for me with:
```
error: attribute 'dllexport' cannot be applied to member of 'dllexport' class
```
