### PR TITLE
[DAGCombiner] Don't peek through bitcast when checking isMulAddWithConstProfitable

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -4882,8 +4882,8 @@ template <class MatchContextClass> SDValue DAGCombiner::visitMUL(SDNode *N) {
 
   // fold (mul (add x, c1), c2) -> (add (mul x, c2), c1*c2)
   if (sd_context_match(N0, Matcher, m_Opc(ISD::ADD)) &&
-      DAG.isConstantIntBuildVectorOrConstantInt(N1) &&
-      DAG.isConstantIntBuildVectorOrConstantInt(N0.getOperand(1)) &&
+      isConstantOrConstantVector(N1) &&
+      isConstantOrConstantVector(N0.getOperand(1)) &&
       isMulAddWithConstProfitable(N, N0, N1))
     return Matcher.getNode(
         ISD::ADD, DL, VT,

--- a/llvm/test/CodeGen/RISCV/mul.ll
+++ b/llvm/test/CodeGen/RISCV/mul.ll
@@ -2292,3 +2292,31 @@ define i32 @mulor_demand(i32 signext %x, i32 signext %y) nounwind {
   %mul2 = mul i32 %or, 380141568
   ret i32 %mul2
 }
+
+define i64 @mul_add_bitcast(i64 %x) {
+; RV32I-LABEL: mul_add_bitcast:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    li a0, 0
+; RV32I-NEXT:    li a1, 0
+; RV32I-NEXT:    ret
+;
+; RV32IM-LABEL: mul_add_bitcast:
+; RV32IM:       # %bb.0:
+; RV32IM-NEXT:    li a0, 0
+; RV32IM-NEXT:    li a1, 0
+; RV32IM-NEXT:    ret
+;
+; RV64I-LABEL: mul_add_bitcast:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    li a0, 0
+; RV64I-NEXT:    ret
+;
+; RV64IM-LABEL: mul_add_bitcast:
+; RV64IM:       # %bb.0:
+; RV64IM-NEXT:    li a0, 0
+; RV64IM-NEXT:    ret
+  %add = add i64 %x, 1
+  %bitcast = bitcast <2 x i32> zeroinitializer to i64
+  %mul = mul i64 %add, %bitcast
+  ret i64 %mul
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/171035
Peeking through bitcast may cause type mismatch between `AddNode` and `ConstNode` in `isMulAddWithConstProfitable`.