### PR TITLE
Add CXX special member attribute support

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -1012,6 +1012,98 @@ def CIR_InlineAttr : CIR_EnumAttr<CIR_InlineKind, "inline"> {
 }
 
 //===----------------------------------------------------------------------===//
+// CXX Special Member Attributes
+//===----------------------------------------------------------------------===//
+
+def CIR_CtorKind : CIR_I32EnumAttr<"CtorKind", "CXX Constructor Kind", [
+  I32EnumAttrCase<"Custom", 0, "custom">,
+  I32EnumAttrCase<"Default", 1, "default">,
+  I32EnumAttrCase<"Copy", 2, "copy">,
+  I32EnumAttrCase<"Move", 3, "move">,
+]> {
+  let genSpecializedAttr = 0;
+}
+
+def CIR_CXXCtorAttr : CIR_Attr<"CXXCtor", "cxx_ctor"> {
+  let summary = "Marks a function as a CXX constructor";
+  let description = [{
+    Functions with this attribute are CXX constructors.
+    The `custom` kind is used if the constructor is a custom constructor.
+    The `default` kind is used if the constructor is a default constructor.
+    The `copy` kind is used if the constructor is a copy constructor.
+    The `move` kind is used if the constructor is a move constructor.
+  }];
+  let parameters = (ins "mlir::Type":$type,
+                        EnumParameter<CIR_CtorKind>:$ctorKind);
+
+  let assemblyFormat = [{
+    `<` $type `,` $ctorKind `>`
+  }];
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "mlir::Type":$type,
+        CArg<"CtorKind", "cir::CtorKind::Custom">:$ctorKind), [{
+      return $_get(type.getContext(), type, ctorKind);
+    }]>
+  ];
+}
+
+def CIR_CXXDtorAttr : CIR_Attr<"CXXDtor", "cxx_dtor"> {
+  let summary = "Marks a function as a CXX destructor";
+  let description = [{
+    Functions with this attribute are CXX destructors
+  }];
+  let parameters = (ins "mlir::Type":$type);
+
+  let assemblyFormat = [{
+    `<` $type `>`
+  }];
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "mlir::Type":$type), [{
+      return $_get(type.getContext(), type);
+    }]>
+  ];
+}
+
+def CIR_AssignKind : CIR_I32EnumAttr<"AssignKind", "CXX Assignment Operator Kind", [
+  I32EnumAttrCase<"Copy", 0, "copy">,
+  I32EnumAttrCase<"Move", 1, "move">,
+]> {
+  let genSpecializedAttr = 0;
+}
+
+def CIR_CXXAssignAttr : CIR_Attr<"CXXAssign", "cxx_assign"> {
+  let summary = "Marks a function as a CXX assignment operator";
+  let description = [{
+    Functions with this attribute are CXX assignment operators.
+    The `copy` kind is used if the assignment operator is a copy assignment operator.
+    The `move` kind is used if the assignment operator is a move assignment operator.
+  }];
+  let parameters = (ins
+    "mlir::Type":$type,
+    EnumParameter<CIR_AssignKind>:$assignKind
+  );
+
+  let assemblyFormat = [{
+    `<` $type `,` $assignKind `>`
+  }];
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "mlir::Type":$type,
+        CArg<"AssignKind">:$assignKind), [{
+      return $_get(type.getContext(), type, assignKind);
+    }]>
+  ];
+}
+
+def CIR_CXXSpecialMemberAttr : AnyAttrOf<[
+  CIR_CXXCtorAttr,
+  CIR_CXXDtorAttr,
+  CIR_CXXAssignAttr
+]>;
+
+//===----------------------------------------------------------------------===//
 // CatchAllAttr & UnwindAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2521,7 +2521,9 @@ def CIR_FuncOp : CIR_Op<"func", [
                        OptionalAttr<DictArrayAttr>:$res_attrs,
                        OptionalAttr<FlatSymbolRefAttr>:$aliasee,
                        CIR_OptionalPriorityAttr:$global_ctor_priority,
-                       CIR_OptionalPriorityAttr:$global_dtor_priority);
+                       CIR_OptionalPriorityAttr:$global_dtor_priority,
+                       OptionalAttr<ArrayAttr>:$annotations,
+                       OptionalAttr<CIR_CXXSpecialMemberAttr>:$cxx_special_member);
 
   let regions = (region AnyRegion:$body);
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -486,6 +486,11 @@ public:
                                 cir::FuncType funcType,
                                 const clang::FunctionDecl *funcDecl);
 
+  /// Sets the CXX special member attribute for the function based on the
+  /// function declaration.
+  void setCXXSpecialMemberAttr(cir::FuncOp func,
+                               const clang::FunctionDecl *funcDecl);
+
   /// Create a CIR function with builtin attribute set.
   cir::FuncOp createCIRBuiltinFunction(mlir::Location loc, llvm::StringRef name,
                                        cir::FuncType ty,

--- a/clang/test/CIR/IR/cxx-special-member.cir
+++ b/clang/test/CIR/IR/cxx-special-member.cir
@@ -1,0 +1,21 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!rec_S = !cir.record<struct "S" {!s32i}>
+module {
+  cir.func private @_ZN1SC1ERKS_(!cir.ptr<!rec_S>, !cir.ptr<!rec_S>) special_member<#cir.cxx_ctor<!rec_S, copy>>
+  cir.func private @_ZN1SC1EOS_(!cir.ptr<!rec_S>, !cir.ptr<!rec_S>) special_member<#cir.cxx_ctor<!rec_S, move>>
+  cir.func private @_ZN1SC2Ei(!cir.ptr<!rec_S>, !cir.ptr<!rec_S>)
+  cir.func private @_ZN1SC2Ev(!cir.ptr<!rec_S>) special_member<#cir.cxx_ctor<!rec_S, default>>
+  cir.func private @_ZN1SD2Ev(!cir.ptr<!rec_S>) special_member<#cir.cxx_dtor<!rec_S>>
+}
+
+// CHECK: !s32i = !cir.int<s, 32>
+// CHECK: !rec_S = !cir.record<struct "S" {!s32i}>
+// CHECK: module {
+// CHECK:   cir.func private @_ZN1SC1ERKS_(!cir.ptr<!rec_S>, !cir.ptr<!rec_S>) special_member<#cir.cxx_ctor<!rec_S, copy>>
+// CHECK:   cir.func private @_ZN1SC1EOS_(!cir.ptr<!rec_S>, !cir.ptr<!rec_S>) special_member<#cir.cxx_ctor<!rec_S, move>>
+// CHECK:   cir.func private @_ZN1SC2Ei(!cir.ptr<!rec_S>, !cir.ptr<!rec_S>)
+// CHECK:   cir.func private @_ZN1SC2Ev(!cir.ptr<!rec_S>) special_member<#cir.cxx_ctor<!rec_S, default>>
+// CHECK:   cir.func private @_ZN1SD2Ev(!cir.ptr<!rec_S>) special_member<#cir.cxx_dtor<!rec_S>>
+// CHECK: }


### PR DESCRIPTION
This PR upstreams the special_member attribute feature from the incubator, which marks C++ constructors, destructors, and assignment operators in CIR.

This is a prerequisite for the member initializer array non-record feature, as the test for that feature expects special_member attributes on copy constructors.

## Changes
- Add dialect attribute definitions (CtorKind, CXXCtorAttr, CXXDtorAttr, AssignKind, CXXAssignAttr, CXXSpecialMemberAttr)
- Add cxx_special_member attribute to FuncOp
- Implement setCXXSpecialMemberAttr() in CIRGenModule to detect and set appropriate attributes for constructors, destructors, and assignment operators
- Update custom assembly format to serialize/deserialize special_member attribute in FuncOp print/parse functions
- Add IR test to verify roundtrip parsing of special_member attributes

The attribute is automatically set during function creation for C++ special member functions, providing metadata that can be used by downstream passes and analysis tools.