### PR TITLE
[flang][nfc] make size and offset optional so you can check if they have been set

### DIFF
--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -875,20 +875,20 @@ public:
   const Scope *scope() const { return scope_; }
   void set_scope(Scope *scope) { scope_ = scope; }
   std::optional<std::size_t> sizeOpt() const { return size_; }
-  std::size_t size() const { 
-    // NOTE: I tried to insert the following check, but there are places where we are
-    // relying on the fact that the size is 0 if it is not set.
+  std::size_t size() const {
+    // NOTE: I tried to insert the following check, but there are places where
+    // we are relying on the fact that the size is 0 if it is not set.
     // CHECK(size_.has_value());
-    return size_.value_or(0); 
+    return size_.value_or(0);
   }
   void set_size(std::size_t size) { size_ = size; }
   void set_size(std::optional<std::size_t> size) { size_ = size; }
   std::optional<std::size_t> offsetOpt() const { return offset_; }
-  std::size_t offset() const { 
-    // NOTE: I tried to insert the following check, but there are places where we are
-    // relying on the fact that the offset is 0 if it is not set.
+  std::size_t offset() const {
+    // NOTE: I tried to insert the following check, but there are places where
+    // we are relying on the fact that the offset is 0 if it is not set.
     // CHECK(offset_.has_value());
-    return offset_.value_or(0); 
+    return offset_.value_or(0);
   }
   void set_offset(std::size_t offset) { offset_ = offset; }
   void set_offset(std::optional<std::size_t> offset) { offset_ = offset; }

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -874,10 +874,24 @@ public:
   Scope *scope() { return scope_; }
   const Scope *scope() const { return scope_; }
   void set_scope(Scope *scope) { scope_ = scope; }
-  std::size_t size() const { return size_; }
+  std::optional<std::size_t> sizeOpt() const { return size_; }
+  std::size_t size() const { 
+    // NOTE: I tried to insert the following check, but there are places where we are
+    // relying on the fact that the size is 0 if it is not set.
+    // CHECK(size_.has_value());
+    return size_.value_or(0); 
+  }
   void set_size(std::size_t size) { size_ = size; }
-  std::size_t offset() const { return offset_; }
+  void set_size(std::optional<std::size_t> size) { size_ = size; }
+  std::optional<std::size_t> offsetOpt() const { return offset_; }
+  std::size_t offset() const { 
+    // NOTE: I tried to insert the following check, but there are places where we are
+    // relying on the fact that the offset is 0 if it is not set.
+    // CHECK(offset_.has_value());
+    return offset_.value_or(0); 
+  }
   void set_offset(std::size_t offset) { offset_ = offset; }
+  void set_offset(std::optional<std::size_t> offset) { offset_ = offset; }
   // Give the symbol a name with a different source location but same chars.
   void ReplaceName(const SourceName &);
   static std::string OmpFlagToClauseName(Flag ompFlag);
@@ -986,8 +1000,8 @@ private:
   Attrs implicitAttrs_; // subset of attrs_ that were not explicit
   Flags flags_;
   Scope *scope_{nullptr};
-  std::size_t size_{0}; // size in bytes
-  std::size_t offset_{0}; // byte offset in scope or common block
+  std::optional<std::size_t> size_; // size in bytes
+  std::optional<std::size_t> offset_; // byte offset in scope or common block
   Details details_;
 
   Symbol() {} // only created in class Symbols

--- a/flang/lib/Semantics/compute-offsets.cpp
+++ b/flang/lib/Semantics/compute-offsets.cpp
@@ -283,7 +283,6 @@ void ComputeOffsetsHelper::DoCommonBlock(Symbol &commonBlock) {
       } else {
         eqIter = equivalenceBlock_.find(base);
         base.get<ObjectEntityDetails>().set_commonBlock(commonBlock);
-        CHECK(symbol.offsetOpt().has_value());
         base.set_offset(symbol.offset() - dep.offset);
         previous.emplace(base);
       }

--- a/flang/lib/Semantics/data-to-inits.cpp
+++ b/flang/lib/Semantics/data-to-inits.cpp
@@ -786,7 +786,7 @@ static bool CombineEquivalencedInitialization(
     combinedSymbol.set(Symbol::Flag::CompilerCreated);
     inits.emplace(&combinedSymbol, std::move(combined));
     auto &details{combinedSymbol.get<ObjectEntityDetails>()};
-    combinedSymbol.set_offset(first.offset());
+    combinedSymbol.set_offset(first.offsetOpt());
     combinedSymbol.set_size(bytes);
     std::size_t minElementBytes{
         ComputeMinElementBytes(associated, foldingContext)};

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -723,8 +723,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Symbol &symbol) {
   if (!symbol.flags().empty()) {
     os << " (" << symbol.flags() << ')';
   }
-  if (symbol.size_) {
-    os << " size=" << symbol.size_ << " offset=" << symbol.offset_;
+  if (symbol.size_ && *symbol.size_) {
+    os << " size=" << symbol.size_ << " offset=" << symbol.offset();
   }
   os << ": " << symbol.details_;
   return os;


### PR DESCRIPTION
This PR makes the size field optional in symbols so that you can tell when it has been set. A later PR checks if a size is set before running some routines that will fail if it wasn't reasonable because we use 0 if the value hasn't been set because an error condition occurred that precluded setting it.