### PR TITLE
[libc++] remove yield from timed_backoff_policy

### DIFF
--- a/libcxx/include/__thread/timed_backoff_policy.h
+++ b/libcxx/include/__thread/timed_backoff_policy.h
@@ -29,8 +29,6 @@ struct __libcpp_timed_backoff_policy {
       __libcpp_thread_sleep_for(chrono::milliseconds(8));
     else if (__elapsed > chrono::microseconds(64))
       __libcpp_thread_sleep_for(__elapsed / 2);
-    else if (__elapsed > chrono::microseconds(4))
-      __libcpp_thread_yield();
     else {
     } // poll
     return false;


### PR DESCRIPTION
hmm. one of the test that is impacted is lost_wake_up test  for semaphore (which ueses std::barrier).  but that test will become irrelevant after
https://github.com/llvm/llvm-project/pull/171041

for this patch, here are some stats for the CI runner

Linux 

before
```
43.34s: llvm-libc++-shared.cfg.in :: std/thread/thread.semaphore/lost_wakeup.pass.cpp
```

after 
```
108.76s: llvm-libc++-shared.cfg.in :: std/thread/thread.semaphore/lost_wakeup.pass.cpp
```


macOS

before
```
475.32s: llvm-libc++-shared.cfg.in :: std/thread/thread.semaphore/lost_wakeup.pass.cpp
```
after
```
248.71s: llvm-libc++-shared.cfg.in :: std/thread/thread.semaphore/lost_wakeup.pass.cpp
```

windows

before
```
80.29s: llvm-libc++-shared-clangcl.cfg.in :: std/thread/thread.semaphore/lost_wakeup.pass.cpp
```

after

timeout