### PR TITLE
[asan] Add config for AArch64 Linux with 39-bit VA.

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -200,7 +200,7 @@ const uptr kAllocatorSpace = ~(uptr)0;
 #    if defined(__powerpc64__)
 const uptr kAllocatorSize  =  0x20000000000ULL;  // 2T.
 typedef DefaultSizeClassMap SizeClassMap;
-#    elif defined(__aarch64__) && SANITIZER_ANDROID
+#    elif defined(__aarch64__) && (SANITIZER_ANDROID || defined(SANITIZER_AARCH64_39BIT_VA))
 // Android needs to support 39, 42 and 48 bit VMA.
 const uptr kAllocatorSize  =  0x2000000000ULL;  // 128G.
 typedef VeryCompactSizeClassMap SizeClassMap;

--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -200,7 +200,8 @@ const uptr kAllocatorSpace = ~(uptr)0;
 #    if defined(__powerpc64__)
 const uptr kAllocatorSize  =  0x20000000000ULL;  // 2T.
 typedef DefaultSizeClassMap SizeClassMap;
-#    elif defined(__aarch64__) && (SANITIZER_ANDROID || defined(SANITIZER_AARCH64_39BIT_VA))
+#    elif defined(__aarch64__) && \
+        (SANITIZER_ANDROID || defined(SANITIZER_AARCH64_39BIT_VA))
 // Android needs to support 39, 42 and 48 bit VMA.
 const uptr kAllocatorSize  =  0x2000000000ULL;  // 128G.
 typedef VeryCompactSizeClassMap SizeClassMap;


### PR DESCRIPTION
This is leveraging work which has already been done for Android, which ships 39-bit VA kernels, and extending it to other embedded Linux targets.

(SANITIZER_AARCH64_39BIT_VA was added in 58c8f57681.)