### PR TITLE
[profcheck][test] Use quotes for when not using the internal lit shell

### DIFF
--- a/llvm/test/Transforms/PGOProfile/prof-verify-known-cold.ll
+++ b/llvm/test/Transforms/PGOProfile/prof-verify-known-cold.ll
@@ -1,6 +1,6 @@
 ; Test prof-verify for functions explicitly marked as cold
 
-; RUN: opt -passes=function(prof-inject),module(prof-verify) %s -o - 2>&1 | FileCheck %s
+; RUN: opt -passes='function(prof-inject),module(prof-verify)' %s -o - 2>&1 | FileCheck %s
 
 define void @foo(i32 %i) !prof !0 {
   %c = icmp eq i32 %i, 0

--- a/llvm/test/Transforms/PGOProfile/prof-verify.ll
+++ b/llvm/test/Transforms/PGOProfile/prof-verify.ll
@@ -6,7 +6,7 @@
 
 ; RUN: opt -passes=prof-inject %s -S -o - | FileCheck %s --check-prefix=INJECT
 ; RUN: not opt -passes=prof-verify %s -S -o - 2>&1 | FileCheck %s --check-prefix=VERIFY
-; RUN: opt -passes=function(prof-inject),module(prof-verify) %s --disable-output
+; RUN: opt -passes='function(prof-inject),module(prof-verify)' %s --disable-output
 ; RUN: opt -enable-profcheck %s -S -o - | FileCheck %s --check-prefix=INJECT
 
 define void @foo(i32 %i) !prof !0 {


### PR DESCRIPTION
Using `-passes=function(prof-inject),module(prof-verify)` needs to be quoted when using a non-lit shell.

Fixes tests in 4b4294473280a8e37d818a9362e33544799cb4e4 when not using lit's shell