### PR TITLE
[llc][NPM] Return error code instead of calling exit() in NPM driver

### DIFF
--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -198,7 +198,7 @@ int llvm::compileModuleWithNewPM(
   MPM.run(*M, MAM);
 
   if (Context.getDiagHandlerPtr()->HasErrors)
-    exit(1);
+    return 1;
 
   // Declare success.
   Out->keep();


### PR DESCRIPTION
This patch changes NPM driver error handling to return error code instead of calling `exit(1)` directly.