### PR TITLE
[RISCV] Add Propeller support for RISC-V

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6098,7 +6098,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (Arg *A = Args.getLastArg(options::OPT_fbasic_block_address_map,
                                options::OPT_fno_basic_block_address_map)) {
-    if ((Triple.isX86() || Triple.isAArch64()) && Triple.isOSBinFormatELF()) {
+    if ((Triple.isX86() || Triple.isAArch64() || Triple.isRISCV()) && Triple.isOSBinFormatELF()) {
       if (A->getOption().matches(options::OPT_fbasic_block_address_map))
         A->render(Args, CmdArgs);
     } else {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6128,6 +6128,13 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
             << A->getAsString(Args) << A->getValue();
       else
         A->render(Args, CmdArgs);
+    } else if (Triple.isRISCV() && Triple.isOSBinFormatELF()) {
+      // Add RISC-V support for basic block sections
+      if (Val != "labels" && Val != "none" && !Val.starts_with("list="))
+        D.Diag(diag::err_drv_invalid_value)
+            << A->getAsString(Args) << A->getValue();
+      else
+        A->render(Args, CmdArgs);
     } else if (Triple.isNVPTX()) {
       // Do not pass the option to the GPU compilation. We still want it enabled
       // for the host-side compilation, so seeing it here is not an error.

--- a/clang/test/Driver/basic-block-address-map.c
+++ b/clang/test/Driver/basic-block-address-map.c
@@ -1,5 +1,6 @@
 // RUN: %clang -### --target=x86_64 -fbasic-block-address-map %s -S 2>&1 | FileCheck -check-prefix=CHECK-PRESENT %s
 // RUN: %clang -### --target=aarch64 -fbasic-block-address-map %s -S 2>&1 | FileCheck -check-prefix=CHECK-PRESENT %s
+// RUN: %clang -### --target=riscv64 -fbasic-block-address-map %s -S 2>&1 | FileCheck -check-prefix=CHECK-PRESENT %s
 // CHECK-PRESENT: -fbasic-block-address-map
 
 // RUN: %clang -### --target=x86_64 -fno-basic-block-address-map %s -S 2>&1 | FileCheck %s --check-prefix=CHECK-ABSENT

--- a/clang/test/Driver/fbasic-block-sections.c
+++ b/clang/test/Driver/fbasic-block-sections.c
@@ -9,6 +9,11 @@
 // RUN: not %clang -c --target=arm-unknown-linux -fbasic-block-sections=all %s -S 2>&1 | FileCheck -check-prefix=CHECK-TRIPLE %s
 // RUN: %clang -### --target=arm-unknown-linux -fbasic-block-sections=all -fbasic-block-sections=none %s -S 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NOOPT %s
+// RUN: %clang -### --target=riscv64 -fbasic-block-sections=none %s -S 2>&1 | FileCheck -check-prefix=CHECK-OPT-NONE %s
+// RUN: %clang -### --target=riscv64 -fbasic-block-sections=list=%s %s -S 2>&1 | FileCheck -check-prefix=CHECK-OPT-LIST %s
+// RUN: %clang -### --target=riscv64 -fbasic-block-sections=labels %s -S 2>&1 | FileCheck -check-prefix=CHECK-OPT-LABELS %s
+// RUN: not %clang -### --target=riscv64 -fbasic-block-sections=all %s -S 2>&1 | FileCheck -check-prefix=CHECK-INVALID-VALUE %s
+// RUN: not %clang -c --target=riscv64-unknown-linux -fbasic-block-sections=all %s -S 2>&1 | FileCheck -check-prefix=CHECK-INVALID-VALUE %s
 // RUN: not %clang -c --target=x86_64-apple-darwin10 -fbasic-block-sections=all %s -S 2>&1 | FileCheck -check-prefix=CHECK-TRIPLE %s
 // RUN: not %clang -### --target=x86_64 -fbasic-block-sections=alll %s -S 2>&1 | FileCheck -check-prefix=CHECK-INVALID-VALUE %s
 // RUN: not %clang -### --target=x86_64 -fbasic-block-sections=list %s -S 2>&1 | FileCheck -check-prefix=CHECK-INVALID-VALUE %s

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -93,11 +93,12 @@ void RISCVInstrInfo::insertNoop(MachineBasicBlock &MBB,
                                 MachineBasicBlock::iterator MI) const {
   DebugLoc DL;
   if (STI.hasStdExtZca())
-    BuildMI(MBB, MI, DL, get(RISCV::C_NOP));;
-  BuildMI(MBB, MI, DL, get(RISCV::ADDI))
-      .addReg(RISCV::X0)
-      .addReg(RISCV::X0)
-      .addImm(0);
+    BuildMI(MBB, MI, DL, get(RISCV::C_NOP));
+  else
+    BuildMI(MBB, MI, DL, get(RISCV::ADDI))
+        .addReg(RISCV::X0)
+        .addReg(RISCV::X0)
+        .addImm(0);
 }
 
 MCInst RISCVInstrInfo::getNop() const {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -92,6 +92,8 @@ RISCVInstrInfo::RISCVInstrInfo(const RISCVSubtarget &STI)
 void RISCVInstrInfo::insertNoop(MachineBasicBlock &MBB,
                                 MachineBasicBlock::iterator MI) const {
   DebugLoc DL;
+  if (STI.hasStdExtZca())
+    BuildMI(MBB, MI, DL, get(RISCV::C_NOP));;
   BuildMI(MBB, MI, DL, get(RISCV::ADDI))
       .addReg(RISCV::X0)
       .addReg(RISCV::X0)

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -89,6 +89,15 @@ RISCVInstrInfo::RISCVInstrInfo(const RISCVSubtarget &STI)
 #define GET_INSTRINFO_HELPERS
 #include "RISCVGenInstrInfo.inc"
 
+void RISCVInstrInfo::insertNoop(MachineBasicBlock &MBB,
+                                MachineBasicBlock::iterator MI) const {
+  DebugLoc DL;
+  BuildMI(MBB, MI, DL, get(RISCV::ADDI))
+      .addReg(RISCV::X0)
+      .addReg(RISCV::X0)
+      .addImm(0);
+}
+
 MCInst RISCVInstrInfo::getNop() const {
   if (STI.hasStdExtZca())
     return MCInstBuilder(RISCV::C_NOP);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -86,6 +86,9 @@ public:
 
   const RISCVRegisterInfo &getRegisterInfo() const { return RegInfo; }
 
+  void insertNoop(MachineBasicBlock &MBB,
+                  MachineBasicBlock::iterator MI) const override;
+
   MCInst getNop() const override;
 
   Register isLoadFromStackSlot(const MachineInstr &MI,


### PR DESCRIPTION
## Summary
This PR adds Propeller optimization framework support to the RISC-V backend.

## Motivation
Currently, LLVM's Propeller is only supported on x86 and aarch64. This limits profile-guided 
optimizations for RISC-V targets. This patch extends Propeller support to RISC-V.