### PR TITLE
[libc++][filesystem] Applied `[[nodiscard]]`

### DIFF
--- a/libcxx/include/__filesystem/copy_options.h
+++ b/libcxx/include/__filesystem/copy_options.h
@@ -34,31 +34,31 @@ enum class copy_options : unsigned short {
   __in_recursive_copy = 512,
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr copy_options operator&(copy_options __lhs, copy_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr copy_options operator&(copy_options __lhs, copy_options __rhs) {
   return static_cast<copy_options>(static_cast<unsigned short>(__lhs) & static_cast<unsigned short>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr copy_options operator|(copy_options __lhs, copy_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr copy_options operator|(copy_options __lhs, copy_options __rhs) {
   return static_cast<copy_options>(static_cast<unsigned short>(__lhs) | static_cast<unsigned short>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr copy_options operator^(copy_options __lhs, copy_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr copy_options operator^(copy_options __lhs, copy_options __rhs) {
   return static_cast<copy_options>(static_cast<unsigned short>(__lhs) ^ static_cast<unsigned short>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr copy_options operator~(copy_options __lhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr copy_options operator~(copy_options __lhs) {
   return static_cast<copy_options>(~static_cast<unsigned short>(__lhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline copy_options& operator&=(copy_options& __lhs, copy_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline copy_options& operator&=(copy_options& __lhs, copy_options __rhs) {
   return __lhs = __lhs & __rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline copy_options& operator|=(copy_options& __lhs, copy_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline copy_options& operator|=(copy_options& __lhs, copy_options __rhs) {
   return __lhs = __lhs | __rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline copy_options& operator^=(copy_options& __lhs, copy_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline copy_options& operator^=(copy_options& __lhs, copy_options __rhs) {
   return __lhs = __lhs ^ __rhs;
 }
 

--- a/libcxx/include/__filesystem/directory_entry.h
+++ b/libcxx/include/__filesystem/directory_entry.h
@@ -87,80 +87,88 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI void refresh(error_code& __ec) noexcept { __refresh(&__ec); }
 
-  _LIBCPP_HIDE_FROM_ABI _Path const& path() const noexcept { return __p_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _Path const& path() const noexcept { return __p_; }
 
   _LIBCPP_HIDE_FROM_ABI operator const _Path&() const noexcept { return __p_; }
 
-  _LIBCPP_HIDE_FROM_ABI bool exists() const { return filesystem::exists(file_status{__get_ft()}); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool exists() const { return filesystem::exists(file_status{__get_ft()}); }
 
-  _LIBCPP_HIDE_FROM_ABI bool exists(error_code& __ec) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool exists(error_code& __ec) const noexcept {
     return filesystem::exists(file_status{__get_ft(&__ec)});
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_block_file() const { return __get_ft() == file_type::block; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_block_file() const { return __get_ft() == file_type::block; }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_block_file(error_code& __ec) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_block_file(error_code& __ec) const noexcept {
     return __get_ft(&__ec) == file_type::block;
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_character_file() const { return __get_ft() == file_type::character; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_character_file() const { return __get_ft() == file_type::character; }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_character_file(error_code& __ec) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_character_file(error_code& __ec) const noexcept {
     return __get_ft(&__ec) == file_type::character;
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_directory() const { return __get_ft() == file_type::directory; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_directory() const { return __get_ft() == file_type::directory; }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_directory(error_code& __ec) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_directory(error_code& __ec) const noexcept {
     return __get_ft(&__ec) == file_type::directory;
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_fifo() const { return __get_ft() == file_type::fifo; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_fifo() const { return __get_ft() == file_type::fifo; }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_fifo(error_code& __ec) const noexcept { return __get_ft(&__ec) == file_type::fifo; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_fifo(error_code& __ec) const noexcept {
+    return __get_ft(&__ec) == file_type::fifo;
+  }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_other() const { return filesystem::is_other(file_status{__get_ft()}); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_other() const { return filesystem::is_other(file_status{__get_ft()}); }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_other(error_code& __ec) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_other(error_code& __ec) const noexcept {
     return filesystem::is_other(file_status{__get_ft(&__ec)});
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_regular_file() const { return __get_ft() == file_type::regular; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_regular_file() const { return __get_ft() == file_type::regular; }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_regular_file(error_code& __ec) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_regular_file(error_code& __ec) const noexcept {
     return __get_ft(&__ec) == file_type::regular;
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_socket() const { return __get_ft() == file_type::socket; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_socket() const { return __get_ft() == file_type::socket; }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_socket(error_code& __ec) const noexcept { return __get_ft(&__ec) == file_type::socket; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_socket(error_code& __ec) const noexcept {
+    return __get_ft(&__ec) == file_type::socket;
+  }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_symlink() const { return __get_sym_ft() == file_type::symlink; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_symlink() const { return __get_sym_ft() == file_type::symlink; }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_symlink(error_code& __ec) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_symlink(error_code& __ec) const noexcept {
     return __get_sym_ft(&__ec) == file_type::symlink;
   }
-  _LIBCPP_HIDE_FROM_ABI uintmax_t file_size() const { return __get_size(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI uintmax_t file_size() const { return __get_size(); }
 
-  _LIBCPP_HIDE_FROM_ABI uintmax_t file_size(error_code& __ec) const noexcept { return __get_size(&__ec); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI uintmax_t file_size(error_code& __ec) const noexcept { return __get_size(&__ec); }
 
-  _LIBCPP_HIDE_FROM_ABI uintmax_t hard_link_count() const { return __get_nlink(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI uintmax_t hard_link_count() const { return __get_nlink(); }
 
-  _LIBCPP_HIDE_FROM_ABI uintmax_t hard_link_count(error_code& __ec) const noexcept { return __get_nlink(&__ec); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI uintmax_t hard_link_count(error_code& __ec) const noexcept {
+    return __get_nlink(&__ec);
+  }
 
-  _LIBCPP_HIDE_FROM_ABI file_time_type last_write_time() const { return __get_write_time(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI file_time_type last_write_time() const { return __get_write_time(); }
 
-  _LIBCPP_HIDE_FROM_ABI file_time_type last_write_time(error_code& __ec) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI file_time_type last_write_time(error_code& __ec) const noexcept {
     return __get_write_time(&__ec);
   }
 
-  _LIBCPP_HIDE_FROM_ABI file_status status() const { return __get_status(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI file_status status() const { return __get_status(); }
 
-  _LIBCPP_HIDE_FROM_ABI file_status status(error_code& __ec) const noexcept { return __get_status(&__ec); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI file_status status(error_code& __ec) const noexcept {
+    return __get_status(&__ec);
+  }
 
-  _LIBCPP_HIDE_FROM_ABI file_status symlink_status() const { return __get_symlink_status(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI file_status symlink_status() const { return __get_symlink_status(); }
 
-  _LIBCPP_HIDE_FROM_ABI file_status symlink_status(error_code& __ec) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI file_status symlink_status(error_code& __ec) const noexcept {
     return __get_symlink_status(&__ec);
   }
 

--- a/libcxx/include/__filesystem/directory_iterator.h
+++ b/libcxx/include/__filesystem/directory_iterator.h
@@ -71,7 +71,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI ~directory_iterator() = default;
 
-  _LIBCPP_HIDE_FROM_ABI const directory_entry& operator*() const {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const directory_entry& operator*() const {
     // Note: this check duplicates a check in `__dereference()`.
     _LIBCPP_ASSERT_NON_NULL(__imp_, "The end iterator cannot be dereferenced");
     return __dereference();
@@ -121,9 +121,13 @@ operator!=(const directory_iterator& __lhs, const directory_iterator& __rhs) noe
 }
 
 // enable directory_iterator range-based for statements
-inline _LIBCPP_HIDE_FROM_ABI directory_iterator begin(directory_iterator __iter) noexcept { return __iter; }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI directory_iterator begin(directory_iterator __iter) noexcept {
+  return __iter;
+}
 
-inline _LIBCPP_HIDE_FROM_ABI directory_iterator end(directory_iterator) noexcept { return directory_iterator(); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI directory_iterator end(directory_iterator) noexcept {
+  return directory_iterator();
+}
 
 _LIBCPP_END_NAMESPACE_FILESYSTEM
 

--- a/libcxx/include/__filesystem/directory_options.h
+++ b/libcxx/include/__filesystem/directory_options.h
@@ -22,19 +22,22 @@ _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
 enum class directory_options : unsigned char { none = 0, follow_directory_symlink = 1, skip_permission_denied = 2 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr directory_options operator&(directory_options __lhs, directory_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr directory_options
+operator&(directory_options __lhs, directory_options __rhs) {
   return static_cast<directory_options>(static_cast<unsigned char>(__lhs) & static_cast<unsigned char>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr directory_options operator|(directory_options __lhs, directory_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr directory_options
+operator|(directory_options __lhs, directory_options __rhs) {
   return static_cast<directory_options>(static_cast<unsigned char>(__lhs) | static_cast<unsigned char>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr directory_options operator^(directory_options __lhs, directory_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr directory_options
+operator^(directory_options __lhs, directory_options __rhs) {
   return static_cast<directory_options>(static_cast<unsigned char>(__lhs) ^ static_cast<unsigned char>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr directory_options operator~(directory_options __lhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr directory_options operator~(directory_options __lhs) {
   return static_cast<directory_options>(~static_cast<unsigned char>(__lhs));
 }
 

--- a/libcxx/include/__filesystem/file_status.h
+++ b/libcxx/include/__filesystem/file_status.h
@@ -38,9 +38,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI file_status& operator=(file_status&&) noexcept      = default;
 
   // observers
-  _LIBCPP_HIDE_FROM_ABI file_type type() const noexcept { return __ft_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI file_type type() const noexcept { return __ft_; }
 
-  _LIBCPP_HIDE_FROM_ABI perms permissions() const noexcept { return __prms_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI perms permissions() const noexcept { return __prms_; }
 
   // modifiers
   _LIBCPP_HIDE_FROM_ABI void type(file_type __ft) noexcept { __ft_ = __ft; }

--- a/libcxx/include/__filesystem/filesystem_error.h
+++ b/libcxx/include/__filesystem/filesystem_error.h
@@ -44,15 +44,16 @@ public:
     __create_what(2);
   }
 
-  _LIBCPP_HIDE_FROM_ABI const path& path1() const noexcept { return __storage_->__p1_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const path& path1() const noexcept { return __storage_->__p1_; }
 
-  _LIBCPP_HIDE_FROM_ABI const path& path2() const noexcept { return __storage_->__p2_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const path& path2() const noexcept { return __storage_->__p2_; }
 
-  _LIBCPP_HIDE_FROM_ABI filesystem_error(const filesystem_error&) = default;
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI filesystem_error(const filesystem_error&) = default;
   ~filesystem_error() override; // key function
 
-  _LIBCPP_HIDE_FROM_ABI_VIRTUAL
-  const char* what() const noexcept override { return __storage_->__what_.c_str(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI_VIRTUAL const char* what() const noexcept override {
+    return __storage_->__what_.c_str();
+  }
 
   void __create_what(int __num_paths);
 

--- a/libcxx/include/__filesystem/operations.h
+++ b/libcxx/include/__filesystem/operations.h
@@ -68,10 +68,14 @@ _LIBCPP_EXPORTED_FROM_ABI bool __fs_is_empty(const path& __p, error_code* __ec =
 _LIBCPP_EXPORTED_FROM_ABI void __permissions(const path&, perms, perm_options, error_code* = nullptr);
 _LIBCPP_EXPORTED_FROM_ABI space_info __space(const path&, error_code* __ec = nullptr);
 
-inline _LIBCPP_HIDE_FROM_ABI path absolute(const path& __p) { return __absolute(__p); }
-inline _LIBCPP_HIDE_FROM_ABI path absolute(const path& __p, error_code& __ec) { return __absolute(__p, &__ec); }
-inline _LIBCPP_HIDE_FROM_ABI path canonical(const path& __p) { return __canonical(__p); }
-inline _LIBCPP_HIDE_FROM_ABI path canonical(const path& __p, error_code& __ec) { return __canonical(__p, &__ec); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path absolute(const path& __p) { return __absolute(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path absolute(const path& __p, error_code& __ec) {
+  return __absolute(__p, &__ec);
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path canonical(const path& __p) { return __canonical(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path canonical(const path& __p, error_code& __ec) {
+  return __canonical(__p, &__ec);
+}
 inline _LIBCPP_HIDE_FROM_ABI bool copy_file(const path& __from, const path& __to) {
   return __copy_file(__from, __to, copy_options::none);
 }
@@ -135,85 +139,112 @@ inline _LIBCPP_HIDE_FROM_ABI void create_symlink(const path& __target, const pat
 inline _LIBCPP_HIDE_FROM_ABI void create_symlink(const path& __target, const path& __link, error_code& __ec) noexcept {
   return __create_symlink(__target, __link, &__ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI path current_path() { return __current_path(); }
-inline _LIBCPP_HIDE_FROM_ABI path current_path(error_code& __ec) { return __current_path(&__ec); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path current_path() { return __current_path(); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path current_path(error_code& __ec) { return __current_path(&__ec); }
 inline _LIBCPP_HIDE_FROM_ABI void current_path(const path& __p) { __current_path(__p); }
 inline _LIBCPP_HIDE_FROM_ABI void current_path(const path& __p, error_code& __ec) noexcept {
   __current_path(__p, &__ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI bool equivalent(const path& __p1, const path& __p2) { return __equivalent(__p1, __p2); }
-inline _LIBCPP_HIDE_FROM_ABI bool equivalent(const path& __p1, const path& __p2, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool equivalent(const path& __p1, const path& __p2) {
+  return __equivalent(__p1, __p2);
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool
+equivalent(const path& __p1, const path& __p2, error_code& __ec) noexcept {
   return __equivalent(__p1, __p2, &__ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI bool status_known(file_status __s) noexcept { return __s.type() != file_type::none; }
-inline _LIBCPP_HIDE_FROM_ABI bool exists(file_status __s) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool status_known(file_status __s) noexcept {
+  return __s.type() != file_type::none;
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool exists(file_status __s) noexcept {
   return status_known(__s) && __s.type() != file_type::not_found;
 }
-inline _LIBCPP_HIDE_FROM_ABI bool exists(const path& __p) { return exists(__status(__p)); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool exists(const path& __p) { return exists(__status(__p)); }
 
-inline _LIBCPP_HIDE_FROM_ABI bool exists(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool exists(const path& __p, error_code& __ec) noexcept {
   auto __s = __status(__p, &__ec);
   if (status_known(__s))
     __ec.clear();
   return exists(__s);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI uintmax_t file_size(const path& __p) { return __file_size(__p); }
-inline _LIBCPP_HIDE_FROM_ABI uintmax_t file_size(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI uintmax_t file_size(const path& __p) { return __file_size(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI uintmax_t file_size(const path& __p, error_code& __ec) noexcept {
   return __file_size(__p, &__ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI uintmax_t hard_link_count(const path& __p) { return __hard_link_count(__p); }
-inline _LIBCPP_HIDE_FROM_ABI uintmax_t hard_link_count(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI uintmax_t hard_link_count(const path& __p) { return __hard_link_count(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI uintmax_t hard_link_count(const path& __p, error_code& __ec) noexcept {
   return __hard_link_count(__p, &__ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_block_file(file_status __s) noexcept { return __s.type() == file_type::block; }
-inline _LIBCPP_HIDE_FROM_ABI bool is_block_file(const path& __p) { return is_block_file(__status(__p)); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_block_file(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_block_file(file_status __s) noexcept {
+  return __s.type() == file_type::block;
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_block_file(const path& __p) { return is_block_file(__status(__p)); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_block_file(const path& __p, error_code& __ec) noexcept {
   return is_block_file(__status(__p, &__ec));
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_character_file(file_status __s) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_character_file(file_status __s) noexcept {
   return __s.type() == file_type::character;
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_character_file(const path& __p) { return is_character_file(__status(__p)); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_character_file(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_character_file(const path& __p) {
+  return is_character_file(__status(__p));
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_character_file(const path& __p, error_code& __ec) noexcept {
   return is_character_file(__status(__p, &__ec));
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_directory(file_status __s) noexcept { return __s.type() == file_type::directory; }
-inline _LIBCPP_HIDE_FROM_ABI bool is_directory(const path& __p) { return is_directory(__status(__p)); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_directory(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_directory(file_status __s) noexcept {
+  return __s.type() == file_type::directory;
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_directory(const path& __p) { return is_directory(__status(__p)); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_directory(const path& __p, error_code& __ec) noexcept {
   return is_directory(__status(__p, &__ec));
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_empty(const path& __p) { return __fs_is_empty(__p); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_empty(const path& __p, error_code& __ec) { return __fs_is_empty(__p, &__ec); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_fifo(file_status __s) noexcept { return __s.type() == file_type::fifo; }
-inline _LIBCPP_HIDE_FROM_ABI bool is_fifo(const path& __p) { return is_fifo(__status(__p)); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_fifo(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_empty(const path& __p) { return __fs_is_empty(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_empty(const path& __p, error_code& __ec) {
+  return __fs_is_empty(__p, &__ec);
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_fifo(file_status __s) noexcept {
+  return __s.type() == file_type::fifo;
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_fifo(const path& __p) { return is_fifo(__status(__p)); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_fifo(const path& __p, error_code& __ec) noexcept {
   return is_fifo(__status(__p, &__ec));
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_regular_file(file_status __s) noexcept { return __s.type() == file_type::regular; }
-inline _LIBCPP_HIDE_FROM_ABI bool is_regular_file(const path& __p) { return is_regular_file(__status(__p)); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_regular_file(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_regular_file(file_status __s) noexcept {
+  return __s.type() == file_type::regular;
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_regular_file(const path& __p) {
+  return is_regular_file(__status(__p));
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_regular_file(const path& __p, error_code& __ec) noexcept {
   return is_regular_file(__status(__p, &__ec));
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_symlink(file_status __s) noexcept { return __s.type() == file_type::symlink; }
-inline _LIBCPP_HIDE_FROM_ABI bool is_symlink(const path& __p) { return is_symlink(__symlink_status(__p)); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_symlink(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_symlink(file_status __s) noexcept {
+  return __s.type() == file_type::symlink;
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_symlink(const path& __p) {
+  return is_symlink(__symlink_status(__p));
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_symlink(const path& __p, error_code& __ec) noexcept {
   return is_symlink(__symlink_status(__p, &__ec));
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_other(file_status __s) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_other(file_status __s) noexcept {
   return exists(__s) && !is_regular_file(__s) && !is_directory(__s) && !is_symlink(__s);
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_other(const path& __p) { return is_other(__status(__p)); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_other(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_other(const path& __p) { return is_other(__status(__p)); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_other(const path& __p, error_code& __ec) noexcept {
   return is_other(__status(__p, &__ec));
 }
-inline _LIBCPP_HIDE_FROM_ABI bool is_socket(file_status __s) noexcept { return __s.type() == file_type::socket; }
-inline _LIBCPP_HIDE_FROM_ABI bool is_socket(const path& __p) { return is_socket(__status(__p)); }
-inline _LIBCPP_HIDE_FROM_ABI bool is_socket(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_socket(file_status __s) noexcept {
+  return __s.type() == file_type::socket;
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_socket(const path& __p) { return is_socket(__status(__p)); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI bool is_socket(const path& __p, error_code& __ec) noexcept {
   return is_socket(__status(__p, &__ec));
 }
-inline _LIBCPP_HIDE_FROM_ABI file_time_type last_write_time(const path& __p) { return __last_write_time(__p); }
-inline _LIBCPP_HIDE_FROM_ABI file_time_type last_write_time(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI file_time_type last_write_time(const path& __p) {
+  return __last_write_time(__p);
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI file_time_type last_write_time(const path& __p, error_code& __ec) noexcept {
   return __last_write_time(__p, &__ec);
 }
 inline _LIBCPP_HIDE_FROM_ABI void last_write_time(const path& __p, file_time_type __t) { __last_write_time(__p, __t); }
@@ -231,7 +262,7 @@ inline _LIBCPP_HIDE_FROM_ABI void permissions(const path& __p, perms __prms, per
   __permissions(__p, __prms, __opts, &__ec);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI path proximate(const path& __p, const path& __base, error_code& __ec) {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path proximate(const path& __p, const path& __base, error_code& __ec) {
   path __tmp = __weakly_canonical(__p, &__ec);
   if (__ec)
     return {};
@@ -241,16 +272,18 @@ inline _LIBCPP_HIDE_FROM_ABI path proximate(const path& __p, const path& __base,
   return __tmp.lexically_proximate(__tmp_base);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI path proximate(const path& __p, error_code& __ec) {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path proximate(const path& __p, error_code& __ec) {
   return proximate(__p, current_path(), __ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI path proximate(const path& __p, const path& __base = current_path()) {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path proximate(const path& __p, const path& __base = current_path()) {
   return __weakly_canonical(__p).lexically_proximate(__weakly_canonical(__base));
 }
-inline _LIBCPP_HIDE_FROM_ABI path read_symlink(const path& __p) { return __read_symlink(__p); }
-inline _LIBCPP_HIDE_FROM_ABI path read_symlink(const path& __p, error_code& __ec) { return __read_symlink(__p, &__ec); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path read_symlink(const path& __p) { return __read_symlink(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path read_symlink(const path& __p, error_code& __ec) {
+  return __read_symlink(__p, &__ec);
+}
 
-inline _LIBCPP_HIDE_FROM_ABI path relative(const path& __p, const path& __base, error_code& __ec) {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path relative(const path& __p, const path& __base, error_code& __ec) {
   path __tmp = __weakly_canonical(__p, &__ec);
   if (__ec)
     return path();
@@ -260,10 +293,10 @@ inline _LIBCPP_HIDE_FROM_ABI path relative(const path& __p, const path& __base, 
   return __tmp.lexically_relative(__tmpbase);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI path relative(const path& __p, error_code& __ec) {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path relative(const path& __p, error_code& __ec) {
   return relative(__p, current_path(), __ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI path relative(const path& __p, const path& __base = current_path()) {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path relative(const path& __p, const path& __base = current_path()) {
   return __weakly_canonical(__p).lexically_relative(__weakly_canonical(__base));
 }
 inline _LIBCPP_HIDE_FROM_ABI uintmax_t remove_all(const path& __p) { return __remove_all(__p); }
@@ -280,22 +313,24 @@ inline _LIBCPP_HIDE_FROM_ABI void resize_file(const path& __p, uintmax_t __ns) {
 inline _LIBCPP_HIDE_FROM_ABI void resize_file(const path& __p, uintmax_t __ns, error_code& __ec) noexcept {
   return __resize_file(__p, __ns, &__ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI space_info space(const path& __p) { return __space(__p); }
-inline _LIBCPP_HIDE_FROM_ABI space_info space(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI space_info space(const path& __p) { return __space(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI space_info space(const path& __p, error_code& __ec) noexcept {
   return __space(__p, &__ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI file_status status(const path& __p) { return __status(__p); }
-inline _LIBCPP_HIDE_FROM_ABI file_status status(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI file_status status(const path& __p) { return __status(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI file_status status(const path& __p, error_code& __ec) noexcept {
   return __status(__p, &__ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI file_status symlink_status(const path& __p) { return __symlink_status(__p); }
-inline _LIBCPP_HIDE_FROM_ABI file_status symlink_status(const path& __p, error_code& __ec) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI file_status symlink_status(const path& __p) { return __symlink_status(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI file_status symlink_status(const path& __p, error_code& __ec) noexcept {
   return __symlink_status(__p, &__ec);
 }
-inline _LIBCPP_HIDE_FROM_ABI path temp_directory_path() { return __temp_directory_path(); }
-inline _LIBCPP_HIDE_FROM_ABI path temp_directory_path(error_code& __ec) { return __temp_directory_path(&__ec); }
-inline _LIBCPP_HIDE_FROM_ABI path weakly_canonical(path const& __p) { return __weakly_canonical(__p); }
-inline _LIBCPP_HIDE_FROM_ABI path weakly_canonical(path const& __p, error_code& __ec) {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path temp_directory_path() { return __temp_directory_path(); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path temp_directory_path(error_code& __ec) {
+  return __temp_directory_path(&__ec);
+}
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path weakly_canonical(path const& __p) { return __weakly_canonical(__p); }
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI path weakly_canonical(path const& __p, error_code& __ec) {
   return __weakly_canonical(__p, &__ec);
 }
 

--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -667,16 +667,16 @@ public:
   _LIBCPP_HIDE_FROM_ABI void __reserve(size_t __s) { __pn_.reserve(__s); }
 
   // native format observers
-  _LIBCPP_HIDE_FROM_ABI const string_type& native() const noexcept { return __pn_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const string_type& native() const noexcept { return __pn_; }
 
-  _LIBCPP_HIDE_FROM_ABI const value_type* c_str() const noexcept { return __pn_.c_str(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const value_type* c_str() const noexcept { return __pn_.c_str(); }
 
   _LIBCPP_HIDE_FROM_ABI operator string_type() const { return __pn_; }
 
 #  if defined(_LIBCPP_WIN32API)
-  _LIBCPP_HIDE_FROM_ABI std::wstring wstring() const { return __pn_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::wstring wstring() const { return __pn_; }
 
-  _LIBCPP_HIDE_FROM_ABI std::wstring generic_wstring() const {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::wstring generic_wstring() const {
     std::wstring __s;
     __s.resize(__pn_.size());
     std::replace_copy(__pn_.begin(), __pn_.end(), __s.begin(), '\\', '/');
@@ -685,6 +685,7 @@ public:
 
 #    if _LIBCPP_HAS_LOCALIZATION
   template <class _ECharT, class _Traits = char_traits<_ECharT>, class _Allocator = allocator<_ECharT> >
+  [[nodiscard]]
   _LIBCPP_HIDE_FROM_ABI basic_string<_ECharT, _Traits, _Allocator> string(const _Allocator& __a = _Allocator()) const {
     using _Str = basic_string<_ECharT, _Traits, _Allocator>;
     _Str __s(__a);
@@ -693,8 +694,8 @@ public:
     return __s;
   }
 
-  _LIBCPP_HIDE_FROM_ABI std::string string() const { return string<char>(); }
-  _LIBCPP_HIDE_FROM_ABI __u8_string u8string() const {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::string string() const { return string<char>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI __u8_string u8string() const {
     using _CVT = __narrow_to_utf8<sizeof(wchar_t) * __CHAR_BIT__>;
     __u8_string __s;
     __s.reserve(__pn_.size());
@@ -702,12 +703,12 @@ public:
     return __s;
   }
 
-  _LIBCPP_HIDE_FROM_ABI std::u16string u16string() const { return string<char16_t>(); }
-  _LIBCPP_HIDE_FROM_ABI std::u32string u32string() const { return string<char32_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u16string u16string() const { return string<char16_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u32string u32string() const { return string<char32_t>(); }
 
   // generic format observers
   template <class _ECharT, class _Traits = char_traits<_ECharT>, class _Allocator = allocator<_ECharT> >
-  _LIBCPP_HIDE_FROM_ABI basic_string<_ECharT, _Traits, _Allocator>
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI basic_string<_ECharT, _Traits, _Allocator>
   generic_string(const _Allocator& __a = _Allocator()) const {
     using _Str = basic_string<_ECharT, _Traits, _Allocator>;
     _Str __s   = string<_ECharT, _Traits, _Allocator>(__a);
@@ -718,10 +719,10 @@ public:
     return __s;
   }
 
-  _LIBCPP_HIDE_FROM_ABI std::string generic_string() const { return generic_string<char>(); }
-  _LIBCPP_HIDE_FROM_ABI std::u16string generic_u16string() const { return generic_string<char16_t>(); }
-  _LIBCPP_HIDE_FROM_ABI std::u32string generic_u32string() const { return generic_string<char32_t>(); }
-  _LIBCPP_HIDE_FROM_ABI __u8_string generic_u8string() const {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::string generic_string() const { return generic_string<char>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u16string generic_u16string() const { return generic_string<char16_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u32string generic_u32string() const { return generic_string<char32_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI __u8_string generic_u8string() const {
     __u8_string __s = u8string();
     std::replace(__s.begin(), __s.end(), '\\', '/');
     return __s;
@@ -729,15 +730,18 @@ public:
 #    endif // _LIBCPP_HAS_LOCALIZATION
 #  else    /* _LIBCPP_WIN32API */
 
-  _LIBCPP_HIDE_FROM_ABI std::string string() const { return __pn_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::string string() const { return __pn_; }
 #    if _LIBCPP_HAS_CHAR8_T
-  _LIBCPP_HIDE_FROM_ABI std::u8string u8string() const { return std::u8string(__pn_.begin(), __pn_.end()); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u8string u8string() const {
+    return std::u8string(__pn_.begin(), __pn_.end());
+  }
 #    else
-  _LIBCPP_HIDE_FROM_ABI std::string u8string() const { return __pn_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::string u8string() const { return __pn_; }
 #    endif
 
 #    if _LIBCPP_HAS_LOCALIZATION
   template <class _ECharT, class _Traits = char_traits<_ECharT>, class _Allocator = allocator<_ECharT> >
+  [[nodiscard]]
   _LIBCPP_HIDE_FROM_ABI basic_string<_ECharT, _Traits, _Allocator> string(const _Allocator& __a = _Allocator()) const {
     using _CVT = __widen_from_utf8<sizeof(_ECharT) * __CHAR_BIT__>;
     using _Str = basic_string<_ECharT, _Traits, _Allocator>;
@@ -748,32 +752,34 @@ public:
   }
 
 #      if _LIBCPP_HAS_WIDE_CHARACTERS
-  _LIBCPP_HIDE_FROM_ABI std::wstring wstring() const { return string<wchar_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::wstring wstring() const { return string<wchar_t>(); }
 #      endif
-  _LIBCPP_HIDE_FROM_ABI std::u16string u16string() const { return string<char16_t>(); }
-  _LIBCPP_HIDE_FROM_ABI std::u32string u32string() const { return string<char32_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u16string u16string() const { return string<char16_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u32string u32string() const { return string<char32_t>(); }
 #    endif // _LIBCPP_HAS_LOCALIZATION
 
   // generic format observers
-  _LIBCPP_HIDE_FROM_ABI std::string generic_string() const { return __pn_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::string generic_string() const { return __pn_; }
 #    if _LIBCPP_HAS_CHAR8_T
-  _LIBCPP_HIDE_FROM_ABI std::u8string generic_u8string() const { return std::u8string(__pn_.begin(), __pn_.end()); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u8string generic_u8string() const {
+    return std::u8string(__pn_.begin(), __pn_.end());
+  }
 #    else
-  _LIBCPP_HIDE_FROM_ABI std::string generic_u8string() const { return __pn_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::string generic_u8string() const { return __pn_; }
 #    endif
 
 #    if _LIBCPP_HAS_LOCALIZATION
   template <class _ECharT, class _Traits = char_traits<_ECharT>, class _Allocator = allocator<_ECharT> >
-  _LIBCPP_HIDE_FROM_ABI basic_string<_ECharT, _Traits, _Allocator>
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI basic_string<_ECharT, _Traits, _Allocator>
   generic_string(const _Allocator& __a = _Allocator()) const {
     return string<_ECharT, _Traits, _Allocator>(__a);
   }
 
 #      if _LIBCPP_HAS_WIDE_CHARACTERS
-  _LIBCPP_HIDE_FROM_ABI std::wstring generic_wstring() const { return string<wchar_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::wstring generic_wstring() const { return string<wchar_t>(); }
 #      endif
-  _LIBCPP_HIDE_FROM_ABI std::u16string generic_u16string() const { return string<char16_t>(); }
-  _LIBCPP_HIDE_FROM_ABI std::u32string generic_u32string() const { return string<char32_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u16string generic_u16string() const { return string<char16_t>(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u32string generic_u32string() const { return string<char32_t>(); }
 #    endif // _LIBCPP_HAS_LOCALIZATION
 #  endif   /* !_LIBCPP_WIN32API */
 
@@ -790,40 +796,40 @@ private:
 
 public:
   // compare
-  _LIBCPP_HIDE_FROM_ABI int compare(const path& __p) const noexcept { return __compare(__p.__pn_); }
-  _LIBCPP_HIDE_FROM_ABI int compare(const string_type& __s) const { return __compare(__s); }
-  _LIBCPP_HIDE_FROM_ABI int compare(__string_view __s) const { return __compare(__s); }
-  _LIBCPP_HIDE_FROM_ABI int compare(const value_type* __s) const { return __compare(__s); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI int compare(const path& __p) const noexcept { return __compare(__p.__pn_); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI int compare(const string_type& __s) const { return __compare(__s); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI int compare(__string_view __s) const { return __compare(__s); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI int compare(const value_type* __s) const { return __compare(__s); }
 
   // decomposition
-  _LIBCPP_HIDE_FROM_ABI path root_name() const { return string_type(__root_name()); }
-  _LIBCPP_HIDE_FROM_ABI path root_directory() const { return string_type(__root_directory()); }
-  _LIBCPP_HIDE_FROM_ABI path root_path() const {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path root_name() const { return string_type(__root_name()); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path root_directory() const { return string_type(__root_directory()); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path root_path() const {
 #  if defined(_LIBCPP_WIN32API)
     return string_type(__root_path_raw());
 #  else
     return root_name().append(string_type(__root_directory()));
 #  endif
   }
-  _LIBCPP_HIDE_FROM_ABI path relative_path() const { return string_type(__relative_path()); }
-  _LIBCPP_HIDE_FROM_ABI path parent_path() const { return string_type(__parent_path()); }
-  _LIBCPP_HIDE_FROM_ABI path filename() const { return string_type(__filename()); }
-  _LIBCPP_HIDE_FROM_ABI path stem() const { return string_type(__stem()); }
-  _LIBCPP_HIDE_FROM_ABI path extension() const { return string_type(__extension()); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path relative_path() const { return string_type(__relative_path()); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path parent_path() const { return string_type(__parent_path()); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path filename() const { return string_type(__filename()); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path stem() const { return string_type(__stem()); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path extension() const { return string_type(__extension()); }
 
   // query
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const noexcept { return __pn_.empty(); }
 
-  _LIBCPP_HIDE_FROM_ABI bool has_root_name() const { return !__root_name().empty(); }
-  _LIBCPP_HIDE_FROM_ABI bool has_root_directory() const { return !__root_directory().empty(); }
-  _LIBCPP_HIDE_FROM_ABI bool has_root_path() const { return !__root_path_raw().empty(); }
-  _LIBCPP_HIDE_FROM_ABI bool has_relative_path() const { return !__relative_path().empty(); }
-  _LIBCPP_HIDE_FROM_ABI bool has_parent_path() const { return !__parent_path().empty(); }
-  _LIBCPP_HIDE_FROM_ABI bool has_filename() const { return !__filename().empty(); }
-  _LIBCPP_HIDE_FROM_ABI bool has_stem() const { return !__stem().empty(); }
-  _LIBCPP_HIDE_FROM_ABI bool has_extension() const { return !__extension().empty(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool has_root_name() const { return !__root_name().empty(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool has_root_directory() const { return !__root_directory().empty(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool has_root_path() const { return !__root_path_raw().empty(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool has_relative_path() const { return !__relative_path().empty(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool has_parent_path() const { return !__parent_path().empty(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool has_filename() const { return !__filename().empty(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool has_stem() const { return !__stem().empty(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool has_extension() const { return !__extension().empty(); }
 
-  _LIBCPP_HIDE_FROM_ABI bool is_absolute() const {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_absolute() const {
 #  if defined(_LIBCPP_WIN32API)
     __string_view __root_name_str = __root_name();
     __string_view __root_dir      = __root_directory();
@@ -847,13 +853,13 @@ public:
     return has_root_directory();
 #  endif
   }
-  _LIBCPP_HIDE_FROM_ABI bool is_relative() const { return !is_absolute(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_relative() const { return !is_absolute(); }
 
   // relative paths
-  path lexically_normal() const;
-  path lexically_relative(const path& __base) const;
+  [[nodiscard]] path lexically_normal() const;
+  [[nodiscard]] path lexically_relative(const path& __base) const;
 
-  _LIBCPP_HIDE_FROM_ABI path lexically_proximate(const path& __base) const {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path lexically_proximate(const path& __base) const {
     path __result = this->lexically_relative(__base);
     if (__result.native().empty())
       return *this;
@@ -864,8 +870,8 @@ public:
   class iterator;
   typedef iterator const_iterator;
 
-  iterator begin() const;
-  iterator end() const;
+  [[nodiscard]] iterator begin() const;
+  [[nodiscard]] iterator end() const;
 
 #  if _LIBCPP_HAS_LOCALIZATION
   template <
@@ -908,7 +914,7 @@ private:
 
 inline _LIBCPP_HIDE_FROM_ABI void swap(path& __lhs, path& __rhs) noexcept { __lhs.swap(__rhs); }
 
-_LIBCPP_EXPORTED_FROM_ABI size_t hash_value(const path& __p) noexcept;
+[[nodiscard]] _LIBCPP_EXPORTED_FROM_ABI size_t hash_value(const path& __p) noexcept;
 
 _LIBCPP_END_NAMESPACE_FILESYSTEM
 
@@ -916,7 +922,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <>
 struct hash<filesystem::path> : __unary_function<filesystem::path, size_t> {
-  _LIBCPP_HIDE_FROM_ABI size_t operator()(filesystem::path const& __p) const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI size_t operator()(filesystem::path const& __p) const noexcept {
     return filesystem::hash_value(__p);
   }
 };

--- a/libcxx/include/__filesystem/path_iterator.h
+++ b/libcxx/include/__filesystem/path_iterator.h
@@ -52,7 +52,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI iterator& operator=(const iterator&) = default;
 
-  _LIBCPP_HIDE_FROM_ABI reference operator*() const { return __stashed_elem_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI reference operator*() const { return __stashed_elem_; }
 
   _LIBCPP_HIDE_FROM_ABI pointer operator->() const { return &__stashed_elem_; }
 

--- a/libcxx/include/__filesystem/perm_options.h
+++ b/libcxx/include/__filesystem/perm_options.h
@@ -22,19 +22,19 @@ _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
 enum class perm_options : unsigned char { replace = 1, add = 2, remove = 4, nofollow = 8 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr perm_options operator&(perm_options __lhs, perm_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr perm_options operator&(perm_options __lhs, perm_options __rhs) {
   return static_cast<perm_options>(static_cast<unsigned>(__lhs) & static_cast<unsigned>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr perm_options operator|(perm_options __lhs, perm_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr perm_options operator|(perm_options __lhs, perm_options __rhs) {
   return static_cast<perm_options>(static_cast<unsigned>(__lhs) | static_cast<unsigned>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr perm_options operator^(perm_options __lhs, perm_options __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr perm_options operator^(perm_options __lhs, perm_options __rhs) {
   return static_cast<perm_options>(static_cast<unsigned>(__lhs) ^ static_cast<unsigned>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr perm_options operator~(perm_options __lhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr perm_options operator~(perm_options __lhs) {
   return static_cast<perm_options>(~static_cast<unsigned>(__lhs));
 }
 

--- a/libcxx/include/__filesystem/perms.h
+++ b/libcxx/include/__filesystem/perms.h
@@ -51,19 +51,19 @@ enum class perms : unsigned {
   unknown    = 0xFFFF,
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr perms operator&(perms __lhs, perms __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr perms operator&(perms __lhs, perms __rhs) {
   return static_cast<perms>(static_cast<unsigned>(__lhs) & static_cast<unsigned>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr perms operator|(perms __lhs, perms __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr perms operator|(perms __lhs, perms __rhs) {
   return static_cast<perms>(static_cast<unsigned>(__lhs) | static_cast<unsigned>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr perms operator^(perms __lhs, perms __rhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr perms operator^(perms __lhs, perms __rhs) {
   return static_cast<perms>(static_cast<unsigned>(__lhs) ^ static_cast<unsigned>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr perms operator~(perms __lhs) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr perms operator~(perms __lhs) {
   return static_cast<perms>(~static_cast<unsigned>(__lhs));
 }
 

--- a/libcxx/include/__filesystem/recursive_directory_iterator.h
+++ b/libcxx/include/__filesystem/recursive_directory_iterator.h
@@ -71,7 +71,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI ~recursive_directory_iterator() = default;
 
-  _LIBCPP_HIDE_FROM_ABI const directory_entry& operator*() const { return __dereference(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI const directory_entry& operator*() const { return __dereference(); }
 
   _LIBCPP_HIDE_FROM_ABI const directory_entry* operator->() const { return &__dereference(); }
 
@@ -85,14 +85,14 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI recursive_directory_iterator& increment(error_code& __ec) { return __increment(&__ec); }
 
-  _LIBCPP_EXPORTED_FROM_ABI directory_options options() const;
-  _LIBCPP_EXPORTED_FROM_ABI int depth() const;
+  [[nodiscard]] _LIBCPP_EXPORTED_FROM_ABI directory_options options() const;
+  [[nodiscard]] _LIBCPP_EXPORTED_FROM_ABI int depth() const;
 
   _LIBCPP_HIDE_FROM_ABI void pop() { __pop(); }
 
   _LIBCPP_HIDE_FROM_ABI void pop(error_code& __ec) { __pop(&__ec); }
 
-  _LIBCPP_HIDE_FROM_ABI bool recursion_pending() const { return __rec_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool recursion_pending() const { return __rec_; }
 
   _LIBCPP_HIDE_FROM_ABI void disable_recursion_pending() { __rec_ = false; }
 
@@ -130,11 +130,12 @@ operator!=(const recursive_directory_iterator& __lhs, const recursive_directory_
   return !(__lhs == __rhs);
 }
 // enable recursive_directory_iterator range-based for statements
-inline _LIBCPP_HIDE_FROM_ABI recursive_directory_iterator begin(recursive_directory_iterator __iter) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI recursive_directory_iterator
+begin(recursive_directory_iterator __iter) noexcept {
   return __iter;
 }
 
-inline _LIBCPP_HIDE_FROM_ABI recursive_directory_iterator end(recursive_directory_iterator) noexcept {
+[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI recursive_directory_iterator end(recursive_directory_iterator) noexcept {
   return recursive_directory_iterator();
 }
 

--- a/libcxx/include/__filesystem/u8path.h
+++ b/libcxx/include/__filesystem/u8path.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
 #  if !defined(_LIBCPP_WIN32API) || _LIBCPP_HAS_LOCALIZATION
 template <class _InputIt, __enable_if_t<__is_pathable<_InputIt>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, _InputIt __l) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, _InputIt __l) {
   static_assert(
 #    if _LIBCPP_HAS_CHAR8_T
       is_same<typename __is_pathable<_InputIt>::__char_type, char8_t>::value ||
@@ -49,7 +49,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, 
 
 #  if defined(_LIBCPP_WIN32API) && _LIBCPP_HAS_LOCALIZATION
 template <class _InputIt, __enable_if_t<__is_pathable<_InputIt>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, _NullSentinel) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, _NullSentinel) {
   static_assert(
 #    if _LIBCPP_HAS_CHAR8_T
       is_same<typename __is_pathable<_InputIt>::__char_type, char8_t>::value ||
@@ -70,7 +70,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, 
 #  endif // defined(_LIBCPP_WIN32API) && _LIBCPP_HAS_LOCALIZATION
 
 template <class _Source, __enable_if_t<__is_pathable<_Source>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(const _Source& __s) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(const _Source& __s) {
   static_assert(
 #  if _LIBCPP_HAS_CHAR8_T
       is_same<typename __is_pathable<_Source>::__char_type, char8_t>::value ||

--- a/libcxx/test/libcxx/diagnostics/filesystem.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/filesystem.nodiscard.verify.cpp
@@ -6,13 +6,449 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03, c++11, c++14
+// REQUIRES: std-at-least-c++17
 
-// check that <filesystem> functions are marked [[nodiscard]]
+// UNSUPPORTED: no-filesystem
+
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// <filesystem>
+
+// Check that functions are marked [[nodiscard]]
 
 #include <filesystem>
+#include <string>
+#include <string_view>
+
+#include "test_macros.h"
 
 void test() {
-  std::filesystem::path path;
-  path.empty(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  {
+    const auto op = std::filesystem::copy_options::none;
+
+    op & op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    op | op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    op ^ op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ~op;     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
+
+  {
+    const std::filesystem::directory_entry de;
+    std::error_code ec;
+
+    de.path(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    de.exists();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.exists(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    de.is_block_file();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_block_file(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_character_file();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_character_file(ec);
+
+    de.is_directory();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_directory(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    de.is_fifo();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_fifo(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    de.is_other();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_other(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_regular_file();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_regular_file(ec);
+
+    de.is_socket();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_socket(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    de.is_symlink();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.is_symlink(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    de.file_size();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.file_size(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.hard_link_count();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.hard_link_count(ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.last_write_time();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.last_write_time(ec);
+
+    de.status();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.status(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    de.symlink_status();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    de.symlink_status(ec); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
+
+  {
+    const std::filesystem::directory_iterator di;
+
+    *di; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::begin(di);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::end(di);
+  }
+
+  {
+    const auto op = std::filesystem::directory_options::none;
+
+    op & op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    op | op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    op ^ op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ~op;     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
+
+  {
+    const std::filesystem::file_status fs;
+
+    fs.type();        // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    fs.permissions(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
+
+  {
+    std::error_code ec;
+    const std::filesystem::filesystem_error fs("zmt", ec);
+
+    fs.path1(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    fs.path2(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    fs.what(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
+
+  {
+    const std::filesystem::path p;
+    std::error_code ec;
+    const std::filesystem::file_status fs;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::absolute(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::absolute(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::canonical(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::canonical(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::current_path();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::current_path(ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::equivalent(p, p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::equivalent(p, p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::status_known(fs);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::exists(fs);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::exists(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::exists(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::file_size(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::file_size(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::hard_link_count(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::hard_link_count(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_block_file(fs);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_block_file(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_block_file(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_character_file(fs);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_character_file(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_character_file(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_directory(fs);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_directory(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_directory(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_empty(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_empty(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_fifo(fs);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_fifo(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_fifo(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_regular_file(fs);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_regular_file(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_regular_file(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_symlink(fs);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_symlink(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_symlink(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_other(fs);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_other(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_other(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_socket(fs);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_socket(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::is_socket(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::last_write_time(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::last_write_time(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::proximate(p, p, ec);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::proximate(p, ec);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::proximate(p);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::read_symlink(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::read_symlink(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::relative(p, p, ec);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::relative(p, ec);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::relative(p);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::space(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::space(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::status(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::status(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::symlink_status(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::symlink_status(p, ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::temp_directory_path();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::temp_directory_path(ec);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::weakly_canonical(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::weakly_canonical(p, ec);
+  }
+
+  {
+    std::filesystem::path::iterator it;
+
+    *it; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
+
+  {
+    std::filesystem::path p;
+    const std::string src;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.native();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.c_str();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.string();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.u8string();
+#if !defined(TEST_HAS_NO_LOCALIZATION)
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.string<char>();
+
+#  if !defined(TEST_HAS_NO_WIDE_CHARACTERS)
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.wstring();
+#  endif
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.u16string();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.u32string();
+#endif // !defined(TEST_HAS_NO_LOCALIZATION)
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.generic_string();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.generic_u8string();
+#if !defined(TEST_HAS_NO_LOCALIZATION)
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.generic_string<char>();
+
+#  if !defined(TEST_HAS_NO_WIDE_CHARACTERS)
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.generic_wstring();
+#  endif
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.generic_u16string();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.generic_u32string();
+#endif // !defined(TEST_HAS_NO_LOCALIZATION)
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.compare(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.compare(std::string{});
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.compare(std::string_view{});
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.compare("");
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.root_name();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.root_directory();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.root_path();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.relative_path();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.parent_path();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.filename();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.stem();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.empty();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.has_root_name();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.has_root_directory();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.has_root_path();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.has_relative_path();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.has_parent_path();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.has_filename();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.has_stem();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.has_extension();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.is_absolute();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.is_relative();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.lexically_normal();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.lexically_relative(p);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.lexically_proximate(p);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.begin();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    p.end();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::hash_value(p);
+
+    std::hash<std::filesystem::path> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(p);
+  }
+
+  {
+    const auto op = std::filesystem::perm_options::add;
+
+    op & op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    op | op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    op ^ op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ~op;     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
+
+  {
+    const auto op = std::filesystem::perms::all;
+
+    op & op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    op | op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    op ^ op; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ~op;     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
+
+  {
+    const std::filesystem::recursive_directory_iterator it;
+
+    *it; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    it.options(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    it.depth();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    it.recursion_pending();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::begin(it);
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::end(it);
+  }
+
+  {
+    const std::string str;
+
+#if !defined(TEST_HAS_NO_LOCALIZATION)
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::u8path(str.begin(), str.end());
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::u8path(str.begin());
+#endif
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::filesystem::u8path(str);
+  }
 }

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.status/status.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.status/status.pass.cpp
@@ -96,7 +96,7 @@ static void test_status_cannot_resolve()
 #ifndef TEST_HAS_NO_EXCEPTIONS
         { // test throwing case
             try {
-                status(TC.p);
+              (void)status(TC.p);
             } catch (filesystem_error const& err) {
                 assert(err.path1() == TC.p);
                 assert(err.path2() == "");


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

- https://libcxx.llvm.org/CodingGuidelines.html