### PR TITLE
[mlir][OpenMP] Fix crash in MapInfoOp conversion when type conversion fails

### DIFF
--- a/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
+++ b/mlir/lib/Conversion/OpenMPToLLVM/OpenMPToLLVM.cpp
@@ -66,6 +66,9 @@ struct OpenMPOpConversion : public ConvertOpToLLVMPattern<T> {
     for (NamedAttribute attr : op->getAttrs()) {
       if (auto typeAttr = dyn_cast<TypeAttr>(attr.getValue())) {
         Type convertedType = converter->convertType(typeAttr.getValue());
+        if (!convertedType)
+          return rewriter.notifyMatchFailure(
+              op, "failed to convert type in attribute");
         convertedAttrs.emplace_back(attr.getName(),
                                     TypeAttr::get(convertedType));
       } else {

--- a/mlir/test/Conversion/OpenMPToLLVM/map-info-type-conversion-fail.mlir
+++ b/mlir/test/Conversion/OpenMPToLLVM/map-info-type-conversion-fail.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-opt -convert-openmp-to-llvm -split-input-file -verify-diagnostics %s
+
+// Indicates that the TypeConversion has failed for the MPMapInfoOp.
+// In this specific case, the `tensor` type (used in a TypeAttr) cannot be converted
+// to an LLVM type. This test ensures that the conversion fails gracefully with a
+// legalization error instead of crashing.
+func.func @fail_map_info_tensor_type(%arg0: memref<?xf32>) {
+  // expected-error@+1 {{failed to legalize operation 'omp.map.info' that was explicitly marked illegal}}
+  %map_info = omp.map.info var_ptr(%arg0: memref<?xf32>, tensor<?xf32>) map_clauses(to) capture(ByRef) -> memref<?xf32>
+  omp.target_update map_entries(%map_info: memref<?xf32>) {
+    omp.terminator
+  }
+  return
+}


### PR DESCRIPTION
Check the result of `convertType` before calling `TypeAttr::get`. This prevents a crash on unsupported types (e.g. `tensor`) by ensuring the pattern fails gracefully.

Added regression test: map-info-type-conversion-fail.mlir

Fixes: #108159 