### PR TITLE
[libc++] Use native wait in std::barrier instead of sleep loop

### DIFF
--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -57,8 +57,6 @@ namespace std
 #    include <__atomic/memory_order.h>
 #    include <__cstddef/ptrdiff_t.h>
 #    include <__memory/unique_ptr.h>
-#    include <__thread/poll_with_backoff.h>
-#    include <__thread/timed_backoff_policy.h>
 #    include <__utility/move.h>
 #    include <cstdint>
 #    include <limits>

--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -142,8 +142,7 @@ public:
     return __old_phase;
   }
   _LIBCPP_HIDE_FROM_ABI void wait(arrival_token&& __old_phase) const {
-    auto const __test_fn = [this, __old_phase]() -> bool { return __phase_.load(memory_order_acquire) != __old_phase; };
-    std::__libcpp_thread_poll_with_backoff(__test_fn, __libcpp_timed_backoff_policy());
+    __phase_.wait(__old_phase, std::memory_order_acquire);
   }
   _LIBCPP_HIDE_FROM_ABI void arrive_and_drop() {
     __expected_adjustment_.fetch_sub(1, memory_order_relaxed);


### PR DESCRIPTION
For some reason, the current `std::barrier`'s wait implementation polls the underlying atomic in a loop with sleeps instead of using the native wait.

Before this change, on the CI runner , lost_wakeup.pass.cpp was the slowest test , which uses `std::barrier`

===
macOS CXX23

Before:
```
475.32s: llvm-libc++-shared.cfg.in :: std/thread/thread.semaphore/lost_wakeup.pass.cpp
```

After

```
10.83s: llvm-libc++-shared.cfg.in :: std/thread/thread.semaphore/lost_wakeup.pass.cpp
```

===
Linux CXX23:

Before

```
43.34s: llvm-libc++-shared.cfg.in :: std/thread/thread.semaphore/lost_wakeup.pass.cpp
```

After:

No longer in the slowest tests list

===
Windows:

Before

```
80.29s: llvm-libc++-shared-clangcl.cfg.in :: std/thread/thread.semaphore/lost_wakeup.pass.cpp
```

After

No longer in the slowest test list


This change should also indirectly fix the performance issue of `std::barrier` described in https://github.com/llvm/llvm-project/issues/123855.

Fixes #123855