### PR TITLE
[InstCombine] Preserve range information for `Op0 -nsw umin(X, Op0) --> usub.sat(Op0, X)`

### DIFF
--- a/llvm/test/Transforms/InstCombine/sub-minmax.ll
+++ b/llvm/test/Transforms/InstCombine/sub-minmax.ll
@@ -666,7 +666,7 @@ define i8 @umin_sub_op0_use(i8 %x, i8 %y) {
 define i8 @umin_nsw_sub_op1_rhs_nneg_constant(i8 %y) {
 ; CHECK-LABEL: define {{[^@]+}}@umin_nsw_sub_op1_rhs_nneg_constant
 ; CHECK-SAME: (i8 [[Y:%.*]]) {
-; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.usub.sat.i8(i8 [[Y]], i8 13)
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.usub.sat.i8(i8 range(i8 -115, -128) [[Y]], i8 13)
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %u = call i8 @llvm.umin.i8(i8 %y, i8 13)

--- a/llvm/test/Transforms/InstCombine/sub-minmax.ll
+++ b/llvm/test/Transforms/InstCombine/sub-minmax.ll
@@ -663,6 +663,28 @@ define i8 @umin_sub_op0_use(i8 %x, i8 %y) {
   ret i8 %r
 }
 
+define i8 @umin_nsw_sub_op1_rhs_nneg_constant(i8 %y) {
+; CHECK-LABEL: define {{[^@]+}}@umin_nsw_sub_op1_rhs_nneg_constant
+; CHECK-SAME: (i8 [[Y:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.usub.sat.i8(i8 [[Y]], i8 13)
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %u = call i8 @llvm.umin.i8(i8 %y, i8 13)
+  %r = sub nsw i8 %y, %u
+  ret i8 %r
+}
+
+define i8 @umin_nsw_sub_op1_rhs_neg_constant(i8 %y) {
+; CHECK-LABEL: define {{[^@]+}}@umin_nsw_sub_op1_rhs_neg_constant
+; CHECK-SAME: (i8 [[Y:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.usub.sat.i8(i8 [[Y]], i8 -13)
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %u = call i8 @llvm.umin.i8(i8 %y, i8 -13)
+  %r = sub nsw i8 %y, %u
+  ret i8 %r
+}
+
 ;
 ; sub(add(X,Y), s/umin(X,Y)) --> s/umax(X,Y)
 ; sub(add(X,Y), s/umax(X,Y)) --> s/umin(X,Y)


### PR DESCRIPTION
This implements the first part discussed in https://github.com/llvm/llvm-project/issues/168880.
Alive2: https://alive2.llvm.org/ce/z/CXAcff

For `umin(X, Op0) - Op0` we can also preserve the information implied by the nsw flag. But it is a bit more complicated and doesn't benefit real-world cases (See https://github.com/dtcxzyw/llvm-opt-benchmark/issues/3123 and https://github.com/dtcxzyw/llvm-opt-benchmark/issues/3122).
