### PR TITLE
[ASan] Do not return from void functions in asan_abi_shim.cpp

### DIFF
--- a/compiler-rt/lib/asan_abi/asan_abi.h
+++ b/compiler-rt/lib/asan_abi/asan_abi.h
@@ -76,8 +76,8 @@ void *__asan_abi_load_cxx_array_cookie(void **p);
 void *__asan_abi_get_current_fake_stack();
 void *__asan_abi_addr_is_in_fake_stack(void *fake_stack, void *addr, void **beg,
                                        void **end);
-void *__asan_abi_suppress_fake_stack();
-void *__asan_abi_unsuppress_fake_stack();
+void __asan_abi_suppress_fake_stack();
+void __asan_abi_unsuppress_fake_stack();
 
 // Functions concerning poisoning and unpoisoning fake stack alloca
 void __asan_abi_alloca_poison(void *addr, size_t size);

--- a/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
+++ b/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
@@ -365,12 +365,8 @@ void *__asan_addr_is_in_fake_stack(void *fake_stack, void *addr, void **beg,
                                    void **end) {
   return __asan_abi_addr_is_in_fake_stack(fake_stack, addr, beg, end);
 }
-void __asan_suppress_fake_stack(void) {
-  __asan_abi_suppress_fake_stack();
-}
-void __asan_unsuppress_fake_stack(void) {
-  __asan_abi_unsuppress_fake_stack();
-}
+void __asan_suppress_fake_stack(void) { __asan_abi_suppress_fake_stack(); }
+void __asan_unsuppress_fake_stack(void) { __asan_abi_unsuppress_fake_stack(); }
 
 // Functions concerning poisoning and unpoisoning fake stack alloca
 void __asan_alloca_poison(uptr addr, uptr size) {

--- a/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
+++ b/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
@@ -366,10 +366,10 @@ void *__asan_addr_is_in_fake_stack(void *fake_stack, void *addr, void **beg,
   return __asan_abi_addr_is_in_fake_stack(fake_stack, addr, beg, end);
 }
 void __asan_suppress_fake_stack(void) {
-  return __asan_abi_suppress_fake_stack();
+  __asan_abi_suppress_fake_stack();
 }
 void __asan_unsuppress_fake_stack(void) {
-  return __asan_abi_unsuppress_fake_stack();
+  __asan_abi_unsuppress_fake_stack();
 }
 
 // Functions concerning poisoning and unpoisoning fake stack alloca


### PR DESCRIPTION
This was causing compilation failures on MacOS.