### PR TITLE
[HLSL] Update CheckAccessFullyMapped definition

### DIFF
--- a/clang/lib/Headers/hlsl/hlsl_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_intrinsics.h
@@ -667,7 +667,9 @@ smoothstep(__detail::HLSL_FIXED_VECTOR<float, N> Min,
 }
 
 inline bool CheckAccessFullyMapped(uint Status) {
-  return static_cast<bool>(Status);
+  // The bool cast should only apply to the LSB.
+  uint TruncStatus = Status % 2;
+  return static_cast<bool>(TruncStatus);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This PR updates the definition for CheckAccessFullyMapped  in hlsl_intrinsics.h.
Previously, the whole uint would be cast to a bool, which means any value > 0 would be treated as true.
However, the DXC implementation actually casts just the LSB to bool and returns that. So all even values would result in false, and odd values would result in true after running CheckAccessFullyMapped on it.

This PR changes the implementation to match the DXC implementation.
