### PR TITLE
[MLIR][NVVM] Add binaryCallback

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/CompilationInterfaces.h
+++ b/mlir/include/mlir/Dialect/GPU/IR/CompilationInterfaces.h
@@ -58,7 +58,8 @@ public:
       function_ref<void(llvm::Module &)> initialLlvmIRCallback = {},
       function_ref<void(llvm::Module &)> linkedLlvmIRCallback = {},
       function_ref<void(llvm::Module &)> optimizedLlvmIRCallback = {},
-      function_ref<void(StringRef)> isaCallback = {});
+      function_ref<void(StringRef)> isaCallback = {},
+      function_ref<void(StringRef)> binaryCompilerDiagnosticCallback = {});
 
   /// Returns the typeID.
   TypeID getTypeID() const;
@@ -111,6 +112,9 @@ public:
   /// for example PTX assembly.
   function_ref<void(StringRef)> getISACallback() const;
 
+  /// Returns the callback invoked with the compilation target for the device.
+  function_ref<void(StringRef)> getbinaryCompilerDiagnosticCallback() const;
+
   /// Returns the default compilation target: `CompilationTarget::Fatbin`.
   static CompilationTarget getDefaultCompilationTarget();
 
@@ -130,7 +134,8 @@ protected:
       function_ref<void(llvm::Module &)> initialLlvmIRCallback = {},
       function_ref<void(llvm::Module &)> linkedLlvmIRCallback = {},
       function_ref<void(llvm::Module &)> optimizedLlvmIRCallback = {},
-      function_ref<void(StringRef)> isaCallback = {});
+      function_ref<void(StringRef)> isaCallback = {},
+      function_ref<void(StringRef)> binaryCompilerDiagnosticCallback = {});
 
   /// Path to the target toolkit.
   std::string toolkitPath;
@@ -166,6 +171,9 @@ protected:
   /// Callback invoked with the target ISA for the device,
   /// for example PTX assembly.
   function_ref<void(StringRef)> isaCallback;
+
+  /// Callback invoked with the compilation target for the device.
+  function_ref<void(StringRef)> binaryCompilerDiagnosticCallback;
 
 private:
   TypeID typeID;

--- a/mlir/include/mlir/Target/LLVM/ModuleToObject.h
+++ b/mlir/include/mlir/Target/LLVM/ModuleToObject.h
@@ -35,7 +35,8 @@ public:
       function_ref<void(llvm::Module &)> initialLlvmIRCallback = {},
       function_ref<void(llvm::Module &)> linkedLlvmIRCallback = {},
       function_ref<void(llvm::Module &)> optimizedLlvmIRCallback = {},
-      function_ref<void(StringRef)> isaCallback = {});
+      function_ref<void(StringRef)> isaCallback = {},
+      function_ref<void(StringRef)> binaryCompilerDiagnosticCallback = {});
   virtual ~ModuleToObject();
 
   /// Returns the operation being serialized.
@@ -133,6 +134,9 @@ protected:
   /// Callback invoked with the target ISA for the device,
   /// for example PTX assembly.
   function_ref<void(StringRef)> isaCallback;
+
+  /// Callback for diagnostic messages from the binary compiler.
+  function_ref<void(StringRef)> binaryCompilerDiagnosticCallback;
 
 private:
   /// The TargetMachine created for the given Triple, if available.

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -2655,12 +2655,13 @@ TargetOptions::TargetOptions(
     function_ref<void(llvm::Module &)> initialLlvmIRCallback,
     function_ref<void(llvm::Module &)> linkedLlvmIRCallback,
     function_ref<void(llvm::Module &)> optimizedLlvmIRCallback,
-    function_ref<void(StringRef)> isaCallback)
+    function_ref<void(StringRef)> isaCallback,
+    function_ref<void(StringRef)> binaryCompilerDiagnosticCallback)
     : TargetOptions(TypeID::get<TargetOptions>(), toolkitPath, librariesToLink,
                     cmdOptions, elfSection, compilationTarget,
                     getSymbolTableCallback, initialLlvmIRCallback,
-                    linkedLlvmIRCallback, optimizedLlvmIRCallback,
-                    isaCallback) {}
+                    linkedLlvmIRCallback, optimizedLlvmIRCallback, isaCallback,
+                    binaryCompilerDiagnosticCallback) {}
 
 TargetOptions::TargetOptions(
     TypeID typeID, StringRef toolkitPath, ArrayRef<Attribute> librariesToLink,
@@ -2670,7 +2671,8 @@ TargetOptions::TargetOptions(
     function_ref<void(llvm::Module &)> initialLlvmIRCallback,
     function_ref<void(llvm::Module &)> linkedLlvmIRCallback,
     function_ref<void(llvm::Module &)> optimizedLlvmIRCallback,
-    function_ref<void(StringRef)> isaCallback)
+    function_ref<void(StringRef)> isaCallback,
+    function_ref<void(StringRef)> binaryCompilerDiagnosticCallback)
     : toolkitPath(toolkitPath.str()), librariesToLink(librariesToLink),
       cmdOptions(cmdOptions.str()), elfSection(elfSection.str()),
       compilationTarget(compilationTarget),
@@ -2678,7 +2680,9 @@ TargetOptions::TargetOptions(
       initialLlvmIRCallback(initialLlvmIRCallback),
       linkedLlvmIRCallback(linkedLlvmIRCallback),
       optimizedLlvmIRCallback(optimizedLlvmIRCallback),
-      isaCallback(isaCallback), typeID(typeID) {}
+      isaCallback(isaCallback),
+      binaryCompilerDiagnosticCallback(binaryCompilerDiagnosticCallback),
+      typeID(typeID) {}
 
 TypeID TargetOptions::getTypeID() const { return typeID; }
 
@@ -2713,6 +2717,11 @@ TargetOptions::getOptimizedLlvmIRCallback() const {
 
 function_ref<void(StringRef)> TargetOptions::getISACallback() const {
   return isaCallback;
+}
+
+function_ref<void(StringRef)>
+TargetOptions::getbinaryCompilerDiagnosticCallback() const {
+  return binaryCompilerDiagnosticCallback;
 }
 
 CompilationTarget TargetOptions::getCompilationTarget() const {

--- a/mlir/lib/Target/LLVM/ModuleToObject.cpp
+++ b/mlir/lib/Target/LLVM/ModuleToObject.cpp
@@ -39,12 +39,14 @@ ModuleToObject::ModuleToObject(
     int optLevel, function_ref<void(llvm::Module &)> initialLlvmIRCallback,
     function_ref<void(llvm::Module &)> linkedLlvmIRCallback,
     function_ref<void(llvm::Module &)> optimizedLlvmIRCallback,
-    function_ref<void(StringRef)> isaCallback)
+    function_ref<void(StringRef)> isaCallback,
+    function_ref<void(StringRef)> binaryCompilerDiagnosticCallback)
     : module(module), triple(triple), chip(chip), features(features),
       optLevel(optLevel), initialLlvmIRCallback(initialLlvmIRCallback),
       linkedLlvmIRCallback(linkedLlvmIRCallback),
       optimizedLlvmIRCallback(optimizedLlvmIRCallback),
-      isaCallback(isaCallback) {}
+      isaCallback(isaCallback),
+      binaryCompilerDiagnosticCallback(binaryCompilerDiagnosticCallback) {}
 
 ModuleToObject::~ModuleToObject() = default;
 


### PR DESCRIPTION
When compiling PTX to binary, we can pass flags. However, the callback is not implemented for that case. This PR address this issue. 