### PR TITLE
[clang-tidy] Fix fragile test in `read-parameters-from-file`

### DIFF
--- a/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/param/parameters.txt
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/param/parameters.txt
@@ -1,2 +1,2 @@
--checks='-*,llvm-namespace-comment'
+-checks=-*,llvm-namespace-comment
 --warnings-as-errors=llvm-namespace-comment


### PR DESCRIPTION
[CommandLine.cpp](https://github.com/llvm/llvm-project/blob/fb0400fe1f1f9e83f3148db8ce2c72ab5bc6728e/llvm/lib/Support/CommandLine.cpp#L940) treats single quote as literal characters on Windows, so the argument is parsed as a check named `' -*,llvm-namespace-comment '`, which matches no existing checks, so no checks are enabled via the command line.

Previously, the test passed because it fell back to the root `.clang-tidy` configuration which enables `llvm-*`.