### PR TITLE
[clang] Fix string literal parsing on some attributes

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2117,7 +2117,7 @@ private:
 
   ExprResult ParseUnevaluatedStringInAttribute(const IdentifierInfo &AttrName);
 
-  bool parseAttributeArgumentList(
+  bool ParseAttributeArgumentList(
       const IdentifierInfo &AttrName, SmallVectorImpl<Expr *> &Exprs,
       ParsedAttributeArgumentsProperties ArgsProperties, unsigned Arg);
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2117,10 +2117,9 @@ private:
 
   ExprResult ParseUnevaluatedStringInAttribute(const IdentifierInfo &AttrName);
 
-  bool
-  ParseAttributeArgumentList(const clang::IdentifierInfo &AttrName,
-                             SmallVectorImpl<Expr *> &Exprs,
-                             ParsedAttributeArgumentsProperties ArgsProperties);
+  bool parseAttributeArgumentList(
+      const IdentifierInfo &AttrName, SmallVectorImpl<Expr *> &Exprs,
+      ParsedAttributeArgumentsProperties ArgsProperties, unsigned Arg);
 
   /// Parses syntax-generic attribute arguments for attributes which are
   /// known to the implementation, and adds them to the given ParsedAttributes

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2117,6 +2117,11 @@ private:
 
   ExprResult ParseUnevaluatedStringInAttribute(const IdentifierInfo &AttrName);
 
+  /// Parses a comma-delimited list of arguments of an attribute \p AttrName,
+  /// filling \p Exprs. \p ArgsProperties specifies which of the arguments
+  /// should be parsed as unevaluated string literals. \p Arg is the number
+  /// of arguments parsed before calling / this function (the index of the
+  /// argument to be parsed next).
   bool ParseAttributeArgumentList(
       const IdentifierInfo &AttrName, SmallVectorImpl<Expr *> &Exprs,
       ParsedAttributeArgumentsProperties ArgsProperties, unsigned Arg);

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -421,11 +421,10 @@ Parser::ParseUnevaluatedStringInAttribute(const IdentifierInfo &AttrName) {
   return ParseUnevaluatedStringLiteralExpression();
 }
 
-bool Parser::ParseAttributeArgumentList(
+bool Parser::parseAttributeArgumentList(
     const IdentifierInfo &AttrName, SmallVectorImpl<Expr *> &Exprs,
-    ParsedAttributeArgumentsProperties ArgsProperties) {
+    ParsedAttributeArgumentsProperties ArgsProperties, unsigned Arg) {
   bool SawError = false;
-  unsigned Arg = 0;
   while (true) {
     ExprResult Expr;
     if (ArgsProperties.isStringLiteralArg(Arg)) {
@@ -580,7 +579,8 @@ unsigned Parser::ParseAttributeArgsCommon(
       ParsedAttributeArgumentsProperties ArgProperties =
           attributeStringLiteralListArg(getTargetInfo().getTriple(), *AttrName,
                                         Form.getSyntax(), ScopeName);
-      if (ParseAttributeArgumentList(*AttrName, ParsedExprs, ArgProperties)) {
+      if (parseAttributeArgumentList(*AttrName, ParsedExprs, ArgProperties,
+                                     ArgExprs.size())) {
         SkipUntil(tok::r_paren, StopAtSemi);
         return 0;
       }

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -421,7 +421,7 @@ Parser::ParseUnevaluatedStringInAttribute(const IdentifierInfo &AttrName) {
   return ParseUnevaluatedStringLiteralExpression();
 }
 
-bool Parser::parseAttributeArgumentList(
+bool Parser::ParseAttributeArgumentList(
     const IdentifierInfo &AttrName, SmallVectorImpl<Expr *> &Exprs,
     ParsedAttributeArgumentsProperties ArgsProperties, unsigned Arg) {
   bool SawError = false;
@@ -579,7 +579,7 @@ unsigned Parser::ParseAttributeArgsCommon(
       ParsedAttributeArgumentsProperties ArgProperties =
           attributeStringLiteralListArg(getTargetInfo().getTriple(), *AttrName,
                                         Form.getSyntax(), ScopeName);
-      if (parseAttributeArgumentList(*AttrName, ParsedExprs, ArgProperties,
+      if (ParseAttributeArgumentList(*AttrName, ParsedExprs, ArgProperties,
                                      ArgExprs.size())) {
         SkipUntil(tok::r_paren, StopAtSemi);
         return 0;

--- a/clang/test/Sema/attr-modular-format.c
+++ b/clang/test/Sema/attr-modular-format.c
@@ -3,6 +3,10 @@
 int printf(const char *fmt, ...)  __attribute__((modular_format(__modular_printf, "__printf", "float")));  // no-error
 int myprintf(const char *fmt, ...)  __attribute__((modular_format(__modular_printf, "__printf", "float")));  // expected-error {{'modular_format' attribute requires 'format' attribute}}
 
+int lprintf(const char *fmt, ...) __attribute__((modular_format(__modular_printf, L"__printf", L"float"), format(printf, 1, 2)));
+// expected-error@-1 {{'modular_format' attribute requires a string}}
+// expected-warning@-2 {{encoding prefix 'L' on an unevaluated string literal has no effect}}
+
 int dupe(const char *fmt, ...)  __attribute__((modular_format(__modular_printf, "__printf", "float", "int", "float"), format(printf, 1, 2))); // expected-error {{duplicate aspect 'float' in 'modular_format' attribute}}
 int multi_dupe(const char *fmt, ...)  __attribute__((modular_format(__modular_printf, "__printf", "float", "int", "float", "int"), format(printf, 1, 2))); // expected-error {{duplicate aspect 'float' in 'modular_format' attribute}} \
                                                                                                                                                                  // expected-error {{duplicate aspect 'int' in 'modular_format' attribute}}

--- a/clang/test/Sema/attr-modular-format.c
+++ b/clang/test/Sema/attr-modular-format.c
@@ -4,8 +4,7 @@ int printf(const char *fmt, ...)  __attribute__((modular_format(__modular_printf
 int myprintf(const char *fmt, ...)  __attribute__((modular_format(__modular_printf, "__printf", "float")));  // expected-error {{'modular_format' attribute requires 'format' attribute}}
 
 int lprintf(const char *fmt, ...) __attribute__((modular_format(__modular_printf, L"__printf", L"float"), format(printf, 1, 2)));
-// expected-error@-1 {{'modular_format' attribute requires a string}}
-// expected-warning@-2 {{encoding prefix 'L' on an unevaluated string literal has no effect}}
+// expected-warning@-1 2{{encoding prefix 'L' on an unevaluated string literal has no effect}}
 
 int dupe(const char *fmt, ...)  __attribute__((modular_format(__modular_printf, "__printf", "float", "int", "float"), format(printf, 1, 2))); // expected-error {{duplicate aspect 'float' in 'modular_format' attribute}}
 int multi_dupe(const char *fmt, ...)  __attribute__((modular_format(__modular_printf, "__printf", "float", "int", "float", "int"), format(printf, 1, 2))); // expected-error {{duplicate aspect 'float' in 'modular_format' attribute}} \


### PR DESCRIPTION
At the time ParseAttributeArgumentList is called, the first argument
of an attribute may have already been parsed. We need to take this into
account when accessing ParsedAttributeArgumentsProperties mask, which
specifies which of the attribute arguments are string literals.
