### PR TITLE
Fix char traits eq hide from abi

### DIFF
--- a/libcxx/include/__string/char_traits.h
+++ b/libcxx/include/__string/char_traits.h
@@ -93,7 +93,6 @@ struct char_traits<char> {
     __c1 = __c2;
   }
 
-  // TODO: Make this _LIBCPP_HIDE_FROM_ABI
   static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool eq(char_type __c1, char_type __c2) _NOEXCEPT {
     return __c1 == __c2;
   }

--- a/libcxx/include/__string/char_traits.h
+++ b/libcxx/include/__string/char_traits.h
@@ -94,7 +94,7 @@ struct char_traits<char> {
   }
 
   // TODO: Make this _LIBCPP_HIDE_FROM_ABI
-  static inline _LIBCPP_HIDDEN _LIBCPP_CONSTEXPR bool eq(char_type __c1, char_type __c2) _NOEXCEPT {
+  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool eq(char_type __c1, char_type __c2) _NOEXCEPT {
     return __c1 == __c2;
   }
   static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool lt(char_type __c1, char_type __c2) _NOEXCEPT {


### PR DESCRIPTION
[libcxx] Replace _LIBCPP_HIDDEN with _LIBCPP_HIDE_FROM_ABI in char_traits::eq

This removes the TODO comment and makes the eq function consistent
with the lt function below it, which already uses _LIBCPP_HIDE_FROM_ABI.