### PR TITLE
[LLVM][ADT] Add helper class for working with caches

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -2610,6 +2610,30 @@ template <typename T> using has_sizeof = decltype(sizeof(T));
 template <typename T>
 constexpr bool is_incomplete_v = !is_detected<detail::has_sizeof, T>::value;
 
+/// A utility for working with maps that allows concisely expressing "perform
+/// and cache this expensive computation only if it isn't already cached".
+/// Use it like so:
+///
+/// ```cpp
+/// std::unordered_map<K, V> Cache;
+/// auto& Value = Cache.try_emplace(
+///     Key, llvm::defer {[] { /* heavy work */ }}).first->second;
+/// ```
+template <typename FnT> class defer {
+public:
+  constexpr defer(FnT &&F LLVM_LIFETIME_BOUND) : Fn(std::forward<FnT>(F)) {}
+
+  template <typename T> constexpr operator T() {
+    return std::forward<FnT>(Fn)();
+  }
+
+private:
+  FnT &&Fn;
+};
+
+// Silence -Wctad-maybe-unsupported.
+template <typename FnT> defer(FnT &&) -> defer<FnT>;
+
 } // end namespace llvm
 
 namespace std {

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1699,4 +1699,15 @@ struct Bar {};
 static_assert(is_incomplete_v<Foo>, "Foo is incomplete");
 static_assert(!is_incomplete_v<Bar>, "Bar is defined");
 
+TEST(STLExtrasTest, Defer) {
+  std::unordered_map<int, int> Cache;
+  const auto [It, Inserted]{Cache.try_emplace(1, defer{[] { return 10; }})};
+  ASSERT_TRUE(Inserted);
+  ASSERT_EQ(It->second, 10);
+  Cache.try_emplace(1, defer{[] {
+                      assert(false && "this should never be executed");
+                      return 0;
+                    }});
+}
+
 } // namespace


### PR DESCRIPTION
See the doc comment for how it works.

I'm planning to use this in an upcoming refactor of [this function](https://github.com/llvm/llvm-project/blob/315c904e3e1c00ea1ec7f0757e4c538ec2513624/clang-tools-extra/clang-tidy/fuchsia/MultipleInheritanceCheck.cpp#L65). Here's [another, completely unrelated function](https://github.com/llvm/llvm-project/blob/315c904e3e1c00ea1ec7f0757e4c538ec2513624/clang/lib/Tooling/Inclusions/Stdlib/StandardLibrary.cpp#L253) it could simplify; this seems like a generally useful feature.