### PR TITLE
Fix a typo in "breakpoint add file" and add a test

### DIFF
--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -767,7 +767,7 @@ public:
           m_cur_value.SetLine(line_num);
         }
         break;
-      case 'c':
+      case 'u':
         uint32_t column_num;
         if (option_arg.getAsInteger(0, column_num))
           error = Status::FromError(


### PR DESCRIPTION
lldbutil.run_to_line_breakpoint had usages that set column breakpoints, so I thought there was coverage of that on the command-line, but actually all the `run_to` utilities use the SB API's, and there weren't any tests of setting file line & column breakpoint through `run_break_set`.  So I missed that I had typed the column option `c` - that's taken by `--command`.

This patch fixes that typo and adds a CLI test for file + line + column.