### PR TITLE
[lldb-dap] Migrate pause request to structured types

### DIFF
--- a/lldb/tools/lldb-dap/Handler/PauseRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/PauseRequestHandler.cpp
@@ -8,6 +8,7 @@
 
 #include "DAP.h"
 #include "EventHelper.h"
+#include "LLDBUtils.h"
 #include "Protocol/ProtocolRequests.h"
 #include "RequestHandler.h"
 
@@ -20,7 +21,7 @@ llvm::Error
 PauseRequestHandler::Run(const protocol::PauseArguments &args) const {
   lldb::SBProcess process = dap.target.GetProcess();
   lldb::SBError error = process.Stop();
-  return llvm::Error::success();
+  return ToError(error);
 }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/PauseRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/PauseRequestHandler.cpp
@@ -8,53 +8,19 @@
 
 #include "DAP.h"
 #include "EventHelper.h"
-#include "JSONUtils.h"
+#include "Protocol/ProtocolRequests.h"
 #include "RequestHandler.h"
 
 namespace lldb_dap {
 
-// "PauseRequest": {
-//   "allOf": [ { "$ref": "#/definitions/Request" }, {
-//     "type": "object",
-//     "description": "Pause request; value of command field is 'pause'. The
-//     request suspenses the debuggee. The debug adapter first sends the
-//     PauseResponse and then a StoppedEvent (event type 'pause') after the
-//     thread has been paused successfully.", "properties": {
-//       "command": {
-//         "type": "string",
-//         "enum": [ "pause" ]
-//       },
-//       "arguments": {
-//         "$ref": "#/definitions/PauseArguments"
-//       }
-//     },
-//     "required": [ "command", "arguments"  ]
-//   }]
-// },
-// "PauseArguments": {
-//   "type": "object",
-//   "description": "Arguments for 'pause' request.",
-//   "properties": {
-//     "threadId": {
-//       "type": "integer",
-//       "description": "Pause execution for this thread."
-//     }
-//   },
-//   "required": [ "threadId" ]
-// },
-// "PauseResponse": {
-//   "allOf": [ { "$ref": "#/definitions/Response" }, {
-//     "type": "object",
-//     "description": "Response to 'pause' request. This is just an
-//     acknowledgement, so no body field is required."
-//   }]
-// }
-void PauseRequestHandler::operator()(const llvm::json::Object &request) const {
-  llvm::json::Object response;
-  FillResponse(request, response);
+/// The request suspenses the debuggee. The debug adapter first sends the
+/// PauseResponse and then a StoppedEvent (event type 'pause') after the thread
+/// has been paused successfully.
+llvm::Error
+PauseRequestHandler::Run(const protocol::PauseArguments &args) const {
   lldb::SBProcess process = dap.target.GetProcess();
   lldb::SBError error = process.Stop();
-  dap.SendJSON(llvm::json::Value(std::move(response)));
+  return llvm::Error::success();
 }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -492,11 +492,12 @@ public:
   Run(const std::optional<protocol::ModulesArguments> &args) const override;
 };
 
-class PauseRequestHandler : public LegacyRequestHandler {
+class PauseRequestHandler
+    : public RequestHandler<protocol::PauseArguments, protocol::PauseResponse> {
 public:
-  using LegacyRequestHandler::LegacyRequestHandler;
+  using RequestHandler::RequestHandler;
   static llvm::StringLiteral GetCommand() { return "pause"; }
-  void operator()(const llvm::json::Object &request) const override;
+  llvm::Error Run(const protocol::PauseArguments &args) const override;
 };
 
 class ScopesRequestHandler final

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
@@ -695,4 +695,10 @@ llvm::json::Value toJSON(const EvaluateResponseBody &Body) {
   return result;
 }
 
+bool fromJSON(const llvm::json::Value &Params, PauseArguments &Args,
+              llvm::json::Path Path) {
+  json::ObjectMapper O(Params, Path);
+  return O && O.map("threadId", Args.threadId);
+}
+
 } // namespace lldb_dap::protocol

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -1184,6 +1184,17 @@ struct EvaluateResponseBody {
 };
 llvm::json::Value toJSON(const EvaluateResponseBody &);
 
+/// Arguments for `pause` request.
+struct PauseArguments {
+  /// Pause execution for this thread.
+  lldb::tid_t threadId = LLDB_INVALID_THREAD_ID;
+};
+bool fromJSON(const llvm::json::Value &, PauseArguments &, llvm::json::Path);
+
+/// Response to `pause` request. This is just an acknowledgement, so no body
+/// field is required.
+using PauseResponse = VoidResponse;
+
 } // namespace lldb_dap::protocol
 
 #endif

--- a/lldb/unittests/DAP/ProtocolRequestsTest.cpp
+++ b/lldb/unittests/DAP/ProtocolRequestsTest.cpp
@@ -182,3 +182,14 @@ TEST(ProtocolRequestsTest, InitializeRequestArguments) {
   EXPECT_THAT_EXPECTED(parse<InitializeRequestArguments>(R"({})"),
                        FailedWithMessage("missing value at (root).adapterID"));
 }
+
+TEST(ProtocolRequestsTest, PauseRequestArguments) {
+  llvm::Expected<PauseArguments> expected =
+      parse<PauseArguments>(R"({"threadId": 123})");
+  ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
+  EXPECT_EQ(expected->threadId, 123U);
+
+  // Check required keys.
+  EXPECT_THAT_EXPECTED(parse<PauseArguments>(R"({})"),
+                       FailedWithMessage("missing value at (root).threadId"));
+}


### PR DESCRIPTION
This patch migrates `pause` request into structured types and adds test for it.