### PR TITLE
[hwasan] Add config for AArch64 Linux with 39-bit VA.

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan_allocator.h
+++ b/compiler-rt/lib/hwasan/hwasan_allocator.h
@@ -74,7 +74,7 @@ struct AP64 {
 #if defined(HWASAN_ALIASING_MODE)
   static const uptr kSpaceSize = 1ULL << kAddressTagShift;
   typedef __sanitizer::DefaultSizeClassMap SizeClassMap;
-#elif SANITIZER_LINUX && !SANITIZER_ANDROID
+#elif SANITIZER_LINUX && !SANITIZER_ANDROID && !defined(SANITIZER_AARCH64_39BIT_VA)
   static const uptr kSpaceSize = 0x40000000000ULL;  // 4T.
   typedef __sanitizer::DefaultSizeClassMap SizeClassMap;
 #else

--- a/compiler-rt/lib/hwasan/hwasan_allocator.h
+++ b/compiler-rt/lib/hwasan/hwasan_allocator.h
@@ -74,7 +74,8 @@ struct AP64 {
 #if defined(HWASAN_ALIASING_MODE)
   static const uptr kSpaceSize = 1ULL << kAddressTagShift;
   typedef __sanitizer::DefaultSizeClassMap SizeClassMap;
-#elif SANITIZER_LINUX && !SANITIZER_ANDROID && !defined(SANITIZER_AARCH64_39BIT_VA)
+#elif SANITIZER_LINUX && !SANITIZER_ANDROID && \
+    !defined(SANITIZER_AARCH64_39BIT_VA)
   static const uptr kSpaceSize = 0x40000000000ULL;  // 4T.
   typedef __sanitizer::DefaultSizeClassMap SizeClassMap;
 #else


### PR DESCRIPTION
This is leveraging work which has already been done for Android, which ships 39-bit VA kernels, and extending it to other embedded Linux targets.

(SANITIZER_AARCH64_39BIT_VA was added in 58c8f57681.)