### PR TITLE
Revert "[IR] Don't store switch case values as operands"

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -74,7 +74,6 @@ Changes to the LLVM IR
   format string function implementations from statically-linked libc's based on
   the requirements of each call. Currently only `float` is supported; this can
   keep floating point support out of printf if it can be proven unused.
-* Case values are no longer operands of `SwitchInst`.
 
 Changes to LLVM infrastructure
 ------------------------------
@@ -179,7 +178,6 @@ Changes to the C API
 * Add `LLVMGetOrInsertFunction` to get or insert a function, replacing the combination of `LLVMGetNamedFunction` and `LLVMAddFunction`.
 * Allow `LLVMGetVolatile` to work with any kind of Instruction.
 * Add `LLVMConstFPFromBits` to get a constant floating-point value from an array of 64 bit values.
-* Add `LLVMGetSwitchCaseValue` and `LLVMSetSwitchCaseValue` to get and set switch case values; switch case values are no longer operands of the instruction.
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -4214,30 +4214,6 @@ LLVM_C_ABI void LLVMSetCondition(LLVMValueRef Branch, LLVMValueRef Cond);
 LLVM_C_ABI LLVMBasicBlockRef LLVMGetSwitchDefaultDest(LLVMValueRef SwitchInstr);
 
 /**
- * Obtain the case value for a successor of a switch instruction. i corresponds
- * to the successor index. The first successor is the default destination, so i
- * must be greater than zero.
- *
- * This only works on llvm::SwitchInst instructions.
- *
- * @see llvm::SwitchInst::CaseHandle::getCaseValue()
- */
-LLVM_C_ABI LLVMValueRef LLVMGetSwitchCaseValue(LLVMValueRef SwitchInstr,
-                                               unsigned i);
-
-/**
- * Set the case value for a successor of a switch instruction. i corresponds to
- * the successor index. The first successor is the default destination, so i
- * must be greater than zero.
- *
- * This only works on llvm::SwitchInst instructions.
- *
- * @see llvm::SwitchInst::CaseHandle::setValue()
- */
-LLVM_C_ABI void LLVMSetSwitchCaseValue(LLVMValueRef SwitchInstr, unsigned i,
-                                       LLVMValueRef CaseValue);
-
-/**
  * @}
  */
 

--- a/llvm/include/llvm/IR/User.h
+++ b/llvm/include/llvm/IR/User.h
@@ -132,13 +132,13 @@ protected:
 
   /// Allocate the array of Uses, followed by a pointer
   /// (with bottom bit set) to the User.
-  /// \param WithExtraValues identifies callers which need N Value* allocated
-  /// along the N operands.
-  LLVM_ABI void allocHungoffUses(unsigned N, bool WithExtraValues = false);
+  /// \param IsPhi identifies callers which are phi nodes and which need
+  /// N BasicBlock* allocated along with N
+  LLVM_ABI void allocHungoffUses(unsigned N, bool IsPhi = false);
 
   /// Grow the number of hung off uses.  Note that allocHungoffUses
   /// should be called if there are no uses.
-  LLVM_ABI void growHungoffUses(unsigned N, bool WithExtraValues = false);
+  LLVM_ABI void growHungoffUses(unsigned N, bool IsPhi = false);
 
 protected:
   ~User() = default; // Use deleteValue() to delete a generic Instruction.

--- a/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
+++ b/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
@@ -164,10 +164,6 @@ static OrderMap orderModule(const Module &M) {
           orderConstantValue(Op);
         if (auto *SVI = dyn_cast<ShuffleVectorInst>(&I))
           orderValue(SVI->getShuffleMaskForBitcode(), OM);
-        if (auto *SI = dyn_cast<SwitchInst>(&I)) {
-          for (const auto &Case : SI->cases())
-            orderValue(Case.getCaseValue(), OM);
-        }
         orderValue(&I, OM);
       }
   }
@@ -1096,10 +1092,6 @@ void ValueEnumerator::incorporateFunction(const Function &F) {
       }
       if (auto *SVI = dyn_cast<ShuffleVectorInst>(&I))
         EnumerateValue(SVI->getShuffleMaskForBitcode());
-      if (auto *SI = dyn_cast<SwitchInst>(&I)) {
-        for (const auto &Case : SI->cases())
-          EnumerateValue(Case.getCaseValue());
-      }
     }
     BasicBlocks.push_back(&BB);
     ValueMap[&BB] = BasicBlocks.size();

--- a/llvm/lib/CodeGen/TypePromotion.cpp
+++ b/llvm/lib/CodeGen/TypePromotion.cpp
@@ -512,14 +512,6 @@ void IRPromoter::PromoteTree() {
         I->setOperand(i, ConstantInt::get(ExtTy, 0));
     }
 
-    // For switch, also mutate case values, which are not operands.
-    if (auto *SI = dyn_cast<SwitchInst>(I)) {
-      for (auto Case : SI->cases()) {
-        APInt NewConst = Case.getCaseValue()->getValue().zext(PromotedWidth);
-        Case.setValue(ConstantInt::get(SI->getContext(), NewConst));
-      }
-    }
-
     // Mutate the result type, unless this is an icmp or switch.
     if (!isa<ICmpInst>(I) && !isa<SwitchInst>(I)) {
       I->mutateType(ExtTy);

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -3257,19 +3257,6 @@ LLVMBasicBlockRef LLVMGetSwitchDefaultDest(LLVMValueRef Switch) {
   return wrap(unwrap<SwitchInst>(Switch)->getDefaultDest());
 }
 
-LLVMValueRef LLVMGetSwitchCaseValue(LLVMValueRef Switch, unsigned i) {
-  assert(i > 0 && i <= unwrap<SwitchInst>(Switch)->getNumCases());
-  auto It = unwrap<SwitchInst>(Switch)->case_begin() + (i - 1);
-  return wrap(It->getCaseValue());
-}
-
-void LLVMSetSwitchCaseValue(LLVMValueRef Switch, unsigned i,
-                            LLVMValueRef CaseValue) {
-  assert(i > 0 && i <= unwrap<SwitchInst>(Switch)->getNumCases());
-  auto It = unwrap<SwitchInst>(Switch)->case_begin() + (i - 1);
-  It->setValue(unwrap<ConstantInt>(CaseValue));
-}
-
 /*--.. Operations on alloca instructions (only) ............................--*/
 
 LLVMTypeRef LLVMGetAllocatedType(LLVMValueRef Alloca) {

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -202,7 +202,7 @@ void PHINode::growOperands() {
   if (NumOps < 2) NumOps = 2;      // 2 op PHI nodes are VERY common.
 
   ReservedSpace = NumOps;
-  growHungoffUses(ReservedSpace, /*WithExtraValues=*/true);
+  growHungoffUses(ReservedSpace, /* IsPhi */ true);
 }
 
 /// hasConstantValue - If the specified PHI node always merges together the same
@@ -4076,7 +4076,7 @@ SwitchInst::SwitchInst(Value *Value, BasicBlock *Default, unsigned NumCases,
                        InsertPosition InsertBefore)
     : Instruction(Type::getVoidTy(Value->getContext()), Instruction::Switch,
                   AllocMarker, InsertBefore) {
-  init(Value, Default, 2 + NumCases);
+  init(Value, Default, 2+NumCases*2);
 }
 
 SwitchInst::SwitchInst(const SwitchInst &SI)
@@ -4084,12 +4084,10 @@ SwitchInst::SwitchInst(const SwitchInst &SI)
   init(SI.getCondition(), SI.getDefaultDest(), SI.getNumOperands());
   setNumHungOffUseOperands(SI.getNumOperands());
   Use *OL = getOperandList();
-  ConstantInt **VL = case_values();
   const Use *InOL = SI.getOperandList();
-  ConstantInt *const *InVL = SI.case_values();
-  for (unsigned i = 2, E = SI.getNumOperands(); i != E; ++i) {
+  for (unsigned i = 2, E = SI.getNumOperands(); i != E; i += 2) {
     OL[i] = InOL[i];
-    VL[i - 2] = InVL[i - 2];
+    OL[i+1] = InOL[i+1];
   }
   SubclassOptionalData = SI.SubclassOptionalData;
 }
@@ -4099,11 +4097,11 @@ SwitchInst::SwitchInst(const SwitchInst &SI)
 void SwitchInst::addCase(ConstantInt *OnVal, BasicBlock *Dest) {
   unsigned NewCaseIdx = getNumCases();
   unsigned OpNo = getNumOperands();
-  if (OpNo + 1 > ReservedSpace)
+  if (OpNo+2 > ReservedSpace)
     growOperands();  // Get more space!
   // Initialize some new operands.
-  assert(OpNo < ReservedSpace && "Growing didn't work!");
-  setNumHungOffUseOperands(OpNo + 1);
+  assert(OpNo+1 < ReservedSpace && "Growing didn't work!");
+  setNumHungOffUseOperands(OpNo+2);
   CaseHandle Case(this, NewCaseIdx);
   Case.setValue(OnVal);
   Case.setSuccessor(Dest);
@@ -4114,22 +4112,21 @@ void SwitchInst::addCase(ConstantInt *OnVal, BasicBlock *Dest) {
 SwitchInst::CaseIt SwitchInst::removeCase(CaseIt I) {
   unsigned idx = I->getCaseIndex();
 
-  assert(2 + idx < getNumOperands() && "Case index out of range!!!");
+  assert(2 + idx*2 < getNumOperands() && "Case index out of range!!!");
 
   unsigned NumOps = getNumOperands();
   Use *OL = getOperandList();
-  ConstantInt **VL = case_values();
 
   // Overwrite this case with the end of the list.
-  if (2 + idx + 1 != NumOps) {
-    OL[2 + idx] = OL[NumOps - 1];
-    VL[idx] = VL[NumOps - 2 - 1];
+  if (2 + (idx + 1) * 2 != NumOps) {
+    OL[2 + idx * 2] = OL[NumOps - 2];
+    OL[2 + idx * 2 + 1] = OL[NumOps - 1];
   }
 
   // Nuke the last value.
-  OL[NumOps - 1].set(nullptr);
-  VL[NumOps - 2 - 1] = nullptr;
-  setNumHungOffUseOperands(NumOps - 1);
+  OL[NumOps-2].set(nullptr);
+  OL[NumOps-2+1].set(nullptr);
+  setNumHungOffUseOperands(NumOps-2);
 
   return CaseIt(this, idx);
 }
@@ -4142,7 +4139,7 @@ void SwitchInst::growOperands() {
   unsigned NumOps = e*3;
 
   ReservedSpace = NumOps;
-  growHungoffUses(ReservedSpace, /*WithExtraValues=*/true);
+  growHungoffUses(ReservedSpace);
 }
 
 void SwitchInstProfUpdateWrapper::init() {

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3424,7 +3424,7 @@ void Verifier::visitSwitchInst(SwitchInst &SI) {
   Type *SwitchTy = SI.getCondition()->getType();
   SmallPtrSet<ConstantInt*, 32> Constants;
   for (auto &Case : SI.cases()) {
-    Check(isa<ConstantInt>(Case.getCaseValue()),
+    Check(isa<ConstantInt>(SI.getOperand(Case.getCaseIndex() * 2 + 2)),
           "Case value is not a constant integer.", &SI);
     Check(Case.getCaseValue()->getType() == SwitchTy,
           "Switch constants must all be same type as switch value!", &SI);

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -968,29 +968,6 @@ TEST(InstructionsTest, SwitchInst) {
   const auto &Handle = *CCI;
   EXPECT_EQ(1, Handle.getCaseValue()->getSExtValue());
   EXPECT_EQ(BB1.get(), Handle.getCaseSuccessor());
-
-  // C API tests.
-  EXPECT_EQ(BB0.get(), unwrap(LLVMGetSwitchDefaultDest(wrap(SI))));
-  EXPECT_EQ(BB0.get(), unwrap(LLVMGetSuccessor(wrap(SI), 0)));
-  EXPECT_EQ(BB1.get(), unwrap(LLVMGetSuccessor(wrap(SI), 1)));
-  EXPECT_EQ(
-      1,
-      unwrap<ConstantInt>(LLVMGetSwitchCaseValue(wrap(SI), 1))->getSExtValue());
-  EXPECT_EQ(BB2.get(), unwrap(LLVMGetSuccessor(wrap(SI), 2)));
-  EXPECT_EQ(
-      2,
-      unwrap<ConstantInt>(LLVMGetSwitchCaseValue(wrap(SI), 2))->getSExtValue());
-  EXPECT_EQ(BB3.get(), unwrap(LLVMGetSuccessor(wrap(SI), 3)));
-  EXPECT_EQ(
-      3,
-      unwrap<ConstantInt>(LLVMGetSwitchCaseValue(wrap(SI), 3))->getSExtValue());
-  // Test case value modification. The C API provides case value indices
-  // matching the successor indices.
-  LLVMSetSwitchCaseValue(wrap(SI), 2, wrap(ConstantInt::get(Int32Ty, 12)));
-  EXPECT_EQ(12, (SI->case_begin() + 1)->getCaseValue()->getSExtValue());
-  EXPECT_EQ(
-      12,
-      unwrap<ConstantInt>(LLVMGetSwitchCaseValue(wrap(SI), 2))->getSExtValue());
 }
 
 TEST(InstructionsTest, SwitchInstProfUpdateWrapper) {

--- a/llvm/unittests/IR/VerifierTest.cpp
+++ b/llvm/unittests/IR/VerifierTest.cpp
@@ -329,6 +329,9 @@ TEST(VerifierTest, SwitchInst) {
   Switch->addCase(ConstantInt::get(Int32Ty, 2), OnTwo);
 
   EXPECT_FALSE(verifyFunction(*F));
+  // set one case value to function argument.
+  Switch->setOperand(2, F->getArg(1));
+  EXPECT_TRUE(verifyFunction(*F));
 }
 
 TEST(VerifierTest, CrossFunctionRef) {


### PR DESCRIPTION
Reverts llvm/llvm-project#166842

Breaks Mips LLVM tests, and LLD on bots.
See llvm/llvm-project#166842