### PR TITLE
[mlir][affine] Require a vector size in affine-super-vectorize

### DIFF
--- a/mlir/lib/Dialect/Affine/Transforms/SuperVectorize.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/SuperVectorize.cpp
@@ -1841,6 +1841,17 @@ void affine::vectorizeChildAffineLoops(
 /// predetermined patterns.
 void Vectorize::runOnOperation() {
   func::FuncOp f = getOperation();
+  if (vectorSizes.empty()) {
+    f.emitError("The 'virtual-vector-size' option must be specified.");
+    return signalPassFailure();
+  }
+
+  if (llvm::any_of(vectorSizes, [](int64_t size) { return size <= 0; })) {
+    f.emitError(
+        "The 'virtual-vector-size' option must contain only positive values.");
+    return signalPassFailure();
+  }
+
   if (!fastestVaryingPattern.empty() &&
       fastestVaryingPattern.size() != vectorSizes.size()) {
     f.emitRemark("Fastest varying pattern specified with different size than "
@@ -1850,11 +1861,6 @@ void Vectorize::runOnOperation() {
 
   if (vectorizeReductions && vectorSizes.size() != 1) {
     f.emitError("Vectorizing reductions is supported only for 1-D vectors.");
-    return signalPassFailure();
-  }
-
-  if (llvm::any_of(vectorSizes, [](int64_t size) { return size <= 0; })) {
-    f.emitError("Vectorization factor must be greater than zero.");
     return signalPassFailure();
   }
 

--- a/mlir/test/Dialect/Affine/SuperVectorize/invalid-zero-size.mlir
+++ b/mlir/test/Dialect/Affine/SuperVectorize/invalid-zero-size.mlir
@@ -1,9 +1,0 @@
-// RUN: mlir-opt %s -verify-diagnostics --affine-super-vectorize=virtual-vector-size=0
-
-// expected-error@+1 {{Vectorization factor must be greater than zero}} 
-func.func @with_zero_vector_size(%arg0: memref<21x12x12xi1>) {
-  affine.for %arg1 = 0 to 84 step 4294967295 {
-  }
-  return
-}
-

--- a/mlir/test/Dialect/Affine/SuperVectorize/invalid_missing_vector_size.mlir
+++ b/mlir/test/Dialect/Affine/SuperVectorize/invalid_missing_vector_size.mlir
@@ -1,0 +1,6 @@
+// RUN: mlir-opt %s -verify-diagnostics --affine-super-vectorize
+
+// expected-error@+1 {{The 'virtual-vector-size' option must be specified.}}
+func.func @missing_vector_size() {
+  return
+}

--- a/mlir/test/Dialect/Affine/SuperVectorize/invalid_zero_size.mlir
+++ b/mlir/test/Dialect/Affine/SuperVectorize/invalid_zero_size.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-opt %s -verify-diagnostics --affine-super-vectorize=virtual-vector-size=0
+// RUN: mlir-opt %s -verify-diagnostics \
+// RUN:   -affine-super-vectorize="virtual-vector-size=4,0 vectorize-reductions=true"
+
+// expected-error@+1 {{The 'virtual-vector-size' option must contain only positive values.}}
+func.func @with_zero_vector_size(%arg0: memref<21x12x12xi1>) {
+  affine.for %arg1 = 0 to 84 step 4294967295 {
+  }
+  return
+}


### PR DESCRIPTION
Diagnose invocations that omit the `virtual-vector-size` option. A vector rank is required to construct a vectorization pattern, so accepting an empty size list would silently leave the input unchanged.

Check that vector sizes are present and positive before applying rank-dependent constraints.

Fixes #114528