### PR TITLE
[DebugInfo][test] Fix llvm/test/ThinLTO/X86/pr35472.ll (NFC)

### DIFF
--- a/llvm/test/ThinLTO/X86/pr35472.ll
+++ b/llvm/test/ThinLTO/X86/pr35472.ll
@@ -8,10 +8,34 @@
 ; RUN: llvm-lto -thinlto-action=run %t1.bc %t2.bc -exported-symbol=_Z5Alphav
 ; RUN: llvm-nm %t1.bc.thinlto.o | FileCheck %s -check-prefix=ThinLTOa
 ; RUN: llvm-nm %t2.bc.thinlto.o | FileCheck %s -check-prefix=ThinLTOb
+; RUN: llvm-bcanalyzer -dump %t1.bc | FileCheck %s --implicit-check-not='<METADATA_BLOCK'
 
 ; ThinLTOa-DAG: T _Z5Bravov
 ; ThinLTOa-DAG: W _ZN4EchoD2Ev
 ; ThinLTOb-DAG: T _Z5Alphav
+
+; Make sure that lexical block was emitted into the module level metadata block,
+; and that metadata index for the module level metadata block is present, as it
+; is necessary to trigger lazy loading.
+; CHECK:  <MODULE_BLOCK
+; CHECK:      <METADATA_BLOCK
+; CHECK:      <INDEX_OFFSET
+; CHECK:      <LEXICAL_BLOCK
+; CHECK:      <INDEX
+; CHECK:    </METADATA_BLOCK>
+; CHECK:    <FUNCTION_BLOCK
+; CHECK:      <METADATA_BLOCK
+; CHECK:      </METADATA_BLOCK>
+; CHECK:    </FUNCTION_BLOCK
+; CHECK:    <FUNCTION_BLOCK
+; CHECK:      <METADATA_BLOCK
+; CHECK:      </METADATA_BLOCK>
+; CHECK:    </FUNCTION_BLOCK
+; CHECK:    <FUNCTION_BLOCK
+; CHECK:      <METADATA_BLOCK
+; CHECK:      </METADATA_BLOCK>
+; CHECK:    </FUNCTION_BLOCK
+; CHECK: </MODULE_BLOCK
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
@@ -36,14 +60,14 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata)
 define linkonce_odr void @_ZN4EchoD2Ev(ptr %this) unnamed_addr comdat align 2 {
   %this.addr.i = alloca ptr, align 8
   call void @llvm.dbg.declare(metadata ptr %this.addr.i, metadata !29, metadata !DIExpression()), !dbg !32
-  %this1.i = load ptr, ptr %this.addr.i, align 8
+  %this1.i = load ptr, ptr %this.addr.i, align 8, !dbg !33
   ret void
 }
 
 define linkonce_odr void @_ZN5DeltaD2Ev(ptr %this) unnamed_addr comdat align 2 !dbg !36 {
   %this.addr.i = alloca ptr, align 8
   call void @llvm.dbg.declare(metadata ptr %this.addr.i, metadata !29, metadata !DIExpression()), !dbg !41
-  %this1.i = load ptr, ptr %this.addr.i, align 8
+  %this1.i = load ptr, ptr %this.addr.i, align 8, !dbg !48
   ret void
 }
 


### PR DESCRIPTION
The test is intended to verify lazy loading of debug-location scope metadata. However, after d5d3eb16b7ab72529c83dacb2889811491e48909, DILexicalScope that was expected to be lazily loaded was not used in IR, so lazy loading did not occur.

This patch fixes that, and adds an extra bcanalyzer check to ensure that DILexicalScope record is emitted.

(Found that when fixing https://github.com/llvm/llvm-project/pull/165032#issuecomment-3614576314)