### PR TITLE
[BOLT][ReorderData] Remove .bss from DefaultSections

### DIFF
--- a/bolt/lib/Passes/ReorderData.cpp
+++ b/bolt/lib/Passes/ReorderData.cpp
@@ -437,7 +437,7 @@ bool ReorderData::markUnmoveableSymbols(BinaryContext &BC,
 }
 
 Error ReorderData::runOnFunctions(BinaryContext &BC) {
-  static const char *DefaultSections[] = {".rodata", ".data", ".bss", nullptr};
+  static const char *DefaultSections[] = {".rodata", ".data", nullptr};
 
   if (!BC.HasRelocations || opts::ReorderData.empty())
     return Error::success();


### PR DESCRIPTION
Remove .bss from DefaultSections in ReorderData, since it isn't support for now.