### PR TITLE
Move checking m_dummy_target to after raw-plus-option parsing.

### DIFF
--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -1255,8 +1255,6 @@ protected:
                  CommandReturnObject &result) override {
     const bool internal = false;
     ExecutionContext exe_ctx = GetCommandInterpreter().GetExecutionContext();
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
     m_all_options.NotifyOptionParsingStarting(&exe_ctx);
 
     if (command.empty()) {
@@ -1278,6 +1276,9 @@ protected:
       return;
     }
     printf("Pattern: '%s'\n", pattern.str().c_str());
+
+    Target &target =
+        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
 
     BreakpointSP bp_sp;
     const size_t num_files = m_options.m_files.GetSize();


### PR DESCRIPTION
CommandObjectBreakpointAddPattern is a raw command.  I was adjusting the patch for changes to handle the dummy target changes done while the patch was in review, and I copied the lines to the beginning of the DoExecute, but in the case of raw commands, you have to do the option parsing by hand, and this was before the parsing was done so the state wasn't determined yet.