### PR TITLE
[clang][DependencyScanning] Use ArrayRef in function signatures over const std::vector& (NFC)

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -100,7 +100,7 @@ public:
   /// \returns false if clang errors occurred (with diagnostics reported to
   /// \c DiagConsumer), true otherwise.
   bool computeDependencies(
-      StringRef WorkingDirectory, const std::vector<std::string> &CommandLine,
+      StringRef WorkingDirectory, ArrayRef<std::string> CommandLine,
       DependencyConsumer &DepConsumer, DependencyActionController &Controller,
       DiagnosticConsumer &DiagConsumer,
       std::optional<llvm::MemoryBufferRef> TUBuffer = std::nullopt);
@@ -111,7 +111,7 @@ public:
   /// \returns A \c StringError with the diagnostic output if clang errors
   /// occurred, success otherwise.
   llvm::Error computeDependencies(
-      StringRef WorkingDirectory, const std::vector<std::string> &CommandLine,
+      StringRef WorkingDirectory, ArrayRef<std::string> CommandLine,
       DependencyConsumer &Consumer, DependencyActionController &Controller,
       std::optional<llvm::MemoryBufferRef> TUBuffer = std::nullopt);
 
@@ -125,7 +125,7 @@ public:
   /// @param CommandLine The commandline used for the scan.
   /// @return Error if the initializaiton fails.
   llvm::Error initializeCompilerInstanceWithContextOrError(
-      StringRef CWD, const std::vector<std::string> &CommandLine);
+      StringRef CWD, ArrayRef<std::string> CommandLine);
 
   /// @brief Performaces dependency scanning for the module whose name is
   ///        specified.
@@ -147,9 +147,9 @@ public:
   /// three methods return a flag to indicate if the call is successful.
   /// The initialization function asks the client for a DiagnosticsConsumer
   /// that it direct the diagnostics to.
-  bool initializeCompilerInstanceWithContext(
-      StringRef CWD, const std::vector<std::string> &CommandLine,
-      DiagnosticConsumer *DC = nullptr);
+  bool initializeCompilerInstanceWithContext(StringRef CWD,
+                                             ArrayRef<std::string> CommandLine,
+                                             DiagnosticConsumer *DC = nullptr);
   bool
   computeDependenciesByNameWithContext(StringRef ModuleName,
                                        DependencyConsumer &Consumer,
@@ -172,7 +172,7 @@ private:
   /// Actually carries out the scan. If \c OverlayFS is provided, it must be
   /// based on top of DepFS.
   bool scanDependencies(
-      StringRef WorkingDirectory, const std::vector<std::string> &CommandLine,
+      StringRef WorkingDirectory, ArrayRef<std::string> CommandLine,
       DependencyConsumer &Consumer, DependencyActionController &Controller,
       DiagnosticConsumer &DC,
       IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS = nullptr);

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -47,7 +47,7 @@ public:
   /// \returns A \c StringError with the diagnostic output if clang errors
   /// occurred, dependency file contents otherwise.
   llvm::Expected<std::string>
-  getDependencyFile(const std::vector<std::string> &CommandLine, StringRef CWD);
+  getDependencyFile(ArrayRef<std::string> CommandLine, StringRef CWD);
 
   /// Collect the module dependency in P1689 format for C++20 named modules.
   ///
@@ -92,7 +92,7 @@ public:
   /// occurred, \c TranslationUnitDeps otherwise.
   llvm::Expected<dependencies::TranslationUnitDeps>
   getTranslationUnitDependencies(
-      const std::vector<std::string> &CommandLine, StringRef CWD,
+      ArrayRef<std::string> CommandLine, StringRef CWD,
       const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
       dependencies::LookupModuleOutputCallback LookupModuleOutput,
       std::optional<llvm::MemoryBufferRef> TUBuffer = std::nullopt);
@@ -104,8 +104,8 @@ public:
   /// CompilerInstanceWithContext. We are keeping it here so that it is easier
   /// to coordinate with Swift and C-API changes.
   llvm::Expected<dependencies::TranslationUnitDeps> getModuleDependencies(
-      StringRef ModuleName, const std::vector<std::string> &CommandLine,
-      StringRef CWD, const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
+      StringRef ModuleName, ArrayRef<std::string> CommandLine, StringRef CWD,
+      const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
       dependencies::LookupModuleOutputCallback LookupModuleOutput);
 
   /// The following three methods provide a new interface to perform
@@ -119,8 +119,9 @@ public:
   /// @param CWD The current working directory used during the scan.
   /// @param CommandLine The commandline used for the scan.
   /// @return Error if the initializaiton fails.
-  llvm::Error initializeCompilerInstanceWithContext(
-      StringRef CWD, const std::vector<std::string> &CommandLine);
+  llvm::Error
+  initializeCompilerInstanceWithContext(StringRef CWD,
+                                        ArrayRef<std::string> CommandLine);
 
   /// @brief Computes the dependeny for the module named ModuleName.
   /// @param ModuleName The name of the module for which this method computes

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -815,7 +815,7 @@ bool CompilerInstanceWithContext::computeDependencies(
     // file. In this case, we call BeginSourceFile to initialize.
     std::unique_ptr<FrontendAction> Action =
         std::make_unique<PreprocessOnlyAction>();
-    auto InputFile = CI.getFrontendOpts().Inputs.begin();
+    auto *InputFile = CI.getFrontendOpts().Inputs.begin();
     bool ActionBeginSucceeded = Action->BeginSourceFile(CI, *InputFile);
     assert(ActionBeginSucceeded && "Action BeginSourceFile must succeed");
     (void)ActionBeginSucceeded;

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -38,7 +38,7 @@ DependencyScanningWorker::~DependencyScanningWorker() = default;
 DependencyActionController::~DependencyActionController() = default;
 
 llvm::Error DependencyScanningWorker::computeDependencies(
-    StringRef WorkingDirectory, const std::vector<std::string> &CommandLine,
+    StringRef WorkingDirectory, ArrayRef<std::string> CommandLine,
     DependencyConsumer &Consumer, DependencyActionController &Controller,
     std::optional<llvm::MemoryBufferRef> TUBuffer) {
   // Capture the emitted diagnostics and report them to the client
@@ -71,8 +71,7 @@ static bool forEachDriverJob(
 }
 
 static bool createAndRunToolInvocation(
-    const std::vector<std::string> &CommandLine,
-    DependencyScanningAction &Action,
+    ArrayRef<std::string> CommandLine, DependencyScanningAction &Action,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS,
     std::shared_ptr<clang::PCHContainerOperations> &PCHContainerOps,
     DiagnosticsEngine &Diags) {
@@ -86,7 +85,7 @@ static bool createAndRunToolInvocation(
 }
 
 bool DependencyScanningWorker::scanDependencies(
-    StringRef WorkingDirectory, const std::vector<std::string> &CommandLine,
+    StringRef WorkingDirectory, ArrayRef<std::string> CommandLine,
     DependencyConsumer &Consumer, DependencyActionController &Controller,
     DiagnosticConsumer &DC,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS) {
@@ -151,7 +150,7 @@ bool DependencyScanningWorker::scanDependencies(
 }
 
 bool DependencyScanningWorker::computeDependencies(
-    StringRef WorkingDirectory, const std::vector<std::string> &CommandLine,
+    StringRef WorkingDirectory, ArrayRef<std::string> CommandLine,
     DependencyConsumer &Consumer, DependencyActionController &Controller,
     DiagnosticConsumer &DC, std::optional<llvm::MemoryBufferRef> TUBuffer) {
   if (TUBuffer) {
@@ -159,16 +158,16 @@ bool DependencyScanningWorker::computeDependencies(
         DepFS, CommandLine, WorkingDirectory, *TUBuffer);
     return scanDependencies(WorkingDirectory, FinalCommandLine, Consumer,
                             Controller, DC, FinalFS);
-  } else {
-    DepFS->setCurrentWorkingDirectory(WorkingDirectory);
-    return scanDependencies(WorkingDirectory, CommandLine, Consumer, Controller,
-                            DC);
   }
+
+  DepFS->setCurrentWorkingDirectory(WorkingDirectory);
+  return scanDependencies(WorkingDirectory, CommandLine, Consumer, Controller,
+                          DC);
 }
 
 llvm::Error
 DependencyScanningWorker::initializeCompilerInstanceWithContextOrError(
-    StringRef CWD, const std::vector<std::string> &CommandLine) {
+    StringRef CWD, ArrayRef<std::string> CommandLine) {
   bool Success = initializeCompilerInstanceWithContext(CWD, CommandLine);
   return CIWithContext->handleReturnStatus(Success);
 }
@@ -189,8 +188,7 @@ DependencyScanningWorker::finalizeCompilerInstanceWithContextOrError() {
 }
 
 bool DependencyScanningWorker::initializeCompilerInstanceWithContext(
-    StringRef CWD, const std::vector<std::string> &CommandLine,
-    DiagnosticConsumer *DC) {
+    StringRef CWD, ArrayRef<std::string> CommandLine, DiagnosticConsumer *DC) {
   CIWithContext =
       std::make_unique<CompilerInstanceWithContext>(*this, CWD, CommandLine);
   return CIWithContext->initialize(DC);

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -71,8 +71,9 @@ protected:
 };
 } // anonymous namespace
 
-llvm::Expected<std::string> DependencyScanningTool::getDependencyFile(
-    const std::vector<std::string> &CommandLine, StringRef CWD) {
+llvm::Expected<std::string>
+DependencyScanningTool::getDependencyFile(ArrayRef<std::string> CommandLine,
+                                          StringRef CWD) {
   MakeDependencyPrinterConsumer Consumer;
   CallbackActionController Controller(nullptr);
   auto Result =
@@ -141,7 +142,7 @@ llvm::Expected<P1689Rule> DependencyScanningTool::getP1689ModuleDependencyFile(
 
 llvm::Expected<TranslationUnitDeps>
 DependencyScanningTool::getTranslationUnitDependencies(
-    const std::vector<std::string> &CommandLine, StringRef CWD,
+    ArrayRef<std::string> CommandLine, StringRef CWD,
     const llvm::DenseSet<ModuleID> &AlreadySeen,
     LookupModuleOutputCallback LookupModuleOutput,
     std::optional<llvm::MemoryBufferRef> TUBuffer) {
@@ -157,8 +158,8 @@ DependencyScanningTool::getTranslationUnitDependencies(
 
 llvm::Expected<TranslationUnitDeps>
 DependencyScanningTool::getModuleDependencies(
-    StringRef ModuleName, const std::vector<std::string> &CommandLine,
-    StringRef CWD, const llvm::DenseSet<ModuleID> &AlreadySeen,
+    StringRef ModuleName, ArrayRef<std::string> CommandLine, StringRef CWD,
+    const llvm::DenseSet<ModuleID> &AlreadySeen,
     LookupModuleOutputCallback LookupModuleOutput) {
   FullDependencyConsumer Consumer(AlreadySeen);
   CallbackActionController Controller(LookupModuleOutput);
@@ -179,7 +180,7 @@ DependencyScanningTool::getModuleDependencies(
 }
 
 llvm::Error DependencyScanningTool::initializeCompilerInstanceWithContext(
-    StringRef CWD, const std::vector<std::string> &CommandLine) {
+    StringRef CWD, ArrayRef<std::string> CommandLine) {
   return Worker.initializeCompilerInstanceWithContextOrError(CWD, CommandLine);
 }
 


### PR DESCRIPTION
This updates the dependency-scanning tooling to consistently use `ArrayRef<std::string>` rather than `const std::vector<std::string>&` in function signatures.

This is done to help break PR #169964 into smaller, more manageable pieces.