### PR TITLE
[dsymutil] Remove spurious exit when falling back to fat64 header

### DIFF
--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -873,7 +873,6 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
                 "-fat64 flag to force a 64-bit header and silence this "
                 "warning.",
                 FileOffset);
-            return EXIT_FAILURE;
           }
           FileOffset += stat->getSize();
         }


### PR DESCRIPTION
In #118898 I changed dsymutil to emit a warning instead of an error when exceeding the 4GB limit for a slice and automatically fall back to using the fat64 header. However, while doing so, I forgot to remove the return which defeats that purpose.

rdar://140998416