### PR TITLE
[CAS] Fix deprecation warning in `getBootTime`

### DIFF
--- a/llvm/lib/CAS/OnDiskCommon.cpp
+++ b/llvm/lib/CAS/OnDiskCommon.cpp
@@ -30,6 +30,12 @@
 #include <sys/mount.h> // statfs
 #endif
 
+#ifdef __APPLE__
+#if __has_include(<sys/sysctl.h>)
+#include <sys/sysctl.h>
+#endif
+#endif
+
 using namespace llvm;
 
 static uint64_t OnDiskCASMaxMappingSize = 0;
@@ -178,4 +184,31 @@ bool cas::ondisk::useSmallMappingSize(const Twine &P) {
 #endif
   // Default to use regular database file.
   return false;
+}
+
+Expected<uint64_t> cas::ondisk::getBootTime() {
+#ifdef __APPLE__
+#if __has_include(<sys/sysctl.h>) && defined(KERN_BOOTTIME)
+  struct timeval TV;
+  size_t TVLen = sizeof(TV);
+  int KernBoot[2] = {CTL_KERN, KERN_BOOTTIME};
+  if (sysctl(KernBoot, 2, &TV, &TVLen, nullptr, 0) < 0)
+    return createStringError(llvm::errnoAsErrorCode(),
+                             "failed to get boottime");
+  if (TVLen != sizeof(TV))
+    return createStringError("sysctl kern.boottime unexpected format");
+  return TV.tv_sec;
+#else
+  return 0;
+#endif
+#elif defined(__linux__)
+  // Use the mtime for /proc, which is recreated during system boot.
+  // We could also read /proc/stat and search for 'btime'.
+  sys::fs::file_status Status;
+  if (std::error_code EC = sys::fs::status("/proc", Status))
+    return createFileError("/proc", EC);
+  return Status.getLastModificationTime().time_since_epoch().count();
+#else
+  return 0;
+#endif
 }

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -63,6 +63,13 @@ std::error_code tryLockFileThreadSafe(
 Expected<size_t> preallocateFileTail(int FD, size_t CurrentSize,
                                      size_t NewSize);
 
+/// Get boot time for the OS. This can be used to check if the CAS has been
+/// validated since boot.
+///
+/// \returns the boot time in seconds (0 if operation not supported), or an \c
+/// Error.
+Expected<uint64_t> getBootTime();
+
 } // namespace llvm::cas::ondisk
 
 #endif // LLVM_LIB_CAS_ONDISKCOMMON_H


### PR DESCRIPTION
For some older Linux distro that still ships deprecated sysctl header,
there can be deprecation warnings when building LLVMCAS. This also
results LLVMCAS to use the deprecated sysctl function, while it is only
intended to be used on Darwin platforms.

Fix the issue by only including sysctl on Apple platforms. Also move the
platform dependent `getBootTime` code into OnDiskCommon.cpp.
