### PR TITLE
[Driver][Hurd] Remove llvm_unreachable

### DIFF
--- a/clang/lib/Driver/ToolChains/Hurd.cpp
+++ b/clang/lib/Driver/ToolChains/Hurd.cpp
@@ -160,7 +160,7 @@ std::string Hurd::getDynamicLinker(const ArgList &Args) const {
     break;
   }
 
-  llvm_unreachable("unsupported architecture");
+  return "";
 }
 
 void Hurd::AddClangSystemIncludeArgs(const ArgList &DriverArgs,

--- a/clang/lib/Driver/ToolChains/Managarm.cpp
+++ b/clang/lib/Driver/ToolChains/Managarm.cpp
@@ -127,8 +127,9 @@ std::string Managarm::getDynamicLinker(const ArgList &Args) const {
   case llvm::Triple::x86_64:
     return "/lib/x86_64-managarm/ld.so";
   default:
-    llvm_unreachable("unsupported architecture");
+    break;
   }
+  return "";
 }
 
 void Managarm::AddClangSystemIncludeArgs(const ArgList &DriverArgs,


### PR DESCRIPTION
Remove the llvm_unreachable from getDynamicLinker(). The code path is
reachable. In the case of an unsupported architecture we're not worrying
about trying to actually determine the dynamic linker, and I don't think
it makes sense for the Driver to crash.

Pointed out by bug report #64194