### PR TITLE
[LLVM][Option] Support multiline option parsing

### DIFF
--- a/llvm/lib/Option/OptTable.cpp
+++ b/llvm/lib/Option/OptTable.cpp
@@ -537,7 +537,7 @@ InputArgList OptTable::internalParseArgs(
   MissingArgIndex = MissingArgCount = 0;
   unsigned Index = 0, End = ArgArr.size();
   while (Index < End) {
-    // Ingore nullptrs, they are response file's EOL markers
+    // Ignore nullptrs, they are response file's EOL markers.
     if (Args.getArgString(Index) == nullptr) {
       ++Index;
       continue;


### PR DESCRIPTION
Consider arguments as belonging even if they are defined on (multiple) lines after the introducing argument. Empty lines between arguments are ignored as well.

This allows for more flexible argument definitions. For example,

```
-Xclang
-disable-llvm-passes
```

would currently err, but works with this PR.