### PR TITLE
[mlir][py] partially use mlir_type_subclass for IRTypes.cpp

### DIFF
--- a/mlir/lib/Bindings/Python/MainModule.cpp
+++ b/mlir/lib/Bindings/Python/MainModule.cpp
@@ -145,6 +145,21 @@ NB_MODULE(_mlir, m) {
 
   // Define and populate IR submodule.
   auto irModule = m.def_submodule("ir", "MLIR IR Bindings");
+  irModule.def(
+      MLIR_PYTHON_CAPI_TYPE_CASTER_REGISTER_ATTR,
+      [](MlirTypeID mlirTypeID, bool replace) -> nb::object {
+        return nb::cpp_function([mlirTypeID, replace](
+                                    nb::callable typeCaster) -> nb::object {
+          PyGlobals::get().registerTypeCaster(mlirTypeID, typeCaster, replace);
+          return typeCaster;
+        });
+      },
+      // clang-format off
+    nb::sig("def register_type_caster(typeid: _mlir.ir.TypeID, *, replace: bool = False) "
+                      "-> typing.Callable[[typing.Callable[[T], U]], typing.Callable[[T], U]]"),
+      // clang-format on
+      "typeid"_a, nb::kw_only(), "replace"_a = false,
+      "Register a type caster for casting MLIR types to custom user types.");
   populateIRCore(irModule);
   populateIRAffine(irModule);
   populateIRAttributes(irModule);

--- a/mlir/test/python/dialects/arith_dialect.py
+++ b/mlir/test/python/dialects/arith_dialect.py
@@ -54,10 +54,10 @@ def testArithValue():
         op = getattr(arith, f"{op}Op")
         return op(lhs, rhs).result
 
-    @register_value_caster(F16Type.static_typeid)
-    @register_value_caster(F32Type.static_typeid)
-    @register_value_caster(F64Type.static_typeid)
-    @register_value_caster(IntegerType.static_typeid)
+    @register_value_caster(F16Type.get_static_typeid())
+    @register_value_caster(F32Type.get_static_typeid())
+    @register_value_caster(F64Type.get_static_typeid())
+    @register_value_caster(IntegerType.get_static_typeid())
     class ArithValue(Value):
         def __init__(self, v):
             super().__init__(v)

--- a/mlir/test/python/dialects/pdl_types.py
+++ b/mlir/test/python/dialects/pdl_types.py
@@ -148,3 +148,16 @@ def test_value_type():
     print(parsedType)
     # CHECK: !pdl.value
     print(constructedType)
+
+
+# CHECK-LABEL: TEST: test_type_without_context
+@run
+def test_type_without_context():
+  # Constructing a type without the surrounding ir.Context context manager
+  # should raise an exception but not crash.
+  try:
+    constructedType = pdl.ValueType.get()
+  except TypeError:
+    pass
+  else:
+    assert False, "Expected TypeError to be raised."

--- a/mlir/test/python/ir/builtin_types.py
+++ b/mlir/test/python/ir/builtin_types.py
@@ -185,7 +185,7 @@ def testStandardTypeCasts():
     try:
         tillegal = IntegerType(Type.parse("f32", ctx))
     except ValueError as e:
-        # CHECK: ValueError: Cannot cast type to IntegerType (from Type(f32))
+        # CHECK: ValueError: Cannot cast type to IntegerType (from F32Type(f32))
         print("ValueError:", e)
     else:
         print("Exception not produced")
@@ -302,7 +302,7 @@ def testComplexType():
         try:
             complex_invalid = ComplexType.get(index)
         except ValueError as e:
-            # CHECK: invalid 'Type(index)' and expected floating point or integer type.
+            # CHECK: Invalid element type for ComplexType: expected floating point or integer type.
             print(e)
         else:
             print("Exception not produced")
@@ -714,7 +714,8 @@ def testTypeIDs():
         # mlirTypeGetTypeID(self) for an instance.
         # CHECK: all equal
         for t1, t2 in types:
-            tid1, tid2 = t1.static_typeid, Type(t2).typeid
+            # TODO: remove the alternative once mlir_type_subclass transition is complete.
+            tid1, tid2 = t1.static_typeid if hasattr(t1, "static_typeid") else t1.get_static_typeid(), Type(t2).typeid
             assert tid1 == tid2 and hash(tid1) == hash(
                 tid2
             ), f"expected hash and value equality {t1} {t2}"
@@ -728,7 +729,9 @@ def testTypeIDs():
 
         # CHECK: all equal
         for t1, t2 in typeid_dict.items():
-            assert t1.static_typeid == t2.typeid and hash(t1.static_typeid) == hash(
+            # TODO: remove the alternative once mlir_type_subclass transition is complete.
+            tid1 = t1.static_typeid if hasattr(t1, "static_typeid") else t1.get_static_typeid()
+            assert tid1 == t2.typeid and hash(tid1) == hash(
                 t2.typeid
             ), f"expected hash and value equality {t1} {t2}"
         else:

--- a/mlir/test/python/ir/value.py
+++ b/mlir/test/python/ir/value.py
@@ -361,7 +361,7 @@ def testValueCasters():
         def __str__(self):
             return super().__str__().replace(Value.__name__, NOPBlockArg.__name__)
 
-    @register_value_caster(IntegerType.static_typeid)
+    @register_value_caster(IntegerType.get_static_typeid())
     def cast_int(v) -> Value:
         print("in caster", v.__class__.__name__)
         if isinstance(v, OpResult):
@@ -425,7 +425,7 @@ def testValueCasters():
 
     try:
 
-        @register_value_caster(IntegerType.static_typeid)
+        @register_value_caster(IntegerType.get_static_typeid())
         def dont_cast_int_shouldnt_register(v):
             ...
 
@@ -433,7 +433,7 @@ def testValueCasters():
         # CHECK: Value caster is already registered: {{.*}}cast_int
         print(e)
 
-    @register_value_caster(IntegerType.static_typeid, replace=True)
+    @register_value_caster(IntegerType.get_static_typeid(), replace=True)
     def dont_cast_int(v) -> OpResult:
         assert isinstance(v, OpResult)
         print("don't cast", v.result_number, v)


### PR DESCRIPTION
Port the bindings for non-shaped builtin types in IRTypes.cpp to use the `mlir_type_subclass` mechanism used by non-builtin types. This is part of a longer-term cleanup to only support one subclassing mechanism. Eventually, the `PyConcreteType` mechanism will be removed.

This required a surgery in the type casters and the `mlir_type_subclass` logic to avoid circular imports of the `_mlir.ir` module that would otherwise when using `mlir_type_subclass` to define classes in the `_mlir.ir` module.

Tests are updated to use the `.get_static_typeid()` function instead of the `.static_typeid` property that was specific to builtin types due to the `PyConcreteType` mechanism. The change should be NFC otherwise.