### PR TITLE
[clang-tidy] Enable C99 in `implicit-bool-conversion` and avoid FP with `bool` operands in C23

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -28,8 +28,9 @@ AST_MATCHER(Stmt, isMacroExpansion) {
 }
 
 AST_MATCHER(Stmt, isC) {
-  return !Finder->getASTContext().getLangOpts().CPlusPlus &&
-         !Finder->getASTContext().getLangOpts().ObjC;
+  const auto &LO = Finder->getASTContext().getLangOpts();
+  return !LO.CPlusPlus && !LO.ObjC && !LO.OpenCL && !LO.CUDA && !LO.HIP &&
+         !LO.HLSL;
 }
 
 // Preserve same name as AST_MATCHER(isNULLMacroExpansion)

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -352,9 +352,7 @@ void ImplicitBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
                                        BoolOpAssignment, BitfieldAssignment)))),
               // Exclude logical operators in C
               unless(allOf(isC(), hasParent(binaryOperator(
-                                      hasAnyOperatorName("&&", "||"),
-                                      hasLHS(ImplicitCastFromBool),
-                                      hasRHS(ImplicitCastFromBool))))),
+                                      hasAnyOperatorName("&&", "||"))))),
               implicitCastExpr().bind("implicitCastFromBool"),
               unless(hasParent(BitfieldConstruct)),
               // Check also for nested casts, for example: bool -> int -> float.

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -27,11 +27,7 @@ AST_MATCHER(Stmt, isMacroExpansion) {
   return SM.isMacroBodyExpansion(Loc) || SM.isMacroArgExpansion(Loc);
 }
 
-AST_MATCHER(Stmt, isC) {
-  const auto &LO = Finder->getASTContext().getLangOpts();
-  return !LO.CPlusPlus && !LO.ObjC && !LO.OpenCL && !LO.CUDA && !LO.HIP &&
-         !LO.HLSL;
-}
+AST_MATCHER(Stmt, isC) { return Finder->getASTContext().getLangOpts().C99; }
 
 // Preserve same name as AST_MATCHER(isNULLMacroExpansion)
 // NOLINTNEXTLINE(llvm-prefer-static-over-anonymous-namespace)

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -28,7 +28,8 @@ AST_MATCHER(Stmt, isMacroExpansion) {
 }
 
 AST_MATCHER(Stmt, isC) {
-  return !Finder->getASTContext().getLangOpts().CPlusPlus;
+  return !Finder->getASTContext().getLangOpts().CPlusPlus &&
+         !Finder->getASTContext().getLangOpts().ObjC;
 }
 
 // Preserve same name as AST_MATCHER(isNULLMacroExpansion)

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.h
@@ -21,7 +21,7 @@ class ImplicitBoolConversionCheck : public ClangTidyCheck {
 public:
   ImplicitBoolConversionCheck(StringRef Name, ClangTidyContext *Context);
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
-    return LangOpts.Bool;
+    return LangOpts.Bool || LangOpts.C99;
   }
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -542,9 +542,10 @@ Changes in existing checks
 
 - Improved :doc:`readability-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check by correctly
-  adding parentheses when the inner expression are implicitly converted
-  multiple times, enabling the check in C99, and avoiding false positives when
-  using logical operators with ``bool`` operands in C23.
+  adding parentheses when inner expressions are implicitly converted multiple
+  times, enabling the check for C99 and later standards, and allowing implicit
+  conversions from ``bool`` to integer when used as operands of logical
+  operators (``&&``, ``||``) in C.
 
 - Improved :doc:`readability-qualified-auto
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -543,7 +543,8 @@ Changes in existing checks
 - Improved :doc:`readability-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check by correctly
   adding parentheses when the inner expression are implicitly converted
-  multiple times.
+  multiple times, enabling the check in C99,  and avoiding false positives when
+  using logical operators with ``bool`` operands in C23.
 
 - Improved :doc:`readability-qualified-auto
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -543,7 +543,7 @@ Changes in existing checks
 - Improved :doc:`readability-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check by correctly
   adding parentheses when the inner expression are implicitly converted
-  multiple times, enabling the check in C99,  and avoiding false positives when
+  multiple times, enabling the check in C99, and avoiding false positives when
   using logical operators with ``bool`` operands in C23.
 
 - Improved :doc:`readability-qualified-auto

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/implicit-bool-conversion.rst
@@ -118,6 +118,11 @@ Some additional accommodations are made for pre-C++11 dialects:
 
 - instead of ``nullptr`` literal, ``0`` is proposed as replacement.
 
+Some additional accommodations are made for C:
+
+- ``bool`` (or ``_Bool``) operands in logical operators (``&&``, ``||``) are
+  ignored.
+
 Occurrences of implicit conversions inside macros and template instantiations
 are deliberately ignored, as it is not clear how to deal with such cases.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c99 %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy -std=c99,c11,c17 %s readability-implicit-bool-conversion %t
 
 #define true 1
 #define false 0

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c99 %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy -std=c99-or-later %s readability-implicit-bool-conversion %t
 
 #define true 1
 #define false 0

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c99-or-later %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy -std=c99 %s readability-implicit-bool-conversion %t
 
 #define true 1
 #define false 0

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
@@ -11,10 +11,7 @@ void test_c99_logical_ops(void) {
   _Bool b2 = false;
 
   if (b1 && b2) {}
-
   if (b1 && returns_int()) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: implicit conversion 'bool' -> 'int' [readability-implicit-bool-conversion]
-  // CHECK-FIXES: if ((int)b1 && returns_int()) {}
 }
 
 void test_c99_comparison(void) {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
@@ -1,0 +1,25 @@
+// RUN: %check_clang_tidy -std=c99 %s readability-implicit-bool-conversion %t
+
+typedef _Bool bool;
+#define true 1
+#define false 0
+
+bool returns_bool(void) { return true; }
+int returns_int(void) { return 1; }
+
+void test_c99_logical_ops(void) {
+  bool b1 = true;
+  bool b2 = false;
+
+  if (b1 && b2) {}
+
+  if (b1 && returns_int()) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: implicit conversion 'bool' -> 'int' [readability-implicit-bool-conversion]
+  // CHECK-FIXES: if ((int)b1 && returns_int()) {}
+}
+
+void test_c99_comparison(void) {
+  int x = 1;
+  int y = 2;
+  bool b = x > y;
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion-c99.c
@@ -1,15 +1,14 @@
 // RUN: %check_clang_tidy -std=c99 %s readability-implicit-bool-conversion %t
 
-typedef _Bool bool;
 #define true 1
 #define false 0
 
-bool returns_bool(void) { return true; }
+_Bool returns_bool(void) { return true; }
 int returns_int(void) { return 1; }
 
 void test_c99_logical_ops(void) {
-  bool b1 = true;
-  bool b2 = false;
+  _Bool b1 = true;
+  _Bool b2 = false;
 
   if (b1 && b2) {}
 
@@ -21,5 +20,27 @@ void test_c99_logical_ops(void) {
 void test_c99_comparison(void) {
   int x = 1;
   int y = 2;
-  bool b = x > y;
+  _Bool b = x > y;
+}
+
+void test_c99_native_keyword(void) {
+  _Bool raw_bool = 1;
+  // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: implicit conversion 'int' -> 'bool' [readability-implicit-bool-conversion]
+  // CHECK-FIXES: _Bool raw_bool = true;
+  int i = raw_bool;
+  // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: implicit conversion 'bool' -> 'int'
+  // CHECK-FIXES: int i = (int)raw_bool;
+}
+
+void test_c99_macro_behavior(void) {
+  _Bool b = true;
+  int i = b + 1;
+  // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: implicit conversion 'bool' -> 'int'
+  // CHECK-FIXES: int i = (int)b + 1;
+}
+
+void test_c99_pointer_conversion(int *p) {
+  _Bool b = p;
+  // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: implicit conversion 'int *' -> 'bool'
+  // CHECK-FIXES: _Bool b = p != 0;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -77,8 +77,6 @@ void implicitConversionFromBoolInComplexBoolExpressions() {
   int integer = boolean && anotherBoolean;
   float floating = (boolean || anotherBoolean) * 0.3f;
   double doubleFloating = (boolean && (anotherBoolean || boolean)) * 0.3;
-  // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-FIXES: double doubleFloating = ((int)boolean && (anotherBoolean || boolean)) * 0.3;
 }
 
 void implicitConversionFromBoolLiterals() {
@@ -367,17 +365,9 @@ bool returns_bool(void) { return true; }
 void implicitConversionFromBoolInLogicalOps(int len) {
   while (returns_bool()) {}
   while ((len > 0) && returns_bool()) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-FIXES: while ((len > 0) && (int)returns_bool()) {}
   while (returns_bool() && (len > 0)) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-FIXES: while ((int)returns_bool() && (len > 0)) {}
   while ((len > 0) || returns_bool()) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-FIXES: while ((len > 0) || (int)returns_bool()) {}
   while (returns_bool() || (len > 0)) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-FIXES: while ((int)returns_bool() || (len > 0)) {}
 }
 
 void checkResultAssignment(void) {
@@ -393,10 +383,5 @@ void checkNestedLogic(void) {
   bool c = true;
 
   if ((a && b) || c) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: implicit conversion 'bool' -> 'int' [readability-implicit-bool-conversion]
-  // CHECK-FIXES: if ((a && b) || (int)c) {}
-
   if (c && (a || b)) {}
-  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: implicit conversion 'bool' -> 'int' [readability-implicit-bool-conversion]
-  // CHECK-FIXES: if ((int)c && (a || b)) {}
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -386,3 +386,17 @@ void checkResultAssignment(void) {
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'int' -> 'bool'
   // CHECK-FIXES: bool b = (returns_bool() && returns_bool()) != 0;
 }
+
+void checkNestedLogic(void) {
+  bool a = true;
+  bool b = false;
+  bool c = true;
+
+  if ((a && b) || c) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: implicit conversion 'bool' -> 'int' [readability-implicit-bool-conversion]
+  // CHECK-FIXES: if ((a && b) || (int)c) {}
+
+  if (c && (a || b)) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: implicit conversion 'bool' -> 'int' [readability-implicit-bool-conversion]
+  // CHECK-FIXES: if ((int)c && (a || b)) {}
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -75,20 +75,10 @@ void implicitConversionFromBoolInComplexBoolExpressions() {
   bool anotherBoolean = false;
 
   int integer = boolean && anotherBoolean;
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-MESSAGES: :[[@LINE-2]]:28: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-FIXES: int integer = (int)boolean && (int)anotherBoolean;
-
   float floating = (boolean || anotherBoolean) * 0.3f;
-  // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-MESSAGES: :[[@LINE-2]]:32: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-FIXES: float floating = ((int)boolean || (int)anotherBoolean) * 0.3f;
-
   double doubleFloating = (boolean && (anotherBoolean || boolean)) * 0.3;
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-MESSAGES: :[[@LINE-2]]:40: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-MESSAGES: :[[@LINE-3]]:58: warning: implicit conversion 'bool' -> 'int'
-  // CHECK-FIXES: double doubleFloating = ((int)boolean && ((int)anotherBoolean || (int)boolean)) * 0.3;
+  // CHECK-FIXES: double doubleFloating = ((int)boolean && (anotherBoolean || boolean)) * 0.3;
 }
 
 void implicitConversionFromBoolLiterals() {
@@ -370,4 +360,29 @@ int keepCompactReturnInC_PR71848() {
   return( foo );
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: implicit conversion 'bool' -> 'int' [readability-implicit-bool-conversion]
 // CHECK-FIXES: return(int)( foo );
+}
+
+bool returns_bool(void) { return true; }
+
+void implicitConversionFromBoolInLogicalOps(int len) {
+  while (returns_bool()) {}
+  while ((len > 0) && returns_bool()) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: implicit conversion 'bool' -> 'int'
+  // CHECK-FIXES: while ((len > 0) && (int)returns_bool()) {}
+  while (returns_bool() && (len > 0)) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'bool' -> 'int'
+  // CHECK-FIXES: while ((int)returns_bool() && (len > 0)) {}
+  while ((len > 0) || returns_bool()) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: implicit conversion 'bool' -> 'int'
+  // CHECK-FIXES: while ((len > 0) || (int)returns_bool()) {}
+  while (returns_bool() || (len > 0)) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: implicit conversion 'bool' -> 'int'
+  // CHECK-FIXES: while ((int)returns_bool() || (len > 0)) {}
+}
+
+void checkResultAssignment(void) {
+  int a = returns_bool() || returns_bool();
+  bool b = returns_bool() && returns_bool();
+  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: implicit conversion 'int' -> 'bool'
+  // CHECK-FIXES: bool b = (returns_bool() && returns_bool()) != 0;
 }


### PR DESCRIPTION
Closes [#170596](https://github.com/llvm/llvm-project/issues/170596)