### PR TITLE
[llvm-objcopy] Allow -p on COFF targets

### DIFF
--- a/llvm/lib/ObjCopy/ConfigManager.cpp
+++ b/llvm/lib/ObjCopy/ConfigManager.cpp
@@ -28,9 +28,8 @@ Expected<const COFFConfig &> ConfigManager::getCOFFConfig() const {
       !Common.SymbolsToLocalize.empty() || !Common.SymbolsToWeaken.empty() ||
       !Common.SymbolsToKeepGlobal.empty() || !Common.SectionsToRename.empty() ||
       !Common.SetSectionAlignment.empty() || !Common.SetSectionType.empty() ||
-      Common.ExtractDWO || Common.PreserveDates || Common.StripDWO ||
-      Common.StripNonAlloc || Common.StripSections || Common.Weaken ||
-      Common.DecompressDebugSections ||
+      Common.ExtractDWO || Common.StripDWO || Common.StripNonAlloc ||
+      Common.StripSections || Common.Weaken || Common.DecompressDebugSections ||
       Common.DiscardMode == DiscardType::Locals ||
       !Common.SymbolsToAdd.empty() || Common.GapFill != 0 ||
       Common.PadTo != 0 || Common.ChangeSectionLMAValAll != 0 ||

--- a/llvm/test/tools/llvm-objcopy/COFF/strip-preserve-mtime.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/strip-preserve-mtime.test
@@ -1,0 +1,43 @@
+## Note: ls -l prints the modified timestamp
+
+## Preserve dates when stripping to an output file.
+# RUN: yaml2obj %s -o %t.1.o
+# RUN: touch -m -t 199705050555.55 %t.1.o
+# RUN: llvm-strip -p %t.1.o -o %t-preserved.1.o
+# RUN: ls -l %t-preserved.1.o | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
+# Check that the stripped output is in fact a valid object file.
+# RUN: llvm-readobj %t-preserved.1.o
+
+## Preserve dates available via objcopy interface as well.
+# RUN: yaml2obj %s -o %t.2.o
+# RUN: touch -m -t 199705050555.55 %t.2.o
+# RUN: llvm-objcopy -p %t.2.o %t-preserved.2.o
+# RUN: ls -l %t-preserved.2.o | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
+# RUN: llvm-readobj %t-preserved.2.o
+
+## Preserve dates when stripping in place.
+# RUN: yaml2obj %s -o %t.3.o
+# RUN: touch -m -t 199705050555.55 %t.3.o
+# RUN: llvm-strip -p %t.3.o
+# RUN: ls -l %t.3.o | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
+# RUN: llvm-readobj %t.3.o
+
+## Without -p set, don't preserve dates.
+# RUN: yaml2obj %s -o %t.4.o
+# RUN: touch -m -t 199705050555.55 %t.4.o
+# RUN: llvm-strip %t.4.o
+# RUN: ls -l %t.4.o | FileCheck %s --check-prefix=CHECK-NO-PRESERVE-MTIME
+# RUN: llvm-readobj %t.4.o
+
+# CHECK-PRESERVE-MTIME:        {{[[:space:]]1997}}
+# CHECK-NO-PRESERVE-MTIME-NOT: {{[[:space:]]1997}}
+
+!COFF
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+sections:
+  - Name:            .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    VirtualSize:     20
+symbols:         []
+...

--- a/llvm/test/tools/llvm-objcopy/COFF/strip-preserve-mtime.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/strip-preserve-mtime.test
@@ -1,29 +1,31 @@
-## Note: ls -l prints the modified timestamp
+## Note: ls -l prints the modified timestamp.
+
+# RUN: yaml2obj %s -o %t.exe
 
 ## Preserve dates when stripping to an output file.
-# RUN: yaml2obj %s -o %t.1.exe
+# RUN: cp %t.exe %t.1.exe
 # RUN: touch -m -t 199705050555.55 %t.1.exe
 # RUN: llvm-strip -p %t.1.exe -o %t-preserved.1.exe
 # RUN: ls -l %t-preserved.1.exe | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
-# Check that the stripped output is in fact a valid object file.
+## Check that the stripped output is in fact a valid object file and the timestamp in the PE header is preserved.
 # RUN: llvm-readobj --headers %t-preserved.1.exe | FileCheck %s
 
 ## Preserve dates available via objcopy interface as well.
-# RUN: yaml2obj %s -o %t.2.exe
+# RUN: cp %t.exe %t.2.exe
 # RUN: touch -m -t 199705050555.55 %t.2.exe
 # RUN: llvm-objcopy -p %t.2.exe %t-preserved.2.exe
 # RUN: ls -l %t-preserved.2.exe | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
 # RUN: llvm-readobj --headers %t-preserved.2.exe | FileCheck %s
 
 ## Preserve dates when stripping in place.
-# RUN: yaml2obj %s -o %t.3.exe
+# RUN: cp %t.exe %t.3.exe
 # RUN: touch -m -t 199705050555.55 %t.3.exe
 # RUN: llvm-strip -p %t.3.exe
 # RUN: ls -l %t.3.exe | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
 # RUN: llvm-readobj --headers %t.3.exe | FileCheck %s
 
 ## Without -p set, don't preserve dates.
-# RUN: yaml2obj %s -o %t.4.exe
+# RUN: cp %t.exe %t.4.exe
 # RUN: touch -m -t 199705050555.55 %t.4.exe
 # RUN: llvm-strip %t.4.exe
 # RUN: ls -l %t.4.exe | FileCheck %s --check-prefix=CHECK-NO-PRESERVE-MTIME

--- a/llvm/test/tools/llvm-objcopy/COFF/strip-preserve-mtime.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/strip-preserve-mtime.test
@@ -1,38 +1,43 @@
 ## Note: ls -l prints the modified timestamp
 
 ## Preserve dates when stripping to an output file.
-# RUN: yaml2obj %s -o %t.1.o
-# RUN: touch -m -t 199705050555.55 %t.1.o
-# RUN: llvm-strip -p %t.1.o -o %t-preserved.1.o
-# RUN: ls -l %t-preserved.1.o | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
+# RUN: yaml2obj %s -o %t.1.exe
+# RUN: touch -m -t 199705050555.55 %t.1.exe
+# RUN: llvm-strip -p %t.1.exe -o %t-preserved.1.exe
+# RUN: ls -l %t-preserved.1.exe | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
 # Check that the stripped output is in fact a valid object file.
-# RUN: llvm-readobj %t-preserved.1.o
+# RUN: llvm-readobj --headers %t-preserved.1.exe | FileCheck %s
 
 ## Preserve dates available via objcopy interface as well.
-# RUN: yaml2obj %s -o %t.2.o
-# RUN: touch -m -t 199705050555.55 %t.2.o
-# RUN: llvm-objcopy -p %t.2.o %t-preserved.2.o
-# RUN: ls -l %t-preserved.2.o | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
-# RUN: llvm-readobj %t-preserved.2.o
+# RUN: yaml2obj %s -o %t.2.exe
+# RUN: touch -m -t 199705050555.55 %t.2.exe
+# RUN: llvm-objcopy -p %t.2.exe %t-preserved.2.exe
+# RUN: ls -l %t-preserved.2.exe | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
+# RUN: llvm-readobj --headers %t-preserved.2.exe | FileCheck %s
 
 ## Preserve dates when stripping in place.
-# RUN: yaml2obj %s -o %t.3.o
-# RUN: touch -m -t 199705050555.55 %t.3.o
-# RUN: llvm-strip -p %t.3.o
-# RUN: ls -l %t.3.o | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
-# RUN: llvm-readobj %t.3.o
+# RUN: yaml2obj %s -o %t.3.exe
+# RUN: touch -m -t 199705050555.55 %t.3.exe
+# RUN: llvm-strip -p %t.3.exe
+# RUN: ls -l %t.3.exe | FileCheck %s --check-prefix=CHECK-PRESERVE-MTIME
+# RUN: llvm-readobj --headers %t.3.exe | FileCheck %s
 
 ## Without -p set, don't preserve dates.
-# RUN: yaml2obj %s -o %t.4.o
-# RUN: touch -m -t 199705050555.55 %t.4.o
-# RUN: llvm-strip %t.4.o
-# RUN: ls -l %t.4.o | FileCheck %s --check-prefix=CHECK-NO-PRESERVE-MTIME
-# RUN: llvm-readobj %t.4.o
+# RUN: yaml2obj %s -o %t.4.exe
+# RUN: touch -m -t 199705050555.55 %t.4.exe
+# RUN: llvm-strip %t.4.exe
+# RUN: ls -l %t.4.exe | FileCheck %s --check-prefix=CHECK-NO-PRESERVE-MTIME
+# RUN: llvm-readobj --headers %t.4.exe | FileCheck %s
+
+## Always preserve the timestamp in the PE header.
+# CHECK: TimeDateStamp: 1970-01-01 00:00:00 (0x0)
 
 # CHECK-PRESERVE-MTIME:        {{[[:space:]]1997}}
 # CHECK-NO-PRESERVE-MTIME-NOT: {{[[:space:]]1997}}
 
 !COFF
+OptionalHeader:
+  Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
 header:
   Machine:         IMAGE_FILE_MACHINE_AMD64
 sections:


### PR DESCRIPTION
Binutils allows `-p`, which prevents it from modifying the timestamp. `llvm-objcopy` already preserves the timestamp in the COFF header, so the only missing piece is allowing the option in the config manager.