### PR TITLE
[mlir][emitc] Fix bug in dereference translation

### DIFF
--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -333,7 +333,8 @@ private:
 
 /// Determine whether expression \p op should be emitted in a deferred way.
 static bool hasDeferredEmission(Operation *op) {
-  return isa_and_nonnull<emitc::GetGlobalOp, emitc::LiteralOp, emitc::MemberOp,
+  return isa_and_nonnull<emitc::DereferenceOp, emitc::GetGlobalOp,
+                         emitc::LiteralOp, emitc::MemberOp,
                          emitc::MemberOfPtrOp, emitc::SubscriptOp,
                          emitc::GetFieldOp>(op);
 }

--- a/mlir/test/Target/Cpp/common-cpp.mlir
+++ b/mlir/test/Target/Cpp/common-cpp.mlir
@@ -118,7 +118,7 @@ func.func @address_of() {
 // CHECK-LABEL: void dereference
 // CHECK-SAME:                   (int32_t* [[ARG0:[^ ]*]]) {
 func.func @dereference(%arg0: !emitc.ptr<i32>) {
-  // CHECK: int32_t [[V1:[^ ]*]] = *[[ARG0]];
+  // CHECK-NEXT: int32_t [[V1:[^ ]*]] = *[[ARG0]];
   %2 = emitc.dereference %arg0 : !emitc.ptr<i32>
   emitc.load %2 : !emitc.lvalue<i32>
   return


### PR DESCRIPTION
The op was not added to `hasDeferredEmission()` when introduced by f17abc280c70, causing incorrect translation.