### PR TITLE
[CodeGen][ObjC] Try/Catch support for WebAssembly

### DIFF
--- a/clang/lib/CodeGen/CGCleanup.h
+++ b/clang/lib/CodeGen/CGCleanup.h
@@ -682,6 +682,7 @@ struct EHPersonality {
   static const EHPersonality GNU_ObjC_SJLJ;
   static const EHPersonality GNU_ObjC_SEH;
   static const EHPersonality GNUstep_ObjC;
+  static const EHPersonality GNUstep_Wasm_ObjC;
   static const EHPersonality GNU_ObjCXX;
   static const EHPersonality NeXT_ObjC;
   static const EHPersonality GNU_CPlusPlus;

--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -159,9 +159,11 @@ static const EHPersonality &getObjCPersonality(const TargetInfo &Target,
   case ObjCRuntime::WatchOS:
     return EHPersonality::NeXT_ObjC;
   case ObjCRuntime::GNUstep:
+    if (CGOpts.hasWasmExceptions())
+      return EHPersonality::GNU_Wasm_CPlusPlus;
     if (T.isOSCygMing())
       return EHPersonality::GNU_CPlusPlus_SEH;
-    else if (L.ObjCRuntime.getVersion() >= VersionTuple(1, 7))
+    if (L.ObjCRuntime.getVersion() >= VersionTuple(1, 7))
       return EHPersonality::GNUstep_ObjC;
     [[fallthrough]];
   case ObjCRuntime::GCC:
@@ -218,6 +220,8 @@ static const EHPersonality &getObjCXXPersonality(const TargetInfo &Target,
     return getObjCPersonality(Target, CGOpts, L);
 
   case ObjCRuntime::GNUstep:
+    if (CGOpts.hasWasmExceptions())
+      return EHPersonality::GNU_Wasm_CPlusPlus;
     return Target.getTriple().isOSCygMing() ? EHPersonality::GNU_CPlusPlus_SEH
                                             : EHPersonality::GNU_ObjCXX;
 
@@ -1207,11 +1211,13 @@ static void emitCatchDispatchBlock(CodeGenFunction &CGF,
   }
 }
 
-void CodeGenFunction::popCatchScope() {
+llvm::BasicBlock *CodeGenFunction::popCatchScope() {
   EHCatchScope &catchScope = cast<EHCatchScope>(*EHStack.begin());
+  llvm::BasicBlock *dispatchBlock = catchScope.getCachedEHDispatchBlock();
   if (catchScope.hasEHBranches())
     emitCatchDispatchBlock(*this, catchScope);
   EHStack.popCatch();
+  return dispatchBlock;
 }
 
 void CodeGenFunction::ExitCXXTryStmt(const CXXTryStmt &S, bool IsFnTryBlock) {

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -1326,7 +1326,7 @@ public:
   /// popCatchScope - Pops the catch scope at the top of the EHScope
   /// stack, emitting any required code (other than the catch handlers
   /// themselves).
-  void popCatchScope();
+  llvm::BasicBlock* popCatchScope();
 
   llvm::BasicBlock *getEHResumeBlock(bool isCleanup);
   llvm::BasicBlock *getEHDispatchBlock(EHScopeStack::stable_iterator scope);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8638,7 +8638,8 @@ ObjCRuntime Clang::AddObjCRuntimeArgs(const ArgList &args,
     if ((runtime.getKind() == ObjCRuntime::GNUstep) &&
         (runtime.getVersion() >= VersionTuple(2, 0)))
       if (!getToolChain().getTriple().isOSBinFormatELF() &&
-          !getToolChain().getTriple().isOSBinFormatCOFF()) {
+          !getToolChain().getTriple().isOSBinFormatCOFF() &&
+          !getToolChain().getTriple().isOSBinFormatWasm()) {
         getToolChain().getDriver().Diag(
             diag::err_drv_gnustep_objc_runtime_incompatible_binary)
           << runtime.getVersion().getMajor();


### PR DESCRIPTION
Related to #169043 and part of a broader effort to support targetting WebAssembly for ObjectiveC.

This PR is work in progress and adds basic support for generating funclet-style exception handling (try/catch) for WebAssembly. For now, I've set the `gxx_wasm` personality function. I'm not entirely sure whether we need to define out own.

For these examples, the generated IR matches the IR generated from an equivalent C++ program (Aside from the exception type ID).

```
extern void might_throw(void);

void test_simple_try_catch(void) {
  @try {
    might_throw();
  } @catch (id e) {
  } @catch (id e) {
  } 
}

void test_catch_specific_type(void) {
  @try {
    might_throw();
  } @catch (id e) {
  }
}

void test_nested_try_catch(void) {
  @try {
    @try {
      might_throw();
    } @catch (id e) {
    }
  } @catch (id e) {
  }
}
```