### PR TITLE
[ADT] Make use of subsetOf and anyCommon methods of BitVector (NFC)

### DIFF
--- a/bolt/include/bolt/Passes/LivenessAnalysis.h
+++ b/bolt/include/bolt/Passes/LivenessAnalysis.h
@@ -37,10 +37,9 @@ public:
   virtual ~LivenessAnalysis();
 
   bool isAlive(ProgramPoint PP, MCPhysReg Reg) const {
-    BitVector BV = (*this->getStateAt(PP));
+    const BitVector &BV = *this->getStateAt(PP);
     const BitVector &RegAliases = BC.MIB->getAliases(Reg);
-    BV &= RegAliases;
-    return BV.any();
+    return BV.anyCommon(RegAliases);
   }
 
   void run() { Parent::run(); }

--- a/bolt/include/bolt/Passes/ReachingDefOrUse.h
+++ b/bolt/include/bolt/Passes/ReachingDefOrUse.h
@@ -133,8 +133,7 @@ protected:
           RA.getInstClobberList(Point, Regs);
         else
           RA.getInstUsedRegsList(Point, Regs, false);
-        Regs &= this->BC.MIB->getAliases(*TrackingReg);
-        if (Regs.any())
+        if (Regs.anyCommon(this->BC.MIB->getAliases(*TrackingReg)))
           Next.set(this->ExprToIdx[&Point]);
       }
     }

--- a/bolt/lib/Passes/RegReAssign.cpp
+++ b/bolt/lib/Passes/RegReAssign.cpp
@@ -316,18 +316,14 @@ void RegReAssign::aggressivePassOverFunction(BinaryFunction &Function) {
       break;
     }
 
-    BitVector AnyAliasAlive = AliveAtStart;
-    AnyAliasAlive &= BC.MIB->getAliases(ClassicReg);
-    if (AnyAliasAlive.any()) {
+    if (AliveAtStart.anyCommon(BC.MIB->getAliases(ClassicReg))) {
       LLVM_DEBUG(dbgs() << " Bailed on " << BC.MRI->getName(ClassicReg)
                         << " with " << BC.MRI->getName(ExtReg)
                         << " because classic reg is alive\n");
       --End;
       continue;
     }
-    AnyAliasAlive = AliveAtStart;
-    AnyAliasAlive &= BC.MIB->getAliases(ExtReg);
-    if (AnyAliasAlive.any()) {
+    if (AliveAtStart.anyCommon(BC.MIB->getAliases(ExtReg))) {
       LLVM_DEBUG(dbgs() << " Bailed on " << BC.MRI->getName(ClassicReg)
                         << " with " << BC.MRI->getName(ExtReg)
                         << " because extended reg is alive\n");

--- a/bolt/lib/Passes/ShrinkWrapping.cpp
+++ b/bolt/lib/Passes/ShrinkWrapping.cpp
@@ -1100,9 +1100,8 @@ SmallVector<ProgramPoint, 4> ShrinkWrapping::fixPopsPlacements(
     bool Found = false;
     if (SPT.getStateAt(ProgramPoint::getLastPointAt(*BB))->first ==
         SaveOffset) {
-      BitVector BV = *RI.getStateAt(ProgramPoint::getLastPointAt(*BB));
-      BV &= UsesByReg[CSR];
-      if (!BV.any()) {
+      const BitVector &BV = *RI.getStateAt(ProgramPoint::getLastPointAt(*BB));
+      if (!BV.anyCommon(UsesByReg[CSR])) {
         Found = true;
         PP = BB;
         continue;
@@ -1110,9 +1109,8 @@ SmallVector<ProgramPoint, 4> ShrinkWrapping::fixPopsPlacements(
     }
     for (MCInst &Inst : llvm::reverse(*BB)) {
       if (SPT.getStateBefore(Inst)->first == SaveOffset) {
-        BitVector BV = *RI.getStateAt(Inst);
-        BV &= UsesByReg[CSR];
-        if (!BV.any()) {
+        const BitVector &BV = *RI.getStateAt(Inst);
+        if (!BV.anyCommon(UsesByReg[CSR])) {
           Found = true;
           PP = &Inst;
           break;

--- a/bolt/lib/Passes/StackAvailableExpressions.cpp
+++ b/bolt/lib/Passes/StackAvailableExpressions.cpp
@@ -103,8 +103,7 @@ bool StackAvailableExpressions::doesXKillsY(const MCInst *X, const MCInst *Y) {
   else
     RA.getInstClobberList(*Y, YClobbers);
 
-  XClobbers &= YClobbers;
-  return XClobbers.any();
+  return XClobbers.anyCommon(YClobbers);
 }
 
 BitVector StackAvailableExpressions::computeNext(const MCInst &Point,

--- a/bolt/lib/Passes/TailDuplication.cpp
+++ b/bolt/lib/Passes/TailDuplication.cpp
@@ -97,8 +97,8 @@ bool TailDuplication::regIsPossiblyOverwritten(const MCInst &Inst, unsigned Reg,
   getCallerSavedRegs(Inst, WrittenRegs, BC);
   if (BC.MIB->isRep(Inst))
     BC.MIB->getRepRegs(WrittenRegs);
-  WrittenRegs &= BC.MIB->getAliases(Reg, false);
-  return WrittenRegs.any();
+  const BitVector &AllAliases = BC.MIB->getAliases(Reg, false);
+  return WrittenRegs.anyCommon(AllAliases);
 }
 
 bool TailDuplication::regIsDefinitelyOverwritten(const MCInst &Inst,
@@ -117,8 +117,8 @@ bool TailDuplication::regIsUsed(const MCInst &Inst, unsigned Reg,
                                 BinaryContext &BC) const {
   BitVector SrcRegs = BitVector(BC.MRI->getNumRegs(), false);
   BC.MIB->getSrcRegs(Inst, SrcRegs);
-  SrcRegs &= BC.MIB->getAliases(Reg, true);
-  return SrcRegs.any();
+  const BitVector &SmallerAliases = BC.MIB->getAliases(Reg, true);
+  return SrcRegs.anyCommon(SmallerAliases);
 }
 
 bool TailDuplication::isOverwrittenBeforeUsed(BinaryBasicBlock &StartBB,

--- a/llvm/lib/CodeGen/RDFRegisters.cpp
+++ b/llvm/lib/CodeGen/RDFRegisters.cpp
@@ -287,10 +287,8 @@ bool RegisterAggr::hasAliasOf(RegisterRef RR) const {
 }
 
 bool RegisterAggr::hasCoverOf(RegisterRef RR) const {
-  if (RR.isMask()) {
-    BitVector T(PRI.getMaskUnits(RR));
-    return T.reset(Units).none();
-  }
+  if (RR.isMask())
+    return PRI.getMaskUnits(RR).subsetOf(Units);
 
   for (MCRegUnitMaskIterator U(RR.asMCReg(), &PRI.getTRI()); U.isValid(); ++U) {
     auto [Unit, LaneMask] = *U;

--- a/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
@@ -274,9 +274,11 @@ static Error randomizeMCOperand(const LLVMState &State,
     break;
   case MCOI::OperandType::OPERAND_REGISTER: {
     assert(Op.isReg());
-    const BitVector &AllowedRegs = Op.getRegisterAliasing().sourceBits();
+    auto AllowedRegs = Op.getRegisterAliasing().sourceBits();
     assert(AllowedRegs.size() == ForbiddenRegs.size());
-    if (AllowedRegs.subsetOf(ForbiddenRegs))
+    for (auto I : ForbiddenRegs.set_bits())
+      AllowedRegs.reset(I);
+    if (!AllowedRegs.any())
       return make_error<Failure>(
           Twine("no available registers:\ncandidates:\n")
               .concat(debugString(State.getRegInfo(),

--- a/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
@@ -274,11 +274,9 @@ static Error randomizeMCOperand(const LLVMState &State,
     break;
   case MCOI::OperandType::OPERAND_REGISTER: {
     assert(Op.isReg());
-    auto AllowedRegs = Op.getRegisterAliasing().sourceBits();
+    const BitVector &AllowedRegs = Op.getRegisterAliasing().sourceBits();
     assert(AllowedRegs.size() == ForbiddenRegs.size());
-    for (auto I : ForbiddenRegs.set_bits())
-      AllowedRegs.reset(I);
-    if (!AllowedRegs.any())
+    if (AllowedRegs.subsetOf(ForbiddenRegs))
       return make_error<Failure>(
           Twine("no available registers:\ncandidates:\n")
               .concat(debugString(State.getRegInfo(),


### PR DESCRIPTION
Replace the code along these lines

    BitVector Tmp = LHS;
    Tmp &= RHS;
    return Tmp.any();

and

    BitVector Tmp = LHS;
    Tmp.reset(RHS);
    return Tmp.none();

with `LHS.anyCommon(RHS)` and `LHS.subsetOf(RHS)`, correspondingly, which
do not require creating temporary BitVector and can return early.