### PR TITLE
[LifetimeSafety] Infer [[clang::lifetimebound]] annotation

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -499,6 +499,8 @@ LANGOPT(BoundsSafety, 1, 0, NotCompatible, "Bounds safety extension for C")
 
 LANGOPT(EnableLifetimeSafety, 1, 0, NotCompatible, "Experimental lifetime safety analysis for C++")
 
+LANGOPT(EnableLifetimeSafetyInference, 1, 0, NotCompatible, "Experimental lifetime safety inference analysis for C++")
+
 LANGOPT(PreserveVec3Type, 1, 0, NotCompatible, "Preserve 3-component vector type")
 
 #undef LANGOPT

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -1955,6 +1955,14 @@ defm lifetime_safety : BoolFOption<
   BothFlags<[], [CC1Option],
           " experimental lifetime safety for C++">>;
 
+defm lifetime_safety_inference
+    : BoolFOption<"experimental-lifetime-safety-inference",
+                  LangOpts<"EnableLifetimeSafetyInference">, DefaultFalse,
+                  PosFlag<SetTrue, [], [CC1Option], "Enable">,
+                  NegFlag<SetFalse, [], [CC1Option], "Disable">,
+                  BothFlags<[], [CC1Option],
+                            " experimental lifetime safety inference for C++">>;
+
 defm addrsig : BoolFOption<"addrsig",
   CodeGenOpts<"Addrsig">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option], "Emit">,

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -Wexperimental-lifetime-safety-suggestions -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -fexperimental-lifetime-safety-inference -Wexperimental-lifetime-safety-suggestions -verify %s
 
 struct MyObj {
   int id;
@@ -117,14 +117,14 @@ View return_view_callee(View a) {     // expected-warning {{param should be mark
 } // incorrect_order_inference_view
 
 namespace incorrect_order_inference_object {
-View return_object_callee(View a);
+MyObj* return_object_callee(MyObj* a);
 
 // FIXME: No lifetime annotation suggestion warning when functions are not present in the callee-before-caller pattern
-View return_object_caller(View a) {
+MyObj* return_object_caller(MyObj* a) {
   return return_object_callee(a);
 }
 
-View return_object_callee(View a) {     // expected-warning {{param should be marked [[clang::lifetimebound]]}}.
+MyObj* return_object_callee(MyObj* a) {     // expected-warning {{param should be marked [[clang::lifetimebound]]}}.
   return a;                           // expected-note {{param returned here}}
 }   
 } // incorrect_order_inference_object

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -90,6 +90,18 @@ void test_getView_on_temporary() {
 }
 
 //===----------------------------------------------------------------------===//
+// Annotation Inference Test Cases
+//===----------------------------------------------------------------------===//
+
+View return_view_by_func (View a) {    // expected-warning {{param should be marked [[clang::lifetimebound]]}}.
+  return return_view_directly(a);      // expected-note {{param returned here}}
+}
+
+MyObj* return_pointer_by_func (MyObj* a) {         // expected-warning {{param should be marked [[clang::lifetimebound]]}}.
+  return return_pointer_object(a);                 // expected-note {{param returned here}} 
+}
+
+//===----------------------------------------------------------------------===//
 // Negative Test Cases
 //===----------------------------------------------------------------------===//
 

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -93,6 +93,7 @@ void test_getView_on_temporary() {
 // Annotation Inference Test Cases
 //===----------------------------------------------------------------------===//
 
+namespace correct_order_inference {
 View return_view_by_func (View a) {    // expected-warning {{param should be marked [[clang::lifetimebound]]}}.
   return return_view_directly(a);      // expected-note {{param returned here}}
 }
@@ -100,6 +101,33 @@ View return_view_by_func (View a) {    // expected-warning {{param should be mar
 MyObj* return_pointer_by_func (MyObj* a) {         // expected-warning {{param should be marked [[clang::lifetimebound]]}}.
   return return_pointer_object(a);                 // expected-note {{param returned here}} 
 }
+} // correct_order_inference
+
+namespace incorrect_order_inference_view {
+View return_view_callee(View a);
+
+// FIXME: No lifetime annotation suggestion when functions are not present in the callee-before-caller pattern
+View return_view_caller(View a) {
+  return return_view_callee(a);
+}
+
+View return_view_callee(View a) {     // expected-warning {{param should be marked [[clang::lifetimebound]]}}.
+  return a;                           // expected-note {{param returned here}}
+}   
+} // incorrect_order_inference_view
+
+namespace incorrect_order_inference_object {
+View return_object_callee(View a);
+
+// FIXME: No lifetime annotation suggestion warning when functions are not present in the callee-before-caller pattern
+View return_object_caller(View a) {
+  return return_object_callee(a);
+}
+
+View return_object_callee(View a) {     // expected-warning {{param should be marked [[clang::lifetimebound]]}}.
+  return a;                           // expected-note {{param returned here}}
+}   
+} // incorrect_order_inference_object
 
 //===----------------------------------------------------------------------===//
 // Negative Test Cases

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -fexperimental-lifetime-safety-inference -Wexperimental-lifetime-safety -Wno-dangling -Wno-experimental-lifetime-safety-suggestions -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -Wexperimental-lifetime-safety -Wno-dangling -Wno-experimental-lifetime-safety-suggestions -verify %s
 
 struct MyObj {
   int id;
@@ -551,58 +551,6 @@ const int& get_ref_to_local() {
     return a;         // expected-warning {{address of stack memory is returned later}}
                       // expected-note@-1 {{returned here}}
 }
-
-namespace simple_annotation_inference {
-View inference_callee_return_identity(View a) {
-  return a;
-}
-
-View inference_caller_forwards_callee(View a) {
-  return inference_callee_return_identity(a);
-}
-
-View inference_top_level_return_stack_view() {
-  MyObj local_stack;
-  return inference_caller_forwards_callee(local_stack);     // expected-warning {{address of stack memory is returned later}}
-                                                            // expected-note@-1 {{returned here}}
-}
-} // simple_annotation_inference
-
-namespace inference_in_order_with_redecls {
-View inference_callee_return_identity(View a);
-View inference_callee_return_identity(View a) {
-  return a;
-}
-
-View inference_caller_forwards_callee(View a);
-View inference_caller_forwards_callee(View a) {
-  return inference_callee_return_identity(a);
-}
-  
-View inference_top_level_return_stack_view() {
-  MyObj local_stack;
-  return inference_caller_forwards_callee(local_stack);     // expected-warning {{address of stack memory is returned later}}
-                                                            // expected-note@-1 {{returned here}}
-}
-} // namespace inference_in_order_with_redecls
-
-namespace inference_with_templates {
-template<typename T>
-T* template_identity(T* a) {
-  return a;
-}
-
-template<typename T>
-T* template_caller(T* a) {
-  return template_identity(a);
-}
-
-// FIXME: Fails to detect UAR as template instantiations are deferred to the end of the Translation Unit.
-MyObj* test_template_inference_with_stack() {
-  MyObj local_stack;
-  return template_caller(&local_stack);                                              
-}
-} // inference_with_templates
 
 //===----------------------------------------------------------------------===//
 // Use-After-Scope & Use-After-Return (Return-Stack-Address) Combined

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -Wexperimental-lifetime-safety -Wno-dangling -Wno-experimental-lifetime-safety-suggestions -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -Wexperimental-lifetime-safety -Wno-dangling -verify %s
 
 struct MyObj {
   int id;

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -Wexperimental-lifetime-safety -Wno-dangling -Wno-experimental-lifetime-safety-suggestions -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -fexperimental-lifetime-safety-inference -Wexperimental-lifetime-safety -Wno-dangling -Wno-experimental-lifetime-safety-suggestions -verify %s
 
 struct MyObj {
   int id;

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -Wexperimental-lifetime-safety -Wno-dangling -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-lifetime-safety -Wexperimental-lifetime-safety -Wno-dangling -Wno-experimental-lifetime-safety-suggestions -verify %s
 
 struct MyObj {
   int id;
@@ -550,6 +550,20 @@ const int& get_ref_to_local() {
     int a = 42;
     return a;         // expected-warning {{address of stack memory is returned later}}
                       // expected-note@-1 {{returned here}}
+}
+
+View inference_callee_return_identity(View a) {
+  return a;
+}
+
+View inference_caller_forwards_callee(View a) {
+  return inference_callee_return_identity(a);
+}
+
+View inference_top_level_return_stack_view() {
+  MyObj local_stack;
+  return inference_caller_forwards_callee(local_stack);     // expected-warning {{address of stack memory is returned later}}
+                                                            // expected-note@-1 {{returned here}}
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Adding Annotation Inference in Lifetime Analysis.

This PR implicitly adds lifetime bound annotations to the AST which is then used by functions which are parsed later to detect UARs etc. Example:

```cpp
std::string_view f1(std::string_view a) {
  return a;
}

std::string_view f2(std::string_view a) {
  return f1(a);
}

std::string_view ff(std::string_view a) {
  std::string stack = "something on stack";
  return f2(stack); // warning: address of stack memory is returned
}
```

Note:

1. We only add lifetime bound annotations to the functions being analyzed currently.
2. Currently, both annotation suggestion and inference work simultaneously. This can be modified based on requirements.
3. The current approach works given that functions are already present in the correct order (callee-before-caller). For not so ideal cases, we can create a CallGraph prior to calling the analysis. This can be done in the next PR.