### PR TITLE
[clang-tidy] Show correct diff instructions when check_alphabetical_order.py fails

### DIFF
--- a/clang-tools-extra/test/clang-tidy/infrastructure/alphabetical-order.test
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/alphabetical-order.test
@@ -1,5 +1,5 @@
 // RUN: %python %S/../../../clang-tidy/tool/check_alphabetical_order.py -o %t.clang-tidy-checks-list.rst
-// RUN: diff --strip-trailing-cr %t.clang-tidy-checks-list.rst %S/../../../docs/clang-tidy/checks/list.rst
+// RUN: diff --strip-trailing-cr %S/../../../docs/clang-tidy/checks/list.rst %t.clang-tidy-checks-list.rst
 
 // RUN: %python %S/../../../clang-tidy/tool/check_alphabetical_order.py -o %t.ReleaseNotes.rst
-// RUN: diff --strip-trailing-cr %t.ReleaseNotes.rst %S/../../../docs/ReleaseNotes.rst
+// RUN: diff --strip-trailing-cr %S/../../../docs/ReleaseNotes.rst %t.ReleaseNotes.rst


### PR DESCRIPTION
Before the change, when given such incorrect ordering:
```
   :doc:`modernize-use-designated-initializers <modernize/use-designated-initializers>`, "Yes"
   :doc:`modernize-use-equals-default <modernize/use-equals-default>`, "Yes"
   :doc:`modernize-use-emplace <modernize/use-emplace>`, "Yes"
   :doc:`modernize-use-equals-delete <modernize/use-equals-delete>`, "Yes"
   :doc:`modernize-use-integer-sign-comparison <modernize/use-integer-sign-comparison>`, "Yes"
```
Script output suggested removing `modernize-use-equals-default` line that came after `modernize-use-emplace` but in my actual file, we can see that current ordering is different (same as 2nd part of the diff):
```
# |      :doc:`modernize-use-constraints <modernize/use-constraints>`, "Yes"
# |      :doc:`modernize-use-default-member-init <modernize/use-default-member-init>`, "Yes"
# |      :doc:`modernize-use-designated-initializers <modernize/use-designated-initializers>`, "Yes"
# |      :doc:`modernize-use-emplace <modernize/use-emplace>`, "Yes"
# | -    :doc:`modernize-use-equals-default <modernize/use-equals-default>`, "Yes"
# |      :doc:`modernize-use-equals-delete <modernize/use-equals-delete>`, "Yes"
# |      :doc:`modernize-use-integer-sign-comparison <modernize/use-integer-sign-comparison>`, "Yes"
# |      :doc:`modernize-use-nodiscard <modernize/use-nodiscard>`, "Yes"
# | --- 316,323 ----
# |      :doc:`modernize-use-constraints <modernize/use-constraints>`, "Yes"
# |      :doc:`modernize-use-default-member-init <modernize/use-default-member-init>`, "Yes"
# |      :doc:`modernize-use-designated-initializers <modernize/use-designated-initializers>`, "Yes"
# | +    :doc:`modernize-use-equals-default <modernize/use-equals-default>`, "Yes"
# |      :doc:`modernize-use-emplace <modernize/use-emplace>`, "Yes"
# |      :doc:`modernize-use-equals-delete <modernize/use-equals-delete>`, "Yes"
```

We need to invert the diff, so the user can correctly follow its recommendations.
