### PR TITLE
Fix emulated TLS alignment for large variables

### DIFF
--- a/llvm/lib/CodeGen/LowerEmuTLS.cpp
+++ b/llvm/lib/CodeGen/LowerEmuTLS.cpp
@@ -148,7 +148,7 @@ bool addEmuTlsVar(Module &M, const GlobalVariable *GV) {
     return true;
 
   Type *GVType = GV->getValueType();
-  Align GVAlignment = DL.getPreferredAlign(GV);
+  Align GVAlignment = GV->getPointerAlignment(DL);
 
   // Define "__emutls_t.*" if there is InitValue
   GlobalVariable *EmuTlsTmplVar = nullptr;

--- a/llvm/lib/CodeGen/LowerEmuTLS.cpp
+++ b/llvm/lib/CodeGen/LowerEmuTLS.cpp
@@ -148,14 +148,7 @@ bool addEmuTlsVar(Module &M, const GlobalVariable *GV) {
     return true;
 
   Type *GVType = GV->getValueType();
-  Align GVAlignment = DL.getValueOrABITypeAlignment(GV->getAlign(), GVType);
-
-  // For types larger than a vector register, use preferred alignment.
-  // This ensures the backend can use vectorized load/store instructions
-  // (e.g., memcpy of large arrays may use ARM NEON vld1.64 which requires
-  // 16-byte alignment). See https://github.com/llvm/llvm-project/issues/167219
-  if (DL.getTypeStoreSize(GVType) > 16)
-    GVAlignment = std::max(GVAlignment, DL.getPreferredAlign(GV));
+  Align GVAlignment = DL.getPreferredAlign(GV);
 
   // Define "__emutls_t.*" if there is InitValue
   GlobalVariable *EmuTlsTmplVar = nullptr;

--- a/llvm/test/CodeGen/AArch64/emutls.ll
+++ b/llvm/test/CodeGen/AArch64/emutls.ll
@@ -175,7 +175,7 @@ entry:
 ; ARM64:      .globl __emutls_v.s1
 ; ARM64-LABEL: __emutls_v.s1:
 ; ARM64-NEXT: .xword 2
-; ARM64-NEXT: .xword 2
+; ARM64-NEXT: .xword 4
 ; ARM64-NEXT: .xword 0
 ; ARM64-NEXT: .xword __emutls_t.s1
 
@@ -186,7 +186,7 @@ entry:
 ; ARM64:      .data{{$}}
 ; ARM64-LABEL: __emutls_v.b1:
 ; ARM64-NEXT: .xword 1
-; ARM64-NEXT: .xword 1
+; ARM64-NEXT: .xword 4
 ; ARM64-NEXT: .xword 0
 ; ARM64-NEXT: .xword 0
 

--- a/llvm/test/CodeGen/ARM/emutls-alignment.ll
+++ b/llvm/test/CodeGen/ARM/emutls-alignment.ll
@@ -1,0 +1,20 @@
+; RUN: llc -emulated-tls -mtriple=armv7-linux-android -relocation-model=pic < %s | FileCheck %s
+
+; Test that emulated TLS uses preferred alignment for variables.
+; This fixes a bug where emutls would use lower alignment than expected
+; by the code generator, causing crashes with vectorized accesses.
+; Fixes https://github.com/llvm/llvm-project/issues/167219
+
+; A 64-byte array should get 16-byte alignment (preferred for ARM NEON).
+@large_array = internal thread_local global [64 x i8] c"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+define ptr @get_large_array() {
+entry:
+  ret ptr @large_array
+}
+
+; CHECK-LABEL: __emutls_v.large_array:
+; CHECK-NEXT:   .long 64
+; CHECK-NEXT:   .long 16
+; CHECK-NEXT:   .long 0
+; CHECK-NEXT:   .long __emutls_t.large_array


### PR DESCRIPTION
Fix emulated TLS alignment for larger variables (>= 32 bytes) to use preferred alignment.

Fixes #167219