### PR TITLE
[scudo] Add last release time info to getStats

### DIFF
--- a/compiler-rt/lib/scudo/standalone/primary64.h
+++ b/compiler-rt/lib/scudo/standalone/primary64.h
@@ -24,6 +24,8 @@
 #include "thread_annotations.h"
 #include "tracing.h"
 
+#include <inttypes.h>
+
 namespace scudo {
 
 // SizeClassAllocator64 is an allocator tuned for 64-bit address space.
@@ -1150,13 +1152,25 @@ void SizeClassAllocator64<Config>::getStats(ScopedString *Str, uptr ClassId,
       "%s %02zu (%6zu): mapped: %6zuK popped: %7zu pushed: %7zu "
       "inuse: %6zu total: %6zu releases attempted: %6zu last "
       "released: %6zuK latest pushed bytes: %6zuK region: 0x%zx "
-      "(0x%zx)\n",
+      "(0x%zx)",
       Region->Exhausted ? "E" : " ", ClassId, getSizeByClassId(ClassId),
       Region->MemMapInfo.MappedUser >> 10, Region->FreeListInfo.PoppedBlocks,
       Region->FreeListInfo.PushedBlocks, InUseBlocks, TotalChunks,
       Region->ReleaseInfo.NumReleasesAttempted,
       Region->ReleaseInfo.LastReleasedBytes >> 10, RegionPushedBytesDelta >> 10,
       Region->RegionBeg, getRegionBaseByClassId(ClassId));
+  const u64 CurTimeNs = getMonotonicTimeFast();
+  const u64 LastReleaseAtNs = Region->ReleaseInfo.LastReleaseAtNs;
+  if (LastReleaseAtNs != 0 && CurTimeNs != LastReleaseAtNs) {
+    const u64 DiffSinceLastReleaseNs =
+        CurTimeNs - Region->ReleaseInfo.LastReleaseAtNs;
+    const u64 LastReleaseSecAgo = DiffSinceLastReleaseNs / 1000000000;
+    const u64 LastReleaseMsAgo =
+        (DiffSinceLastReleaseNs % 1000000000) / 1000000;
+    Str->append("Latest release: %" PRIu64 ":%" PRIu64 " seconds ago",
+                LastReleaseSecAgo, LastReleaseMsAgo);
+  }
+  Str->append("\n");
 }
 
 template <typename Config>


### PR DESCRIPTION
Knowing when the last page release happened can help us figure out if the page release is skipped or not.