### PR TITLE
[AMDGPU] Use different name scope for MIMGEncoding and MIMGDim

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstrInfo.h
@@ -85,7 +85,7 @@ struct ImageDimIntrinsicInfo {
 const ImageDimIntrinsicInfo *getImageDimIntrinsicInfo(unsigned Intr);
 
 const ImageDimIntrinsicInfo *
-getImageDimIntrinsicByBaseOpcode(MIMGBaseOpcode BaseOpcode, unsigned Dim);
+getImageDimIntrinsicByBaseOpcode(MIMGBaseOpcode BaseOpcode, MIMGDim Dim);
 
 } // end AMDGPU namespace
 } // End llvm namespace

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -2196,22 +2196,26 @@ bool AMDGPUInstructionSelector::selectImageIntrinsic(
 
   int Opcode = -1;
   if (IsGFX12Plus) {
-    Opcode = AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncGfx12,
-                                   NumVDataDwords, NumVAddrDwords);
+    Opcode =
+        AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncoding::MIMGEncGfx12,
+                              NumVDataDwords, NumVAddrDwords);
   } else if (IsGFX11Plus) {
-    Opcode = AMDGPU::getMIMGOpcode(IntrOpcode,
-                                   UseNSA ? AMDGPU::MIMGEncGfx11NSA
-                                          : AMDGPU::MIMGEncGfx11Default,
-                                   NumVDataDwords, NumVAddrDwords);
+    Opcode = AMDGPU::getMIMGOpcode(
+        IntrOpcode,
+        UseNSA ? AMDGPU::MIMGEncoding::MIMGEncGfx11NSA
+               : AMDGPU::MIMGEncoding::MIMGEncGfx11Default,
+        NumVDataDwords, NumVAddrDwords);
   } else if (IsGFX10Plus) {
-    Opcode = AMDGPU::getMIMGOpcode(IntrOpcode,
-                                   UseNSA ? AMDGPU::MIMGEncGfx10NSA
-                                          : AMDGPU::MIMGEncGfx10Default,
-                                   NumVDataDwords, NumVAddrDwords);
+    Opcode = AMDGPU::getMIMGOpcode(
+        IntrOpcode,
+        UseNSA ? AMDGPU::MIMGEncoding::MIMGEncGfx10NSA
+               : AMDGPU::MIMGEncoding::MIMGEncGfx10Default,
+        NumVDataDwords, NumVAddrDwords);
   } else {
     if (Subtarget->hasGFX90AInsts()) {
-      Opcode = AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncGfx90a,
-                                     NumVDataDwords, NumVAddrDwords);
+      Opcode =
+          AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncoding::MIMGEncGfx90a,
+                                NumVDataDwords, NumVAddrDwords);
       if (Opcode == -1) {
         LLVM_DEBUG(
             dbgs()
@@ -2221,11 +2225,13 @@ bool AMDGPUInstructionSelector::selectImageIntrinsic(
     }
     if (Opcode == -1 &&
         STI.getGeneration() >= AMDGPUSubtarget::VOLCANIC_ISLANDS)
-      Opcode = AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncGfx8,
-                                     NumVDataDwords, NumVAddrDwords);
+      Opcode =
+          AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncoding::MIMGEncGfx8,
+                                NumVDataDwords, NumVAddrDwords);
     if (Opcode == -1)
-      Opcode = AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncGfx6,
-                                     NumVDataDwords, NumVAddrDwords);
+      Opcode =
+          AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncoding::MIMGEncGfx6,
+                                NumVDataDwords, NumVAddrDwords);
   }
   if (Opcode == -1)
     return false;

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -7485,17 +7485,19 @@ bool AMDGPULegalizerInfo::legalizeBVHIntersectRayIntrinsic(
        AMDGPU::MIMGBaseOpcode::IMAGE_BVH64_INTERSECT_RAY_a16}};
   int Opcode;
   if (UseNSA) {
-    Opcode = AMDGPU::getMIMGOpcode(BaseOpcodes[Is64][IsA16],
-                                   IsGFX12Plus ? AMDGPU::MIMGEncGfx12
-                                   : IsGFX11   ? AMDGPU::MIMGEncGfx11NSA
-                                               : AMDGPU::MIMGEncGfx10NSA,
-                                   NumVDataDwords, NumVAddrDwords);
+    Opcode =
+        AMDGPU::getMIMGOpcode(BaseOpcodes[Is64][IsA16],
+                              IsGFX12Plus ? AMDGPU::MIMGEncoding::MIMGEncGfx12
+                              : IsGFX11 ? AMDGPU::MIMGEncoding::MIMGEncGfx11NSA
+                                        : AMDGPU::MIMGEncoding::MIMGEncGfx10NSA,
+                              NumVDataDwords, NumVAddrDwords);
   } else {
     assert(!IsGFX12Plus);
-    Opcode = AMDGPU::getMIMGOpcode(BaseOpcodes[Is64][IsA16],
-                                   IsGFX11 ? AMDGPU::MIMGEncGfx11Default
-                                           : AMDGPU::MIMGEncGfx10Default,
-                                   NumVDataDwords, NumVAddrDwords);
+    Opcode = AMDGPU::getMIMGOpcode(
+        BaseOpcodes[Is64][IsA16],
+        IsGFX11 ? AMDGPU::MIMGEncoding::MIMGEncGfx11Default
+                : AMDGPU::MIMGEncoding::MIMGEncGfx10Default,
+        NumVDataDwords, NumVAddrDwords);
   }
   assert(Opcode != -1);
 
@@ -7627,7 +7629,7 @@ bool AMDGPULegalizerInfo::legalizeBVHDualOrBVH8IntersectRayIntrinsic(
   int Opcode = AMDGPU::getMIMGOpcode(
       IsBVH8 ? AMDGPU::MIMGBaseOpcode::IMAGE_BVH8_INTERSECT_RAY
              : AMDGPU::MIMGBaseOpcode::IMAGE_BVH_DUAL_INTERSECT_RAY,
-      AMDGPU::MIMGEncGfx12, NumVDataDwords, NumVAddrDwords);
+      AMDGPU::MIMGEncoding::MIMGEncGfx12, NumVDataDwords, NumVAddrDwords);
   assert(Opcode != -1);
 
   auto RayExtentInstanceMaskVec = B.buildMergeLikeInstr(

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -1274,9 +1274,9 @@ void AMDGPUDisassembler::convertMIMGInst(MCInst &MI) const {
 
     // VSAMPLE insts that do not use vaddr3 behave the same as NSA forms.
     // VIMAGE insts other than BVH never use vaddr4.
-    IsNSA = Info->MIMGEncoding == AMDGPU::MIMGEncGfx10NSA ||
-            Info->MIMGEncoding == AMDGPU::MIMGEncGfx11NSA ||
-            Info->MIMGEncoding == AMDGPU::MIMGEncGfx12;
+    IsNSA = Info->Encoding == AMDGPU::MIMGEncoding::MIMGEncGfx10NSA ||
+            Info->Encoding == AMDGPU::MIMGEncoding::MIMGEncGfx11NSA ||
+            Info->Encoding == AMDGPU::MIMGEncoding::MIMGEncGfx12;
     if (!IsNSA) {
       if (!IsVSample && AddrSize > 12)
         AddrSize = 16;
@@ -1306,8 +1306,8 @@ void AMDGPUDisassembler::convertMIMGInst(MCInst &MI) const {
   if (DstSize == Info->VDataDwords && AddrSize == Info->VAddrDwords)
     return;
 
-  int NewOpcode =
-      AMDGPU::getMIMGOpcode(Info->BaseOpcode, Info->MIMGEncoding, DstSize, AddrSize);
+  int NewOpcode = AMDGPU::getMIMGOpcode(Info->BaseOpcode, Info->Encoding,
+                                        DstSize, AddrSize);
   if (NewOpcode == -1)
     return;
 

--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -2311,7 +2311,7 @@ int GCNHazardRecognizer::checkNSAtoVMEMHazard(MachineInstr *MI) {
     if (!SIInstrInfo::isMIMG(I))
       return false;
     const AMDGPU::MIMGInfo *Info = AMDGPU::getMIMGInfo(I.getOpcode());
-    return Info->MIMGEncoding == AMDGPU::MIMGEncGfx10NSA &&
+    return Info->Encoding == AMDGPU::MIMGEncoding::MIMGEncGfx10NSA &&
            TII->getInstSizeInBytes(I) >= 16;
   };
 

--- a/llvm/lib/Target/AMDGPU/GCNNSAReassign.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNNSAReassign.cpp
@@ -170,9 +170,9 @@ GCNNSAReassignImpl::CheckNSA(const MachineInstr &MI, bool Fast) const {
   if (!Info)
     return NSA_Status::NOT_NSA;
 
-  switch (Info->MIMGEncoding) {
-  case AMDGPU::MIMGEncGfx10NSA:
-  case AMDGPU::MIMGEncGfx11NSA:
+  switch (Info->Encoding) {
+  case AMDGPU::MIMGEncoding::MIMGEncGfx10NSA:
+  case AMDGPU::MIMGEncoding::MIMGEncGfx11NSA:
     break;
   default:
     return NSA_Status::NOT_NSA;

--- a/llvm/lib/Target/AMDGPU/MIMGInstructions.td
+++ b/llvm/lib/Target/AMDGPU/MIMGInstructions.td
@@ -28,8 +28,9 @@ def MIMGEncGfx11Default : MIMGEncoding;
 def MIMGEncGfx11NSA : MIMGEncoding;
 def MIMGEncGfx12 : MIMGEncoding;
 
-def MIMGEncoding : GenericEnum {
+def MIMGEncoding : GenericEnumClass {
   let FilterClass = "MIMGEncoding";
+  let Size = 8;
 }
 
 // Represent an ISA-level opcode, independent of the encoding and the
@@ -73,8 +74,9 @@ def MIMGBaseOpcodesTable : GenericTable {
   let PrimaryKeyName = "getMIMGBaseOpcodeInfo";
 }
 
-def MIMGDim : GenericEnum {
+def MIMGDim : GenericEnumClass {
   let FilterClass = "AMDGPUDimProps";
+  let Size = 8;
 }
 
 def MIMGDimInfoTable : GenericTable {
@@ -219,7 +221,7 @@ class MIMG <dag outs, string dns = "">
 
   Instruction Opcode = !cast<Instruction>(NAME);
   MIMGBaseOpcode BaseOpcode;
-  MIMGEncoding MIMGEncoding;
+  MIMGEncoding Encoding;
   bits<8> VDataDwords;
   bits<8> VAddrDwords;
 
@@ -240,12 +242,12 @@ class VSAMPLE <dag outs, string dns = ""> : MIMG<outs, dns> {
 def MIMGInfoTable : GenericTable {
   let FilterClass = "MIMG";
   let CppTypeName = "MIMGInfo";
-  let Fields = ["Opcode", "BaseOpcode", "MIMGEncoding", "VDataDwords",
+  let Fields = ["Opcode", "BaseOpcode", "Encoding", "VDataDwords",
                 "VAddrDwords", "VAddrOperands"];
   string TypeOf_BaseOpcode = "MIMGBaseOpcode";
-  string TypeOf_MIMGEncoding = "MIMGEncoding";
+  string TypeOf_Encoding = "MIMGEncoding";
 
-  let PrimaryKey = ["BaseOpcode", "MIMGEncoding", "VDataDwords", "VAddrDwords"];
+  let PrimaryKey = ["BaseOpcode", "Encoding", "VDataDwords", "VAddrDwords"];
   let PrimaryKeyName = "getMIMGOpcodeHelper";
 }
 
@@ -299,7 +301,7 @@ class MIMG_gfx6789<bits<8> op, dag outs, string dns = "">
   let SubtargetPredicate = isGFX6GFX7GFX8GFX9NotGFX90A;
   let AssemblerPredicate = isGFX6GFX7GFX8GFX9NotGFX90A;
 
-  let MIMGEncoding = MIMGEncGfx6;
+  let Encoding = MIMGEncGfx6;
   let VAddrOperands = 1;
 
   let d16 = !if(BaseOpcode.HasD16, ?, 0);
@@ -310,7 +312,7 @@ class MIMG_gfx90a<bits<8> op, dag outs, string dns = "">
   let SubtargetPredicate = isGFX90APlus;
   let AssemblerPredicate = isGFX90APlus;
 
-  let MIMGEncoding = MIMGEncGfx90a;
+  let Encoding = MIMGEncGfx90a;
   let VAddrOperands = 1;
 
   let d16 = !if(BaseOpcode.HasD16, ?, 0);
@@ -322,7 +324,7 @@ class MIMG_gfx10<int op, dag outs, string dns = "">
   let SubtargetPredicate = isGFX10Only;
   let AssemblerPredicate = isGFX10Only;
 
-  let MIMGEncoding = MIMGEncGfx10Default;
+  let Encoding = MIMGEncGfx10Default;
   let VAddrOperands = 1;
 
   let d16 = !if(BaseOpcode.HasD16, ?, 0);
@@ -336,7 +338,7 @@ class MIMG_nsa_gfx10<int op, dag outs, int num_addrs, string dns="">
   let SubtargetPredicate = isGFX10Only;
   let AssemblerPredicate = isGFX10Only;
 
-  let MIMGEncoding = MIMGEncGfx10NSA;
+  let Encoding = MIMGEncGfx10NSA;
   let VAddrOperands = num_addrs;
 
   MIMGNSAHelper nsah = MIMGNSAHelper<num_addrs>;
@@ -353,7 +355,7 @@ class MIMG_gfx11<int op, dag outs, string dns = "">
   let SubtargetPredicate = isGFX11Only;
   let AssemblerPredicate = isGFX11Only;
 
-  let MIMGEncoding = MIMGEncGfx11Default;
+  let Encoding = MIMGEncGfx11Default;
   let VAddrOperands = 1;
 
   let d16 = !if(BaseOpcode.HasD16, ?, 0);
@@ -369,7 +371,7 @@ class MIMG_nsa_gfx11<int op, dag outs, int num_addrs, string dns="",
   let SubtargetPredicate = isGFX11Only;
   let AssemblerPredicate = isGFX11Only;
 
-  let MIMGEncoding = MIMGEncGfx11NSA;
+  let Encoding = MIMGEncGfx11NSA;
   let VAddrOperands = num_addrs;
 
   NSAHelper nsah = !if(!empty(addr_types),
@@ -388,7 +390,7 @@ class VIMAGE_gfx12<int op, dag outs, int num_addrs, string dns="",
   let SubtargetPredicate = isGFX12Plus;
   let AssemblerPredicate = isGFX12Plus;
 
-  let MIMGEncoding = MIMGEncGfx12;
+  let Encoding = MIMGEncGfx12;
   let VAddrOperands = num_addrs;
 
   MIMGNSAHelper nsah = !if(!empty(addr_types),
@@ -410,7 +412,7 @@ class VSAMPLE_gfx12<int op, dag outs, int num_addrs, string dns="",
   let SubtargetPredicate = isGFX12Plus;
   let AssemblerPredicate = isGFX12Plus;
 
-  let MIMGEncoding = MIMGEncGfx12;
+  let Encoding = MIMGEncGfx12;
   let VAddrOperands = num_addrs;
 
   PartialNSAHelper nsah = PartialNSAHelper<num_addrs, 4, Addr3RC>;
@@ -911,14 +913,14 @@ class MIMG_Atomic_vi<mimgopc op, string asm, RegisterOperand data_rc,
                      RegisterClass addr_rc, bit noRtn = 0, bit enableDasm = 0>
   : MIMG_Atomic_gfx6789_base<op.VI, asm, data_rc, addr_rc, noRtn, !if(enableDasm, "GFX8", "")> {
   let AssemblerPredicate = isGFX8GFX9NotGFX90A;
-  let MIMGEncoding = MIMGEncGfx8;
+  let Encoding = MIMGEncGfx8;
 }
 
 class MIMG_Atomic_gfx90a<mimgopc op, string asm, RegisterOperand data_rc,
                          RegisterClass addr_rc, bit noRtn = 0, bit enableDasm = 0>
   : MIMG_Atomic_gfx90a_base<op.VI, asm, data_rc, addr_rc, noRtn, !if(enableDasm, "GFX90A", "")> {
   let AssemblerPredicate = isGFX90APlus;
-  let MIMGEncoding = MIMGEncGfx90a;
+  let Encoding = MIMGEncGfx90a;
 }
 
 class MIMG_Atomic_gfx10<mimgopc op, string opcode,

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -9591,22 +9591,26 @@ SDValue SITargetLowering::lowerImage(SDValue Op,
   int Opcode = -1;
 
   if (IsGFX12Plus) {
-    Opcode = AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncGfx12,
-                                   NumVDataDwords, NumVAddrDwords);
+    Opcode =
+        AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncoding::MIMGEncGfx12,
+                              NumVDataDwords, NumVAddrDwords);
   } else if (IsGFX11Plus) {
-    Opcode = AMDGPU::getMIMGOpcode(IntrOpcode,
-                                   UseNSA ? AMDGPU::MIMGEncGfx11NSA
-                                          : AMDGPU::MIMGEncGfx11Default,
-                                   NumVDataDwords, NumVAddrDwords);
+    Opcode = AMDGPU::getMIMGOpcode(
+        IntrOpcode,
+        UseNSA ? AMDGPU::MIMGEncoding::MIMGEncGfx11NSA
+               : AMDGPU::MIMGEncoding::MIMGEncGfx11Default,
+        NumVDataDwords, NumVAddrDwords);
   } else if (IsGFX10Plus) {
-    Opcode = AMDGPU::getMIMGOpcode(IntrOpcode,
-                                   UseNSA ? AMDGPU::MIMGEncGfx10NSA
-                                          : AMDGPU::MIMGEncGfx10Default,
-                                   NumVDataDwords, NumVAddrDwords);
+    Opcode = AMDGPU::getMIMGOpcode(
+        IntrOpcode,
+        UseNSA ? AMDGPU::MIMGEncoding::MIMGEncGfx10NSA
+               : AMDGPU::MIMGEncoding::MIMGEncGfx10Default,
+        NumVDataDwords, NumVAddrDwords);
   } else {
     if (Subtarget->hasGFX90AInsts()) {
-      Opcode = AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncGfx90a,
-                                     NumVDataDwords, NumVAddrDwords);
+      Opcode =
+          AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncoding::MIMGEncGfx90a,
+                                NumVDataDwords, NumVAddrDwords);
       if (Opcode == -1) {
         DAG.getContext()->diagnose(DiagnosticInfoUnsupported(
             DAG.getMachineFunction().getFunction(),
@@ -9627,11 +9631,13 @@ SDValue SITargetLowering::lowerImage(SDValue Op,
     }
     if (Opcode == -1 &&
         Subtarget->getGeneration() >= AMDGPUSubtarget::VOLCANIC_ISLANDS)
-      Opcode = AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncGfx8,
-                                     NumVDataDwords, NumVAddrDwords);
+      Opcode =
+          AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncoding::MIMGEncGfx8,
+                                NumVDataDwords, NumVAddrDwords);
     if (Opcode == -1)
-      Opcode = AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncGfx6,
-                                     NumVDataDwords, NumVAddrDwords);
+      Opcode =
+          AMDGPU::getMIMGOpcode(IntrOpcode, AMDGPU::MIMGEncoding::MIMGEncGfx6,
+                                NumVDataDwords, NumVAddrDwords);
   }
   if (Opcode == -1)
     return Op;
@@ -10724,7 +10730,7 @@ SDValue SITargetLowering::LowerINTRINSIC_W_CHAIN(SDValue Op,
     int Opcode = AMDGPU::getMIMGOpcode(
         IsBVH8 ? AMDGPU::MIMGBaseOpcode::IMAGE_BVH8_INTERSECT_RAY
                : AMDGPU::MIMGBaseOpcode::IMAGE_BVH_DUAL_INTERSECT_RAY,
-        AMDGPU::MIMGEncGfx12, NumVDataDwords, NumVAddrDwords);
+        AMDGPU::MIMGEncoding::MIMGEncGfx12, NumVDataDwords, NumVAddrDwords);
     assert(Opcode != -1);
 
     SmallVector<SDValue, 7> Ops;
@@ -10781,17 +10787,19 @@ SDValue SITargetLowering::LowerINTRINSIC_W_CHAIN(SDValue Op,
          AMDGPU::MIMGBaseOpcode::IMAGE_BVH64_INTERSECT_RAY_a16}};
     int Opcode;
     if (UseNSA) {
-      Opcode = AMDGPU::getMIMGOpcode(BaseOpcodes[Is64][IsA16],
-                                     IsGFX12Plus ? AMDGPU::MIMGEncGfx12
-                                     : IsGFX11   ? AMDGPU::MIMGEncGfx11NSA
-                                                 : AMDGPU::MIMGEncGfx10NSA,
-                                     NumVDataDwords, NumVAddrDwords);
+      Opcode = AMDGPU::getMIMGOpcode(
+          BaseOpcodes[Is64][IsA16],
+          IsGFX12Plus ? AMDGPU::MIMGEncoding::MIMGEncGfx12
+          : IsGFX11   ? AMDGPU::MIMGEncoding::MIMGEncGfx11NSA
+                      : AMDGPU::MIMGEncoding::MIMGEncGfx10NSA,
+          NumVDataDwords, NumVAddrDwords);
     } else {
       assert(!IsGFX12Plus);
-      Opcode = AMDGPU::getMIMGOpcode(BaseOpcodes[Is64][IsA16],
-                                     IsGFX11 ? AMDGPU::MIMGEncGfx11Default
-                                             : AMDGPU::MIMGEncGfx10Default,
-                                     NumVDataDwords, NumVAddrDwords);
+      Opcode = AMDGPU::getMIMGOpcode(
+          BaseOpcodes[Is64][IsA16],
+          IsGFX11 ? AMDGPU::MIMGEncoding::MIMGEncGfx11Default
+                  : AMDGPU::MIMGEncoding::MIMGEncGfx10Default,
+          NumVDataDwords, NumVAddrDwords);
     }
     assert(Opcode != -1);
 

--- a/llvm/lib/Target/AMDGPU/SIInsertHardClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertHardClauses.cpp
@@ -108,7 +108,7 @@ public:
             SIInstrInfo::isSegmentSpecificFLAT(MI)) {
           if (ST->hasNSAClauseBug()) {
             const AMDGPU::MIMGInfo *Info = AMDGPU::getMIMGInfo(MI.getOpcode());
-            if (Info && Info->MIMGEncoding == AMDGPU::MIMGEncGfx10NSA)
+            if (Info && Info->Encoding == AMDGPU::MIMGEncoding::MIMGEncGfx10NSA)
               return HARDCLAUSE_ILLEGAL;
           }
           return HARDCLAUSE_VMEM;

--- a/llvm/lib/Target/AMDGPU/SIShrinkInstructions.cpp
+++ b/llvm/lib/Target/AMDGPU/SIShrinkInstructions.cpp
@@ -296,13 +296,13 @@ void SIShrinkInstructions::shrinkMIMG(MachineInstr &MI) const {
   if (!Info)
     return;
 
-  uint8_t NewEncoding;
-  switch (Info->MIMGEncoding) {
-  case AMDGPU::MIMGEncGfx10NSA:
-    NewEncoding = AMDGPU::MIMGEncGfx10Default;
+  AMDGPU::MIMGEncoding NewEncoding;
+  switch (Info->Encoding) {
+  case AMDGPU::MIMGEncoding::MIMGEncGfx10NSA:
+    NewEncoding = AMDGPU::MIMGEncoding::MIMGEncGfx10Default;
     break;
-  case AMDGPU::MIMGEncGfx11NSA:
-    NewEncoding = AMDGPU::MIMGEncGfx11Default;
+  case AMDGPU::MIMGEncoding::MIMGEncGfx11NSA:
+    NewEncoding = AMDGPU::MIMGEncoding::MIMGEncGfx11Default;
     break;
   default:
     return;

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -300,10 +300,10 @@ unsigned getCompletionActionImplicitArgPosition(unsigned CodeObjectVersion) {
 #define GET_WMMAInstInfoTable_IMPL
 #include "AMDGPUGenSearchableTables.inc"
 
-int getMIMGOpcode(MIMGBaseOpcode BaseOpcode, unsigned MIMGEncoding,
+int getMIMGOpcode(MIMGBaseOpcode BaseOpcode, MIMGEncoding Encoding,
                   unsigned VDataDwords, unsigned VAddrDwords) {
   const MIMGInfo *Info =
-      getMIMGOpcodeHelper(BaseOpcode, MIMGEncoding, VDataDwords, VAddrDwords);
+      getMIMGOpcodeHelper(BaseOpcode, Encoding, VDataDwords, VAddrDwords);
   return Info ? Info->Opcode : -1;
 }
 
@@ -315,8 +315,8 @@ const MIMGBaseOpcodeInfo *getMIMGBaseOpcode(unsigned Opc) {
 int getMaskedMIMGOp(unsigned Opc, unsigned NewChannels) {
   const MIMGInfo *OrigInfo = getMIMGInfo(Opc);
   const MIMGInfo *NewInfo =
-      getMIMGOpcodeHelper(OrigInfo->BaseOpcode, OrigInfo->MIMGEncoding,
-                          NewChannels, OrigInfo->VAddrDwords);
+      getMIMGOpcodeHelper(OrigInfo->BaseOpcode, OrigInfo->Encoding, NewChannels,
+                          OrigInfo->VAddrDwords);
   return NewInfo ? NewInfo->Opcode : -1;
 }
 

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -456,7 +456,7 @@ struct MIMGDimInfo {
 };
 
 LLVM_READONLY
-const MIMGDimInfo *getMIMGDimInfo(unsigned DimEnum);
+const MIMGDimInfo *getMIMGDimInfo(MIMGDim DimEnum);
 
 LLVM_READONLY
 const MIMGDimInfo *getMIMGDimInfoByEncoding(uint8_t DimEnc);
@@ -510,7 +510,7 @@ LLVM_READONLY
 const MIMGG16MappingInfo *getMIMGG16MappingInfo(MIMGBaseOpcode G);
 
 LLVM_READONLY
-int getMIMGOpcode(MIMGBaseOpcode BaseOpcode, unsigned MIMGEncoding,
+int getMIMGOpcode(MIMGBaseOpcode BaseOpcode, MIMGEncoding Encoding,
                   unsigned VDataDwords, unsigned VAddrDwords);
 
 LLVM_READONLY
@@ -524,7 +524,7 @@ unsigned getAddrSizeMIMGOp(const MIMGBaseOpcodeInfo *BaseOpcode,
 struct MIMGInfo {
   uint16_t Opcode;
   MIMGBaseOpcode BaseOpcode;
-  uint8_t MIMGEncoding;
+  MIMGEncoding Encoding;
   uint8_t VDataDwords;
   uint8_t VAddrDwords;
   uint8_t VAddrOperands;


### PR DESCRIPTION
Use new scoped enums with type set to uint8_t.