### PR TITLE
[MLIR] Use dynamic dim in PushDownUnPackThroughPadOp

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/DataLayoutPropagation.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/DataLayoutPropagation.cpp
@@ -1317,9 +1317,10 @@ struct PushDownUnPackThroughPadOp : public OpRewritePattern<tensor::PadOp> {
     SmallVector<OpFoldResult> outputSizes;
     AffineExpr d0, d1, d2;
     bindDims(rewriter.getContext(), d0, d1, d2);
+    AffineExpr sumExpr = d0 + d1 + d2;
     for (size_t i = 0; i < sourceSizes.size(); ++i) {
       outputSizes.push_back(affine::makeComposedFoldedAffineApply(
-          rewriter, loc, d0 + d1 + d2,
+          rewriter, loc, sumExpr,
           {sourceSizes[i], originalLowPad[i], originalHighPad[i]}));
     }
     Value outputUnPack = tensor::EmptyOp::create(

--- a/mlir/test/Dialect/Linalg/data-layout-propagation.mlir
+++ b/mlir/test/Dialect/Linalg/data-layout-propagation.mlir
@@ -1651,22 +1651,16 @@ func.func @test_dynamic_unpack_pad(%arg0: tensor<?x4x8xf32>, %dim: index) -> ten
   return %pad : tensor<?x32xf32>
 }
 
-// CHECK-DAG:  #[[$MAP:.+]] = affine_map<()[s0] -> (s0 + 5)>
 // CHECK-LABEL: func.func @test_dynamic_unpack_pad
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[DIM:[a-zA-Z0-9]+]]
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:     %[[CST:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK:         %[[EMPTY0:.+]] = tensor.empty(%[[DIM]])
-// CHECK:         %[[UNPACK0:.+]] = linalg.unpack %[[ARG0]]
-// CHECK-SAME:      inner_dims_pos = [1] inner_tiles = [8]
-// CHECK-SAME:      into %[[EMPTY0]]
 // CHECK:         %[[PAD:.+]] = tensor.pad %[[ARG0]] low[2, 0, 0] high[3, 0, 0]
 // CHECK:           tensor.yield %[[CST]]
-// CHECK:         %[[DIM_VAL:.+]] = tensor.dim %[[UNPACK0]], %[[C0]]
-// CHECK:         %[[NEW_DIM:.+]] = affine.apply #[[$MAP]]()[%[[DIM_VAL]]]
-// CHECK:         %[[EMPTY1:.+]] = tensor.empty(%[[NEW_DIM]])
-// CHECK:         %[[UNPACK1:.+]] = linalg.unpack %[[PAD]]
+// CHECK:         %[[DIM_VAL:.+]] = tensor.dim %[[PAD]], %[[C0]]
+// CHECK:         %[[EMPTY:.+]] = tensor.empty(%[[DIM_VAL]])
+// CHECK:         %[[UNPACK:.+]] = linalg.unpack %[[PAD]]
 // CHECK-SAME:      inner_dims_pos = [1] inner_tiles = [8]
-// CHECK-SAME:      into %[[EMPTY1]]
-// CHECK:         return %[[UNPACK1]]
+// CHECK-SAME:      into %[[EMPTY]]
+// CHECK:         return %[[UNPACK]]


### PR DESCRIPTION
In the case below, current DataLayoutPropagation pass will crash:
```
func.func @test_dynamic_unpack_pad(%arg0: tensor<?x4x8xf32>, %dim: index) -> tensor<?x32xf32> {
  %dest = tensor.empty(%dim) : tensor<?x32xf32>
  %unpack = tensor.unpack %arg0 inner_dims_pos = [1] inner_tiles = [8]
            into %dest : tensor<?x4x8xf32> -> tensor<?x32xf32>

  %c0 = arith.constant 0.0 : f32
  %pad = tensor.pad %unpack low[2, 0] high[3, 0] {
    ^bb0(%arg1: index, %arg2: index):
      tensor.yield %c0 : f32
  } : tensor<?x32xf32> to tensor<?x32xf32>

  return %pad : tensor<?x32xf32>
}

```
I ran into this problem when I'm using iree, tring to convert a conv with dynamic dim from nchw to nhwc, the pass is in [here](https://github.com/iree-org/iree/blob/836670fb3545f884c0ab5c33598bfca8efa3ed03/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp#L457) 
This pass will generate pack and unpack, and use DataLayoutPropagation
