### PR TITLE
[flang] Don't evaluate initializers for arrays with invalid rank

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -9209,6 +9209,11 @@ bool DeclarationVisitor::CheckNonPointerInitialization(
 
 void DeclarationVisitor::NonPointerInitialization(
     const parser::Name &name, const parser::ConstantExpr &constExpr) {
+  // Don't evaluate initializers for arrays with a rank greater than the
+  // maximum supported, to avoid running out of memory.
+  if (name.symbol && name.symbol->Rank() > common::maxRank) {
+    return;
+  }
   if (CheckNonPointerInitialization(
           name, /*inLegacyDataInitialization=*/false)) {
     Symbol &ultimate{name.symbol->GetUltimate()};

--- a/flang/test/Semantics/maxrank.f90
+++ b/flang/test/Semantics/maxrank.f90
@@ -17,6 +17,8 @@ module m
   real :: c
   dimension :: c(1,1,1,1,1,1,1,1,1,1,1,1,1,1)
   codimension :: c[1,*]
+  !ERROR: 'p' has rank 16, which is greater than the maximum supported rank 15
+  integer, parameter :: p(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1) = 1
   interface
     !ERROR: 'foo' has rank 16, which is greater than the maximum supported rank 15
     real function foo()


### PR DESCRIPTION
Evaluating initializers for arrays with a rank greater than the
maximum supported can make the compiler run out of memory.

Fixes #124488
