### PR TITLE
[MLIR][Spirv] Don't lower tensors that can't be represented by an ArrayType

### DIFF
--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -502,6 +502,11 @@ static Type convertTensorType(const spirv::TargetEnv &targetEnv,
                << type << " illegal: cannot handle zero-element tensors\n");
     return nullptr;
   }
+  if (arrayElemCount > std::numeric_limits<unsigned>::max()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << type << " illegal: cannot fit tensor into target type\n");
+    return nullptr;
+  }
 
   Type arrayElemType = convertScalarType(targetEnv, options, scalarType);
   if (!arrayElemType)

--- a/mlir/test/Conversion/TensorToSPIRV/tensor-ops-to-spirv.mlir
+++ b/mlir/test/Conversion/TensorToSPIRV/tensor-ops-to-spirv.mlir
@@ -79,3 +79,12 @@ func.func @tensor_2d_empty() -> () {
   %x = arith.constant dense<> : tensor<2x0xi32>
   return
 }
+
+// Tensors with more than UINT32_MAX elements cannnot fit in a spirv.array.
+// Test that they are not lowered.
+// CHECK-LABEL: func @very_large_tensor
+// CHECK-NEXT:    arith.constant dense<1>
+func.func @very_large_tensor() -> () {
+  %x = arith.constant dense<1> : tensor<4294967296xi32>
+  return
+}


### PR DESCRIPTION
I noticed this because of https://github.com/llvm/llvm-project/issues/159738, though it was only caught by his fuzzer because it wrapped to 0.
Also, is there a reason for the usage of `unsigned` for sizes in spirv types? I believe most of the builtin types use `int64_t` for sizes, so it may make sense to do the same for spirv.