### PR TITLE
[lldb-dap] Increase DAP default timeout

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -15,6 +15,7 @@ import warnings
 import time
 from typing import (
     Any,
+    Final,
     Optional,
     Dict,
     cast,
@@ -30,7 +31,7 @@ from typing import (
 
 # set timeout based on whether ASAN was enabled or not. Increase
 # timeout by a factor of 10 if ASAN is enabled.
-DEFAULT_TIMEOUT = 10 * (10 if ("ASAN_OPTIONS" in os.environ) else 1)
+DEFAULT_TIMEOUT: Final[float] = 50 * (10 if ("ASAN_OPTIONS" in os.environ) else 1)
 
 # See lldbtest.Base.spawnSubprocess, which should help ensure any processes
 # created by the DAP client are terminated correctly when the test ends.
@@ -348,7 +349,7 @@ class DebugCommunication(object):
         self,
         *,
         predicate: Optional[Callable[[ProtocolMessage], bool]] = None,
-        timeout: Optional[float] = DEFAULT_TIMEOUT,
+        timeout: float = DEFAULT_TIMEOUT,
     ) -> Optional[ProtocolMessage]:
         """Processes received packets from the adapter.
         Updates the DebugCommunication stateful properties based on the received

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Optional, Callable, Any, List, Union
+from typing import Optional, Callable, Any, List, Union, Final
 import uuid
 
 import dap_server
@@ -18,7 +18,7 @@ import base64
 class DAPTestCaseBase(TestBase):
     # set timeout based on whether ASAN was enabled or not. Increase
     # timeout by a factor of 10 if ASAN is enabled.
-    DEFAULT_TIMEOUT = dap_server.DEFAULT_TIMEOUT
+    DEFAULT_TIMEOUT: Final[float] = dap_server.DEFAULT_TIMEOUT
     NO_DEBUG_INFO_TESTCASE = True
 
     def create_debug_adapter(


### PR DESCRIPTION
DAP tests easily timeout when the computer is under-load.

This is easily noticeable if you run the test in a loop a compile llvm. or running the test on slower CI/machines. 

This affects mostly the `DAP_launch`, `DAP_attach`, `DAP_restart_console` and occasionally  `DAP_output` tests. 

Would lead in the direction of enabling some of the test on windows. 

```  
File "/Volumes/workspace/Dev/llvm-project/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py", line 1140, in request_launch
    return self._send_recv(command_dict)
  File "/Volumes/workspace/Dev/llvm-project/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py", line 548, in _send_recv
    raise ValueError(f"no response for {request!r}")
ValueError: no response for {'command': 'launch', 'type': 'request', 'arguments': {'program': '/Volumes/workspace/Dev/llvm-build/release/lldb-test-build.noindex/tools/lldb-dap/restart/TestDAP_restart_console.test_basic_functionality/a.out', 'initCommands': ['settings clear --all', 'settings set symbols.enable-external-lookup false', 'settings set target.inherit-tcc true', 'settings set target.disable-aslr false', 'settings set target.detach-on-error false', 'settings set target.auto-apply-fixits false', 'settings set plugin.process.gdb-remote.packet-timeout 60', 'settings set symbols.clang-modules-cache-path "/Volumes/workspace/Dev/llvm-build/release/lldb-test-build.noindex/module-cache-lldb"', 'settings set use-color false', 'settings set show-statusline false'], 'console': 'integratedTerminal', 'disableASLR': False, 'enableAutoVariableSummaries': False, 'enableSyntheticChildDebugging': False, 'displayExtendedBacktrace': False}, 'seq': 2}
Config=arm64-/Volumes/workspace/Dev/llvm-build/release/bin/clang
----------------------------------------------------------------------
Ran 2 tests in 28.579s
```

Increase the DEFAULT_TIMEOUT from 10 to 50 