### PR TITLE
[MLIR][IRDL] Add C API for IRDL Variadicity attributes.

### DIFF
--- a/mlir/include/mlir-c/Dialect/IRDL.h
+++ b/mlir/include/mlir-c/Dialect/IRDL.h
@@ -22,6 +22,20 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(IRDL, irdl);
 /// the module's associated context.
 MLIR_CAPI_EXPORTED MlirLogicalResult mlirLoadIRDLDialects(MlirModule module);
 
+//===----------------------------------------------------------------------===//
+// VariadicityAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirIRDLVariadicityAttrGet(MlirContext ctx, MlirStringRef value);
+
+//===----------------------------------------------------------------------===//
+// VariadicityArrayAttr
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirAttribute mlirIRDLVariadicityArrayAttrGet(
+    MlirContext ctx, intptr_t nValues, MlirAttribute const *values);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mlir/lib/CAPI/Dialect/IRDL.cpp
+++ b/mlir/lib/CAPI/Dialect/IRDL.cpp
@@ -16,3 +16,30 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(IRDL, irdl, mlir::irdl::IRDLDialect)
 MlirLogicalResult mlirLoadIRDLDialects(MlirModule module) {
   return wrap(mlir::irdl::loadDialects(unwrap(module)));
 }
+
+//===----------------------------------------------------------------------===//
+// VariadicityAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute mlirIRDLVariadicityAttrGet(MlirContext ctx, MlirStringRef value) {
+  return wrap(mlir::irdl::VariadicityAttr::get(
+      unwrap(ctx), mlir::irdl::symbolizeVariadicity(unwrap(value)).value()));
+}
+
+//===----------------------------------------------------------------------===//
+// VariadicityArrayAttr
+//===----------------------------------------------------------------------===//
+
+MlirAttribute mlirIRDLVariadicityArrayAttrGet(MlirContext ctx, intptr_t nValues,
+                                              MlirAttribute const *values) {
+  llvm::SmallVector<mlir::Attribute> attrs;
+  llvm::ArrayRef<mlir::Attribute> unwrappedAttrs =
+      unwrapList(nValues, values, attrs);
+
+  llvm::SmallVector<mlir::irdl::VariadicityAttr> variadicities;
+  for (auto attr : unwrappedAttrs)
+    variadicities.push_back(llvm::cast<mlir::irdl::VariadicityAttr>(attr));
+
+  return wrap(
+      mlir::irdl::VariadicityArrayAttr::get(unwrap(ctx), variadicities));
+}

--- a/mlir/test/CAPI/irdl.c
+++ b/mlir/test/CAPI/irdl.c
@@ -12,6 +12,7 @@
 
 #include "mlir-c/Dialect/IRDL.h"
 #include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
 
 const char irdlDialect[] = "\
   irdl.dialect @foo {\
@@ -37,10 +38,39 @@ const char newDialectUsage[] = "\
     \"bar.op\"(%res) : (i32) -> ()\
   }";
 
+void testVariadicityAttributes(MlirContext ctx) {
+  MlirAttribute variadicitySingle =
+      mlirIRDLVariadicityAttrGet(ctx, mlirStringRefCreateFromCString("single"));
+
+  // CHECK: #irdl<variadicity single>
+  mlirAttributeDump(variadicitySingle);
+
+  MlirAttribute variadicityOptional = mlirIRDLVariadicityAttrGet(
+      ctx, mlirStringRefCreateFromCString("optional"));
+
+  // CHECK: #irdl<variadicity optional>
+  mlirAttributeDump(variadicityOptional);
+
+  MlirAttribute variadicityVariadic = mlirIRDLVariadicityAttrGet(
+      ctx, mlirStringRefCreateFromCString("variadic"));
+
+  // CHECK: #irdl<variadicity variadic>
+  mlirAttributeDump(variadicityVariadic);
+
+  MlirAttribute variadicities[] = {variadicitySingle, variadicityOptional,
+                                   variadicityVariadic};
+  MlirAttribute variadicityArray =
+      mlirIRDLVariadicityArrayAttrGet(ctx, 3, variadicities);
+
+  // CHECK: #irdl<variadicity_array[ single, optional,  variadic]>
+  mlirAttributeDump(variadicityArray);
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   mlirDialectHandleLoadDialect(mlirGetDialectHandle__irdl__(), ctx);
 
+  // Test loading an IRDL dialect and using it.
   MlirModule dialectDecl =
       mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(irdlDialect));
 
@@ -53,6 +83,10 @@ int main(void) {
   mlirOperationDump(mlirModuleGetOperation(usingModule));
 
   mlirModuleDestroy(usingModule);
+
+  // Test variadicity attributes.
+  testVariadicityAttributes(ctx);
+
   mlirContextDestroy(ctx);
   return 0;
 }


### PR DESCRIPTION
This add the basic APIs to create VariadicityAttr and
VariadicityArrayAttr attributes from the C API. This is necessary for
C API users that want to create IRDL dialect declarations.