### PR TITLE
[CodeGen][NPM] Fix analysis preservation in UnreachableBlockElim and CodeGenPrepare

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -556,7 +556,6 @@ PreservedAnalyses CodeGenPreparePass::run(Function &F,
   PreservedAnalyses PA;
   PA.preserve<TargetLibraryAnalysis>();
   PA.preserve<TargetIRAnalysis>();
-  PA.preserve<LoopAnalysis>();
   return PA;
 }
 

--- a/llvm/lib/CodeGen/UnreachableBlockElim.cpp
+++ b/llvm/lib/CodeGen/UnreachableBlockElim.cpp
@@ -110,6 +110,7 @@ void UnreachableMachineBlockElimLegacy::getAnalysisUsage(
     AnalysisUsage &AU) const {
   AU.addPreserved<MachineLoopInfoWrapperPass>();
   AU.addPreserved<MachineDominatorTreeWrapperPass>();
+  AU.addPreserved<MachinePostDominatorTreeWrapperPass>();
   MachineFunctionPass::getAnalysisUsage(AU);
 }
 
@@ -125,7 +126,8 @@ UnreachableMachineBlockElimPass::run(MachineFunction &MF,
 
   return getMachineFunctionPassPreservedAnalyses()
       .preserve<MachineLoopAnalysis>()
-      .preserve<MachineDominatorTreeAnalysis>();
+      .preserve<MachineDominatorTreeAnalysis>()
+      .preserve<MachinePostDominatorTreeAnalysis>();
 }
 
 bool UnreachableMachineBlockElimLegacy::runOnMachineFunction(

--- a/llvm/lib/CodeGen/UnreachableBlockElim.cpp
+++ b/llvm/lib/CodeGen/UnreachableBlockElim.cpp
@@ -163,6 +163,7 @@ bool UnreachableMachineBlockElim::run(MachineFunction &F) {
       // Update dominator and loop info.
       if (MLI) MLI->removeBlock(&BB);
       if (MDT && MDT->getNode(&BB)) MDT->eraseNode(&BB);
+      if (MPDT && MPDT->getNode(&BB)) MPDT->eraseNode(&BB);
 
       while (!BB.succ_empty()) {
         (*BB.succ_begin())->removePHIsIncomingValuesForPredecessor(BB);


### PR DESCRIPTION
This patch -
a) Updates MPDT block numbers after removing dead blocks in `UnreachableBlockElimination` and 
b) Removes the incorrect `LoopAnalysis` preservation in `CodeGenPrepare`, as it invalidates loop structures with control flow modifications