### PR TITLE
[flang][OpenMP] Store list of expressions in InitializerT

### DIFF
--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -412,6 +412,7 @@ bool ClauseProcessor::processInitializer(
       }
       // Lower the expression/function call
       lower::StatementContext stmtCtx;
+      const semantics::SomeExpr &initExpr = clause->v.front();
       mlir::Value result = common::visit(
           common::visitors{
               [&](const evaluate::ProcedureRef &procRef) -> mlir::Value {
@@ -422,7 +423,7 @@ bool ClauseProcessor::processInitializer(
               },
               [&](const auto &expr) -> mlir::Value {
                 mlir::Value exprResult = fir::getBase(convertExprToValue(
-                    loc, converter, clause->v, symMap, stmtCtx));
+                    loc, converter, initExpr, symMap, stmtCtx));
                 // Conversion can either give a value or a refrence to a value,
                 // we need to return the reduction type, so an optional load may
                 // be generated.
@@ -432,7 +433,7 @@ bool ClauseProcessor::processInitializer(
                     exprResult = fir::LoadOp::create(builder, loc, exprResult);
                 return exprResult;
               }},
-          clause->v.u);
+          initExpr.u);
       stmtCtx.finalizeAndPop();
       return result;
     };

--- a/llvm/include/llvm/Frontend/OpenMP/ClauseT.h
+++ b/llvm/include/llvm/Frontend/OpenMP/ClauseT.h
@@ -763,8 +763,9 @@ struct InitT {
 template <typename T, typename I, typename E> //
 struct InitializerT {
   using InitializerExpr = E;
+  using List = ListT<InitializerExpr>;
   using WrapperTrait = std::true_type;
-  InitializerExpr v;
+  List v;
 };
 
 // V5.2: [5.5.10] `in_reduction` clause


### PR DESCRIPTION
The INITIALIZER clause holds a stylized expression that can be intiantiated with different types. Currently, the InitializerT class only holds one expression, which happens to correspond to the first type in the DECLARE_REDUCTION type list.

Change InitializerT to hold a list of expressions instead, one for each type. Keep the lowering code unchanged by picking the first expression from the list.