### PR TITLE
[libcxx] Removal of narrowing conversions in `flat_[multi]{set, map}` tests for compatibility with MSVC

### DIFF
--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/copy_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/copy_assign.pass.cpp
@@ -29,8 +29,8 @@ constexpr void test() {
     // test_allocator is not propagated
     using C = test_less<int>;
     KeyContainer<int, test_allocator<int>> ks({1, 3, 5}, test_allocator<int>(6));
-    ValueContainer<char, test_allocator<char>> vs({2, 2, 1}, test_allocator<char>(7));
-    using M = std::flat_map<int, char, C, decltype(ks), decltype(vs)>;
+    ValueContainer<long, test_allocator<long>> vs({2, 2, 1}, test_allocator<long>(7));
+    using M = std::flat_map<int, long, C, decltype(ks), decltype(vs)>;
     auto mo = M(ks, vs, C(5));
     auto m  = M({{3, 3}, {4, 4}, {5, 5}}, C(3), test_allocator<int>(2));
     m       = mo;
@@ -39,23 +39,23 @@ constexpr void test() {
     assert(m.keys() == ks);
     assert(m.values() == vs);
     assert(m.keys().get_allocator() == test_allocator<int>(2));
-    assert(m.values().get_allocator() == test_allocator<char>(2));
+    assert(m.values().get_allocator() == test_allocator<long>(2));
 
     // mo is unchanged
     assert(mo.key_comp() == C(5));
     assert(mo.keys() == ks);
     assert(mo.values() == vs);
     assert(mo.keys().get_allocator() == test_allocator<int>(6));
-    assert(mo.values().get_allocator() == test_allocator<char>(7));
+    assert(mo.values().get_allocator() == test_allocator<long>(7));
   }
   {
     // other_allocator is propagated
     using C  = test_less<int>;
     using Ks = KeyContainer<int, other_allocator<int>>;
-    using Vs = ValueContainer<char, other_allocator<char>>;
+    using Vs = ValueContainer<long, other_allocator<long>>;
     auto ks  = Ks({1, 3, 5}, other_allocator<int>(6));
-    auto vs  = Vs({2, 2, 1}, other_allocator<char>(7));
-    using M  = std::flat_map<int, char, C, Ks, Vs>;
+    auto vs  = Vs({2, 2, 1}, other_allocator<long>(7));
+    using M  = std::flat_map<int, long, C, Ks, Vs>;
     auto mo  = M(Ks(ks, other_allocator<int>(6)), Vs(vs, other_allocator<int>(7)), C(5));
     auto m   = M({{3, 3}, {4, 4}, {5, 5}}, C(3), other_allocator<int>(2));
     m        = mo;
@@ -64,14 +64,14 @@ constexpr void test() {
     assert(m.keys() == ks);
     assert(m.values() == vs);
     assert(m.keys().get_allocator() == other_allocator<int>(6));
-    assert(m.values().get_allocator() == other_allocator<char>(7));
+    assert(m.values().get_allocator() == other_allocator<long>(7));
 
     // mo is unchanged
     assert(mo.key_comp() == C(5));
     assert(mo.keys() == ks);
     assert(mo.values() == vs);
     assert(mo.keys().get_allocator() == other_allocator<int>(6));
-    assert(mo.values().get_allocator() == other_allocator<char>(7));
+    assert(mo.values().get_allocator() == other_allocator<long>(7));
   }
   if (!TEST_IS_CONSTANT_EVALUATED) {
     // comparator is copied and invariant is preserved

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/deduct.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/deduct.pass.cpp
@@ -33,19 +33,19 @@ using PC = std::pair<const int, long>;
 
 void test_copy() {
   {
-    std::flat_map<long, short> source = {{1, 2}, {2, 3}};
+    std::flat_map<long, int> source = {{1, 2}, {2, 3}};
     std::flat_map s(source);
     ASSERT_SAME_TYPE(decltype(s), decltype(source));
     assert(s == source);
   }
   {
-    std::flat_map<long, short, std::greater<long>> source = {{1, 2}, {2, 3}};
+    std::flat_map<long, int, std::greater<long>> source = {{1, 2}, {2, 3}};
     std::flat_map s{source}; // braces instead of parens
     ASSERT_SAME_TYPE(decltype(s), decltype(source));
     assert(s == source);
   }
   {
-    std::flat_map<long, short, std::greater<long>> source = {{1, 2}, {2, 3}};
+    std::flat_map<long, int, std::greater<long>> source = {{1, 2}, {2, 3}};
     std::flat_map s(source, std::allocator<int>());
     ASSERT_SAME_TYPE(decltype(s), decltype(source));
     assert(s == source);
@@ -54,14 +54,14 @@ void test_copy() {
 
 void test_containers() {
   std::deque<int, test_allocator<int>> ks({1, 2, 1, INT_MAX, 3}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> vs({1, 2, 1, 4, 5}, test_allocator<int>(0, 43));
+  std::deque<long, test_allocator<long>> vs({1, 2, 1, 4, 5}, test_allocator<int>(0, 43));
   std::deque<int, test_allocator<int>> sorted_ks({1, 2, 3, INT_MAX}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> sorted_vs({1, 2, 5, 4}, test_allocator<int>(0, 43));
-  const std::pair<int, short> expected[] = {{1, 1}, {2, 2}, {3, 5}, {INT_MAX, 4}};
+  std::deque<long, test_allocator<long>> sorted_vs({1, 2, 5, 4}, test_allocator<int>(0, 43));
+  const std::pair<int, long> expected[] = {{1, 1}, {2, 2}, {3, 5}, {INT_MAX, 4}};
   {
     std::flat_map s(ks, vs);
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::less<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::less<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 43);
@@ -69,7 +69,7 @@ void test_containers() {
   {
     std::flat_map s(std::sorted_unique, sorted_ks, sorted_vs);
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::less<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::less<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 43);
@@ -77,7 +77,7 @@ void test_containers() {
   {
     std::flat_map s(ks, vs, test_allocator<long>(0, 44));
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::less<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::less<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 44);
     assert(s.values().get_allocator().get_id() == 44);
@@ -85,7 +85,7 @@ void test_containers() {
   {
     std::flat_map s(std::sorted_unique, sorted_ks, sorted_vs, test_allocator<long>(0, 44));
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::less<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::less<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 44);
     assert(s.values().get_allocator().get_id() == 44);
@@ -94,14 +94,14 @@ void test_containers() {
 
 void test_containers_compare() {
   std::deque<int, test_allocator<int>> ks({1, 2, 1, INT_MAX, 3}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> vs({1, 2, 1, 4, 5}, test_allocator<int>(0, 43));
+  std::deque<long, test_allocator<long>> vs({1, 2, 1, 4, 5}, test_allocator<int>(0, 43));
   std::deque<int, test_allocator<int>> sorted_ks({INT_MAX, 3, 2, 1}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> sorted_vs({4, 5, 2, 1}, test_allocator<int>(0, 43));
-  const std::pair<int, short> expected[] = {{INT_MAX, 4}, {3, 5}, {2, 2}, {1, 1}};
+  std::deque<long, test_allocator<long>> sorted_vs({4, 5, 2, 1}, test_allocator<int>(0, 43));
+  const std::pair<int, long> expected[] = {{INT_MAX, 4}, {3, 5}, {2, 2}, {1, 1}};
   {
     std::flat_map s(ks, vs, std::greater<int>());
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::greater<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::greater<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 43);
@@ -109,7 +109,7 @@ void test_containers_compare() {
   {
     std::flat_map s(std::sorted_unique, sorted_ks, sorted_vs, std::greater<int>());
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::greater<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::greater<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 43);
@@ -117,7 +117,7 @@ void test_containers_compare() {
   {
     std::flat_map s(ks, vs, std::greater<int>(), test_allocator<long>(0, 44));
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::greater<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::greater<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 44);
     assert(s.values().get_allocator().get_id() == 44);
@@ -125,7 +125,7 @@ void test_containers_compare() {
   {
     std::flat_map s(std::sorted_unique, sorted_ks, sorted_vs, std::greater<int>(), test_allocator<long>(0, 44));
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::greater<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::greater<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 44);
     assert(s.values().get_allocator().get_id() == 44);
@@ -280,11 +280,11 @@ void test_initializer_list_compare() {
 }
 
 void test_from_range() {
-  std::list<std::pair<int, short>> r     = {{1, 1}, {2, 2}, {1, 1}, {INT_MAX, 4}, {3, 5}};
-  const std::pair<int, short> expected[] = {{1, 1}, {2, 2}, {3, 5}, {INT_MAX, 4}};
+  std::list<std::pair<int, long>> r     = {{1, 1}, {2, 2}, {1, 1}, {INT_MAX, 4}, {3, 5}};
+  const std::pair<int, long> expected[] = {{1, 1}, {2, 2}, {3, 5}, {INT_MAX, 4}};
   {
     std::flat_map s(std::from_range, r);
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::less<int>>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::less<int>>);
     assert(std::ranges::equal(s, expected));
   }
   {
@@ -292,10 +292,10 @@ void test_from_range() {
     ASSERT_SAME_TYPE(
         decltype(s),
         std::flat_map<int,
-                      short,
+                      long,
                       std::less<int>,
                       std::vector<int, test_allocator<int>>,
-                      std::vector<short, test_allocator<short>>>);
+                      std::vector<long, test_allocator<long>>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 42);
@@ -303,11 +303,11 @@ void test_from_range() {
 }
 
 void test_from_range_compare() {
-  std::list<std::pair<int, short>> r     = {{1, 1}, {2, 2}, {1, 1}, {INT_MAX, 4}, {3, 5}};
-  const std::pair<int, short> expected[] = {{INT_MAX, 4}, {3, 5}, {2, 2}, {1, 1}};
+  std::list<std::pair<int, long>> r     = {{1, 1}, {2, 2}, {1, 1}, {INT_MAX, 4}, {3, 5}};
+  const std::pair<int, long> expected[] = {{INT_MAX, 4}, {3, 5}, {2, 2}, {1, 1}};
   {
     std::flat_map s(std::from_range, r, std::greater<int>());
-    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, short, std::greater<int>>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_map<int, long, std::greater<int>>);
     assert(std::ranges::equal(s, expected));
   }
   {
@@ -315,10 +315,10 @@ void test_from_range_compare() {
     ASSERT_SAME_TYPE(
         decltype(s),
         std::flat_map<int,
-                      short,
+                      long,
                       std::greater<int>,
                       std::vector<int, test_allocator<int>>,
-                      std::vector<short, test_allocator<short>>>);
+                      std::vector<long, test_allocator<long>>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 42);

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/deduct_pmr.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/deduct_pmr.pass.cpp
@@ -32,19 +32,19 @@ using PC = std::pair<const int, long>;
 
 void test_containers() {
   std::deque<int, test_allocator<int>> ks({1, 2, 1, INT_MAX, 3}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> vs({1, 2, 1, 4, 5}, test_allocator<int>(0, 43));
+  std::deque<long, test_allocator<long>> vs({1, 2, 1, 4, 5}, test_allocator<int>(0, 43));
   std::deque<int, test_allocator<int>> sorted_ks({1, 2, 3, INT_MAX}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> sorted_vs({1, 2, 5, 4}, test_allocator<int>(0, 43));
-  const std::pair<int, short> expected[] = {{1, 1}, {2, 2}, {3, 5}, {INT_MAX, 4}};
+  std::deque<long, test_allocator<long>> sorted_vs({1, 2, 5, 4}, test_allocator<int>(0, 43));
+  const std::pair<int, long> expected[] = {{1, 1}, {2, 2}, {3, 5}, {INT_MAX, 4}};
   {
     std::pmr::monotonic_buffer_resource mr;
     std::pmr::monotonic_buffer_resource mr2;
     std::pmr::deque<int> pks(ks.begin(), ks.end(), &mr);
-    std::pmr::deque<short> pvs(vs.begin(), vs.end(), &mr);
+    std::pmr::deque<long> pvs(vs.begin(), vs.end(), &mr);
     std::flat_map s(std::move(pks), std::move(pvs), &mr2);
 
     ASSERT_SAME_TYPE(
-        decltype(s), std::flat_map<int, short, std::less<int>, std::pmr::deque<int>, std::pmr::deque<short>>);
+        decltype(s), std::flat_map<int, long, std::less<int>, std::pmr::deque<int>, std::pmr::deque<long>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().resource() == &mr2);
     assert(s.values().get_allocator().resource() == &mr2);
@@ -53,11 +53,11 @@ void test_containers() {
     std::pmr::monotonic_buffer_resource mr;
     std::pmr::monotonic_buffer_resource mr2;
     std::pmr::deque<int> pks(sorted_ks.begin(), sorted_ks.end(), &mr);
-    std::pmr::deque<short> pvs(sorted_vs.begin(), sorted_vs.end(), &mr);
+    std::pmr::deque<long> pvs(sorted_vs.begin(), sorted_vs.end(), &mr);
     std::flat_map s(std::sorted_unique, std::move(pks), std::move(pvs), &mr2);
 
     ASSERT_SAME_TYPE(
-        decltype(s), std::flat_map<int, short, std::less<int>, std::pmr::deque<int>, std::pmr::deque<short>>);
+        decltype(s), std::flat_map<int, long, std::less<int>, std::pmr::deque<int>, std::pmr::deque<long>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().resource() == &mr2);
     assert(s.values().get_allocator().resource() == &mr2);
@@ -66,19 +66,19 @@ void test_containers() {
 
 void test_containers_compare() {
   std::deque<int, test_allocator<int>> ks({1, 2, 1, INT_MAX, 3}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> vs({1, 2, 1, 4, 5}, test_allocator<int>(0, 43));
+  std::deque<long, test_allocator<long>> vs({1, 2, 1, 4, 5}, test_allocator<int>(0, 43));
   std::deque<int, test_allocator<int>> sorted_ks({INT_MAX, 3, 2, 1}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> sorted_vs({4, 5, 2, 1}, test_allocator<int>(0, 43));
-  const std::pair<int, short> expected[] = {{INT_MAX, 4}, {3, 5}, {2, 2}, {1, 1}};
+  std::deque<long, test_allocator<long>> sorted_vs({4, 5, 2, 1}, test_allocator<int>(0, 43));
+  const std::pair<int, long> expected[] = {{INT_MAX, 4}, {3, 5}, {2, 2}, {1, 1}};
   {
     std::pmr::monotonic_buffer_resource mr;
     std::pmr::monotonic_buffer_resource mr2;
     std::pmr::deque<int> pks(ks.begin(), ks.end(), &mr);
-    std::pmr::deque<short> pvs(vs.begin(), vs.end(), &mr);
+    std::pmr::deque<long> pvs(vs.begin(), vs.end(), &mr);
     std::flat_map s(std::move(pks), std::move(pvs), std::greater<int>(), &mr2);
 
     ASSERT_SAME_TYPE(
-        decltype(s), std::flat_map<int, short, std::greater<int>, std::pmr::deque<int>, std::pmr::deque<short>>);
+        decltype(s), std::flat_map<int, long, std::greater<int>, std::pmr::deque<int>, std::pmr::deque<long>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().resource() == &mr2);
     assert(s.values().get_allocator().resource() == &mr2);
@@ -87,11 +87,11 @@ void test_containers_compare() {
     std::pmr::monotonic_buffer_resource mr;
     std::pmr::monotonic_buffer_resource mr2;
     std::pmr::deque<int> pks(sorted_ks.begin(), sorted_ks.end(), &mr);
-    std::pmr::deque<short> pvs(sorted_vs.begin(), sorted_vs.end(), &mr);
+    std::pmr::deque<long> pvs(sorted_vs.begin(), sorted_vs.end(), &mr);
     std::flat_map s(std::sorted_unique, std::move(pks), std::move(pvs), std::greater<int>(), &mr2);
 
     ASSERT_SAME_TYPE(
-        decltype(s), std::flat_map<int, short, std::greater<int>, std::pmr::deque<int>, std::pmr::deque<short>>);
+        decltype(s), std::flat_map<int, long, std::greater<int>, std::pmr::deque<int>, std::pmr::deque<long>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().resource() == &mr2);
     assert(s.values().get_allocator().resource() == &mr2);

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/initializer_list.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/initializer_list.pass.cpp
@@ -37,24 +37,24 @@ struct DefaultCtableComp {
 
 template <template <class...> class KeyContainer, template <class...> class ValueContainer>
 constexpr void test() {
-  std::pair<int, short> expected[] = {{1, 1}, {2, 2}, {3, 3}, {5, 2}};
+  std::pair<int, long> expected[] = {{1, 1}, {2, 2}, {3, 3}, {5, 2}};
   {
     // flat_map(initializer_list<value_type>);
-    using M                                         = std::flat_map<int, short>;
-    std::initializer_list<std::pair<int, short>> il = {{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}};
+    using M                                        = std::flat_map<int, long>;
+    std::initializer_list<std::pair<int, long>> il = {{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}};
     M m(il);
     assert(std::equal(m.begin(), m.end(), expected, expected + 4));
   }
   {
     // flat_map(initializer_list<value_type>);
     // explicit(false)
-    using M = std::flat_map<int, short>;
+    using M = std::flat_map<int, long>;
     M m     = {{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}};
     assert(std::equal(m.begin(), m.end(), expected, expected + 4));
   }
   {
     // flat_map(initializer_list<value_type>);
-    using M = std::flat_map<int, short, std::greater<int>, KeyContainer<int, min_allocator<int>>>;
+    using M = std::flat_map<int, long, std::greater<int>, KeyContainer<int, min_allocator<int>>>;
     M m     = {{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}};
     assert(std::equal(m.rbegin(), m.rend(), expected, expected + 4));
   }
@@ -79,7 +79,7 @@ constexpr void test() {
   {
     // flat_map(initializer_list<value_type>, const key_compare&);
     using C = test_less<int>;
-    using M = std::flat_map<int, short, C>;
+    using M = std::flat_map<int, long, C>;
     auto m  = M({{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}}, C(10));
     assert(std::equal(m.begin(), m.end(), expected, expected + 4));
     assert(m.key_comp() == C(10));
@@ -92,7 +92,7 @@ constexpr void test() {
   if (!TEST_IS_CONSTANT_EVALUATED) {
     // flat_map(initializer_list<value_type>, const key_compare&);
     // Sorting uses the comparator that was passed in
-    using M = std::flat_map<int, short, std::function<bool(int, int)>, KeyContainer<int, min_allocator<int>>>;
+    using M = std::flat_map<int, long, std::function<bool(int, int)>, KeyContainer<int, min_allocator<int>>>;
     auto m  = M({{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}}, std::greater<int>());
     assert(std::equal(m.rbegin(), m.rend(), expected, expected + 4));
     assert(m.key_comp()(2, 1) == true);

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/iter_iter.pass.cpp
@@ -101,19 +101,19 @@ constexpr void test() {
 
 template <template <class...> class KeyContainer, template <class...> class ValueContainer>
 constexpr void test_alloc() {
-  using P = std::pair<int, short>;
+  using P = std::pair<int, long>;
   P ar[]  = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {3, 6}, {2, 7}, {3, 8}, {3, 9}};
 
   {
     // flat_map(InputIterator , InputIterator, const Allocator&)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     auto m   = M(ar, ar + 9, A1(5));
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 2, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {4, 5, 7},
             {6, 8, 9},
@@ -125,13 +125,13 @@ constexpr void test_alloc() {
     // flat_map(InputIterator , InputIterator, const Allocator&)
     // explicit(false)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     M m      = {ar, ar + 9, A1(5)}; // implicit ctor
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 2, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {4, 5, 7},
             {6, 8, 9},
@@ -143,13 +143,13 @@ constexpr void test_alloc() {
     // flat_map(InputIterator , InputIterator, const key_compare&, const Allocator&)
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, C, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     auto m   = M(ar, ar + 9, C(3), A1(5));
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 2, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {4, 5, 7},
             {6, 8, 9},
@@ -162,13 +162,13 @@ constexpr void test_alloc() {
     // flat_map(InputIterator , InputIterator, const key_compare&, const Allocator&)
     // explicit(false)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     M m      = {ar, ar + 9, {}, A2(5)}; // implicit ctor
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 2, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {4, 5, 7},
             {6, 8, 9},

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/move_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/move_assign.pass.cpp
@@ -31,8 +31,8 @@ constexpr void test() {
   {
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<char>;
-    using M  = std::flat_map<int, char, C, KeyContainer<int, A1>, ValueContainer<char, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     M mo     = M({{1, 1}, {2, 3}, {3, 2}}, C(5), A1(7));
     M m      = M({}, C(3), A1(7));
     m        = std::move(mo);
@@ -46,8 +46,8 @@ constexpr void test() {
   {
     using C  = test_less<int>;
     using A1 = other_allocator<int>;
-    using A2 = other_allocator<char>;
-    using M  = std::flat_map<int, char, C, KeyContainer<int, A1>, ValueContainer<char, A2>>;
+    using A2 = other_allocator<long>;
+    using M  = std::flat_map<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     M mo     = M({{4, 5}, {5, 4}}, C(5), A1(7));
     M m      = M({{1, 1}, {2, 2}, {3, 3}, {4, 4}}, C(3), A1(7));
     m        = std::move(mo);

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/pmr.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/pmr.pass.cpp
@@ -166,12 +166,12 @@ int main(int, char**) {
   }
   {
     // flat_map(InputIterator first, InputIterator last, const Allocator& a);
-    using P      = std::pair<int, short>;
+    using P      = std::pair<int, long>;
     P ar[]       = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {3, 6}, {2, 7}, {3, 8}, {3, 9}};
     P expected[] = {{1, 1}, {2, 4}, {3, 6}};
     {
       //  cpp17 iterator
-      using M = std::flat_map<int, short, std::less<int>, std::pmr::vector<int>, std::pmr::vector<short>>;
+      using M = std::flat_map<int, long, std::less<int>, std::pmr::vector<int>, std::pmr::vector<long>>;
       std::pmr::monotonic_buffer_resource mr;
       std::pmr::vector<M> vm(&mr);
       vm.emplace_back(cpp17_input_iterator<const P*>(ar), cpp17_input_iterator<const P*>(ar + 9));
@@ -181,7 +181,7 @@ int main(int, char**) {
       assert(vm[0].values().get_allocator().resource() == &mr);
     }
     {
-      using M = std::flat_map<int, short, std::less<int>, std::pmr::vector<int>, std::pmr::vector<short>>;
+      using M = std::flat_map<int, long, std::less<int>, std::pmr::vector<int>, std::pmr::vector<long>>;
       std::pmr::monotonic_buffer_resource mr;
       std::pmr::vector<M> vm(&mr);
       vm.emplace_back(ar, ar);
@@ -242,12 +242,12 @@ int main(int, char**) {
   }
   {
     //  flat_map(from_range_t, R&&, const Alloc&);
-    using P      = std::pair<int, short>;
+    using P      = std::pair<int, long>;
     P ar[]       = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {3, 6}, {2, 7}, {3, 8}, {3, 9}};
     P expected[] = {{1, 1}, {2, 4}, {3, 6}};
     {
       // input_range
-      using M    = std::flat_map<int, short, std::less<int>, std::pmr::vector<int>, std::pmr::vector<short>>;
+      using M    = std::flat_map<int, long, std::less<int>, std::pmr::vector<int>, std::pmr::vector<long>>;
       using Iter = cpp20_input_iterator<const P*>;
       using Sent = sentinel_wrapper<Iter>;
       using R    = std::ranges::subrange<Iter, Sent>;
@@ -260,7 +260,7 @@ int main(int, char**) {
       assert(vm[0].values().get_allocator().resource() == &mr);
     }
     {
-      using M = std::flat_map<int, short, std::less<int>, std::pmr::vector<int>, std::pmr::vector<short>>;
+      using M = std::flat_map<int, long, std::less<int>, std::pmr::vector<int>, std::pmr::vector<long>>;
       using R = std::ranges::subrange<const P*>;
       std::pmr::monotonic_buffer_resource mr;
       std::pmr::vector<M> vm(&mr);

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/range.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/range.pass.cpp
@@ -152,19 +152,19 @@ constexpr void test() {
 
 template <template <class...> class KeyContainer, template <class...> class ValueContainer>
 constexpr void test_alloc() {
-  using P = std::pair<int, short>;
+  using P = std::pair<int, long>;
   P ar[]  = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {3, 6}, {2, 7}, {3, 8}, {3, 9}};
   {
     // flat_map(from_range_t, R&&, const Allocator&)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using R  = std::ranges::subrange<const P*>;
     auto m   = M(std::from_range, R(ar, ar + 9), A1(5));
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 2, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {4, 5, 7},
             {6, 8, 9},
@@ -176,14 +176,14 @@ constexpr void test_alloc() {
     // flat_map(from_range_t, R&&, const Allocator&)
     // explicit(false)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using R  = std::ranges::subrange<const P*>;
     M m      = {std::from_range, R(ar, ar + 9), A1(5)}; // implicit ctor
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 2, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {4, 5, 7},
             {6, 8, 9},
@@ -195,14 +195,14 @@ constexpr void test_alloc() {
     // flat_map(from_range_t, R&&, const key_compare&, const Allocator&)
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, C, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using R  = std::ranges::subrange<const P*>;
     auto m   = M(std::from_range, R(ar, ar + 9), C(3), A1(5));
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 2, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {4, 5, 7},
             {6, 8, 9},
@@ -215,14 +215,14 @@ constexpr void test_alloc() {
     // flat_map(from_range_t, R&&, const key_compare&, const Allocator&)
     // explicit(false)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using R  = std::ranges::subrange<const P*>;
     M m      = {std::from_range, R(ar, ar + 9), {}, A2(5)}; // implicit ctor
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 2, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {4, 5, 7},
             {6, 8, 9},

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/sorted_container.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/sorted_container.pass.cpp
@@ -38,9 +38,9 @@ template <template <class...> class KeyContainer, template <class...> class Valu
 constexpr void test() {
   {
     // flat_map(sorted_unique_t, key_container_type , mapped_container_type)
-    using M                 = std::flat_map<int, char, std::less<int>, KeyContainer<int>, ValueContainer<char>>;
+    using M                 = std::flat_map<int, long, std::less<int>, KeyContainer<int>, ValueContainer<long>>;
     KeyContainer<int> ks    = {1, 2, 4, 10};
-    ValueContainer<char> vs = {4, 3, 2, 1};
+    ValueContainer<long> vs = {4, 3, 2, 1};
     auto ks2                = ks;
     auto vs2                = vs;
 
@@ -59,8 +59,8 @@ constexpr void test() {
     // flat_map(sorted_unique_t, key_container_type , mapped_container_type)
     // non-default container, comparator and allocator type
     using Ks = KeyContainer<int, min_allocator<int>>;
-    using Vs = ValueContainer<char, min_allocator<char>>;
-    using M  = std::flat_map<int, char, std::greater<int>, Ks, Vs>;
+    using Vs = ValueContainer<long, min_allocator<long>>;
+    using M  = std::flat_map<int, long, std::greater<int>, Ks, Vs>;
     Ks ks    = {10, 4, 2, 1};
     Vs vs    = {1, 2, 3, 4};
     auto m   = M(std::sorted_unique, ks, vs);
@@ -87,9 +87,9 @@ constexpr void test() {
   {
     // flat_map(sorted_unique_t, key_container_type , mapped_container_type, key_compare)
     using C                 = test_less<int>;
-    using M                 = std::flat_map<int, char, C, KeyContainer<int>, ValueContainer<char>>;
+    using M                 = std::flat_map<int, long, C, KeyContainer<int>, ValueContainer<long>>;
     KeyContainer<int> ks    = {1, 2, 4, 10};
-    ValueContainer<char> vs = {4, 3, 2, 1};
+    ValueContainer<long> vs = {4, 3, 2, 1};
 
     auto m = M(std::sorted_unique, ks, vs, C(4));
     assert((m == M{{1, 4}, {2, 3}, {4, 2}, {10, 1}}));

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/sorted_initializer_list.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/sorted_initializer_list.pass.cpp
@@ -35,8 +35,8 @@ template <class T, class U>
 constexpr std::initializer_list<std::pair<T, U>> il = {{1, 1}, {2, 2}, {4, 4}, {5, 5}};
 
 constexpr auto il1 = il<int, int>;
-constexpr auto il2 = il<int, short>;
-constexpr auto il3 = il<short, int>;
+constexpr auto il2 = il<int, long>;
+constexpr auto il3 = il<long, int>;
 
 template <template <class...> class KeyContainer, template <class...> class ValueContainer>
 constexpr void test() {
@@ -73,8 +73,8 @@ constexpr void test() {
   {
     // flat_map(sorted_unique_t, initializer_list<value_type>,  const Allocator&)
     using A1      = test_allocator<int>;
-    using A2      = test_allocator<short>;
-    using M       = std::flat_map<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2      = test_allocator<long>;
+    using M       = std::flat_map<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     auto m        = M(std::sorted_unique, il2, A1(5));
     auto expected = M{{1, 1}, {2, 2}, {4, 4}, {5, 5}};
     assert(m == expected);
@@ -91,8 +91,8 @@ constexpr void test() {
     // flat_map(sorted_unique_t, initializer_list<value_type>, const key_compare&, const Allocator&);
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, C, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     auto m   = M(std::sorted_unique, il2, C(3), A1(5));
     assert((m == M{{1, 1}, {2, 2}, {4, 4}, {5, 5}}));
     assert(m.key_comp() == C(3));
@@ -102,9 +102,9 @@ constexpr void test() {
   {
     // flat_map(sorted_unique_t, initializer_list<value_type>, const key_compare&, const Allocator&);
     // explicit(false)
-    using A1 = test_allocator<short>;
+    using A1 = test_allocator<long>;
     using A2 = test_allocator<int>;
-    using M  = std::flat_map<short, int, std::less<int>, KeyContainer<short, A1>, ValueContainer<int, A2>>;
+    using M  = std::flat_map<long, int, std::less<int>, KeyContainer<long, A1>, ValueContainer<int, A2>>;
     M m      = {std::sorted_unique, il3, {}, A1(5)}; // implicit ctor
     assert((m == M{{1, 1}, {2, 2}, {4, 4}, {5, 5}}));
     assert(m.keys().get_allocator() == A1(5));

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/sorted_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.cons/sorted_iter_iter.pass.cpp
@@ -69,7 +69,7 @@ constexpr void test() {
     auto m  = M(std::sorted_unique,
                cpp17_input_iterator<const P*>(ar),
                cpp17_input_iterator<const P*>(ar + 4),
-               std::less<int>());
+               std::less<Value>());
     assert(m == M({{1, 1}, {2, 2}, {4, 4}, {5, 5}}, std::less<>()));
     assert(m.key_comp()(1, 2) == true);
 
@@ -77,19 +77,19 @@ constexpr void test() {
     M m2 = {std::sorted_unique,
             cpp17_input_iterator<const P*>(ar),
             cpp17_input_iterator<const P*>(ar + 4),
-            std::less<int>()};
+            std::less<Value>()};
     assert(m2 == m);
   }
   {
     // flat_map(sorted_unique_t, InputIterator, InputIterator, const key_compare&);
     // greater
-    using M = std::flat_map<Key, Value, std::greater<int>, KeyContainer, ValueContainer>;
+    using M = std::flat_map<Key, Value, std::greater<Value>, KeyContainer, ValueContainer>;
     using P = std::pair<Key, Value>;
     P ar[]  = {{5, 5}, {4, 4}, {2, 2}, {1, 1}};
     auto m  = M(std::sorted_unique,
                cpp17_input_iterator<const P*>(ar),
                cpp17_input_iterator<const P*>(ar + 4),
-               std::greater<int>());
+               std::greater<Value>());
     assert((m == M{{5, 5}, {4, 4}, {2, 2}, {1, 1}}));
   }
   {
@@ -109,8 +109,8 @@ constexpr void test_alloc() {
   {
     // flat_map(sorted_unique_t, InputIterator , InputIterator, const Allocator&)
     using A1      = test_allocator<int>;
-    using A2      = test_allocator<short>;
-    using M       = std::flat_map<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2      = test_allocator<long>;
+    using M       = std::flat_map<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using P       = std::pair<int, int>;
     P ar[]        = {{1, 1}, {2, 2}, {4, 4}, {5, 5}};
     auto m        = M(std::sorted_unique, ar, ar + 4, A1(5));
@@ -129,8 +129,8 @@ constexpr void test_alloc() {
     // flat_map(sorted_unique_t, InputIterator, InputIterator, const key_compare&, const Allocator&);
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_map<int, short, C, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_map<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using P  = std::pair<int, int>;
     P ar[]   = {{1, 1}, {2, 2}, {4, 4}, {5, 5}};
     auto m   = M(std::sorted_unique, ar, ar + 4, C(3), A1(5));
@@ -142,9 +142,9 @@ constexpr void test_alloc() {
   {
     // flat_map(sorted_unique_t, InputIterator, InputIterator, const key_compare&, const Allocator&);
     // explicit(false)
-    using A1 = test_allocator<short>;
+    using A1 = test_allocator<long>;
     using A2 = test_allocator<int>;
-    using M  = std::flat_map<short, int, std::less<int>, KeyContainer<short, A1>, ValueContainer<int, A2>>;
+    using M  = std::flat_map<long, int, std::less<int>, KeyContainer<long, A1>, ValueContainer<int, A2>>;
     using P  = std::pair<int, int>;
     P ar[]   = {{1, 1}, {2, 2}, {4, 4}, {5, 5}};
     M m      = {std::sorted_unique, ar, ar + 4, {}, A1(5)}; // implicit ctor

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/erase_key.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/erase_key.pass.cpp
@@ -27,7 +27,7 @@
 
 template <class KeyContainer, class ValueContainer, class Compare = std::less<>>
 constexpr void test() {
-  using M = std::flat_map<int, char, Compare, KeyContainer, ValueContainer>;
+  using M = std::flat_map<int, long, Compare, KeyContainer, ValueContainer>;
 
   auto make = [](std::initializer_list<int> il) {
     M m;
@@ -71,17 +71,17 @@ constexpr void test() {
 }
 
 constexpr bool test() {
-  test<std::vector<int>, std::vector<char>>();
-  test<std::vector<int>, std::vector<char>, std::greater<>>();
+  test<std::vector<int>, std::vector<long>>();
+  test<std::vector<int>, std::vector<long>, std::greater<>>();
 
 #ifndef __cpp_lib_constexpr_deque
   if (!TEST_IS_CONSTANT_EVALUATED)
 #endif
   {
-    test<std::deque<int>, std::vector<char>>();
+    test<std::deque<int>, std::vector<long>>();
   }
-  test<MinSequenceContainer<int>, MinSequenceContainer<char>>();
-  test<std::vector<int, min_allocator<int>>, std::vector<char, min_allocator<char>>>();
+  test<MinSequenceContainer<int>, MinSequenceContainer<long>>();
+  test<std::vector<int, min_allocator<int>>, std::vector<long, min_allocator<long>>>();
 
   if (!TEST_IS_CONSTANT_EVALUATED) {
     auto erase_function = [](auto& m, auto key_arg) {

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.observers/comp.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.observers/comp.pass.cpp
@@ -35,7 +35,7 @@ constexpr bool test() {
     assert(kc(1, 2));
     assert(!kc(2, 1));
     auto vc = m.value_comp();
-    ASSERT_SAME_TYPE(decltype(vc(std::make_pair(1, 2), std::make_pair(1, 2))), bool);
+    ASSERT_SAME_TYPE(decltype(vc(std::make_pair(1, '2'), std::make_pair(1, '2'))), bool);
     assert(vc({1, '2'}, {2, '1'}));
     assert(!vc({2, '1'}, {1, '2'}));
   }

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/copy_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/copy_assign.pass.cpp
@@ -29,8 +29,8 @@ constexpr void test() {
     // test_allocator is not propagated
     using C = test_less<int>;
     KeyContainer<int, test_allocator<int>> ks({1, 1, 3, 5}, test_allocator<int>(6));
-    ValueContainer<char, test_allocator<char>> vs({2, 2, 2, 1}, test_allocator<char>(7));
-    using M = std::flat_multimap<int, char, C, decltype(ks), decltype(vs)>;
+    ValueContainer<long, test_allocator<long>> vs({2, 2, 2, 1}, test_allocator<long>(7));
+    using M = std::flat_multimap<int, long, C, decltype(ks), decltype(vs)>;
     auto mo = M(ks, vs, C(5));
     auto m  = M({{3, 3}, {4, 4}, {5, 5}, {5, 5}}, C(3), test_allocator<int>(2));
     m       = mo;
@@ -39,23 +39,23 @@ constexpr void test() {
     assert(m.keys() == ks);
     assert(m.values() == vs);
     assert(m.keys().get_allocator() == test_allocator<int>(2));
-    assert(m.values().get_allocator() == test_allocator<char>(2));
+    assert(m.values().get_allocator() == test_allocator<long>(2));
 
     // mo is unchanged
     assert(mo.key_comp() == C(5));
     assert(mo.keys() == ks);
     assert(mo.values() == vs);
     assert(mo.keys().get_allocator() == test_allocator<int>(6));
-    assert(mo.values().get_allocator() == test_allocator<char>(7));
+    assert(mo.values().get_allocator() == test_allocator<long>(7));
   }
   {
     // other_allocator is propagated
     using C  = test_less<int>;
     using Ks = KeyContainer<int, other_allocator<int>>;
-    using Vs = ValueContainer<char, other_allocator<char>>;
+    using Vs = ValueContainer<long, other_allocator<long>>;
     auto ks  = Ks({1, 1, 3, 5}, other_allocator<int>(6));
-    auto vs  = Vs({2, 2, 2, 1}, other_allocator<char>(7));
-    using M  = std::flat_multimap<int, char, C, Ks, Vs>;
+    auto vs  = Vs({2, 2, 2, 1}, other_allocator<long>(7));
+    using M  = std::flat_multimap<int, long, C, Ks, Vs>;
     auto mo  = M(Ks(ks, other_allocator<int>(6)), Vs(vs, other_allocator<int>(7)), C(5));
     auto m   = M({{3, 3}, {4, 4}, {5, 5}, {5, 5}}, C(3), other_allocator<int>(2));
     m        = mo;
@@ -64,14 +64,14 @@ constexpr void test() {
     assert(m.keys() == ks);
     assert(m.values() == vs);
     assert(m.keys().get_allocator() == other_allocator<int>(6));
-    assert(m.values().get_allocator() == other_allocator<char>(7));
+    assert(m.values().get_allocator() == other_allocator<long>(7));
 
     // mo is unchanged
     assert(mo.key_comp() == C(5));
     assert(mo.keys() == ks);
     assert(mo.values() == vs);
     assert(mo.keys().get_allocator() == other_allocator<int>(6));
-    assert(mo.values().get_allocator() == other_allocator<char>(7));
+    assert(mo.values().get_allocator() == other_allocator<long>(7));
   }
   if (!TEST_IS_CONSTANT_EVALUATED) {
     // comparator is copied and invariant is preserved

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/deduct.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/deduct.pass.cpp
@@ -32,19 +32,19 @@ using PC = std::pair<const int, long>;
 
 void test_copy() {
   {
-    std::flat_multimap<long, short> source = {{1, 2}, {1, 3}};
+    std::flat_multimap<long, int> source = {{1, 2}, {1, 3}};
     std::flat_multimap s(source);
     ASSERT_SAME_TYPE(decltype(s), decltype(source));
     assert(s == source);
   }
   {
-    std::flat_multimap<long, short, std::greater<long>> source = {{1, 2}, {1, 3}};
+    std::flat_multimap<long, int, std::greater<long>> source = {{1, 2}, {1, 3}};
     std::flat_multimap s{source}; // braces instead of parens
     ASSERT_SAME_TYPE(decltype(s), decltype(source));
     assert(s == source);
   }
   {
-    std::flat_multimap<long, short, std::greater<long>> source = {{1, 2}, {1, 3}};
+    std::flat_multimap<long, int, std::greater<long>> source = {{1, 2}, {1, 3}};
     std::flat_multimap s(source, std::allocator<int>());
     ASSERT_SAME_TYPE(decltype(s), decltype(source));
     assert(s == source);
@@ -53,14 +53,14 @@ void test_copy() {
 
 void test_containers() {
   std::deque<int, test_allocator<int>> ks({1, 2, 1, 2, 2, INT_MAX, 3}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> vs({1, 2, 3, 4, 5, 3, 4}, test_allocator<int>(0, 43));
+  std::deque<long, test_allocator<long>> vs({1, 2, 3, 4, 5, 3, 4}, test_allocator<int>(0, 43));
   std::deque<int, test_allocator<int>> sorted_ks({1, 1, 2, 2, 2, 3, INT_MAX}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> sorted_vs({1, 3, 2, 4, 5, 4, 3}, test_allocator<int>(0, 43));
-  const std::pair<int, short> expected[] = {{1, 1}, {1, 3}, {2, 2}, {2, 4}, {2, 5}, {3, 4}, {INT_MAX, 3}};
+  std::deque<long, test_allocator<long>> sorted_vs({1, 3, 2, 4, 5, 4, 3}, test_allocator<int>(0, 43));
+  const std::pair<int, long> expected[] = {{1, 1}, {1, 3}, {2, 2}, {2, 4}, {2, 5}, {3, 4}, {INT_MAX, 3}};
   {
     std::flat_multimap s(ks, vs);
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::less<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::less<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 43);
@@ -68,7 +68,7 @@ void test_containers() {
   {
     std::flat_multimap s(std::sorted_equivalent, sorted_ks, sorted_vs);
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::less<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::less<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 43);
@@ -76,7 +76,7 @@ void test_containers() {
   {
     std::flat_multimap s(ks, vs, test_allocator<long>(0, 44));
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::less<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::less<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 44);
     assert(s.values().get_allocator().get_id() == 44);
@@ -84,7 +84,7 @@ void test_containers() {
   {
     std::flat_multimap s(std::sorted_equivalent, sorted_ks, sorted_vs, test_allocator<long>(0, 44));
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::less<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::less<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 44);
     assert(s.values().get_allocator().get_id() == 44);
@@ -93,14 +93,14 @@ void test_containers() {
 
 void test_containers_compare() {
   std::deque<int, test_allocator<int>> ks({1, 2, 1, 2, 2, INT_MAX, 3}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> vs({1, 2, 3, 4, 5, 3, 4}, test_allocator<int>(0, 43));
+  std::deque<long, test_allocator<long>> vs({1, 2, 3, 4, 5, 3, 4}, test_allocator<int>(0, 43));
   std::deque<int, test_allocator<int>> sorted_ks({INT_MAX, 3, 2, 2, 2, 1, 1}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> sorted_vs({3, 4, 2, 4, 5, 1, 3}, test_allocator<int>(0, 43));
-  const std::pair<int, short> expected[] = {{INT_MAX, 3}, {3, 4}, {2, 2}, {2, 4}, {2, 5}, {1, 1}, {1, 3}};
+  std::deque<long, test_allocator<long>> sorted_vs({3, 4, 2, 4, 5, 1, 3}, test_allocator<int>(0, 43));
+  const std::pair<int, long> expected[] = {{INT_MAX, 3}, {3, 4}, {2, 2}, {2, 4}, {2, 5}, {1, 1}, {1, 3}};
   {
     std::flat_multimap s(ks, vs, std::greater<int>());
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::greater<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::greater<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 43);
@@ -108,7 +108,7 @@ void test_containers_compare() {
   {
     std::flat_multimap s(std::sorted_equivalent, sorted_ks, sorted_vs, std::greater<int>());
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::greater<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::greater<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 43);
@@ -116,7 +116,7 @@ void test_containers_compare() {
   {
     std::flat_multimap s(ks, vs, std::greater<int>(), test_allocator<long>(0, 44));
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::greater<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::greater<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 44);
     assert(s.values().get_allocator().get_id() == 44);
@@ -125,7 +125,7 @@ void test_containers_compare() {
     std::flat_multimap s(
         std::sorted_equivalent, sorted_ks, sorted_vs, std::greater<int>(), test_allocator<long>(0, 44));
 
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::greater<int>, decltype(ks), decltype(vs)>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::greater<int>, decltype(ks), decltype(vs)>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 44);
     assert(s.values().get_allocator().get_id() == 44);
@@ -281,11 +281,11 @@ void test_initializer_list_compare() {
 }
 
 void test_from_range() {
-  std::list<std::pair<int, short>> r     = {{1, 1}, {2, 2}, {1, 1}, {INT_MAX, 4}, {3, 5}};
-  const std::pair<int, short> expected[] = {{1, 1}, {1, 1}, {2, 2}, {3, 5}, {INT_MAX, 4}};
+  std::list<std::pair<int, long>> r     = {{1, 1}, {2, 2}, {1, 1}, {INT_MAX, 4}, {3, 5}};
+  const std::pair<int, long> expected[] = {{1, 1}, {1, 1}, {2, 2}, {3, 5}, {INT_MAX, 4}};
   {
     std::flat_multimap s(std::from_range, r);
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::less<int>>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::less<int>>);
     assert(std::ranges::equal(s, expected));
   }
   {
@@ -293,10 +293,10 @@ void test_from_range() {
     ASSERT_SAME_TYPE(
         decltype(s),
         std::flat_multimap<int,
-                           short,
+                           long,
                            std::less<int>,
                            std::vector<int, test_allocator<int>>,
-                           std::vector<short, test_allocator<short>>>);
+                           std::vector<long, test_allocator<long>>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 42);
@@ -304,11 +304,11 @@ void test_from_range() {
 }
 
 void test_from_range_compare() {
-  std::list<std::pair<int, short>> r     = {{1, 1}, {2, 2}, {1, 1}, {INT_MAX, 4}, {3, 5}};
-  const std::pair<int, short> expected[] = {{INT_MAX, 4}, {3, 5}, {2, 2}, {1, 1}, {1, 1}};
+  std::list<std::pair<int, long>> r     = {{1, 1}, {2, 2}, {1, 1}, {INT_MAX, 4}, {3, 5}};
+  const std::pair<int, long> expected[] = {{INT_MAX, 4}, {3, 5}, {2, 2}, {1, 1}, {1, 1}};
   {
     std::flat_multimap s(std::from_range, r, std::greater<int>());
-    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, short, std::greater<int>>);
+    ASSERT_SAME_TYPE(decltype(s), std::flat_multimap<int, long, std::greater<int>>);
     assert(std::ranges::equal(s, expected));
   }
   {
@@ -316,10 +316,10 @@ void test_from_range_compare() {
     ASSERT_SAME_TYPE(
         decltype(s),
         std::flat_multimap<int,
-                           short,
+                           long,
                            std::greater<int>,
                            std::vector<int, test_allocator<int>>,
-                           std::vector<short, test_allocator<short>>>);
+                           std::vector<long, test_allocator<long>>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().get_id() == 42);
     assert(s.values().get_allocator().get_id() == 42);

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/deduct_pmr.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/deduct_pmr.pass.cpp
@@ -32,19 +32,19 @@ using PC = std::pair<const int, long>;
 
 void test_containers() {
   std::deque<int, test_allocator<int>> ks({1, 2, 1, 2, 2, INT_MAX, 3}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> vs({1, 2, 3, 4, 5, 3, 4}, test_allocator<int>(0, 43));
+  std::deque<long, test_allocator<long>> vs({1, 2, 3, 4, 5, 3, 4}, test_allocator<int>(0, 43));
   std::deque<int, test_allocator<int>> sorted_ks({1, 1, 2, 2, 2, 3, INT_MAX}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> sorted_vs({1, 3, 2, 4, 5, 4, 3}, test_allocator<int>(0, 43));
-  const std::pair<int, short> expected[] = {{1, 1}, {1, 3}, {2, 2}, {2, 4}, {2, 5}, {3, 4}, {INT_MAX, 3}};
+  std::deque<long, test_allocator<long>> sorted_vs({1, 3, 2, 4, 5, 4, 3}, test_allocator<int>(0, 43));
+  const std::pair<int, long> expected[] = {{1, 1}, {1, 3}, {2, 2}, {2, 4}, {2, 5}, {3, 4}, {INT_MAX, 3}};
   {
     std::pmr::monotonic_buffer_resource mr;
     std::pmr::monotonic_buffer_resource mr2;
     std::pmr::deque<int> pks(ks.begin(), ks.end(), &mr);
-    std::pmr::deque<short> pvs(vs.begin(), vs.end(), &mr);
+    std::pmr::deque<long> pvs(vs.begin(), vs.end(), &mr);
     std::flat_multimap s(std::move(pks), std::move(pvs), &mr2);
 
     ASSERT_SAME_TYPE(
-        decltype(s), std::flat_multimap<int, short, std::less<int>, std::pmr::deque<int>, std::pmr::deque<short>>);
+        decltype(s), std::flat_multimap<int, long, std::less<int>, std::pmr::deque<int>, std::pmr::deque<long>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().resource() == &mr2);
     assert(s.values().get_allocator().resource() == &mr2);
@@ -53,11 +53,11 @@ void test_containers() {
     std::pmr::monotonic_buffer_resource mr;
     std::pmr::monotonic_buffer_resource mr2;
     std::pmr::deque<int> pks(sorted_ks.begin(), sorted_ks.end(), &mr);
-    std::pmr::deque<short> pvs(sorted_vs.begin(), sorted_vs.end(), &mr);
+    std::pmr::deque<long> pvs(sorted_vs.begin(), sorted_vs.end(), &mr);
     std::flat_multimap s(std::sorted_equivalent, std::move(pks), std::move(pvs), &mr2);
 
     ASSERT_SAME_TYPE(
-        decltype(s), std::flat_multimap<int, short, std::less<int>, std::pmr::deque<int>, std::pmr::deque<short>>);
+        decltype(s), std::flat_multimap<int, long, std::less<int>, std::pmr::deque<int>, std::pmr::deque<long>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().resource() == &mr2);
     assert(s.values().get_allocator().resource() == &mr2);
@@ -66,20 +66,20 @@ void test_containers() {
 
 void test_containers_compare() {
   std::deque<int, test_allocator<int>> ks({1, 2, 1, 2, 2, INT_MAX, 3}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> vs({1, 2, 3, 4, 5, 3, 4}, test_allocator<int>(0, 43));
+  std::deque<long, test_allocator<long>> vs({1, 2, 3, 4, 5, 3, 4}, test_allocator<int>(0, 43));
   std::deque<int, test_allocator<int>> sorted_ks({INT_MAX, 3, 2, 2, 2, 1, 1}, test_allocator<int>(0, 42));
-  std::deque<short, test_allocator<short>> sorted_vs({3, 4, 2, 4, 5, 1, 3}, test_allocator<int>(0, 43));
-  const std::pair<int, short> expected[] = {{INT_MAX, 3}, {3, 4}, {2, 2}, {2, 4}, {2, 5}, {1, 1}, {1, 3}};
+  std::deque<long, test_allocator<long>> sorted_vs({3, 4, 2, 4, 5, 1, 3}, test_allocator<int>(0, 43));
+  const std::pair<int, long> expected[] = {{INT_MAX, 3}, {3, 4}, {2, 2}, {2, 4}, {2, 5}, {1, 1}, {1, 3}};
 
   {
     std::pmr::monotonic_buffer_resource mr;
     std::pmr::monotonic_buffer_resource mr2;
     std::pmr::deque<int> pks(ks.begin(), ks.end(), &mr);
-    std::pmr::deque<short> pvs(vs.begin(), vs.end(), &mr);
+    std::pmr::deque<long> pvs(vs.begin(), vs.end(), &mr);
     std::flat_multimap s(std::move(pks), std::move(pvs), std::greater<int>(), &mr2);
 
     ASSERT_SAME_TYPE(
-        decltype(s), std::flat_multimap<int, short, std::greater<int>, std::pmr::deque<int>, std::pmr::deque<short>>);
+        decltype(s), std::flat_multimap<int, long, std::greater<int>, std::pmr::deque<int>, std::pmr::deque<long>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().resource() == &mr2);
     assert(s.values().get_allocator().resource() == &mr2);
@@ -88,11 +88,11 @@ void test_containers_compare() {
     std::pmr::monotonic_buffer_resource mr;
     std::pmr::monotonic_buffer_resource mr2;
     std::pmr::deque<int> pks(sorted_ks.begin(), sorted_ks.end(), &mr);
-    std::pmr::deque<short> pvs(sorted_vs.begin(), sorted_vs.end(), &mr);
+    std::pmr::deque<long> pvs(sorted_vs.begin(), sorted_vs.end(), &mr);
     std::flat_multimap s(std::sorted_equivalent, std::move(pks), std::move(pvs), std::greater<int>(), &mr2);
 
     ASSERT_SAME_TYPE(
-        decltype(s), std::flat_multimap<int, short, std::greater<int>, std::pmr::deque<int>, std::pmr::deque<short>>);
+        decltype(s), std::flat_multimap<int, long, std::greater<int>, std::pmr::deque<int>, std::pmr::deque<long>>);
     assert(std::ranges::equal(s, expected));
     assert(s.keys().get_allocator().resource() == &mr2);
     assert(s.values().get_allocator().resource() == &mr2);

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/initializer_list.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/initializer_list.pass.cpp
@@ -38,24 +38,24 @@ struct DefaultCtableComp {
 
 template <template <class...> class KeyContainer, template <class...> class ValueContainer>
 constexpr void test() {
-  std::pair<int, short> expected[] = {{1, 1}, {2, 2}, {2, 2}, {3, 3}, {3, 3}, {5, 2}};
+  std::pair<int, long> expected[] = {{1, 1}, {2, 2}, {2, 2}, {3, 3}, {3, 3}, {5, 2}};
   {
     // flat_multimap(initializer_list<value_type>);
-    using M                                         = std::flat_multimap<int, short>;
-    std::initializer_list<std::pair<int, short>> il = {{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}};
+    using M                                        = std::flat_multimap<int, long>;
+    std::initializer_list<std::pair<int, long>> il = {{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}};
     M m(il);
     assert(std::ranges::equal(m, expected));
   }
   {
     // flat_multimap(initializer_list<value_type>);
     // explicit(false)
-    using M = std::flat_multimap<int, short>;
+    using M = std::flat_multimap<int, long>;
     M m     = {{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}};
     assert(std::ranges::equal(m, expected));
   }
   {
     // flat_multimap(initializer_list<value_type>);
-    using M = std::flat_multimap<int, short, std::greater<int>, KeyContainer<int, min_allocator<int>>>;
+    using M = std::flat_multimap<int, long, std::greater<int>, KeyContainer<int, min_allocator<int>>>;
     M m     = {{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}};
     assert(std::equal(m.rbegin(), m.rend(), expected, expected + 6));
   }
@@ -80,7 +80,7 @@ constexpr void test() {
   {
     // flat_multimap(initializer_list<value_type>, const key_compare&);
     using C = test_less<int>;
-    using M = std::flat_multimap<int, short, C>;
+    using M = std::flat_multimap<int, long, C>;
     auto m  = M({{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}}, C(10));
     assert(std::equal(m.begin(), m.end(), expected, expected + 6));
     assert(m.key_comp() == C(10));
@@ -93,7 +93,7 @@ constexpr void test() {
   if (!TEST_IS_CONSTANT_EVALUATED) {
     // flat_multimap(initializer_list<value_type>, const key_compare&);
     // Sorting uses the comparator that was passed in
-    using M = std::flat_multimap<int, short, std::function<bool(int, int)>, KeyContainer<int, min_allocator<int>>>;
+    using M = std::flat_multimap<int, long, std::function<bool(int, int)>, KeyContainer<int, min_allocator<int>>>;
     auto m  = M({{5, 2}, {2, 2}, {2, 2}, {3, 3}, {1, 1}, {3, 3}}, std::greater<int>());
     assert(std::equal(m.rbegin(), m.rend(), expected, expected + 6));
     assert(m.key_comp()(2, 1) == true);

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/iter_iter.pass.cpp
@@ -119,19 +119,19 @@ constexpr void test() {
 
 template <template <class...> class KeyContainer, template <class...> class ValueContainer>
 constexpr void test_alloc() {
-  using P = std::pair<int, short>;
+  using P = std::pair<int, long>;
   P ar[]  = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {3, 6}, {2, 7}, {3, 8}, {3, 9}};
 
   {
     // flat_multimap(InputIterator , InputIterator, const Allocator&)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     auto m   = M(ar, ar + 9, A1(5));
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 1, 1, 2, 2, 2, 3, 3, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {1, 2, 3},
             {1, 2, 3},
@@ -149,13 +149,13 @@ constexpr void test_alloc() {
     // flat_multimap(InputIterator , InputIterator, const Allocator&)
     // explicit(false)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     M m      = {ar, ar + 9, A1(5)}; // implicit ctor
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 1, 1, 2, 2, 2, 3, 3, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {1, 2, 3},
             {1, 2, 3},
@@ -173,13 +173,13 @@ constexpr void test_alloc() {
     // flat_multimap(InputIterator , InputIterator, const key_compare&, const Allocator&)
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, C, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     auto m   = M(ar, ar + 9, C(3), A1(5));
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 1, 1, 2, 2, 2, 3, 3, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {1, 2, 3},
             {1, 2, 3},
@@ -198,13 +198,13 @@ constexpr void test_alloc() {
     // flat_multimap(InputIterator , InputIterator, const key_compare&, const Allocator&)
     // explicit(false)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     M m      = {ar, ar + 9, {}, A2(5)}; // implicit ctor
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 1, 1, 2, 2, 2, 3, 3, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {1, 2, 3},
             {1, 2, 3},

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_assign.pass.cpp
@@ -31,8 +31,8 @@ constexpr void test() {
   {
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<char>;
-    using M  = std::flat_multimap<int, char, C, KeyContainer<int, A1>, ValueContainer<char, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     M mo     = M({{1, 1}, {1, 3}, {3, 2}}, C(5), A1(7));
     M m      = M({}, C(3), A1(7));
     m        = std::move(mo);
@@ -46,8 +46,8 @@ constexpr void test() {
   {
     using C  = test_less<int>;
     using A1 = other_allocator<int>;
-    using A2 = other_allocator<char>;
-    using M  = std::flat_multimap<int, char, C, KeyContainer<int, A1>, ValueContainer<char, A2>>;
+    using A2 = other_allocator<long>;
+    using M  = std::flat_multimap<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     M mo     = M({{4, 5}, {4, 4}}, C(5), A1(7));
     M m      = M({{1, 1}, {2, 2}, {3, 3}, {4, 4}}, C(3), A1(7));
     m        = std::move(mo);

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/pmr.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/pmr.pass.cpp
@@ -166,12 +166,12 @@ int main(int, char**) {
   }
   {
     // flat_multimap(InputIterator first, InputIterator last, const Allocator& a);
-    using P      = std::pair<int, short>;
+    using P      = std::pair<int, long>;
     P ar[]       = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {3, 6}, {2, 7}, {3, 8}, {3, 9}};
     P expected[] = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {2, 7}, {3, 6}, {3, 8}, {3, 9}};
     {
       //  cpp17 iterator
-      using M = std::flat_multimap<int, short, std::less<int>, std::pmr::vector<int>, std::pmr::vector<short>>;
+      using M = std::flat_multimap<int, long, std::less<int>, std::pmr::vector<int>, std::pmr::vector<long>>;
       std::pmr::monotonic_buffer_resource mr;
       std::pmr::vector<M> vm(&mr);
       vm.emplace_back(cpp17_input_iterator<const P*>(ar), cpp17_input_iterator<const P*>(ar + 9));
@@ -181,7 +181,7 @@ int main(int, char**) {
       assert(vm[0].values().get_allocator().resource() == &mr);
     }
     {
-      using M = std::flat_multimap<int, short, std::less<int>, std::pmr::vector<int>, std::pmr::vector<short>>;
+      using M = std::flat_multimap<int, long, std::less<int>, std::pmr::vector<int>, std::pmr::vector<long>>;
       std::pmr::monotonic_buffer_resource mr;
       std::pmr::vector<M> vm(&mr);
       vm.emplace_back(ar, ar);
@@ -242,12 +242,12 @@ int main(int, char**) {
   }
   {
     //  flat_multimap(from_range_t, R&&, const Alloc&);
-    using P      = std::pair<int, short>;
+    using P      = std::pair<int, long>;
     P ar[]       = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {3, 6}, {2, 7}, {3, 8}, {3, 9}};
     P expected[] = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {2, 7}, {3, 6}, {3, 8}, {3, 9}};
     {
       // input_range
-      using M    = std::flat_multimap<int, short, std::less<int>, std::pmr::vector<int>, std::pmr::vector<short>>;
+      using M    = std::flat_multimap<int, long, std::less<int>, std::pmr::vector<int>, std::pmr::vector<long>>;
       using Iter = cpp20_input_iterator<const P*>;
       using Sent = sentinel_wrapper<Iter>;
       using R    = std::ranges::subrange<Iter, Sent>;
@@ -260,7 +260,7 @@ int main(int, char**) {
       assert(vm[0].values().get_allocator().resource() == &mr);
     }
     {
-      using M = std::flat_multimap<int, short, std::less<int>, std::pmr::vector<int>, std::pmr::vector<short>>;
+      using M = std::flat_multimap<int, long, std::less<int>, std::pmr::vector<int>, std::pmr::vector<long>>;
       using R = std::ranges::subrange<const P*>;
       std::pmr::monotonic_buffer_resource mr;
       std::pmr::vector<M> vm(&mr);

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/range.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/range.pass.cpp
@@ -176,19 +176,19 @@ constexpr void test() {
 
 template <template <class...> class KeyContainer, template <class...> class ValueContainer>
 constexpr void test_alloc() {
-  using P = std::pair<int, short>;
+  using P = std::pair<int, long>;
   P ar[]  = {{1, 1}, {1, 2}, {1, 3}, {2, 4}, {2, 5}, {3, 6}, {2, 7}, {3, 8}, {3, 9}};
   {
     // flat_multimap(from_range_t, R&&, const Allocator&)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using R  = std::ranges::subrange<const P*>;
     auto m   = M(std::from_range, R(ar, ar + 9), A1(5));
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 1, 1, 2, 2, 2, 3, 3, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {1, 2, 3},
             {1, 2, 3},
@@ -206,14 +206,14 @@ constexpr void test_alloc() {
     // flat_multimap(from_range_t, R&&, const Allocator&)
     // explicit(false)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using R  = std::ranges::subrange<const P*>;
     M m      = {std::from_range, R(ar, ar + 9), A1(5)}; // implicit ctor
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 1, 1, 2, 2, 2, 3, 3, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {1, 2, 3},
             {1, 2, 3},
@@ -231,14 +231,14 @@ constexpr void test_alloc() {
     // flat_multimap(from_range_t, R&&, const key_compare&, const Allocator&)
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, C, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using R  = std::ranges::subrange<const P*>;
     auto m   = M(std::from_range, R(ar, ar + 9), C(3), A1(5));
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 1, 1, 2, 2, 2, 3, 3, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {1, 2, 3},
             {1, 2, 3},
@@ -257,14 +257,14 @@ constexpr void test_alloc() {
     // flat_multimap(from_range_t, R&&, const key_compare&, const Allocator&)
     // explicit(false)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using R  = std::ranges::subrange<const P*>;
     M m      = {std::from_range, R(ar, ar + 9), {}, A2(5)}; // implicit ctor
     assert(std::ranges::equal(m.keys(), KeyContainer<int, A1>{1, 1, 1, 2, 2, 2, 3, 3, 3}));
     check_possible_values(
         m.values(),
-        std::vector<std::vector<short>>{
+        std::vector<std::vector<long>>{
             {1, 2, 3},
             {1, 2, 3},
             {1, 2, 3},

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/sorted_container.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/sorted_container.pass.cpp
@@ -39,18 +39,18 @@ template <template <class...> class KeyContainer, template <class...> class Valu
 constexpr void test() {
   {
     // flat_multimap(sorted_equivalent_t, key_container_type , mapped_container_type)
-    using M                 = std::flat_multimap<int, char, std::less<int>, KeyContainer<int>, ValueContainer<char>>;
+    using M                 = std::flat_multimap<int, long, std::less<int>, KeyContainer<int>, ValueContainer<long>>;
     KeyContainer<int> ks    = {1, 4, 4, 10};
-    ValueContainer<char> vs = {4, 3, 2, 1};
+    ValueContainer<long> vs = {4, 3, 2, 1};
     auto ks2                = ks;
     auto vs2                = vs;
 
     auto m = M(std::sorted_equivalent, ks, vs);
-    assert(std::ranges::equal(m, std::vector<std::pair<int, char>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
     m = M(std::sorted_equivalent, std::move(ks), std::move(vs));
     assert(ks.empty()); // it was moved-from
     assert(vs.empty()); // it was moved-from
-    assert(std::ranges::equal(m, std::vector<std::pair<int, char>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
 
     // explicit(false)
     M m2 = {std::sorted_equivalent, std::move(ks2), std::move(vs2)};
@@ -60,16 +60,16 @@ constexpr void test() {
     // flat_multimap(sorted_equivalent_t, key_container_type , mapped_container_type)
     // non-default container, comparator and allocator type
     using Ks = KeyContainer<int, min_allocator<int>>;
-    using Vs = ValueContainer<char, min_allocator<char>>;
-    using M  = std::flat_multimap<int, char, std::greater<int>, Ks, Vs>;
+    using Vs = ValueContainer<long, min_allocator<long>>;
+    using M  = std::flat_multimap<int, long, std::greater<int>, Ks, Vs>;
     Ks ks    = {10, 4, 4, 1};
     Vs vs    = {1, 2, 3, 4};
     auto m   = M(std::sorted_equivalent, ks, vs);
-    assert(std::ranges::equal(m, std::vector<std::pair<int, char>>{{10, 1}, {4, 2}, {4, 3}, {1, 4}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{10, 1}, {4, 2}, {4, 3}, {1, 4}}));
     m = M(std::sorted_equivalent, std::move(ks), std::move(vs));
     assert(ks.empty()); // it was moved-from
     assert(vs.empty()); // it was moved-from
-    assert(std::ranges::equal(m, std::vector<std::pair<int, char>>{{10, 1}, {4, 2}, {4, 3}, {1, 4}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{10, 1}, {4, 2}, {4, 3}, {1, 4}}));
   }
   {
     // flat_multimap(sorted_equivalent_t, key_container_type , mapped_container_type)
@@ -81,19 +81,19 @@ constexpr void test() {
     auto m  = M(std::sorted_equivalent, std::move(ks), std::move(vs));
     assert(ks.empty()); // it was moved-from
     assert(vs.empty()); // it was moved-from
-    assert(std::ranges::equal(m, std::vector<std::pair<int, char>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
     assert(m.keys().get_allocator() == A(4));
     assert(m.values().get_allocator() == A(5));
   }
   {
     // flat_multimap(sorted_equivalent_t, key_container_type , mapped_container_type, key_compare)
     using C                 = test_less<int>;
-    using M                 = std::flat_multimap<int, char, C, KeyContainer<int>, ValueContainer<char>>;
+    using M                 = std::flat_multimap<int, long, C, KeyContainer<int>, ValueContainer<long>>;
     KeyContainer<int> ks    = {1, 4, 4, 10};
-    ValueContainer<char> vs = {4, 3, 2, 1};
+    ValueContainer<long> vs = {4, 3, 2, 1};
 
     auto m = M(std::sorted_equivalent, ks, vs, C(4));
-    assert(std::ranges::equal(m, std::vector<std::pair<int, char>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
     assert(m.key_comp() == C(4));
 
     // explicit(false)
@@ -109,7 +109,7 @@ constexpr void test() {
     KeyContainer<int, A> ks   = {1, 4, 4, 10};
     ValueContainer<int, A> vs = {4, 3, 2, 1};
     auto m                    = M(std::sorted_equivalent, ks, vs, C(4), A(5));
-    assert(std::ranges::equal(m, std::vector<std::pair<int, char>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
     assert(m.key_comp() == C(4));
     assert(m.keys().get_allocator() == A(5));
     assert(m.values().get_allocator() == A(5));
@@ -130,7 +130,7 @@ constexpr void test() {
     auto m  = M(std::sorted_equivalent, ks, vs, A(6)); // replaces the allocators
     assert(!ks.empty());                               // it was an lvalue above
     assert(!vs.empty());                               // it was an lvalue above
-    assert(std::ranges::equal(m, std::vector<std::pair<int, char>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{1, 4}, {4, 3}, {4, 2}, {10, 1}}));
     assert(m.keys().get_allocator() == A(6));
     assert(m.values().get_allocator() == A(6));
 

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/sorted_initializer_list.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/sorted_initializer_list.pass.cpp
@@ -36,8 +36,8 @@ template <class T, class U>
 constexpr std::initializer_list<std::pair<T, U>> il = {{1, 4}, {4, 2}, {4, 4}, {5, 5}};
 
 constexpr auto il1 = il<int, int>;
-constexpr auto il2 = il<int, short>;
-constexpr auto il3 = il<short, int>;
+constexpr auto il2 = il<int, long>;
+constexpr auto il3 = il<long, int>;
 
 template <template <class...> class KeyContainer, template <class...> class ValueContainer>
 constexpr void test() {
@@ -74,10 +74,10 @@ constexpr void test() {
   {
     // flat_multimap(sorted_equivalent_t, initializer_list<value_type>,  const Allocator&)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     auto m   = M(std::sorted_equivalent, il2, A1(5));
-    assert(std::ranges::equal(m, std::vector<std::pair<int, short>>{{1, 4}, {4, 2}, {4, 4}, {5, 5}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{1, 4}, {4, 2}, {4, 4}, {5, 5}}));
     assert(m.keys().get_allocator() == A1(5));
     assert(m.values().get_allocator() == A2(5));
 
@@ -91,10 +91,10 @@ constexpr void test() {
     // flat_multimap(sorted_equivalent_t, initializer_list<value_type>, const key_compare&, const Allocator&);
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, C, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     auto m   = M(std::sorted_equivalent, il2, C(3), A1(5));
-    assert(std::ranges::equal(m, std::vector<std::pair<int, short>>{{1, 4}, {4, 2}, {4, 4}, {5, 5}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<int, long>>{{1, 4}, {4, 2}, {4, 4}, {5, 5}}));
     assert(m.key_comp() == C(3));
     assert(m.keys().get_allocator() == A1(5));
     assert(m.values().get_allocator() == A2(5));
@@ -102,11 +102,11 @@ constexpr void test() {
   {
     // flat_multimap(sorted_equivalent_t, initializer_list<value_type>, const key_compare&, const Allocator&);
     // explicit(false)
-    using A1 = test_allocator<short>;
+    using A1 = test_allocator<long>;
     using A2 = test_allocator<int>;
-    using M  = std::flat_multimap<short, int, std::less<int>, KeyContainer<short, A1>, ValueContainer<int, A2>>;
+    using M  = std::flat_multimap<long, int, std::less<int>, KeyContainer<long, A1>, ValueContainer<int, A2>>;
     M m      = {std::sorted_equivalent, il3, {}, A1(5)}; // implicit ctor
-    assert(std::ranges::equal(m, std::vector<std::pair<short, int>>{{1, 4}, {4, 2}, {4, 4}, {5, 5}}));
+    assert(std::ranges::equal(m, std::vector<std::pair<long, int>>{{1, 4}, {4, 2}, {4, 4}, {5, 5}}));
     assert(m.keys().get_allocator() == A1(5));
     assert(m.values().get_allocator() == A2(5));
   }

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/sorted_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.cons/sorted_iter_iter.pass.cpp
@@ -68,7 +68,7 @@ constexpr void test() {
     auto m  = M(std::sorted_equivalent,
                cpp17_input_iterator<const P*>(ar),
                cpp17_input_iterator<const P*>(ar + 4),
-               std::less<int>());
+               std::less<Value>());
     assert(std::ranges::equal(m, std::vector<std::pair<int, int>>{{1, 1}, {4, 2}, {4, 4}, {5, 5}}));
     assert(m.key_comp()(1, 2) == true);
 
@@ -76,19 +76,19 @@ constexpr void test() {
     M m2 = {std::sorted_equivalent,
             cpp17_input_iterator<const P*>(ar),
             cpp17_input_iterator<const P*>(ar + 4),
-            std::less<int>()};
+            std::less<Value>()};
     assert(m2 == m);
   }
   {
     // flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, const key_compare&);
     // greater
-    using M = std::flat_multimap<Key, Value, std::greater<int>, KeyContainer, ValueContainer>;
+    using M = std::flat_multimap<Key, Value, std::greater<Value>, KeyContainer, ValueContainer>;
     using P = std::pair<Key, Value>;
     P ar[]  = {{5, 5}, {4, 4}, {4, 2}, {1, 1}};
     auto m  = M(std::sorted_equivalent,
                cpp17_input_iterator<const P*>(ar),
                cpp17_input_iterator<const P*>(ar + 4),
-               std::greater<int>());
+               std::greater<Value>());
     assert(std::ranges::equal(m, std::vector<std::pair<int, int>>{{5, 5}, {4, 4}, {4, 2}, {1, 1}}));
   }
   {
@@ -108,8 +108,8 @@ constexpr void test_alloc() {
   {
     // flat_multimap(sorted_equivalent_t, InputIterator , InputIterator, const Allocator&)
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, std::less<int>, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, std::less<int>, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using P  = std::pair<int, int>;
     P ar[]   = {{1, 1}, {4, 2}, {4, 4}, {5, 5}};
     auto m   = M(std::sorted_equivalent, ar, ar + 4, A1(5));
@@ -127,8 +127,8 @@ constexpr void test_alloc() {
     // flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, const key_compare&, const Allocator&);
     using C  = test_less<int>;
     using A1 = test_allocator<int>;
-    using A2 = test_allocator<short>;
-    using M  = std::flat_multimap<int, short, C, KeyContainer<int, A1>, ValueContainer<short, A2>>;
+    using A2 = test_allocator<long>;
+    using M  = std::flat_multimap<int, long, C, KeyContainer<int, A1>, ValueContainer<long, A2>>;
     using P  = std::pair<int, int>;
     P ar[]   = {{1, 1}, {4, 2}, {4, 4}, {5, 5}};
     auto m   = M(std::sorted_equivalent, ar, ar + 4, C(3), A1(5));
@@ -140,9 +140,9 @@ constexpr void test_alloc() {
   {
     // flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, const key_compare&, const Allocator&);
     // explicit(false)
-    using A1 = test_allocator<short>;
+    using A1 = test_allocator<long>;
     using A2 = test_allocator<int>;
-    using M  = std::flat_multimap<short, int, std::less<int>, KeyContainer<short, A1>, ValueContainer<int, A2>>;
+    using M  = std::flat_multimap<long, int, std::less<int>, KeyContainer<long, A1>, ValueContainer<int, A2>>;
     using P  = std::pair<int, int>;
     P ar[]   = {{1, 1}, {4, 2}, {4, 4}, {5, 5}};
     M m      = {std::sorted_equivalent, ar, ar + 4, {}, A1(5)}; // implicit ctor

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/erase_key.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/erase_key.pass.cpp
@@ -29,7 +29,7 @@
 
 template <class KeyContainer, class ValueContainer, class Compare = std::less<>>
 constexpr void test() {
-  using M = std::flat_multimap<int, char, Compare, KeyContainer, ValueContainer>;
+  using M = std::flat_multimap<int, long, Compare, KeyContainer, ValueContainer>;
 
   auto make = [](std::initializer_list<int> il) {
     M m;
@@ -79,14 +79,14 @@ constexpr void test() {
 }
 
 constexpr bool test() {
-  test<std::vector<int>, std::vector<char>>();
-  test<std::vector<int>, std::vector<char>, std::greater<>>();
+  test<std::vector<int>, std::vector<long>>();
+  test<std::vector<int>, std::vector<long>, std::greater<>>();
 #ifndef __cpp_lib_constexpr_deque
   if (!TEST_IS_CONSTANT_EVALUATED)
 #endif
-    test<std::deque<int>, std::vector<char>>();
-  test<MinSequenceContainer<int>, MinSequenceContainer<char>>();
-  test<std::vector<int, min_allocator<int>>, std::vector<char, min_allocator<char>>>();
+    test<std::deque<int>, std::vector<long>>();
+  test<MinSequenceContainer<int>, MinSequenceContainer<long>>();
+  test<std::vector<int, min_allocator<int>>, std::vector<long, min_allocator<long>>>();
 
   if (!TEST_IS_CONSTANT_EVALUATED) {
     auto erase_function = [](auto& m, auto key_arg) {

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.observers/comp.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.observers/comp.pass.cpp
@@ -36,7 +36,7 @@ constexpr bool test() {
     assert(kc(1, 2));
     assert(!kc(2, 1));
     auto vc = m.value_comp();
-    ASSERT_SAME_TYPE(decltype(vc(std::make_pair(1, 2), std::make_pair(1, 2))), bool);
+    ASSERT_SAME_TYPE(decltype(vc(std::make_pair(1, '2'), std::make_pair(1, '2'))), bool);
     assert(vc({1, '2'}, {2, '1'}));
     assert(!vc({2, '1'}, {1, '2'}));
   }

--- a/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/move.pass.cpp
@@ -145,7 +145,6 @@ void test_move_noexcept() {
     C c;
     C d = std::move(c);
   }
-#endif // _LIBCPP_VERSION
   {
     // Comparator fails to be nothrow-move-constructible
     using C = std::flat_multiset<int, ThrowingMoveComp>;
@@ -153,6 +152,7 @@ void test_move_noexcept() {
     C c;
     C d = std::move(c);
   }
+#endif // _LIBCPP_VERSION
 }
 
 #if !defined(TEST_HAS_NO_EXCEPTIONS)

--- a/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/move_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/move_assign.pass.cpp
@@ -156,7 +156,7 @@ void test_move_assign_no_except() {
   // This tests a conforming extension
 
   {
-    using C = std::flat_multiset<int, int>;
+    using C [[maybe_unused]] = std::flat_multiset<int, int>;
     LIBCPP_STATIC_ASSERT(std::is_nothrow_move_assignable_v<C>);
   }
   {
@@ -168,16 +168,17 @@ void test_move_assign_no_except() {
     static_assert(!std::is_nothrow_move_assignable_v<C>);
   }
   {
-    using C = std::flat_multiset<MoveOnly, std::less<MoveOnly>, std::vector<MoveOnly, other_allocator<MoveOnly>>>;
+    using C [[maybe_unused]] =
+        std::flat_multiset<MoveOnly, std::less<MoveOnly>, std::vector<MoveOnly, other_allocator<MoveOnly>>>;
     LIBCPP_STATIC_ASSERT(std::is_nothrow_move_assignable_v<C>);
   }
   {
-    using C = std::flat_multiset<int, std::less<int>, std::vector<int, other_allocator<int>>>;
+    using C [[maybe_unused]] = std::flat_multiset<int, std::less<int>, std::vector<int, other_allocator<int>>>;
     LIBCPP_STATIC_ASSERT(std::is_nothrow_move_assignable_v<C>);
   }
   {
     // Test with a comparator that throws on move-assignment.
-    using C = std::flat_multiset<int, MoveThrowsComp>;
+    using C [[maybe_unused]] = std::flat_multiset<int, MoveThrowsComp>;
     LIBCPP_STATIC_ASSERT(!std::is_nothrow_move_assignable_v<C>);
   }
   {

--- a/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/sorted_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.cons/sorted_iter_iter.pass.cpp
@@ -147,8 +147,8 @@ constexpr void test() {
   {
     // flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, const key_compare&, const Allocator&);
     // explicit(false)
-    using A1 = test_allocator<short>;
-    using M  = std::flat_multiset<short, std::less<int>, KeyContainer<short, A1>>;
+    using A1 = test_allocator<long>;
+    using M  = std::flat_multiset<long, std::less<int>, KeyContainer<long, A1>>;
     int ar[] = {1, 2, 4, 4, 5};
     M m      = {std::sorted_equivalent, ar, ar + 5, {}, A1(5)}; // implicit ctor
     assert((m == M{1, 2, 4, 4, 5}));

--- a/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.iterators/iterator.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multiset/flat.multiset.iterators/iterator.pass.cpp
@@ -57,7 +57,7 @@ constexpr void test_one() {
   i                            = m.begin(); // move-assignment
   typename M::const_iterator k = i;         // converting constructor
   assert(i == k);                           // comparison
-  for (int j = 0; j < 9; ++j, ++i) {        // pre-increment
+  for (int j = 0; j < 9; ++j, (void)++i) {  // pre-increment
     assert(*i == expected[j]);              // operator*
   }
   assert(i == m.end());

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/move.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/move.pass.cpp
@@ -123,7 +123,6 @@ constexpr void test_move_noexcept() {
     C c;
     C d = std::move(c);
   }
-#endif // _LIBCPP_VERSION
   {
     // Comparator fails to be nothrow-move-constructible
     using C = std::flat_set<int, ThrowingMoveComp, KeyContainer<int>>;
@@ -131,6 +130,7 @@ constexpr void test_move_noexcept() {
     C c;
     C d = std::move(c);
   }
+#endif // _LIBCPP_VERSION
 }
 
 constexpr bool test() {

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/move_assign.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/move_assign.pass.cpp
@@ -159,7 +159,7 @@ void test_move_assign_no_except() {
   // This tests a conforming extension
 
   {
-    using C = std::flat_set<int, int>;
+    using C [[maybe_unused]] = std::flat_set<int, int>;
     LIBCPP_STATIC_ASSERT(std::is_nothrow_move_assignable_v<C>);
   }
   {
@@ -171,16 +171,17 @@ void test_move_assign_no_except() {
     static_assert(!std::is_nothrow_move_assignable_v<C>);
   }
   {
-    using C = std::flat_set<MoveOnly, std::less<MoveOnly>, std::vector<MoveOnly, other_allocator<MoveOnly>>>;
+    using C [[maybe_unused]] =
+        std::flat_set<MoveOnly, std::less<MoveOnly>, std::vector<MoveOnly, other_allocator<MoveOnly>>>;
     LIBCPP_STATIC_ASSERT(std::is_nothrow_move_assignable_v<C>);
   }
   {
-    using C = std::flat_set<int, std::less<int>, std::vector<int, other_allocator<int>>>;
+    using C [[maybe_unused]] = std::flat_set<int, std::less<int>, std::vector<int, other_allocator<int>>>;
     LIBCPP_STATIC_ASSERT(std::is_nothrow_move_assignable_v<C>);
   }
   {
     // Test with a comparator that throws on move-assignment.
-    using C = std::flat_set<int, MoveThrowsComp>;
+    using C [[maybe_unused]] = std::flat_set<int, MoveThrowsComp>;
     LIBCPP_STATIC_ASSERT(!std::is_nothrow_move_assignable_v<C>);
   }
   {

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/sorted_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.cons/sorted_iter_iter.pass.cpp
@@ -128,8 +128,8 @@ constexpr void test_alloc() {
   {
     // flat_set(sorted_unique_t, InputIterator, InputIterator, const key_compare&, const Allocator&);
     // explicit(false)
-    using A1 = test_allocator<short>;
-    using M  = std::flat_set<short, std::less<int>, KeyContainer<short, A1>>;
+    using A1 = test_allocator<long>;
+    using M  = std::flat_set<long, std::less<int>, KeyContainer<long, A1>>;
     int ar[] = {1, 2, 4, 5};
     M m      = {std::sorted_unique, ar, ar + 4, {}, A1(5)}; // implicit ctor
     assert((m == M{1, 2, 4, 5}));

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.iterators/iterator.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.iterators/iterator.pass.cpp
@@ -56,7 +56,7 @@ constexpr void test_one() {
   i                            = m.begin(); // move-assignment
   typename M::const_iterator k = i;         // converting constructor
   assert(i == k);                           // comparison
-  for (int j = 1; j <= 4; ++j, ++i) {       // pre-increment
+  for (int j = 1; j <= 4; ++j, (void)++i) { // pre-increment
     assert(*i == j);                        // operator*
   }
   assert(i == m.end());


### PR DESCRIPTION
Impacts files in `test/std/containers/container.adaptors/flat.xxx`. No meaning is changed; only appropriate types are spelled out to prevent compiler warnings.

- Replace `char`s and `short`s used in tests of `flat_[multi]{set, map}` with `long`s to prevent warnings about narrowing conversions when running tests. Allow increased test coverage for MSVC STL.
- Make test code robust against evil overloads of operator comma .(2 files)
- Add `[[maybe_unused]]` to some local `typedef`s that are sometimes unused due to usage of `LIBCPP_STATIC_ASSERT`.

For discussion and suggested changes, see the LLVM Discord https://discord.com/channels/636084430946959380/636732894974312448/1445901676400742533