### PR TITLE
[clang][TypePrinter][NFC] Turn SuppressTagKeyword into an enum

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
@@ -187,7 +187,8 @@ void MoveConstArgCheck::check(const MatchFinder::MatchResult &Result) {
 
       QualType NoRefType = (*InvocationParmType)->getPointeeType();
       PrintingPolicy PolicyWithSuppressedTag(getLangOpts());
-      PolicyWithSuppressedTag.SuppressTagKeyword = true;
+      PolicyWithSuppressedTag.SuppressTagKeyword = llvm::to_underlying(
+          PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
       PolicyWithSuppressedTag.SuppressUnwrittenScope = true;
       std::string ExpectParmTypeName =
           NoRefType.getAsString(PolicyWithSuppressedTag);

--- a/clang-tools-extra/clang-tidy/readability/StaticAccessedThroughInstanceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/StaticAccessedThroughInstanceCheck.cpp
@@ -72,7 +72,8 @@ void StaticAccessedThroughInstanceCheck::check(
 
   const ASTContext *AstContext = Result.Context;
   PrintingPolicy PrintingPolicyWithSuppressedTag(AstContext->getLangOpts());
-  PrintingPolicyWithSuppressedTag.SuppressTagKeyword = true;
+  PrintingPolicyWithSuppressedTag.SuppressTagKeyword = llvm::to_underlying(
+      PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
   PrintingPolicyWithSuppressedTag.SuppressUnwrittenScope = true;
 
   PrintingPolicyWithSuppressedTag.PrintAsCanonical =

--- a/clang-tools-extra/clang-tidy/utils/Matchers.cpp
+++ b/clang-tools-extra/clang-tidy/utils/Matchers.cpp
@@ -35,7 +35,8 @@ bool MatchesAnyListedTypeNameMatcher::matches(
   PrintingPolicyWithSuppressedTag.PrintAsCanonical = CanonicalTypes;
   PrintingPolicyWithSuppressedTag.FullyQualifiedName = true;
   PrintingPolicyWithSuppressedTag.SuppressScope = false;
-  PrintingPolicyWithSuppressedTag.SuppressTagKeyword = true;
+  PrintingPolicyWithSuppressedTag.SuppressTagKeyword = llvm::to_underlying(
+      PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
   PrintingPolicyWithSuppressedTag.SuppressUnwrittenScope = true;
   std::string TypeName =
       Node.getUnqualifiedType().getAsString(PrintingPolicyWithSuppressedTag);

--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -419,7 +419,8 @@ std::string printType(const QualType QT, const DeclContext &CurContext,
   std::string Result;
   llvm::raw_string_ostream OS(Result);
   PrintingPolicy PP(CurContext.getParentASTContext().getPrintingPolicy());
-  PP.SuppressTagKeyword = true;
+  PP.SuppressTagKeyword = llvm::to_underlying(
+      PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
   PP.SuppressUnwrittenScope = true;
   PP.FullyQualifiedName = FullyQualify;
 

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -176,7 +176,10 @@ HoverInfo::PrintedType printType(QualType QT, ASTContext &ASTCtx,
   // tag for extra clarity. This isn't very idiomatic, so don't attempt it for
   // complex cases, including pointers/references, template specializations,
   // etc.
-  if (!QT.isNull() && !QT.hasQualifiers() && PP.SuppressTagKeyword) {
+  if (!QT.isNull() && !QT.hasQualifiers() &&
+      PP.SuppressTagKeyword ==
+          llvm::to_underlying(
+              PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames)) {
     if (auto *TT = llvm::dyn_cast<TagType>(QT.getTypePtr());
         TT && TT->isCanonicalUnqualified())
       OS << TT->getDecl()->getKindName() << " ";

--- a/clang/include/clang/AST/PrettyPrinter.h
+++ b/clang/include/clang/AST/PrettyPrinter.h
@@ -65,6 +65,10 @@ struct PrintingPolicy {
 
     /// Suppress keyword when printing the inner type of elaborated types,
     /// (as the tag keyword is part of the elaborated type):
+    ///
+    /// \code
+    /// struct Geometry::Point;
+    /// \endcode
     InElaboratedNames
   };
 
@@ -128,10 +132,6 @@ struct PrintingPolicy {
   unsigned SuppressSpecifiers : 1;
 
   /// Whether type printing should skip printing the tag keyword.
-  ///
-  /// \code
-  /// struct Geometry::Point;
-  /// \endcode
   LLVM_PREFERRED_TYPE(SuppressTagKeywordMode)
   unsigned SuppressTagKeyword : 1;
 

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -759,7 +759,10 @@ std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,
     PrettyCallbacks PrettyCB(Context.getLangOpts());
     Policy.Callbacks = &PrettyCB;
     if (IK == PredefinedIdentKind::Function && ForceElaboratedPrinting)
-      Policy.SuppressTagKeyword = !LO.MSVCCompat;
+      Policy.SuppressTagKeyword = llvm::to_underlying(
+          LO.MSVCCompat
+              ? PrintingPolicy::SuppressTagKeywordMode::None
+              : PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
     std::string Proto;
     llvm::raw_string_ostream POut(Proto);
 

--- a/clang/lib/AST/InferAlloc.cpp
+++ b/clang/lib/AST/InferAlloc.cpp
@@ -184,7 +184,8 @@ infer_alloc::getAllocTokenMetadata(QualType T, const ASTContext &Ctx) {
 
   // Get unique type name.
   PrintingPolicy Policy(Ctx.getLangOpts());
-  Policy.SuppressTagKeyword = true;
+  Policy.SuppressTagKeyword = llvm::to_underlying(
+      PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
   Policy.FullyQualifiedName = true;
   llvm::raw_svector_ostream TypeNameOS(ATMD.TypeName);
   T.getCanonicalType().print(TypeNameOS, Policy);

--- a/clang/lib/AST/NestedNameSpecifier.cpp
+++ b/clang/lib/AST/NestedNameSpecifier.cpp
@@ -111,7 +111,8 @@ void NestedNameSpecifier::print(raw_ostream &OS, const PrintingPolicy &Policy,
     break;
   case Kind::Type: {
     PrintingPolicy InnerPolicy(Policy);
-    InnerPolicy.SuppressTagKeyword = true;
+    InnerPolicy.SuppressTagKeyword = llvm::to_underlying(
+        PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
     QualType(getAsType(), 0).print(OS, InnerPolicy);
     break;
   }

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -92,19 +92,21 @@ public:
 
 class ElaboratedTypePolicyRAII {
   PrintingPolicy &Policy;
-  bool SuppressTagKeyword;
+  PrintingPolicy::SuppressTagKeywordMode SuppressTagKeyword;
   bool SuppressScope;
 
 public:
   explicit ElaboratedTypePolicyRAII(PrintingPolicy &Policy) : Policy(Policy) {
-    SuppressTagKeyword = Policy.SuppressTagKeyword;
+    SuppressTagKeyword = static_cast<PrintingPolicy::SuppressTagKeywordMode>(
+        Policy.SuppressTagKeyword);
     SuppressScope = Policy.SuppressScope;
-    Policy.SuppressTagKeyword = true;
+    Policy.SuppressTagKeyword = llvm::to_underlying(
+        PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
     Policy.SuppressScope = true;
   }
 
   ~ElaboratedTypePolicyRAII() {
-    Policy.SuppressTagKeyword = SuppressTagKeyword;
+    Policy.SuppressTagKeyword = llvm::to_underlying(SuppressTagKeyword);
     Policy.SuppressScope = SuppressScope;
   }
 };
@@ -1521,7 +1523,9 @@ void TypePrinter::printTagType(const TagType *T, raw_ostream &OS) {
   bool HasKindDecoration = false;
 
   if (T->isCanonicalUnqualified()) {
-    if (!Policy.SuppressTagKeyword && !D->getTypedefNameForAnonDecl()) {
+    if (Policy.SuppressTagKeyword ==
+            llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None) &&
+        !D->getTypedefNameForAnonDecl()) {
       HasKindDecoration = true;
       OS << D->getKindName();
       OS << ' ';

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -101,7 +101,8 @@ std::string CIRGenTypes::getRecordTypeName(const clang::RecordDecl *recordDecl,
       llvm::to_underlying(PrintingPolicy::SuppressInlineNamespaceMode::None);
   policy.AlwaysIncludeTypeForTemplateArgument = true;
   policy.PrintAsCanonical = true;
-  policy.SuppressTagKeyword = true;
+  policy.SuppressTagKeyword = llvm::to_underlying(
+      PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
 
   if (recordDecl->getIdentifier())
     QualType(astContext.getCanonicalTagType(recordDecl))

--- a/clang/lib/Index/USRGeneration.cpp
+++ b/clang/lib/Index/USRGeneration.cpp
@@ -656,7 +656,8 @@ static void printQualifier(llvm::raw_ostream &Out, const LangOptions &LangOpts,
                            NestedNameSpecifier NNS) {
   // FIXME: Encode the qualifier, don't just print it.
   PrintingPolicy PO(LangOpts);
-  PO.SuppressTagKeyword = true;
+  PO.SuppressTagKeyword = llvm::to_underlying(
+      PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
   PO.SuppressUnwrittenScope = true;
   PO.ConstantArraySizeAsWritten = false;
   PO.AnonymousTagLocations = false;

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -5342,7 +5342,8 @@ CXString clang_getCursorSpelling(CXCursor C) {
 
       PrintingPolicy Policy = Ctx.getPrintingPolicy();
       Policy.FullyQualifiedName = true;
-      Policy.SuppressTagKeyword = false;
+      Policy.SuppressTagKeyword =
+          llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None);
       return cxstring::createDup(T.getAsString(Policy));
     }
     case CXCursor_TemplateRef: {
@@ -5642,7 +5643,9 @@ clang_PrintingPolicy_getProperty(CXPrintingPolicy Policy,
   case CXPrintingPolicy_SuppressSpecifiers:
     return P->SuppressSpecifiers;
   case CXPrintingPolicy_SuppressTagKeyword:
-    return P->SuppressTagKeyword;
+    return P->SuppressTagKeyword ==
+           llvm::to_underlying(
+               PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
   case CXPrintingPolicy_IncludeTagDefinition:
     return P->IncludeTagDefinition;
   case CXPrintingPolicy_SuppressScope:
@@ -5710,7 +5713,9 @@ void clang_PrintingPolicy_setProperty(CXPrintingPolicy Policy,
     P->SuppressSpecifiers = Value;
     return;
   case CXPrintingPolicy_SuppressTagKeyword:
-    P->SuppressTagKeyword = Value;
+    P->SuppressTagKeyword = llvm::to_underlying(
+        Value ? PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames
+              : PrintingPolicy::SuppressTagKeywordMode::None);
     return;
   case CXPrintingPolicy_IncludeTagDefinition:
     P->IncludeTagDefinition = Value;

--- a/clang/unittests/AST/DeclPrinterTest.cpp
+++ b/clang/unittests/AST/DeclPrinterTest.cpp
@@ -356,40 +356,44 @@ TEST(DeclPrinter, TestCXXRecordDecl11) {
 }
 
 TEST(DeclPrinter, TestCXXRecordDecl12) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches("struct S { int x; };"
-                                      "namespace NS { class C {};}"
-                                      "void foo() {using namespace NS; C c;}",
-                                      "foo",
-                                      "void foo() {\nusing namespace NS;\n"
-                                      "C c;\n}\n",
-                                      [](PrintingPolicy &Policy) {
-                                        Policy.SuppressTagKeyword = false;
-                                        Policy.SuppressScope = true;
-                                        Policy.TerseOutput = false;
-                                      }));
+  ASSERT_TRUE(PrintedDeclCXX98Matches(
+      "struct S { int x; };"
+      "namespace NS { class C {};}"
+      "void foo() {using namespace NS; C c;}",
+      "foo",
+      "void foo() {\nusing namespace NS;\n"
+      "C c;\n}\n",
+      [](PrintingPolicy &Policy) {
+        Policy.SuppressTagKeyword =
+            llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None);
+        Policy.SuppressScope = true;
+        Policy.TerseOutput = false;
+      }));
 }
 
 TEST(DeclPrinter, TestCXXRecordDecl13) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches("struct S { int x; };"
-                                      "S s1;"
-                                      "S foo() {return s1;}",
-                                      "foo", "S foo() {\nreturn s1;\n}\n",
-                                      [](PrintingPolicy &Policy) {
-                                        Policy.SuppressTagKeyword = false;
-                                        Policy.SuppressScope = true;
-                                        Policy.TerseOutput = false;
-                                      }));
+  ASSERT_TRUE(PrintedDeclCXX98Matches(
+      "struct S { int x; };"
+      "S s1;"
+      "S foo() {return s1;}",
+      "foo", "S foo() {\nreturn s1;\n}\n", [](PrintingPolicy &Policy) {
+        Policy.SuppressTagKeyword =
+            llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None);
+        Policy.SuppressScope = true;
+        Policy.TerseOutput = false;
+      }));
 }
 
 TEST(DeclPrinter, TestCXXRecordDecl14) {
-  ASSERT_TRUE(PrintedDeclCXX98Matches("struct S { int x; };"
-                                      "S foo(S s1) {return s1;}",
-                                      "foo", "S foo(S s1) {\nreturn s1;\n}\n",
-                                      [](PrintingPolicy &Policy) {
-                                        Policy.SuppressTagKeyword = false;
-                                        Policy.SuppressScope = true;
-                                        Policy.TerseOutput = false;
-                                      }));
+  ASSERT_TRUE(PrintedDeclCXX98Matches(
+      "struct S { int x; };"
+      "S foo(S s1) {return s1;}",
+      "foo", "S foo(S s1) {\nreturn s1;\n}\n", [](PrintingPolicy &Policy) {
+        Policy.SuppressTagKeyword =
+            llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None);
+        Policy.SuppressScope = true;
+        Policy.TerseOutput = false;
+      }));
 }
 TEST(DeclPrinter, TestCXXRecordDecl15) {
   ASSERT_TRUE(PrintedDeclCXX98Matches(
@@ -400,7 +404,8 @@ TEST(DeclPrinter, TestCXXRecordDecl15) {
       "S foo(S s1, NS::C c1) {\nusing namespace NS;\n"
       "C c;\nreturn s1;\n}\n",
       [](PrintingPolicy &Policy) {
-        Policy.SuppressTagKeyword = false;
+        Policy.SuppressTagKeyword =
+            llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None);
         Policy.SuppressScope = true;
         Policy.TerseOutput = false;
       }));
@@ -1385,8 +1390,10 @@ TEST(DeclPrinter, TestCXXRecordDecl17) {
       "template<typename T> struct Z {};"
       "struct X {};"
       "Z<X> A;",
-      "A", "Z<X> A",
-      [](PrintingPolicy &Policy) { Policy.SuppressTagKeyword = false; }));
+      "A", "Z<X> A", [](PrintingPolicy &Policy) {
+        Policy.SuppressTagKeyword =
+            llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None);
+      }));
 }
 
 TEST(DeclPrinter, TestCXXRecordDecl18) {
@@ -1397,8 +1404,10 @@ TEST(DeclPrinter, TestCXXRecordDecl18) {
       "template <typename T1, int>"
       "struct Y{};"
       "Y<Z<X>, 2> B;",
-      "B", "Y<Z<X>, 2> B",
-      [](PrintingPolicy &Policy) { Policy.SuppressTagKeyword = false; }));
+      "B", "Y<Z<X>, 2> B", [](PrintingPolicy &Policy) {
+        Policy.SuppressTagKeyword =
+            llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None);
+      }));
 }
 
 TEST(DeclPrinter, TestCXXRecordDecl19) {
@@ -1409,8 +1418,10 @@ TEST(DeclPrinter, TestCXXRecordDecl19) {
       "template <typename T1, int>"
       "struct Y{};"
       "Y<Z<X>, 2> B;",
-      "B", "Y<Z<X>, 2> B",
-      [](PrintingPolicy &Policy) { Policy.SuppressTagKeyword = true; }));
+      "B", "Y<Z<X>, 2> B", [](PrintingPolicy &Policy) {
+        Policy.SuppressTagKeyword = llvm::to_underlying(
+            PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
+      }));
 }
 
 TEST(DeclPrinter, TestCXXRecordDecl20) {
@@ -1430,7 +1441,10 @@ TEST(DeclPrinter, TestCXXRecordDecl20) {
       "Outer<Inner<int, 10>, 5>::NestedStruct nestedInstance(100);",
       "nestedInstance",
       "Outer<Inner<int, 10>, 5>::NestedStruct nestedInstance(100)",
-      [](PrintingPolicy &Policy) { Policy.SuppressTagKeyword = false; }));
+      [](PrintingPolicy &Policy) {
+        Policy.SuppressTagKeyword =
+            llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None);
+      }));
 }
 
 TEST(DeclPrinter, TestCXXRecordDecl21) {
@@ -1450,7 +1464,10 @@ TEST(DeclPrinter, TestCXXRecordDecl21) {
       "Outer<Inner<int, 10>, 5>::NestedStruct nestedInstance(100);",
       "nestedInstance",
       "Outer<Inner<int, 10>, 5>::NestedStruct nestedInstance(100)",
-      [](PrintingPolicy &Policy) { Policy.SuppressTagKeyword = true; }));
+      [](PrintingPolicy &Policy) {
+        Policy.SuppressTagKeyword = llvm::to_underlying(
+            PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
+      }));
 }
 
 TEST(DeclPrinter, TestFunctionParamUglified) {

--- a/clang/unittests/AST/TypePrinterTest.cpp
+++ b/clang/unittests/AST/TypePrinterTest.cpp
@@ -161,11 +161,12 @@ TEST(TypePrinter, TemplateArgumentsSubstitution) {
        }
   )cpp";
   auto Matcher = typedefNameDecl(hasName("A"), hasType(qualType().bind("id")));
-  ASSERT_TRUE(PrintedTypeMatches(Code, {}, Matcher, "X<int>",
-                                 [](PrintingPolicy &Policy) {
-                                   Policy.SuppressTagKeyword = false;
-                                   Policy.SuppressScope = true;
-                                 }));
+  ASSERT_TRUE(PrintedTypeMatches(
+      Code, {}, Matcher, "X<int>", [](PrintingPolicy &Policy) {
+        Policy.SuppressTagKeyword =
+            llvm::to_underlying(PrintingPolicy::SuppressTagKeywordMode::None);
+        Policy.SuppressScope = true;
+      }));
 }
 
 TEST(TypePrinter, TemplateArgumentsSubstitution_Expressions) {

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1000,7 +1000,8 @@ public:
     // Ensure that the printing policy is producing a description that is as
     // short as possible.
     m_desc_policy.SuppressScope = true;
-    m_desc_policy.SuppressTagKeyword = true;
+    m_desc_policy.SuppressTagKeyword = llvm::to_underlying(
+        PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
     m_desc_policy.FullyQualifiedName = false;
     m_desc_policy.TerseOutput = true;
     m_desc_policy.IncludeNewlines = false;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -2146,7 +2146,8 @@ TypeSystemClang::GetDeclarationName(llvm::StringRef name,
 
 PrintingPolicy TypeSystemClang::GetTypePrintingPolicy() {
   clang::PrintingPolicy printing_policy(getASTContext().getPrintingPolicy());
-  printing_policy.SuppressTagKeyword = true;
+  printing_policy.SuppressTagKeyword = llvm::to_underlying(
+      PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
   // Inline namespaces are important for some type formatters (e.g., libc++
   // and libstdc++ are differentiated by their inline namespaces).
   printing_policy.SuppressInlineNamespace =
@@ -3868,7 +3869,8 @@ TypeSystemClang::GetDisplayTypeName(lldb::opaque_compiler_type_t type) {
 
   clang::QualType qual_type(GetQualType(type));
   clang::PrintingPolicy printing_policy(getASTContext().getPrintingPolicy());
-  printing_policy.SuppressTagKeyword = true;
+  printing_policy.SuppressTagKeyword = llvm::to_underlying(
+      PrintingPolicy::SuppressTagKeywordMode::InElaboratedNames);
   printing_policy.SuppressScope = false;
   printing_policy.SuppressUnwrittenScope = true;
   // FIXME: should we suppress "All" inline namespaces?


### PR DESCRIPTION
Split out from https://github.com/llvm/llvm-project/pull/169445 where we introduce an additional mode to `SuppressTagKeywordMode`.

Prepares `PrintingPolicy::SuppressTagKeyword` to take enum values. Currently the main use of this flag is to prevent the tag keyword from being printed when we already printed it for the outer elaborated type. Hence I chose the name `SuppressTagKeywordMode::InElaboratedNames`. But happy to consider other names