### PR TITLE
[NFC][AMDGPU] Remove unused TableGen generated enum

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -1364,16 +1364,10 @@ class WMMAOpcodeMapping<Instruction TwoAddr, Instruction ThreeAddr> {
   field bit is_wmma_xdl;
 }
 
-def WMMAOpcode : GenericEnum {
-  let FilterClass = "VOP3P_Pseudo";
-}
-
 class WMMAMappingTable : GenericTable {
   let FilterClass = "WMMAOpcodeMapping";
   let CppTypeName = "WMMAOpcodeMappingInfo";
   let Fields = ["Opcode2Addr", "Opcode3Addr"];
-  string TypeOf_Opcode2Addr = "WMMAOpcode";
-  string TypeOf_Opcode3Addr = "WMMAOpcode";
 }
 
 def WMMAOpcode2AddrMappingTable : WMMAMappingTable {


### PR DESCRIPTION
This GenericEnum was just adding separate values for VOP3P_Pseudo opcodes
in the same namespace as existing opcodes that did not match. They were
defined in AMDGPUGenSearchableTables.inc by tablegen emitter but were
guarded out by #ifdef. Because of that, they were never included in the
code, so the compiler never reported the naming conflict and the bug never
had a chance to surface.
