### PR TITLE
[ADT] Add `llvm::reverse_conditionally()` iterator

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1415,6 +1415,18 @@ template <typename ContainerTy> auto make_second_range(ContainerTy &&c) {
       });
 }
 
+/// Return a range that conditionally reverses \p C. The collection is iterated
+/// in reverse if \p ShouldReverse is true (otherwise, it is iterated forwards).
+template <typename ContainerTy>
+[[nodiscard]] auto reverse_conditionally(ContainerTy &&C, bool ShouldReverse) {
+  using ForwardIteratorT = decltype(C.begin());
+  return map_range(zip_equal(reverse(C), C),
+                   [ShouldReverse](auto I) ->
+                   typename std::iterator_traits<ForwardIteratorT>::reference {
+                     return ShouldReverse ? std::get<0>(I) : std::get<1>(I);
+                   });
+}
+
 //===----------------------------------------------------------------------===//
 //     Extra additions to <utility>
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1419,10 +1419,10 @@ template <typename ContainerTy> auto make_second_range(ContainerTy &&c) {
 /// in reverse if \p ShouldReverse is true (otherwise, it is iterated forwards).
 template <typename ContainerTy>
 [[nodiscard]] auto reverse_conditionally(ContainerTy &&C, bool ShouldReverse) {
-  using ForwardIteratorT = decltype(C.begin());
+  using IterTy = detail::IterOfRange<ContainerTy>;
+  using ReferenceTy = typename std::iterator_traits<IterTy>::reference;
   return map_range(zip_equal(reverse(C), C),
-                   [ShouldReverse](auto I) ->
-                   typename std::iterator_traits<ForwardIteratorT>::reference {
+                   [ShouldReverse](auto I) -> ReferenceTy {
                      return ShouldReverse ? std::get<0>(I) : std::get<1>(I);
                    });
 }

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1693,6 +1693,30 @@ TEST(STLExtrasTest, ProductOf) {
   EXPECT_EQ(product_of(V3), 2.0f);
 }
 
+TEST(STLExtrasTest, ReverseConditionally) {
+  std::vector<char> foo = {'a', 'b', 'c'};
+
+  // Test backwards.
+  std::vector<char> ReverseResults;
+  for (char Value : llvm::reverse_conditionally(foo, /*ShouldReverse=*/true)) {
+    ReverseResults.emplace_back(Value);
+  }
+  EXPECT_THAT(ReverseResults, ElementsAre('c', 'b', 'a'));
+
+  // Test forwards.
+  std::vector<char> ForwardResults;
+  for (char Value : llvm::reverse_conditionally(foo, /*ShouldReverse=*/false)) {
+    ForwardResults.emplace_back(Value);
+  }
+  EXPECT_THAT(ForwardResults, ElementsAre('a', 'b', 'c'));
+
+  // Test modifying collection.
+  for (char &Value : llvm::reverse_conditionally(foo, /*ShouldReverse=*/true)) {
+    ++Value;
+  }
+  EXPECT_THAT(foo, ElementsAre('b', 'c', 'd'));
+}
+
 struct Foo;
 struct Bar {};
 


### PR DESCRIPTION
This patch adds a simple iterator range that allows conditionally iterating a collection in reverse. It works with any collection supported by `llvm::reverse(Collection)`.

```
void foo(bool Reverse, std::vector<int>& C) {
  for (int I : reverse_conditionally(C, Reverse)) {
    // ...
  }
}
```