### PR TITLE
[BOLT][ICP] Propagate parent hash to newly inserted BBs for BAT

### DIFF
--- a/bolt/lib/Passes/IndirectCallPromotion.cpp
+++ b/bolt/lib/Passes/IndirectCallPromotion.cpp
@@ -780,12 +780,9 @@ IndirectCallPromotion::rewriteCall(
       TailInsts.push_back(*++TailInst);
 
   InstructionListType MovedInst = IndCallBlock.splitInstructions(&CallInst);
-  // Link new BBs to the original input offset of the indirect call site or its
-  // containing BB, so we can map samples recorded in new BBs back to the
-  // original BB seen in the input binary (if using BAT).
-  const uint32_t OrigOffset = IndirectInstrOffset
-                                  ? *IndirectInstrOffset
-                                  : IndCallBlock.getInputOffset();
+  // Link new BBs to its containing BB, so we can map samples recorded in new
+  // BBs back to the original BB seen in the input binary (if using BAT).
+  const uint32_t OrigOffset = IndCallBlock.getInputOffset();
 
   IndCallBlock.eraseInstructions(MethodFetchInsns.begin(),
                                  MethodFetchInsns.end());

--- a/bolt/test/X86/icp-inline.s
+++ b/bolt/test/X86/icp-inline.s
@@ -36,6 +36,17 @@
 # CHECK-ICP-INLINE:     callq *(%rcx,%rax,8)
 # CHECK-ICP-INLINE-NOT: callq bar
 # CHECK-ICP-INLINE:     End of Function "main"
+
+# Checks BB hash has been updated correctly after ICP optimization
+# RUN: llvm-bolt %t.exe --icp=calls --icp-calls-topn=1 --inline-small-functions\
+# RUN:   -o %t.null --lite=0 \
+# RUN:   --inline-small-functions-bytes=4 --icp-inline --print-icp \
+# RUN:   --data %t.fdata --enable-bat
+# RUN: llvm-bat-dump --dump-all %t.null | FileCheck %s --check-prefix=CHECK-BB-HASH
+# CHECK-BB-HASH: 0x17 -> 0x0 hash: 0x5b24d9a60000
+# CHECK-BB-HASH: 0x1d -> 0x0 hash: 0x5b24d9a60000
+# CHECK-BB-HASH: 0x1f -> 0x0 hash: 0x5b24d9a60000
+
   .globl bar
 bar:
 	.cfi_startproc


### PR DESCRIPTION
Currently, in BAT mode, if new BBs are added during the optimization pipeline (e.g., via ICP), their index and hash in the BAT section default to 0. The reason is that saveMetadata() executes before runOptimizationPasses() in order to get the unoptimized binary layout, and this results in incorrect information in the YAML profile (specifically duplicated zero BB index/hashes generated by [first-round bat writer](https://github.com/llvm/llvm-project/blob/llvmorg-22-init/bolt/lib/Profile/BoltAddressTranslation.cpp#L269-L274) and [continuous profile writer](  https://github.com/llvm/llvm-project/blob/llvmorg-22-init/bolt/lib/Profile/DataAggregator.cpp#L2325-L2329)), which prevents the use of the infer-stale-profile option([code](https://github.com/llvm/llvm-project/blob/llvmorg-22-init/bolt/lib/Profile/StaleProfileMatching.cpp#L645)).

So this patch tries to resolve this by updating these newly inserted BBs using the index and hash from the original BB at the insertion point (during ICP). This helps to correctly map the new blocks back to the original binary information.