### PR TITLE
[clang-tidy][NFC] Add checks to tests that have no checks specified.

### DIFF
--- a/clang-tools-extra/test/clang-tidy/infrastructure/empty-database.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/empty-database.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: system-windows
 
-// RUN: clang-tidy -p %S/Inputs/empty-database %s 2>&1 | FileCheck %s
+// RUN: clang-tidy -checks='-*,clang-analyzer-*' -p %S/Inputs/empty-database %s 2>&1 | FileCheck %s
 
 // CHECK: 'directory' field of compilation database is empty; using the current working directory instead.

--- a/clang-tools-extra/test/clang-tidy/infrastructure/invalid-database.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/invalid-database.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: system-windows
 
-// RUN: not --crash clang-tidy -p %S/Inputs/invalid-database %s 2>&1 | FileCheck %s
+// RUN: not --crash clang-tidy -checks='-*,clang-analyzer-*' -p %S/Inputs/invalid-database %s 2>&1 | FileCheck %s
 
 // CHECK: LLVM ERROR: Cannot chdir into "/invalid/"!


### PR DESCRIPTION
#157306 removes some default checks and this breaks a few tests where no checks were explicitly specified. 