### PR TITLE
[CIR] Add Function Argument Demotion support

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -954,7 +954,8 @@ public:
   clang::QualType buildFunctionArgList(clang::GlobalDecl gd,
                                        FunctionArgList &args);
 
-  /// Emit the function prologue: declare function arguments in the symbol table.
+  /// Emit the function prologue: declare function arguments in the symbol
+  /// table.
   void emitFunctionProlog(const FunctionArgList &args, mlir::Block *entryBB,
                           const FunctionDecl *fd, SourceLocation bodyBeginLoc);
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -956,7 +956,7 @@ public:
 
   /// Emit the function prologue: declare function arguments in the symbol table.
   void emitFunctionProlog(const FunctionArgList &args, mlir::Block *entryBB,
-                          const FunctionDecl *fd);
+                          const FunctionDecl *fd, SourceLocation bodyBeginLoc);
 
   /// Emit code for the start of a function.
   /// \param loc       The location to be associated with the function.

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -954,6 +954,10 @@ public:
   clang::QualType buildFunctionArgList(clang::GlobalDecl gd,
                                        FunctionArgList &args);
 
+  /// Emit the function prologue: declare function arguments in the symbol table.
+  void emitFunctionProlog(const FunctionArgList &args, mlir::Block *entryBB,
+                          const FunctionDecl *fd);
+
   /// Emit code for the start of a function.
   /// \param loc       The location to be associated with the function.
   /// \param startLoc  The location of the function body.

--- a/clang/test/CIR/CodeGen/kr-func-promote.c
+++ b/clang/test/CIR/CodeGen/kr-func-promote.c
@@ -1,13 +1,42 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c89 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c89 -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c89 -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
 
-// CHECK: cir.func {{.*}}@foo(%arg0: !s32i
-// CHECK:   %0 = cir.alloca !s16i, !cir.ptr<!s16i>, ["x", init]
-// CHECK:   %1 = cir.cast integral %arg0 : !s32i -> !s16i
-// CHECK:   cir.store %1, %0 : !s16i, !cir.ptr<!s16i>
+// CIR: cir.func {{.*}}@foo(%arg0: !s32i
+// CIR:   %0 = cir.alloca !s16i, !cir.ptr<!s16i>, ["x", init]
+// CIR:   %1 = cir.cast integral %arg0 : !s32i -> !s16i
+// CIR:   cir.store %1, %0 : !s16i, !cir.ptr<!s16i>
+// expected-warning@+1 {{a function definition without a prototype is deprecated}}
 void foo(x) short x; {}
 
-// CHECK: cir.func no_proto dso_local @bar(%arg0: !cir.double
-// CHECK:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]
-// CHECK:   %1 = cir.cast floating %arg0 : !cir.double -> !cir.float
-// CHECK:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>
+// LLVM: define{{.*}} void @foo(i32 %0)
+// LLVM:   %[[X_PTR:.*]] = alloca i16, i64 1, align 2
+// LLVM:   %[[X:.*]] = trunc i32 %0 to i16
+// LLVM:   store i16 %[[X]], ptr %[[X_PTR]], align 2
+
+// OGCG: define{{.*}} void @foo(i32 noundef %0)
+// OGCG: entry:
+// OGCG:   %[[X_PTR:.*]] = alloca i16, align 2
+// OGCG:   %[[X:.*]] = trunc i32 %0 to i16
+// OGCG:   store i16 %[[X]], ptr %[[X_PTR]], align 2
+
+// CIR: cir.func no_proto dso_local @bar(%arg0: !cir.double
+// CIR:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]
+// CIR:   %1 = cir.cast floating %arg0 : !cir.double -> !cir.float
+// CIR:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>
+// expected-warning@+1 {{a function definition without a prototype is deprecated}}
 void bar(f) float f; {}
+
+// LLVM: define{{.*}} void @bar(double %0)
+// LLVM:   %[[F_PTR:.*]] = alloca float, i64 1, align 4
+// LLVM:   %[[F:.*]] = fptrunc double %0 to float
+// LLVM:   store float %[[F]], ptr %[[F_PTR]], align 4
+
+// OGCG: define{{.*}} void @bar(double noundef %0)
+// OGCG: entry:
+// OGCG:   %[[F_PTR:.*]] = alloca float, align 4
+// OGCG:   %[[F:.*]] = fptrunc double %0 to float
+// OGCG:   store float %[[F]], ptr %[[F_PTR]], align 4

--- a/clang/test/CIR/CodeGen/kr-func-promote.c
+++ b/clang/test/CIR/CodeGen/kr-func-promote.c
@@ -23,7 +23,7 @@ void foo(x) short x; {}
 // OGCG:   %[[X:.*]] = trunc i32 %0 to i16
 // OGCG:   store i16 %[[X]], ptr %[[X_PTR]], align 2
 
-// CIR: cir.func no_proto dso_local @bar(%arg0: !cir.double
+// CIR: cir.func{{.*}}no_proto dso_local @bar(%arg0: !cir.double
 // CIR:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]
 // CIR:   %1 = cir.cast floating %arg0 : !cir.double -> !cir.float
 // CIR:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>

--- a/clang/test/CIR/CodeGen/kr-func-promote.c
+++ b/clang/test/CIR/CodeGen/kr-func-promote.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o - | FileCheck %s
+
+// CHECK: cir.func {{.*}}@foo(%arg0: !s32i
+// CHECK:   %0 = cir.alloca !s16i, !cir.ptr<!s16i>, ["x", init]
+// CHECK:   %1 = cir.cast integral %arg0 : !s32i -> !s16i
+// CHECK:   cir.store %1, %0 : !s16i, !cir.ptr<!s16i>
+void foo(x) short x; {}
+
+// CHECK: cir.func no_proto dso_local @bar(%arg0: !cir.double
+// CHECK:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init]
+// CHECK:   %1 = cir.cast floating %arg0 : !cir.double -> !cir.float
+// CHECK:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>
+void bar(f) float f; {}


### PR DESCRIPTION
This PR migrates the Function Argument Demotion feature from the incubator repository to upstream. The feature handles K&R-style function parameters that are promoted (e.g., short->int, float->double) and demotes them back to their declared types.

## Changes
- Add emitArgumentDemotion helper function for type demotion
- Create emitFunctionProlog function to handle function prologue setup (addresses existing TODO to move parameter handling logic)
- Move parameter handling logic into emitFunctionProlog
- Add test case kr-func-promote.c to verify the feature

Tested: All CIR tests pass (320/321, 99.69%). The one unsupported test is an expected failure.