### PR TITLE
[LangRef] Fix inequalities and add examples for `loop.dependence.*.mask`

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -24474,7 +24474,7 @@ The element of the result mask is active when loading from %ptrA then storing to
 %ptrB is safe and doesn't result in a write-after-read hazard, meaning that:
 
 * (ptrB - ptrA) <= 0 (guarantees that all lanes are loaded before any stores), or
-* (ptrB - ptrA) > elementSize * lane (guarantees that this lane is loaded
+* elementSize * lane < (ptrB - ptrA) (guarantees that this lane is loaded
   before the store to the same address)
 
 Examples:
@@ -24574,7 +24574,7 @@ or ``%ptrB + VF * %elementSize`` wrap.
 The element of the result mask is active when storing to %ptrA then loading from
 %ptrB is safe and doesn't result in aliasing, meaning that:
 
-* abs(ptrB - ptrA) > elementSize * lane (guarantees that the store of this lane
+* elementSize * lane < abs(ptrB - ptrA) (guarantees that the store of this lane
   occurs before loading from this address), or
 * ptrA == ptrB (doesn't introduce any new hazards that weren't in the scalar
   code)

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -24497,7 +24497,7 @@ Examples:
       ; This results in an all-true mask, as the load always occurs before the
       ; store, so it does not depend on any values to be stored.
       ;
-      ; 2. ptrB - ptrA = elementSize:
+      ; 2. ptrB - ptrA = 2 * elementSize:
       ;
       ;   load =  <0,1,2,3>         ; uint32_t load = array[i];
       ;  store =      <0,1,2,3>     ; array[i+2] = store;
@@ -24506,7 +24506,7 @@ Examples:
       ; we can only read two lanes before we would read values that have yet to
       ; be written.
       ;
-      ; 3. ptrB - ptrA = elementSize * 4
+      ; 3. ptrB - ptrA = 4 * elementSize
       ;
       ;   load =  <0,1,2,3>         ; uint32_t load = array[i];
       ;  store =          <0,1,2,3> ; array[i+4] = store;

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -24500,28 +24500,19 @@ Examples:
       ; 2. ptrB - ptrA = elementSize:
       ;
       ;   load =  <0,1,2,3>         ; uint32_t load = array[i];
-      ;  store =    <0,1,2,3>       ; array[i+1] = store;
-      ;
-      ; This results in a mask with only the first lane active. This is because
-      ; we can only read one lane before we would read values that have yet to
-      ; be written.
-      ;
-      ; 3. ptrB - ptrA = elementSize * 2
-      ;
-      ;   load =  <0,1,2,3>         ; uint32_t load = array[i];
       ;  store =      <0,1,2,3>     ; array[i+2] = store;
       ;
-      ; This is the same as the previous example, but the store is two lanes
-      ; ahead of the load. So this results in a mask with the first two lanes
-      ; active.
+      ; This results in a mask with the first two lanes active. This is because
+      ; we can only read two lanes before we would read values that have yet to
+      ; be written.
       ;
-      ; 4. ptrB - ptrA = elementSize * 4
+      ; 3. ptrB - ptrA = elementSize * 4
       ;
       ;   load =  <0,1,2,3>         ; uint32_t load = array[i];
       ;  store =          <0,1,2,3> ; array[i+4] = store;
       ;
-      ; Finally, in this example, the store is a full vector ahead of the load.
-      ; In this case, the result is an all-true mask.
+      ; This results in an all-true mask, as the store is a full vector ahead
+      ; of the load, so all values will be written before any lane is read.
 
 .. _int_loop_dependence_raw_mask:
 
@@ -24611,9 +24602,9 @@ Examples:
       ;  store =      <0,1,2,3>  ; array[i+2] = store;
       ;   load =  <0,1,2,3>      ; uint32_t load = array[i];
       ;
-      ; This also results in a mask with the first two lanes active. This could
-      ; result in a hazard if the store is scheduled after the load, so we only
-      ; consider the first two lanes to be readable.
+      ; This also results in a mask with the first two lanes active. This is
+      ; because if any more lanes were active the load would be dependent on the
+      ; completion of the store.
 
 .. _int_experimental_vp_splice:
 


### PR DESCRIPTION
For both the war/raw mask, `>=` was used where it should have been `>`.

This change matches the current implementation.

The examples added in this patch should help clarify why this change is needed.