### PR TITLE
[LLVM] Mark reloc-none test unsupported on Hexagon

### DIFF
--- a/llvm/test/CodeGen/Generic/reloc-none.ll
+++ b/llvm/test/CodeGen/Generic/reloc-none.ll
@@ -1,6 +1,7 @@
 ; RUN: llc < %s | FileCheck %s
 
 ; CHECK: .reloc {{.*}}, BFD_RELOC_NONE, foo
+; UNSUPPORTED: target=hexagon{{.*}}
 
 define void @test_reloc_none() {
   call void @llvm.reloc.none(metadata !"foo")


### PR DESCRIPTION
Prevents infinite loop issue recorded in #147427. More work will be required to make @llvm.reloc_none work correctly on Hexagon.