### PR TITLE
[MCAsmStreamer] Print register names in --show-inst mode

### DIFF
--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -2452,7 +2452,7 @@ void MCAsmStreamer::emitInstruction(const MCInst &Inst,
 
   // Show the MCInst if enabled.
   if (ShowInst) {
-    Inst.dump_pretty(getCommentOS(), InstPrinter.get(), "\n ");
+    Inst.dump_pretty(getCommentOS(), InstPrinter.get(), "\n ", &getContext());
     getCommentOS() << "\n";
   }
 

--- a/llvm/test/CodeGen/Mips/llvm-ir/fptosi.ll
+++ b/llvm/test/CodeGen/Mips/llvm-ir/fptosi.ll
@@ -39,123 +39,123 @@ define i32 @test1(float %t) {
 ; M32-LABEL: test1:
 ; M32:       # %bb.0: # %entry
 ; M32-NEXT:    trunc.w.s $f0, $f12 # <MCInst #[[#MCINST1:]] TRUNC_W_S
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; M32-NEXT:    # <MCOperand Reg:F0>
+; M32-NEXT:    # <MCOperand Reg:F12>>
 ; M32-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>>
+; M32-NEXT:    # <MCOperand Reg:RA>>
 ; M32-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3:]] MFC1
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M32-NEXT:    # <MCOperand Reg:V0>
+; M32-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M32R2-FP64-LABEL: test1:
 ; M32R2-FP64:       # %bb.0: # %entry
 ; M32R2-FP64-NEXT:    trunc.w.s $f0, $f12 # <MCInst #[[#MCINST1:]] TRUNC_W_S
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:F0>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:F12>>
 ; M32R2-FP64-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:RA>>
 ; M32R2-FP64-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3:]] MFC1
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:V0>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M32R2-SF-LABEL: test1:
 ; M32R2-SF:       # %bb.0: # %entry
 ; M32R2-SF-NEXT:    addiu $sp, $sp, -24 # <MCInst #[[#MCINST4:]] ADDiu
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5:]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:-24>>
 ; M32R2-SF-NEXT:    .cfi_def_cfa_offset 24
 ; M32R2-SF-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
 ; M32R2-SF-NEXT:    # <MCInst #[[#MCINST5:]] SW
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:RA>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:20>>
 ; M32R2-SF-NEXT:    .cfi_offset 31, -4
 ; M32R2-SF-NEXT:    jal __fixsfsi # <MCInst #[[#MCINST6:]] JAL
 ; M32R2-SF-NEXT:    # <MCOperand Expr:__fixsfsi>>
 ; M32R2-SF-NEXT:    nop # <MCInst #[[#MCINST7:]] SLL
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG6:]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:ZERO>
+; M32R2-SF-NEXT:    # <MCOperand Reg:ZERO>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:0>>
 ; M32R2-SF-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
 ; M32R2-SF-NEXT:    # <MCInst #[[#MCINST8:]] LW
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:RA>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:20>>
 ; M32R2-SF-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; M32R2-SF-NEXT:    # <MCOperand Reg:RA>>
 ; M32R2-SF-NEXT:    addiu $sp, $sp, 24 # <MCInst #[[#MCINST4]] ADDiu
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:24>>
 ;
 ; M32R3R5-LABEL: test1:
 ; M32R3R5:       # %bb.0: # %entry
 ; M32R3R5-NEXT:    trunc.w.s $f0, $f12 # <MCInst #[[#MCINST1:]] TRUNC_W_S
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; M32R3R5-NEXT:    # <MCOperand Reg:F0>
+; M32R3R5-NEXT:    # <MCOperand Reg:F12>>
 ; M32R3R5-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>>
+; M32R3R5-NEXT:    # <MCOperand Reg:RA>>
 ; M32R3R5-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3:]] MFC1
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M32R3R5-NEXT:    # <MCOperand Reg:V0>
+; M32R3R5-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M32R6-LABEL: test1:
 ; M32R6:       # %bb.0: # %entry
 ; M32R6-NEXT:    trunc.w.s $f0, $f12 # <MCInst #[[#MCINST1:]] TRUNC_W_S
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; M32R6-NEXT:    # <MCOperand Reg:F0>
+; M32R6-NEXT:    # <MCOperand Reg:F12>>
 ; M32R6-NEXT:    jr $ra # <MCInst #[[#MCINST9:]] JALR
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG6:]]>
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>>
+; M32R6-NEXT:    # <MCOperand Reg:ZERO>
+; M32R6-NEXT:    # <MCOperand Reg:RA>>
 ; M32R6-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3:]] MFC1
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M32R6-NEXT:    # <MCOperand Reg:V0>
+; M32R6-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M64-LABEL: test1:
 ; M64:       # %bb.0: # %entry
 ; M64-NEXT:    trunc.w.s $f0, $f12 # <MCInst #[[#MCINST1:]] TRUNC_W_S
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; M64-NEXT:    # <MCOperand Reg:F0>
+; M64-NEXT:    # <MCOperand Reg:F12>>
 ; M64-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG7:]]>>
+; M64-NEXT:    # <MCOperand Reg:RA_64>>
 ; M64-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3:]] MFC1
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M64-NEXT:    # <MCOperand Reg:V0>
+; M64-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M64R6-LABEL: test1:
 ; M64R6:       # %bb.0: # %entry
 ; M64R6-NEXT:    trunc.w.s $f0, $f12 # <MCInst #[[#MCINST1:]] TRUNC_W_S
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; M64R6-NEXT:    # <MCOperand Reg:F0>
+; M64R6-NEXT:    # <MCOperand Reg:F12>>
 ; M64R6-NEXT:    jr $ra # <MCInst #[[#MCINST10:]] JALR64
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG8:]]>
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG7:]]>>
+; M64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; M64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; M64R6-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3:]] MFC1
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M64R6-NEXT:    # <MCOperand Reg:V0>
+; M64R6-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; MMR2-FP32-LABEL: test1:
 ; MMR2-FP32:       # %bb.0: # %entry
 ; MMR2-FP32-NEXT:    trunc.w.s $f0, $f12 # <MCInst #[[#MCINST11:]] TRUNC_W_S_MM
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:F0>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:F12>>
 ; MMR2-FP32-NEXT:    jr $ra # <MCInst #[[#MCINST12:]] JR_MM
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:RA>>
 ; MMR2-FP32-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST13:]] MFC1_MM
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:V0>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; MMR2-FP64-LABEL: test1:
 ; MMR2-FP64:       # %bb.0: # %entry
 ; MMR2-FP64-NEXT:    trunc.w.s $f0, $f12 # <MCInst #[[#MCINST11:]] TRUNC_W_S_MM
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:F0>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:F12>>
 ; MMR2-FP64-NEXT:    jr $ra # <MCInst #[[#MCINST12:]] JR_MM
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR2-FP64-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST13:]] MFC1_MM
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:V0>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; MMR2-SF-LABEL: test1:
 ; MMR2-SF:       # %bb.0: # %entry
@@ -164,63 +164,63 @@ define i32 @test1(float %t) {
 ; MMR2-SF-NEXT:    .cfi_def_cfa_offset 24
 ; MMR2-SF-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
 ; MMR2-SF-NEXT:    # <MCInst #[[#MCINST15:]] SWSP_MM
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5:]]>
+; MMR2-SF-NEXT:    # <MCOperand Reg:RA>
+; MMR2-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR2-SF-NEXT:    # <MCOperand Imm:20>>
 ; MMR2-SF-NEXT:    .cfi_offset 31, -4
 ; MMR2-SF-NEXT:    jal __fixsfsi # <MCInst #[[#MCINST16:]] JAL_MM
 ; MMR2-SF-NEXT:    # <MCOperand Expr:__fixsfsi>>
 ; MMR2-SF-NEXT:    nop # <MCInst #[[#MCINST17:]] SLL_MM
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG6:]]>
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR2-SF-NEXT:    # <MCOperand Reg:ZERO>
+; MMR2-SF-NEXT:    # <MCOperand Reg:ZERO>
 ; MMR2-SF-NEXT:    # <MCOperand Imm:0>>
 ; MMR2-SF-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
 ; MMR2-SF-NEXT:    # <MCInst #[[#MCINST18:]] LWSP_MM
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR2-SF-NEXT:    # <MCOperand Reg:RA>
+; MMR2-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR2-SF-NEXT:    # <MCOperand Imm:20>>
 ; MMR2-SF-NEXT:    addiusp 24 # <MCInst #[[#MCINST14]] ADDIUSP_MM
 ; MMR2-SF-NEXT:    # <MCOperand Imm:24>>
 ; MMR2-SF-NEXT:    jrc $ra # <MCInst #[[#MCINST19:]] JRC16_MM
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR2-SF-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MMR6-LABEL: test1:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    trunc.w.s $f0, $f12 # <MCInst #[[#MCINST20:]] TRUNC_W_S_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MMR6-NEXT:    # <MCOperand Reg:F0>
+; MMR6-NEXT:    # <MCOperand Reg:F12>>
 ; MMR6-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST13:]] MFC1_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:F0>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST19:]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MMR6-SF-LABEL: test1:
 ; MMR6-SF:       # %bb.0: # %entry
 ; MMR6-SF-NEXT:    addiu $sp, $sp, -24 # <MCInst #[[#MCINST4:]] ADDiu
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5:]]>
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR6-SF-NEXT:    # <MCOperand Imm:-24>>
 ; MMR6-SF-NEXT:    .cfi_def_cfa_offset 24
 ; MMR6-SF-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
 ; MMR6-SF-NEXT:    # <MCInst #[[#MCINST5:]] SW
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR6-SF-NEXT:    # <MCOperand Reg:RA>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR6-SF-NEXT:    # <MCOperand Imm:20>>
 ; MMR6-SF-NEXT:    .cfi_offset 31, -4
 ; MMR6-SF-NEXT:    balc __fixsfsi # <MCInst #[[#MCINST21:]] BALC_MMR6
 ; MMR6-SF-NEXT:    # <MCOperand Expr:__fixsfsi>>
 ; MMR6-SF-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
 ; MMR6-SF-NEXT:    # <MCInst #[[#MCINST8:]] LW
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR6-SF-NEXT:    # <MCOperand Reg:RA>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR6-SF-NEXT:    # <MCOperand Imm:20>>
 ; MMR6-SF-NEXT:    addiu $sp, $sp, 24 # <MCInst #[[#MCINST4]] ADDiu
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR6-SF-NEXT:    # <MCOperand Imm:24>>
 ; MMR6-SF-NEXT:    jrc $ra # <MCInst #[[#MCINST19:]] JRC16_MM
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-SF-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %conv = fptosi float %t to i32
   ret i32 %conv
@@ -230,123 +230,123 @@ define i32 @test2(double %t) {
 ; M32-LABEL: test2:
 ; M32:       # %bb.0: # %entry
 ; M32-NEXT:    trunc.w.d $f0, $f12 # <MCInst #[[#MCINST22:]] TRUNC_W_D32
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>>
+; M32-NEXT:    # <MCOperand Reg:F0>
+; M32-NEXT:    # <MCOperand Reg:D6>>
 ; M32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; M32-NEXT:    # <MCOperand Reg:RA>>
 ; M32-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3]] MFC1
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; M32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M32-NEXT:    # <MCOperand Reg:V0>
+; M32-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M32R2-FP64-LABEL: test2:
 ; M32R2-FP64:       # %bb.0: # %entry
 ; M32R2-FP64-NEXT:    trunc.w.d $f0, $f12 # <MCInst #[[#MCINST23:]] TRUNC_W_D64
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:F0>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:D12_64>>
 ; M32R2-FP64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:RA>>
 ; M32R2-FP64-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3]] MFC1
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; M32R2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:V0>
+; M32R2-FP64-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M32R2-SF-LABEL: test2:
 ; M32R2-SF:       # %bb.0: # %entry
 ; M32R2-SF-NEXT:    addiu $sp, $sp, -24 # <MCInst #[[#MCINST4]] ADDiu
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:-24>>
 ; M32R2-SF-NEXT:    .cfi_def_cfa_offset 24
 ; M32R2-SF-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
 ; M32R2-SF-NEXT:    # <MCInst #[[#MCINST5]] SW
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:RA>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:20>>
 ; M32R2-SF-NEXT:    .cfi_offset 31, -4
 ; M32R2-SF-NEXT:    jal __fixdfsi # <MCInst #[[#MCINST6]] JAL
 ; M32R2-SF-NEXT:    # <MCOperand Expr:__fixdfsi>>
 ; M32R2-SF-NEXT:    nop # <MCInst #[[#MCINST7]] SLL
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:ZERO>
+; M32R2-SF-NEXT:    # <MCOperand Reg:ZERO>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:0>>
 ; M32R2-SF-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
 ; M32R2-SF-NEXT:    # <MCInst #[[#MCINST8]] LW
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:RA>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:20>>
 ; M32R2-SF-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; M32R2-SF-NEXT:    # <MCOperand Reg:RA>>
 ; M32R2-SF-NEXT:    addiu $sp, $sp, 24 # <MCInst #[[#MCINST4]] ADDiu
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; M32R2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
+; M32R2-SF-NEXT:    # <MCOperand Reg:SP>
 ; M32R2-SF-NEXT:    # <MCOperand Imm:24>>
 ;
 ; M32R3R5-LABEL: test2:
 ; M32R3R5:       # %bb.0: # %entry
 ; M32R3R5-NEXT:    trunc.w.d $f0, $f12 # <MCInst #[[#MCINST22:]] TRUNC_W_D32
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>>
+; M32R3R5-NEXT:    # <MCOperand Reg:F0>
+; M32R3R5-NEXT:    # <MCOperand Reg:D6>>
 ; M32R3R5-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; M32R3R5-NEXT:    # <MCOperand Reg:RA>>
 ; M32R3R5-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3]] MFC1
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; M32R3R5-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M32R3R5-NEXT:    # <MCOperand Reg:V0>
+; M32R3R5-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M32R6-LABEL: test2:
 ; M32R6:       # %bb.0: # %entry
 ; M32R6-NEXT:    trunc.w.d $f0, $f12 # <MCInst #[[#MCINST23:]] TRUNC_W_D64
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>>
+; M32R6-NEXT:    # <MCOperand Reg:F0>
+; M32R6-NEXT:    # <MCOperand Reg:D12_64>>
 ; M32R6-NEXT:    jr $ra # <MCInst #[[#MCINST9]] JALR
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; M32R6-NEXT:    # <MCOperand Reg:ZERO>
+; M32R6-NEXT:    # <MCOperand Reg:RA>>
 ; M32R6-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3]] MFC1
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; M32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M32R6-NEXT:    # <MCOperand Reg:V0>
+; M32R6-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M64-LABEL: test2:
 ; M64:       # %bb.0: # %entry
 ; M64-NEXT:    trunc.w.d $f0, $f12 # <MCInst #[[#MCINST23:]] TRUNC_W_D64
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>>
+; M64-NEXT:    # <MCOperand Reg:F0>
+; M64-NEXT:    # <MCOperand Reg:D12_64>>
 ; M64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG7]]>>
+; M64-NEXT:    # <MCOperand Reg:RA_64>>
 ; M64-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3]] MFC1
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; M64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M64-NEXT:    # <MCOperand Reg:V0>
+; M64-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; M64R6-LABEL: test2:
 ; M64R6:       # %bb.0: # %entry
 ; M64R6-NEXT:    trunc.w.d $f0, $f12 # <MCInst #[[#MCINST23:]] TRUNC_W_D64
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>>
+; M64R6-NEXT:    # <MCOperand Reg:F0>
+; M64R6-NEXT:    # <MCOperand Reg:D12_64>>
 ; M64R6-NEXT:    jr $ra # <MCInst #[[#MCINST10]] JALR64
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>>
+; M64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; M64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; M64R6-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST3]] MFC1
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; M64R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; M64R6-NEXT:    # <MCOperand Reg:V0>
+; M64R6-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; MMR2-FP32-LABEL: test2:
 ; MMR2-FP32:       # %bb.0: # %entry
 ; MMR2-FP32-NEXT:    trunc.w.d $f0, $f12 # <MCInst #[[#MCINST24:]] TRUNC_W_MM
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:F0>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:D6>>
 ; MMR2-FP32-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JR_MM
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:RA>>
 ; MMR2-FP32-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST13]] MFC1_MM
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MMR2-FP32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:V0>
+; MMR2-FP32-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; MMR2-FP64-LABEL: test2:
 ; MMR2-FP64:       # %bb.0: # %entry
 ; MMR2-FP64-NEXT:    cvt.w.d $f0, $f12 # <MCInst #[[#MCINST25:]] CVT_W_D64_MM
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:F0>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:D12_64>>
 ; MMR2-FP64-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JR_MM
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR2-FP64-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST13]] MFC1_MM
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MMR2-FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:V0>
+; MMR2-FP64-NEXT:    # <MCOperand Reg:F0>>
 ;
 ; MMR2-SF-LABEL: test2:
 ; MMR2-SF:       # %bb.0: # %entry
@@ -355,63 +355,63 @@ define i32 @test2(double %t) {
 ; MMR2-SF-NEXT:    .cfi_def_cfa_offset 24
 ; MMR2-SF-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
 ; MMR2-SF-NEXT:    # <MCInst #[[#MCINST15]] SWSP_MM
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR2-SF-NEXT:    # <MCOperand Reg:RA>
+; MMR2-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR2-SF-NEXT:    # <MCOperand Imm:20>>
 ; MMR2-SF-NEXT:    .cfi_offset 31, -4
 ; MMR2-SF-NEXT:    jal __fixdfsi # <MCInst #[[#MCINST16]] JAL_MM
 ; MMR2-SF-NEXT:    # <MCOperand Expr:__fixdfsi>>
 ; MMR2-SF-NEXT:    nop # <MCInst #[[#MCINST17]] SLL_MM
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR2-SF-NEXT:    # <MCOperand Reg:ZERO>
+; MMR2-SF-NEXT:    # <MCOperand Reg:ZERO>
 ; MMR2-SF-NEXT:    # <MCOperand Imm:0>>
 ; MMR2-SF-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
 ; MMR2-SF-NEXT:    # <MCInst #[[#MCINST18]] LWSP_MM
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR2-SF-NEXT:    # <MCOperand Reg:RA>
+; MMR2-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR2-SF-NEXT:    # <MCOperand Imm:20>>
 ; MMR2-SF-NEXT:    addiusp 24 # <MCInst #[[#MCINST14]] ADDIUSP_MM
 ; MMR2-SF-NEXT:    # <MCOperand Imm:24>>
 ; MMR2-SF-NEXT:    jrc $ra # <MCInst #[[#MCINST19]] JRC16_MM
-; MMR2-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR2-SF-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MMR6-LABEL: test2:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    trunc.w.d $f0, $f12 # <MCInst #[[#MCINST26:]] TRUNC_W_D_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>>
+; MMR6-NEXT:    # <MCOperand Reg:F0>
+; MMR6-NEXT:    # <MCOperand Reg:D12_64>>
 ; MMR6-NEXT:    mfc1 $2, $f0 # <MCInst #[[#MCINST13]] MFC1_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:F0>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST19]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MMR6-SF-LABEL: test2:
 ; MMR6-SF:       # %bb.0: # %entry
 ; MMR6-SF-NEXT:    addiu $sp, $sp, -24 # <MCInst #[[#MCINST4]] ADDiu
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR6-SF-NEXT:    # <MCOperand Imm:-24>>
 ; MMR6-SF-NEXT:    .cfi_def_cfa_offset 24
 ; MMR6-SF-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
 ; MMR6-SF-NEXT:    # <MCInst #[[#MCINST5]] SW
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR6-SF-NEXT:    # <MCOperand Reg:RA>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR6-SF-NEXT:    # <MCOperand Imm:20>>
 ; MMR6-SF-NEXT:    .cfi_offset 31, -4
 ; MMR6-SF-NEXT:    balc __fixdfsi # <MCInst #[[#MCINST21]] BALC_MMR6
 ; MMR6-SF-NEXT:    # <MCOperand Expr:__fixdfsi>>
 ; MMR6-SF-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
 ; MMR6-SF-NEXT:    # <MCInst #[[#MCINST8]] LW
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR6-SF-NEXT:    # <MCOperand Reg:RA>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR6-SF-NEXT:    # <MCOperand Imm:20>>
 ; MMR6-SF-NEXT:    addiu $sp, $sp, 24 # <MCInst #[[#MCINST4]] ADDiu
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
+; MMR6-SF-NEXT:    # <MCOperand Reg:SP>
 ; MMR6-SF-NEXT:    # <MCOperand Imm:24>>
 ; MMR6-SF-NEXT:    jrc $ra # <MCInst #[[#MCINST19]] JRC16_MM
-; MMR6-SF-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-SF-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %conv = fptosi double %t to i32
   ret i32 %conv

--- a/llvm/test/CodeGen/Mips/llvm-ir/load.ll
+++ b/llvm/test/CodeGen/Mips/llvm-ir/load.ll
@@ -26,160 +26,160 @@ define i8 @f1() {
 ; MIPS32-LABEL: f1:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST1:]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    lbu $2, %lo(a)($1) # <MCInst #[[#MCINST3:]] LBu
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS32-NEXT:    # <MCOperand Reg:V0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MMR3-LABEL: f1:
 ; MMR3:       # %bb.0: # %entry
 ; MMR3-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST4:]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5:]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    lbu $2, %lo(a)($1) # <MCInst #[[#MCINST6:]] LBu_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MMR3-NEXT:    # <MCOperand Reg:V0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS32R6-LABEL: f1:
 ; MIPS32R6:       # %bb.0: # %entry
 ; MIPS32R6-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST1:]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7:]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    lbu $2, %lo(a)($1) # <MCInst #[[#MCINST3:]] LBu
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MMR6-LABEL: f1:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST4:]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MMR6-NEXT:    lbu $2, %lo(a)($1) # <MCInst #[[#MCINST6:]] LBu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(a)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8:]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS3-LABEL: f1:
 ; MIPS3:       # %bb.0: # %entry
 ; MIPS3-NEXT:    lui $1, %highest(a) # <MCInst #[[#MCINST9:]] LUi64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5:]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4026,a)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%highest(a)>>
 ; MIPS3-NEXT:    daddiu $1, $1, %higher(a) # <MCInst #[[#MCINST10:]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4025,a)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%higher(a)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11:]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    daddiu $1, $1, %hi(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG6:]]>>
+; MIPS3-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS3-NEXT:    lbu $2, %lo(a)($1) # <MCInst #[[#MCINST3:]] LBu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS3-NEXT:    # <MCOperand Reg:V0>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS64-LABEL: f1:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    lui $1, %highest(a) # <MCInst #[[#MCINST9:]] LUi64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5:]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4026,a)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%highest(a)>>
 ; MIPS64-NEXT:    daddiu $1, $1, %higher(a) # <MCInst #[[#MCINST10:]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4025,a)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%higher(a)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11:]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    daddiu $1, $1, %hi(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG6:]]>>
+; MIPS64-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64-NEXT:    lbu $2, %lo(a)($1) # <MCInst #[[#MCINST3:]] LBu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS64-NEXT:    # <MCOperand Reg:V0>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS64R6-LABEL: f1:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    lui $1, %highest(a) # <MCInst #[[#MCINST9:]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5:]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(a)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(a) # <MCInst #[[#MCINST10:]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(a)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11:]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST12:]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7:]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6:]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    lbu $2, %lo(a)($1) # <MCInst #[[#MCINST3:]] LBu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MMR5FP64-LABEL: f1:
 ; MMR5FP64:       # %bb.0: # %entry
 ; MMR5FP64-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST4:]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5:]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    lbu $2, %lo(a)($1) # <MCInst #[[#MCINST6:]] LBu_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS32R5FP643-LABEL: f1:
 ; MIPS32R5FP643:       # %bb.0: # %entry
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST1:]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    lbu $2, %lo(a)($1) # <MCInst #[[#MCINST3:]] LBu
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(a)>>
 entry:
   %0 = load i8, ptr @a
   ret i8 %0
@@ -189,160 +189,160 @@ define i32 @f2() {
 ; MIPS32-LABEL: f2:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    lb $2, %lo(a)($1) # <MCInst #[[#MCINST13:]] LB
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS32-NEXT:    # <MCOperand Reg:V0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MMR3-LABEL: f2:
 ; MMR3:       # %bb.0: # %entry
 ; MMR3-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    lb $2, %lo(a)($1) # <MCInst #[[#MCINST14:]] LB_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MMR3-NEXT:    # <MCOperand Reg:V0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS32R6-LABEL: f2:
 ; MIPS32R6:       # %bb.0: # %entry
 ; MIPS32R6-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    lb $2, %lo(a)($1) # <MCInst #[[#MCINST13:]] LB
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MMR6-LABEL: f2:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MMR6-NEXT:    lb $2, %lo(a)($1) # <MCInst #[[#MCINST14:]] LB_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(a)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS3-LABEL: f2:
 ; MIPS3:       # %bb.0: # %entry
 ; MIPS3-NEXT:    lui $1, %highest(a) # <MCInst #[[#MCINST9]] LUi64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4026,a)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%highest(a)>>
 ; MIPS3-NEXT:    daddiu $1, $1, %higher(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4025,a)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%higher(a)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    daddiu $1, $1, %hi(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS3-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS3-NEXT:    lb $2, %lo(a)($1) # <MCInst #[[#MCINST13:]] LB
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS3-NEXT:    # <MCOperand Reg:V0>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS64-LABEL: f2:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    lui $1, %highest(a) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4026,a)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%highest(a)>>
 ; MIPS64-NEXT:    daddiu $1, $1, %higher(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4025,a)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%higher(a)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    daddiu $1, $1, %hi(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64-NEXT:    lb $2, %lo(a)($1) # <MCInst #[[#MCINST13:]] LB
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS64-NEXT:    # <MCOperand Reg:V0>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS64R6-LABEL: f2:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    lui $1, %highest(a) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(a)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(a)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    lb $2, %lo(a)($1) # <MCInst #[[#MCINST13:]] LB
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MMR5FP64-LABEL: f2:
 ; MMR5FP64:       # %bb.0: # %entry
 ; MMR5FP64-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    lb $2, %lo(a)($1) # <MCInst #[[#MCINST14:]] LB_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS32R5FP643-LABEL: f2:
 ; MIPS32R5FP643:       # %bb.0: # %entry
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    lb $2, %lo(a)($1) # <MCInst #[[#MCINST13:]] LB
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(a)>>
 entry:
   %0 = load i8, ptr @a
   %1 = sext i8 %0 to i32
@@ -353,160 +353,160 @@ define i16 @f3() {
 ; MIPS32-LABEL: f3:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    lhu $2, %lo(b)($1) # <MCInst #[[#MCINST15:]] LHu
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS32-NEXT:    # <MCOperand Reg:V0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MMR3-LABEL: f3:
 ; MMR3:       # %bb.0: # %entry
 ; MMR3-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    lhu $2, %lo(b)($1) # <MCInst #[[#MCINST16:]] LHu_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MMR3-NEXT:    # <MCOperand Reg:V0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS32R6-LABEL: f3:
 ; MIPS32R6:       # %bb.0: # %entry
 ; MIPS32R6-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    lhu $2, %lo(b)($1) # <MCInst #[[#MCINST15:]] LHu
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MMR6-LABEL: f3:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MMR6-NEXT:    lhu $2, %lo(b)($1) # <MCInst #[[#MCINST16:]] LHu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(b)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS3-LABEL: f3:
 ; MIPS3:       # %bb.0: # %entry
 ; MIPS3-NEXT:    lui $1, %highest(b) # <MCInst #[[#MCINST9]] LUi64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4026,b)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%highest(b)>>
 ; MIPS3-NEXT:    daddiu $1, $1, %higher(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4025,b)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%higher(b)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    daddiu $1, $1, %hi(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS3-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS3-NEXT:    lhu $2, %lo(b)($1) # <MCInst #[[#MCINST15:]] LHu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS3-NEXT:    # <MCOperand Reg:V0>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS64-LABEL: f3:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    lui $1, %highest(b) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4026,b)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%highest(b)>>
 ; MIPS64-NEXT:    daddiu $1, $1, %higher(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4025,b)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%higher(b)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    daddiu $1, $1, %hi(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64-NEXT:    lhu $2, %lo(b)($1) # <MCInst #[[#MCINST15:]] LHu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS64-NEXT:    # <MCOperand Reg:V0>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS64R6-LABEL: f3:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    lui $1, %highest(b) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(b)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(b)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    lhu $2, %lo(b)($1) # <MCInst #[[#MCINST15:]] LHu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MMR5FP64-LABEL: f3:
 ; MMR5FP64:       # %bb.0: # %entry
 ; MMR5FP64-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    lhu $2, %lo(b)($1) # <MCInst #[[#MCINST16:]] LHu_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS32R5FP643-LABEL: f3:
 ; MIPS32R5FP643:       # %bb.0: # %entry
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    lhu $2, %lo(b)($1) # <MCInst #[[#MCINST15:]] LHu
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(b)>>
 entry:
   %0 = load i16, ptr @b
   ret i16 %0
@@ -516,160 +516,160 @@ define i32 @f4() {
 ; MIPS32-LABEL: f4:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    lh $2, %lo(b)($1) # <MCInst #[[#MCINST17:]] LH
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS32-NEXT:    # <MCOperand Reg:V0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MMR3-LABEL: f4:
 ; MMR3:       # %bb.0: # %entry
 ; MMR3-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    lh $2, %lo(b)($1) # <MCInst #[[#MCINST18:]] LH_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MMR3-NEXT:    # <MCOperand Reg:V0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS32R6-LABEL: f4:
 ; MIPS32R6:       # %bb.0: # %entry
 ; MIPS32R6-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    lh $2, %lo(b)($1) # <MCInst #[[#MCINST17:]] LH
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MMR6-LABEL: f4:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MMR6-NEXT:    lh $2, %lo(b)($1) # <MCInst #[[#MCINST18:]] LH_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(b)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS3-LABEL: f4:
 ; MIPS3:       # %bb.0: # %entry
 ; MIPS3-NEXT:    lui $1, %highest(b) # <MCInst #[[#MCINST9]] LUi64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4026,b)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%highest(b)>>
 ; MIPS3-NEXT:    daddiu $1, $1, %higher(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4025,b)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%higher(b)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    daddiu $1, $1, %hi(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS3-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS3-NEXT:    lh $2, %lo(b)($1) # <MCInst #[[#MCINST17:]] LH
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS3-NEXT:    # <MCOperand Reg:V0>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS64-LABEL: f4:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    lui $1, %highest(b) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4026,b)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%highest(b)>>
 ; MIPS64-NEXT:    daddiu $1, $1, %higher(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4025,b)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%higher(b)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    daddiu $1, $1, %hi(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64-NEXT:    lh $2, %lo(b)($1) # <MCInst #[[#MCINST17:]] LH
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS64-NEXT:    # <MCOperand Reg:V0>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS64R6-LABEL: f4:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    lui $1, %highest(b) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(b)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(b)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    lh $2, %lo(b)($1) # <MCInst #[[#MCINST17:]] LH
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MMR5FP64-LABEL: f4:
 ; MMR5FP64:       # %bb.0: # %entry
 ; MMR5FP64-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    lh $2, %lo(b)($1) # <MCInst #[[#MCINST18:]] LH_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS32R5FP643-LABEL: f4:
 ; MIPS32R5FP643:       # %bb.0: # %entry
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    lh $2, %lo(b)($1) # <MCInst #[[#MCINST17:]] LH
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(b)>>
 entry:
   %0 = load i16, ptr @b
   %1 = sext i16 %0 to i32
@@ -680,160 +680,160 @@ define i32 @f5() {
 ; MIPS32-LABEL: f5:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST19:]] LW
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32-NEXT:    # <MCOperand Reg:V0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MMR3-LABEL: f5:
 ; MMR3:       # %bb.0: # %entry
 ; MMR3-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST20:]] LW_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR3-NEXT:    # <MCOperand Reg:V0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS32R6-LABEL: f5:
 ; MIPS32R6:       # %bb.0: # %entry
 ; MIPS32R6-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST19:]] LW
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MMR6-LABEL: f5:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR6-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST20:]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS3-LABEL: f5:
 ; MIPS3:       # %bb.0: # %entry
 ; MIPS3-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS3-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS3-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS3-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST19:]] LW
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:V0>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS64-LABEL: f5:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS64-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST19:]] LW
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:V0>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS64R6-LABEL: f5:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST19:]] LW
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MMR5FP64-LABEL: f5:
 ; MMR5FP64:       # %bb.0: # %entry
 ; MMR5FP64-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST20:]] LW_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS32R5FP643-LABEL: f5:
 ; MIPS32R5FP643:       # %bb.0: # %entry
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST19:]] LW
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(c)>>
 entry:
   %0 = load i32, ptr @c
   ret i32 %0
@@ -843,180 +843,180 @@ define i64 @f6() {
 ; MIPS32-LABEL: f6:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST19]] LW
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG8:]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32-NEXT:    # <MCOperand Reg:V1>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    addiu $2, $zero, 0 # <MCInst #[[#MCINST21:]] ADDiu
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
+; MIPS32-NEXT:    # <MCOperand Reg:V0>
+; MIPS32-NEXT:    # <MCOperand Reg:ZERO>
 ; MIPS32-NEXT:    # <MCOperand Imm:0>>
 ;
 ; MMR3-LABEL: f6:
 ; MMR3:       # %bb.0: # %entry
 ; MMR3-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR3-NEXT:    li16 $2, 0 # <MCInst #[[#MCINST22:]] LI16_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
+; MMR3-NEXT:    # <MCOperand Reg:V0>
 ; MMR3-NEXT:    # <MCOperand Imm:0>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST20]] LW_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG8:]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR3-NEXT:    # <MCOperand Reg:V1>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS32R6-LABEL: f6:
 ; MIPS32R6:       # %bb.0: # %entry
 ; MIPS32R6-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32R6-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST19]] LW
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG8:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V1>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    addiu $2, $zero, 0 # <MCInst #[[#MCINST21:]] ADDiu
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
 ; MIPS32R6-NEXT:    # <MCOperand Imm:0>>
 ;
 ; MMR6-LABEL: f6:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR6-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST20]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG8:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR6-NEXT:    # <MCOperand Reg:V1>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MMR6-NEXT:    li16 $2, 0 # <MCInst #[[#MCINST22:]] LI16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:0>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS3-LABEL: f6:
 ; MIPS3:       # %bb.0: # %entry
 ; MIPS3-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS3-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS3-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS3-NEXT:    lwu $2, %lo(c)($1) # <MCInst #[[#MCINST23:]] LWu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:V0_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS64-LABEL: f6:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS64-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64-NEXT:    lwu $2, %lo(c)($1) # <MCInst #[[#MCINST23:]] LWu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:V0_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS64R6-LABEL: f6:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    lwu $2, %lo(c)($1) # <MCInst #[[#MCINST23:]] LWu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:V0_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MMR5FP64-LABEL: f6:
 ; MMR5FP64:       # %bb.0: # %entry
 ; MMR5FP64-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR5FP64-NEXT:    li16 $2, 0 # <MCInst #[[#MCINST22:]] LI16_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V0>
 ; MMR5FP64-NEXT:    # <MCOperand Imm:0>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST20]] LW_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG8:]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V1>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS32R5FP643-LABEL: f6:
 ; MIPS32R5FP643:       # %bb.0: # %entry
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32R5FP643-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST19]] LW
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG8:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V1>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    addiu $2, $zero, 0 # <MCInst #[[#MCINST21:]] ADDiu
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:ZERO>
 ; MIPS32R5FP643-NEXT:    # <MCOperand Imm:0>>
 entry:
   %0 = load i32, ptr @c
@@ -1028,183 +1028,183 @@ define i64 @f7() {
 ; MIPS32-LABEL: f7:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST19]] LW
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32-NEXT:    # <MCOperand Reg:V1>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    sra $2, $3, 31 # <MCInst #[[#MCINST24:]] SRA
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
+; MIPS32-NEXT:    # <MCOperand Reg:V0>
+; MIPS32-NEXT:    # <MCOperand Reg:V1>
 ; MIPS32-NEXT:    # <MCOperand Imm:31>>
 ;
 ; MMR3-LABEL: f7:
 ; MMR3:       # %bb.0: # %entry
 ; MMR3-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR3-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST20]] LW_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR3-NEXT:    # <MCOperand Reg:V1>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    sra $2, $3, 31 # <MCInst #[[#MCINST25:]] SRA_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
+; MMR3-NEXT:    # <MCOperand Reg:V0>
+; MMR3-NEXT:    # <MCOperand Reg:V1>
 ; MMR3-NEXT:    # <MCOperand Imm:31>>
 ;
 ; MIPS32R6-LABEL: f7:
 ; MIPS32R6:       # %bb.0: # %entry
 ; MIPS32R6-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32R6-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST19]] LW
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V1>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    sra $2, $3, 31 # <MCInst #[[#MCINST24:]] SRA
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:V1>
 ; MIPS32R6-NEXT:    # <MCOperand Imm:31>>
 ;
 ; MMR6-LABEL: f7:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR6-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST20]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR6-NEXT:    # <MCOperand Reg:V1>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MMR6-NEXT:    sra $2, $3, 31 # <MCInst #[[#MCINST25:]] SRA_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V1>
 ; MMR6-NEXT:    # <MCOperand Imm:31>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS3-LABEL: f7:
 ; MIPS3:       # %bb.0: # %entry
 ; MIPS3-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS3-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS3-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS3-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST26:]] LW64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG9]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS3-NEXT:    # <MCOperand Reg:V0_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS64-LABEL: f7:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS64-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST26:]] LW64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG9]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS64-NEXT:    # <MCOperand Reg:V0_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS64R6-LABEL: f7:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    lw $2, %lo(c)($1) # <MCInst #[[#MCINST26:]] LW64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG9]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:V0_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MMR5FP64-LABEL: f7:
 ; MMR5FP64:       # %bb.0: # %entry
 ; MMR5FP64-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR5FP64-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST20]] LW_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V1>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    sra $2, $3, 31 # <MCInst #[[#MCINST25:]] SRA_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V1>
 ; MMR5FP64-NEXT:    # <MCOperand Imm:31>>
 ;
 ; MIPS32R5FP643-LABEL: f7:
 ; MIPS32R5FP643:       # %bb.0: # %entry
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32R5FP643-NEXT:    lw $3, %lo(c)($1) # <MCInst #[[#MCINST19]] LW
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V1>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    sra $2, $3, 31 # <MCInst #[[#MCINST24:]] SRA
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:V1>
 ; MIPS32R5FP643-NEXT:    # <MCOperand Imm:31>>
 entry:
   %0 = load i32, ptr @c
@@ -1216,160 +1216,160 @@ define float @f8() {
 ; MIPS32-LABEL: f8:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    lwc1 $f0, %lo(e)($1) # <MCInst #[[#MCINST27:]] LWC1
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS32-NEXT:    # <MCOperand Reg:F0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MMR3-LABEL: f8:
 ; MMR3:       # %bb.0: # %entry
 ; MMR3-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    lwc1 $f0, %lo(e)($1) # <MCInst #[[#MCINST28:]] LWC1_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MMR3-NEXT:    # <MCOperand Reg:F0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MIPS32R6-LABEL: f8:
 ; MIPS32R6:       # %bb.0: # %entry
 ; MIPS32R6-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    lwc1 $f0, %lo(e)($1) # <MCInst #[[#MCINST27:]] LWC1
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:F0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MMR6-LABEL: f8:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MMR6-NEXT:    lwc1 $f0, %lo(e)($1) # <MCInst #[[#MCINST28:]] LWC1_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MMR6-NEXT:    # <MCOperand Reg:F0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(e)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS3-LABEL: f8:
 ; MIPS3:       # %bb.0: # %entry
 ; MIPS3-NEXT:    lui $1, %highest(e) # <MCInst #[[#MCINST9]] LUi64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4026,e)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%highest(e)>>
 ; MIPS3-NEXT:    daddiu $1, $1, %higher(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4025,e)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%higher(e)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    daddiu $1, $1, %hi(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS3-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS3-NEXT:    lwc1 $f0, %lo(e)($1) # <MCInst #[[#MCINST27:]] LWC1
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS3-NEXT:    # <MCOperand Reg:F0>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MIPS64-LABEL: f8:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    lui $1, %highest(e) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4026,e)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%highest(e)>>
 ; MIPS64-NEXT:    daddiu $1, $1, %higher(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4025,e)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%higher(e)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    daddiu $1, $1, %hi(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64-NEXT:    lwc1 $f0, %lo(e)($1) # <MCInst #[[#MCINST27:]] LWC1
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS64-NEXT:    # <MCOperand Reg:F0>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MIPS64R6-LABEL: f8:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    lui $1, %highest(e) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,e)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(e)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,e)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(e)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    lwc1 $f0, %lo(e)($1) # <MCInst #[[#MCINST27:]] LWC1
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:F0>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MMR5FP64-LABEL: f8:
 ; MMR5FP64:       # %bb.0: # %entry
 ; MMR5FP64-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    lwc1 $f0, %lo(e)($1) # <MCInst #[[#MCINST28:]] LWC1_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:F0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MIPS32R5FP643-LABEL: f8:
 ; MIPS32R5FP643:       # %bb.0: # %entry
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    lwc1 $f0, %lo(e)($1) # <MCInst #[[#MCINST27:]] LWC1
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:F0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(e)>>
 entry:
   %0 = load float, ptr @e
   ret float %0
@@ -1379,160 +1379,160 @@ define double @f9() {
 ; MIPS32-LABEL: f9:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    ldc1 $f0, %lo(f)($1) # <MCInst #[[#MCINST29:]] LDC1
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS32-NEXT:    # <MCOperand Reg:D0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MMR3-LABEL: f9:
 ; MMR3:       # %bb.0: # %entry
 ; MMR3-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    ldc1 $f0, %lo(f)($1) # <MCInst #[[#MCINST30:]] LDC1_MM_D32
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MMR3-NEXT:    # <MCOperand Reg:D0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MIPS32R6-LABEL: f9:
 ; MIPS32R6:       # %bb.0: # %entry
 ; MIPS32R6-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    ldc1 $f0, %lo(f)($1) # <MCInst #[[#MCINST31:]] LDC164
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG12:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:D0_64>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MMR6-LABEL: f9:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MMR6-NEXT:    ldc1 $f0, %lo(f)($1) # <MCInst #[[#MCINST32:]] LDC1_D64_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG12:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MMR6-NEXT:    # <MCOperand Reg:D0_64>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(f)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS3-LABEL: f9:
 ; MIPS3:       # %bb.0: # %entry
 ; MIPS3-NEXT:    lui $1, %highest(f) # <MCInst #[[#MCINST9]] LUi64
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4026,f)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%highest(f)>>
 ; MIPS3-NEXT:    daddiu $1, $1, %higher(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4025,f)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%higher(f)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    daddiu $1, $1, %hi(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS3-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS3-NEXT:    # <MCOperand Imm:16>>
 ; MIPS3-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS3-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS3-NEXT:    ldc1 $f0, %lo(f)($1) # <MCInst #[[#MCINST31:]] LDC164
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG12:]]>
-; MIPS3-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS3-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS3-NEXT:    # <MCOperand Reg:D0_64>
+; MIPS3-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS3-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MIPS64-LABEL: f9:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    lui $1, %highest(f) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4026,f)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%highest(f)>>
 ; MIPS64-NEXT:    daddiu $1, $1, %higher(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4025,f)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%higher(f)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    daddiu $1, $1, %hi(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS64-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64-NEXT:    ldc1 $f0, %lo(f)($1) # <MCInst #[[#MCINST31:]] LDC164
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG12:]]>
-; MIPS64-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS64-NEXT:    # <MCOperand Reg:D0_64>
+; MIPS64-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MIPS64R6-LABEL: f9:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    lui $1, %highest(f) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,f)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(f)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,f)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(f)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST12]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    ldc1 $f0, %lo(f)($1) # <MCInst #[[#MCINST31:]] LDC164
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG12:]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:D0_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MMR5FP64-LABEL: f9:
 ; MMR5FP64:       # %bb.0: # %entry
 ; MMR5FP64-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    ldc1 $f0, %lo(f)($1) # <MCInst #[[#MCINST33:]] LDC1_MM_D64
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG12:]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:D0_64>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MIPS32R5FP643-LABEL: f9:
 ; MIPS32R5FP643:       # %bb.0: # %entry
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    ldc1 $f0, %lo(f)($1) # <MCInst #[[#MCINST31:]] LDC164
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG12:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:D0_64>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(f)>>
 entry:
   %0 = load double, ptr @f
   ret double %0

--- a/llvm/test/CodeGen/Mips/llvm-ir/store.ll
+++ b/llvm/test/CodeGen/Mips/llvm-ir/store.ll
@@ -25,132 +25,132 @@ define void @f1(i8 %a) {
 ; MIPS32-LABEL: f1:
 ; MIPS32:       # %bb.0:
 ; MIPS32-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST1:]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    sb $4, %lo(a)($1) # <MCInst #[[#MCINST3:]] SB
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS32-NEXT:    # <MCOperand Reg:A0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MMR3-LABEL: f1:
 ; MMR3:       # %bb.0:
 ; MMR3-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST4:]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5:]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    sb $4, %lo(a)($1) # <MCInst #[[#MCINST6:]] SB_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MMR3-NEXT:    # <MCOperand Reg:A0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS32R6-LABEL: f1:
 ; MIPS32R6:       # %bb.0:
 ; MIPS32R6-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST1:]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7:]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    sb $4, %lo(a)($1) # <MCInst #[[#MCINST3:]] SB
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:A0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MMR6-LABEL: f1:
 ; MMR6:       # %bb.0:
 ; MMR6-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST4:]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MMR6-NEXT:    sb $4, %lo(a)($1) # <MCInst #[[#MCINST6:]] SB_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(a)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8:]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS4-LABEL: f1:
 ; MIPS4:       # %bb.0:
 ; MIPS4-NEXT:    lui $1, %highest(a) # <MCInst #[[#MCINST9:]] LUi64
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5:]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4026,a)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%highest(a)>>
 ; MIPS4-NEXT:    daddiu $1, $1, %higher(a) # <MCInst #[[#MCINST10:]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4025,a)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%higher(a)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11:]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    daddiu $1, $1, %hi(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG6:]]>>
+; MIPS4-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS4-NEXT:    sb $4, %lo(a)($1) # <MCInst #[[#MCINST12:]] SB64
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG7:]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS4-NEXT:    # <MCOperand Reg:A0_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS64R6-LABEL: f1:
 ; MIPS64R6:       # %bb.0:
 ; MIPS64R6-NEXT:    lui $1, %highest(a) # <MCInst #[[#MCINST9:]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5:]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(a)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(a) # <MCInst #[[#MCINST10:]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(a)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11:]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(a) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST13:]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG8:]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6:]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    sb $4, %lo(a)($1) # <MCInst #[[#MCINST12:]] SB64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7:]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:A0_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MMR5FP64-LABEL: f1:
 ; MMR5FP64:       # %bb.0:
 ; MMR5FP64-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST4:]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5:]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    sb $4, %lo(a)($1) # <MCInst #[[#MCINST6:]] SB_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:A0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(a)>>
 ;
 ; MIPS32R5FP643-LABEL: f1:
 ; MIPS32R5FP643:       # %bb.0:
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(a) # <MCInst #[[#MCINST1:]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,a)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(a)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2:]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    sb $4, %lo(a)($1) # <MCInst #[[#MCINST3:]] SB
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,a)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:A0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(a)>>
   store i8 %a, ptr @a
   ret void
 }
@@ -159,132 +159,132 @@ define void @f2(i16 %a) {
 ; MIPS32-LABEL: f2:
 ; MIPS32:       # %bb.0:
 ; MIPS32-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    sh $4, %lo(b)($1) # <MCInst #[[#MCINST14:]] SH
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS32-NEXT:    # <MCOperand Reg:A0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MMR3-LABEL: f2:
 ; MMR3:       # %bb.0:
 ; MMR3-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    sh $4, %lo(b)($1) # <MCInst #[[#MCINST15:]] SH_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MMR3-NEXT:    # <MCOperand Reg:A0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS32R6-LABEL: f2:
 ; MIPS32R6:       # %bb.0:
 ; MIPS32R6-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    sh $4, %lo(b)($1) # <MCInst #[[#MCINST14:]] SH
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:A0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MMR6-LABEL: f2:
 ; MMR6:       # %bb.0:
 ; MMR6-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MMR6-NEXT:    sh $4, %lo(b)($1) # <MCInst #[[#MCINST15:]] SH_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(b)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS4-LABEL: f2:
 ; MIPS4:       # %bb.0:
 ; MIPS4-NEXT:    lui $1, %highest(b) # <MCInst #[[#MCINST9]] LUi64
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4026,b)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%highest(b)>>
 ; MIPS4-NEXT:    daddiu $1, $1, %higher(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4025,b)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%higher(b)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    daddiu $1, $1, %hi(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS4-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS4-NEXT:    sh $4, %lo(b)($1) # <MCInst #[[#MCINST16:]] SH64
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS4-NEXT:    # <MCOperand Reg:A0_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS64R6-LABEL: f2:
 ; MIPS64R6:       # %bb.0:
 ; MIPS64R6-NEXT:    lui $1, %highest(b) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(b)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(b)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(b) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST13]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    sh $4, %lo(b)($1) # <MCInst #[[#MCINST16:]] SH64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:A0_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MMR5FP64-LABEL: f2:
 ; MMR5FP64:       # %bb.0:
 ; MMR5FP64-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    sh $4, %lo(b)($1) # <MCInst #[[#MCINST15:]] SH_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:A0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(b)>>
 ;
 ; MIPS32R5FP643-LABEL: f2:
 ; MIPS32R5FP643:       # %bb.0:
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(b) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,b)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(b)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    sh $4, %lo(b)($1) # <MCInst #[[#MCINST14:]] SH
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,b)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:A0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(b)>>
   store i16 %a, ptr @b
   ret void
 }
@@ -293,132 +293,132 @@ define void @f3(i32 %a) {
 ; MIPS32-LABEL: f3:
 ; MIPS32:       # %bb.0:
 ; MIPS32-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    sw $4, %lo(c)($1) # <MCInst #[[#MCINST17:]] SW
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32-NEXT:    # <MCOperand Reg:A0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MMR3-LABEL: f3:
 ; MMR3:       # %bb.0:
 ; MMR3-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    sw $4, %lo(c)($1) # <MCInst #[[#MCINST18:]] SW_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR3-NEXT:    # <MCOperand Reg:A0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS32R6-LABEL: f3:
 ; MIPS32R6:       # %bb.0:
 ; MIPS32R6-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    sw $4, %lo(c)($1) # <MCInst #[[#MCINST17:]] SW
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:A0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MMR6-LABEL: f3:
 ; MMR6:       # %bb.0:
 ; MMR6-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR6-NEXT:    sw $4, %lo(c)($1) # <MCInst #[[#MCINST18:]] SW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS4-LABEL: f3:
 ; MIPS4:       # %bb.0:
 ; MIPS4-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS4-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS4-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS4-NEXT:    sw $4, %lo(c)($1) # <MCInst #[[#MCINST19:]] SW64
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS4-NEXT:    # <MCOperand Reg:A0_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS64R6-LABEL: f3:
 ; MIPS64R6:       # %bb.0:
 ; MIPS64R6-NEXT:    lui $1, %highest(c) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(c)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(c)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(c) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST13]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    sw $4, %lo(c)($1) # <MCInst #[[#MCINST19:]] SW64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:A0_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MMR5FP64-LABEL: f3:
 ; MMR5FP64:       # %bb.0:
 ; MMR5FP64-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    sw $4, %lo(c)($1) # <MCInst #[[#MCINST18:]] SW_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:A0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(c)>>
 ;
 ; MIPS32R5FP643-LABEL: f3:
 ; MIPS32R5FP643:       # %bb.0:
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(c) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,c)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(c)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    sw $4, %lo(c)($1) # <MCInst #[[#MCINST17:]] SW
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,c)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:A0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(c)>>
   store i32 %a, ptr @c
   ret void
 }
@@ -427,179 +427,179 @@ define void @f4(i64 %a) {
 ; MIPS32-LABEL: f4:
 ; MIPS32:       # %bb.0:
 ; MIPS32-NEXT:    lui $1, %hi(d) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,d)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(d)>>
 ; MIPS32-NEXT:    sw $4, %lo(d)($1) # <MCInst #[[#MCINST17]] SW
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MIPS32-NEXT:    # <MCOperand Reg:A0>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MIPS32-NEXT:    addiu $1, $1, %lo(d) # <MCInst #[[#MCINST20:]] ADDiu
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    sw $5, 4($1) # <MCInst #[[#MCINST17]] SW
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MIPS32-NEXT:    # <MCOperand Reg:A1>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
 ; MIPS32-NEXT:    # <MCOperand Imm:4>>
 ;
 ; MMR3-LABEL: f4:
 ; MMR3:       # %bb.0:
 ; MMR3-NEXT:    lui $1, %hi(d) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,d)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(d)>>
 ; MMR3-NEXT:    sw $4, %lo(d)($1) # <MCInst #[[#MCINST18]] SW_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MMR3-NEXT:    # <MCOperand Reg:A0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MMR3-NEXT:    addiu $2, $1, %lo(d) # <MCInst #[[#MCINST21:]] ADDiu_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MMR3-NEXT:    # <MCOperand Reg:V0>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MMR3-NEXT:    sw16 $5, 4($2) # <MCInst #[[#MCINST22:]] SW16_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG10]]>
+; MMR3-NEXT:    # <MCOperand Reg:A1>
+; MMR3-NEXT:    # <MCOperand Reg:V0>
 ; MMR3-NEXT:    # <MCOperand Imm:4>>
 ; MMR3-NEXT:    jrc $ra # <MCInst #[[#MCINST8:]] JRC16_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS32R6-LABEL: f4:
 ; MIPS32R6:       # %bb.0:
 ; MIPS32R6-NEXT:    lui $1, %hi(d) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,d)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(d)>>
 ; MIPS32R6-NEXT:    sw $4, %lo(d)($1) # <MCInst #[[#MCINST17]] SW
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:A0>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MIPS32R6-NEXT:    addiu $1, $1, %lo(d) # <MCInst #[[#MCINST20:]] ADDiu
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    sw $5, 4($1) # <MCInst #[[#MCINST17]] SW
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MIPS32R6-NEXT:    # <MCOperand Reg:A1>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
 ; MIPS32R6-NEXT:    # <MCOperand Imm:4>>
 ;
 ; MMR6-LABEL: f4:
 ; MMR6:       # %bb.0:
 ; MMR6-NEXT:    lui $1, %hi(d) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,d)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(d)>>
 ; MMR6-NEXT:    sw $4, %lo(d)($1) # <MCInst #[[#MCINST18]] SW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MMR6-NEXT:    addiu $2, $1, %lo(d) # <MCInst #[[#MCINST21:]] ADDiu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MMR6-NEXT:    sw16 $5, 4($2) # <MCInst #[[#MCINST22:]] SW16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG10]]>
+; MMR6-NEXT:    # <MCOperand Reg:A1>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:4>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS4-LABEL: f4:
 ; MIPS4:       # %bb.0:
 ; MIPS4-NEXT:    lui $1, %highest(d) # <MCInst #[[#MCINST9]] LUi64
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4026,d)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%highest(d)>>
 ; MIPS4-NEXT:    daddiu $1, $1, %higher(d) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4025,d)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%higher(d)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    daddiu $1, $1, %hi(d) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4024,d)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%hi(d)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS4-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS4-NEXT:    sd $4, %lo(d)($1) # <MCInst #[[#MCINST23:]] SD
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MIPS4-NEXT:    # <MCOperand Reg:A0_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%lo(d)>>
 ;
 ; MIPS64R6-LABEL: f4:
 ; MIPS64R6:       # %bb.0:
 ; MIPS64R6-NEXT:    lui $1, %highest(d) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,d)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(d)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(d) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,d)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(d)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(d) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,d)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(d)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST13]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    sd $4, %lo(d)($1) # <MCInst #[[#MCINST23:]] SD
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG7]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:A0_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(d)>>
 ;
 ; MMR5FP64-LABEL: f4:
 ; MMR5FP64:       # %bb.0:
 ; MMR5FP64-NEXT:    lui $1, %hi(d) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,d)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(d)>>
 ; MMR5FP64-NEXT:    sw $4, %lo(d)($1) # <MCInst #[[#MCINST18]] SW_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:A0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MMR5FP64-NEXT:    addiu $2, $1, %lo(d) # <MCInst #[[#MCINST21:]] ADDiu_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG10:]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V0>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MMR5FP64-NEXT:    sw16 $5, 4($2) # <MCInst #[[#MCINST22:]] SW16_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG10]]>
+; MMR5FP64-NEXT:    # <MCOperand Reg:A1>
+; MMR5FP64-NEXT:    # <MCOperand Reg:V0>
 ; MMR5FP64-NEXT:    # <MCOperand Imm:4>>
 ; MMR5FP64-NEXT:    jrc $ra # <MCInst #[[#MCINST8:]] JRC16_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS32R5FP643-LABEL: f4:
 ; MIPS32R5FP643:       # %bb.0:
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(d) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,d)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(d)>>
 ; MIPS32R5FP643-NEXT:    sw $4, %lo(d)($1) # <MCInst #[[#MCINST17]] SW
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:A0>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MIPS32R5FP643-NEXT:    addiu $1, $1, %lo(d) # <MCInst #[[#MCINST20:]] ADDiu
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,d)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(d)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    sw $5, 4($1) # <MCInst #[[#MCINST17]] SW
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG9:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:A1>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
 ; MIPS32R5FP643-NEXT:    # <MCOperand Imm:4>>
   store i64 %a, ptr @d
   ret void
@@ -609,132 +609,132 @@ define void @f5(float %e) {
 ; MIPS32-LABEL: f5:
 ; MIPS32:       # %bb.0:
 ; MIPS32-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    swc1 $f12, %lo(e)($1) # <MCInst #[[#MCINST24:]] SWC1
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS32-NEXT:    # <MCOperand Reg:F12>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MMR3-LABEL: f5:
 ; MMR3:       # %bb.0:
 ; MMR3-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    swc1 $f12, %lo(e)($1) # <MCInst #[[#MCINST25:]] SWC1_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MMR3-NEXT:    # <MCOperand Reg:F12>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MIPS32R6-LABEL: f5:
 ; MIPS32R6:       # %bb.0:
 ; MIPS32R6-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    swc1 $f12, %lo(e)($1) # <MCInst #[[#MCINST24:]] SWC1
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:F12>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MMR6-LABEL: f5:
 ; MMR6:       # %bb.0:
 ; MMR6-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MMR6-NEXT:    swc1 $f12, %lo(e)($1) # <MCInst #[[#MCINST25:]] SWC1_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MMR6-NEXT:    # <MCOperand Reg:F12>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(e)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS4-LABEL: f5:
 ; MIPS4:       # %bb.0:
 ; MIPS4-NEXT:    lui $1, %highest(e) # <MCInst #[[#MCINST9]] LUi64
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4026,e)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%highest(e)>>
 ; MIPS4-NEXT:    daddiu $1, $1, %higher(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4025,e)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%higher(e)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    daddiu $1, $1, %hi(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS4-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS4-NEXT:    swc1 $f12, %lo(e)($1) # <MCInst #[[#MCINST24:]] SWC1
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS4-NEXT:    # <MCOperand Reg:F12>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MIPS64R6-LABEL: f5:
 ; MIPS64R6:       # %bb.0:
 ; MIPS64R6-NEXT:    lui $1, %highest(e) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,e)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(e)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,e)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(e)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(e) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST13]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    swc1 $f12, %lo(e)($1) # <MCInst #[[#MCINST24:]] SWC1
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:F12>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MMR5FP64-LABEL: f5:
 ; MMR5FP64:       # %bb.0:
 ; MMR5FP64-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    swc1 $f12, %lo(e)($1) # <MCInst #[[#MCINST25:]] SWC1_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:F12>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(e)>>
 ;
 ; MIPS32R5FP643-LABEL: f5:
 ; MIPS32R5FP643:       # %bb.0:
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(e) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,e)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(e)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    swc1 $f12, %lo(e)($1) # <MCInst #[[#MCINST24:]] SWC1
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG11:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,e)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:F12>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(e)>>
   store float %e, ptr @e
   ret void
 }
@@ -743,132 +743,132 @@ define void @f6(double %f) {
 ; MIPS32-LABEL: f6:
 ; MIPS32:       # %bb.0:
 ; MIPS32-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST1]] LUi
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS32-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32-NEXT:    sdc1 $f12, %lo(f)($1) # <MCInst #[[#MCINST26:]] SDC1
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG12:]]>
-; MIPS32-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS32-NEXT:    # <MCOperand Reg:D6>
+; MIPS32-NEXT:    # <MCOperand Reg:AT>
+; MIPS32-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MMR3-LABEL: f6:
 ; MMR3:       # %bb.0:
 ; MMR3-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MMR3-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR3-NEXT:    # <MCOperand Reg:RA>>
 ; MMR3-NEXT:    sdc1 $f12, %lo(f)($1) # <MCInst #[[#MCINST27:]] SDC1_MM_D32
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG12:]]>
-; MMR3-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR3-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MMR3-NEXT:    # <MCOperand Reg:D6>
+; MMR3-NEXT:    # <MCOperand Reg:AT>
+; MMR3-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MIPS32R6-LABEL: f6:
 ; MIPS32R6:       # %bb.0:
 ; MIPS32R6-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS32R6-NEXT:    jr $ra # <MCInst #[[#MCINST7]] JALR
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:ZERO>
+; MIPS32R6-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R6-NEXT:    sdc1 $f12, %lo(f)($1) # <MCInst #[[#MCINST28:]] SDC164
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG13:]]>
-; MIPS32R6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R6-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS32R6-NEXT:    # <MCOperand Reg:D12_64>
+; MIPS32R6-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R6-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MMR6-LABEL: f6:
 ; MMR6:       # %bb.0:
 ; MMR6-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MMR6-NEXT:    sdc1 $f12, %lo(f)($1) # <MCInst #[[#MCINST29:]] SDC1_D64_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG13:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MMR6-NEXT:    # <MCOperand Reg:D12_64>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(f)>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST8]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MIPS4-LABEL: f6:
 ; MIPS4:       # %bb.0:
 ; MIPS4-NEXT:    lui $1, %highest(f) # <MCInst #[[#MCINST9]] LUi64
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4026,f)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%highest(f)>>
 ; MIPS4-NEXT:    daddiu $1, $1, %higher(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4025,f)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%higher(f)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    daddiu $1, $1, %hi(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS4-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS4-NEXT:    # <MCOperand Imm:16>>
 ; MIPS4-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS4-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS4-NEXT:    sdc1 $f12, %lo(f)($1) # <MCInst #[[#MCINST28:]] SDC164
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG13:]]>
-; MIPS4-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS4-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS4-NEXT:    # <MCOperand Reg:D12_64>
+; MIPS4-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS4-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MIPS64R6-LABEL: f6:
 ; MIPS64R6:       # %bb.0:
 ; MIPS64R6-NEXT:    lui $1, %highest(f) # <MCInst #[[#MCINST9]] LUi64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4026,f)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%highest(f)>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %higher(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4025,f)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%higher(f)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    daddiu $1, $1, %hi(f) # <MCInst #[[#MCINST10]] DADDiu
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS64R6-NEXT:    dsll $1, $1, 16 # <MCInst #[[#MCINST11]] DSLL
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
 ; MIPS64R6-NEXT:    # <MCOperand Imm:16>>
 ; MIPS64R6-NEXT:    jr $ra # <MCInst #[[#MCINST13]] JALR64
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG8]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:ZERO_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:RA_64>>
 ; MIPS64R6-NEXT:    sdc1 $f12, %lo(f)($1) # <MCInst #[[#MCINST28:]] SDC164
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG13:]]>
-; MIPS64R6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>
-; MIPS64R6-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS64R6-NEXT:    # <MCOperand Reg:D12_64>
+; MIPS64R6-NEXT:    # <MCOperand Reg:AT_64>
+; MIPS64R6-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MMR5FP64-LABEL: f6:
 ; MMR5FP64:       # %bb.0:
 ; MMR5FP64-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST4]] LUi_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MMR5FP64-NEXT:    jr $ra # <MCInst #[[#MCINST5]] JR_MM
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:RA>>
 ; MMR5FP64-NEXT:    sdc1 $f12, %lo(f)($1) # <MCInst #[[#MCINST30:]] SDC1_MM_D64
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG13:]]>
-; MMR5FP64-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR5FP64-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MMR5FP64-NEXT:    # <MCOperand Reg:D12_64>
+; MMR5FP64-NEXT:    # <MCOperand Reg:AT>
+; MMR5FP64-NEXT:    # <MCOperand Expr:%lo(f)>>
 ;
 ; MIPS32R5FP643-LABEL: f6:
 ; MIPS32R5FP643:       # %bb.0:
 ; MIPS32R5FP643-NEXT:    lui $1, %hi(f) # <MCInst #[[#MCINST1]] LUi
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4024,f)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%hi(f)>>
 ; MIPS32R5FP643-NEXT:    jr $ra # <MCInst #[[#MCINST2]] JR
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:RA>>
 ; MIPS32R5FP643-NEXT:    sdc1 $f12, %lo(f)($1) # <MCInst #[[#MCINST28:]] SDC164
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG13:]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MIPS32R5FP643-NEXT:    # <MCOperand Expr:specifier(4027,f)>>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:D12_64>
+; MIPS32R5FP643-NEXT:    # <MCOperand Reg:AT>
+; MIPS32R5FP643-NEXT:    # <MCOperand Expr:%lo(f)>>
   store double %f, ptr @f
   ret void
 }

--- a/llvm/test/CodeGen/Mips/micromips-pseudo-mtlohi-expand.ll
+++ b/llvm/test/CodeGen/Mips/micromips-pseudo-mtlohi-expand.ll
@@ -7,53 +7,53 @@
 define i64 @test(i32 signext %a, i32 signext %b) {
 ; MMR2-LABEL: test:
 ; MMR2:       # %bb.0: # %entry
-; MMR2-NEXT:    li16 $2, 0 # <MCInst #{{[0-9]+}} LI16_MM
-; MMR2-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
+; MMR2-NEXT:    li16 $2, 0 # <MCInst #[[#MCINST1:]] LI16_MM
+; MMR2-NEXT:    # <MCOperand Reg:V0>
 ; MMR2-NEXT:    # <MCOperand Imm:0>>
-; MMR2-NEXT:    li16 $3, 1 # <MCInst #{{[0-9]+}} LI16_MM
-; MMR2-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
+; MMR2-NEXT:    li16 $3, 1 # <MCInst #[[#MCINST1]] LI16_MM
+; MMR2-NEXT:    # <MCOperand Reg:V1>
 ; MMR2-NEXT:    # <MCOperand Imm:1>>
-; MMR2-NEXT:    mtlo $3 # <MCInst #{{[0-9]+}} MTLO_MM
-; MMR2-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-NEXT:    mthi $2 # <MCInst #{{[0-9]+}} MTHI_MM
-; MMR2-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-NEXT:    madd $4, $5 # <MCInst #{{[0-9]+}} MADD
-; MMR2-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
-; MMR2-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-NEXT:    mflo16 $2 # <MCInst #{{[0-9]+}} MFLO16_MM
-; MMR2-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-NEXT:    mfhi16 $3 # <MCInst #{{[0-9]+}} MFHI16_MM
-; MMR2-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-NEXT:    jrc $ra # <MCInst #{{[0-9]+}} JRC16_MM
-; MMR2-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
+; MMR2-NEXT:    mtlo $3 # <MCInst #[[#MCINST2:]] MTLO_MM
+; MMR2-NEXT:    # <MCOperand Reg:V1>>
+; MMR2-NEXT:    mthi $2 # <MCInst #[[#MCINST3:]] MTHI_MM
+; MMR2-NEXT:    # <MCOperand Reg:V0>>
+; MMR2-NEXT:    madd $4, $5 # <MCInst #[[#MCINST4:]] MADD
+; MMR2-NEXT:    # <MCOperand Reg:A0>
+; MMR2-NEXT:    # <MCOperand Reg:A1>>
+; MMR2-NEXT:    mflo16 $2 # <MCInst #[[#MCINST5:]] MFLO16_MM
+; MMR2-NEXT:    # <MCOperand Reg:V0>>
+; MMR2-NEXT:    mfhi16 $3 # <MCInst #[[#MCINST6:]] MFHI16_MM
+; MMR2-NEXT:    # <MCOperand Reg:V1>>
+; MMR2-NEXT:    jrc $ra # <MCInst #[[#MCINST7:]] JRC16_MM
+; MMR2-NEXT:    # <MCOperand Reg:RA>>
 ;
 ; MMR2-DSP-LABEL: test:
 ; MMR2-DSP:       # %bb.0: # %entry
-; MMR2-DSP-NEXT:    li16 $2, 0 # <MCInst #{{[0-9]+}} LI16_MM
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
+; MMR2-DSP-NEXT:    li16 $2, 0 # <MCInst #[[#MCINST1:]] LI16_MM
+; MMR2-DSP-NEXT:    # <MCOperand Reg:V0>
 ; MMR2-DSP-NEXT:    # <MCOperand Imm:0>>
-; MMR2-DSP-NEXT:    li16 $3, 1 # <MCInst #{{[0-9]+}} LI16_MM
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
+; MMR2-DSP-NEXT:    li16 $3, 1 # <MCInst #[[#MCINST1]] LI16_MM
+; MMR2-DSP-NEXT:    # <MCOperand Reg:V1>
 ; MMR2-DSP-NEXT:    # <MCOperand Imm:1>>
-; MMR2-DSP-NEXT:    mtlo $3, $ac0 # <MCInst #{{[0-9]+}} MTLO_DSP
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-DSP-NEXT:    mthi $2, $ac0 # <MCInst #{{[0-9]+}} MTHI_DSP
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-DSP-NEXT:    madd $ac0, $4, $5 # <MCInst #{{[0-9]+}} MADD_DSP
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-DSP-NEXT:    mflo $2, $ac0 # <MCInst #{{[0-9]+}} MFLO_DSP
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-DSP-NEXT:    jr $ra # <MCInst #{{[0-9]+}} JR_MM
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
-; MMR2-DSP-NEXT:    mfhi $3, $ac0 # <MCInst #{{[0-9]+}} MFHI_DSP
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>
-; MMR2-DSP-NEXT:    # <MCOperand Reg:{{[0-9]+}}>>
+; MMR2-DSP-NEXT:    mtlo $3, $ac0 # <MCInst #[[#MCINST8:]] MTLO_DSP
+; MMR2-DSP-NEXT:    # <MCOperand Reg:LO0>
+; MMR2-DSP-NEXT:    # <MCOperand Reg:V1>>
+; MMR2-DSP-NEXT:    mthi $2, $ac0 # <MCInst #[[#MCINST9:]] MTHI_DSP
+; MMR2-DSP-NEXT:    # <MCOperand Reg:HI0>
+; MMR2-DSP-NEXT:    # <MCOperand Reg:V0>>
+; MMR2-DSP-NEXT:    madd $ac0, $4, $5 # <MCInst #[[#MCINST10:]] MADD_DSP
+; MMR2-DSP-NEXT:    # <MCOperand Reg:AC0>
+; MMR2-DSP-NEXT:    # <MCOperand Reg:A0>
+; MMR2-DSP-NEXT:    # <MCOperand Reg:A1>
+; MMR2-DSP-NEXT:    # <MCOperand Reg:AC0>>
+; MMR2-DSP-NEXT:    mflo $2, $ac0 # <MCInst #[[#MCINST11:]] MFLO_DSP
+; MMR2-DSP-NEXT:    # <MCOperand Reg:V0>
+; MMR2-DSP-NEXT:    # <MCOperand Reg:AC0>>
+; MMR2-DSP-NEXT:    jr $ra # <MCInst #[[#MCINST12:]] JR_MM
+; MMR2-DSP-NEXT:    # <MCOperand Reg:RA>>
+; MMR2-DSP-NEXT:    mfhi $3, $ac0 # <MCInst #[[#MCINST13:]] MFHI_DSP
+; MMR2-DSP-NEXT:    # <MCOperand Reg:V1>
+; MMR2-DSP-NEXT:    # <MCOperand Reg:AC0>>
 entry:
   %conv = sext i32 %a to i64
   %conv1 = sext i32 %b to i64

--- a/llvm/test/CodeGen/Mips/setcc-se.ll
+++ b/llvm/test/CodeGen/Mips/setcc-se.ll
@@ -13,11 +13,11 @@ define i32 @seteq0(i32 %a) {
 ; MMR6-LABEL: seteq0:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    sltiu $2, $4, 1 # <MCInst #[[#MCINST1:]] SLTiu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
 ; MMR6-NEXT:    # <MCOperand Imm:1>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2:]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp eq i32 %a, 0
   %conv = zext i1 %cmp to i32
@@ -33,11 +33,11 @@ define i32 @setne0(i32 %a) {
 ; MMR6-LABEL: setne0:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    sltu $2, $zero, $4 # <MCInst #[[#MCINST3:]] SLTu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:ZERO>
+; MMR6-NEXT:    # <MCOperand Reg:A0>>
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp ne i32 %a, 0
   %conv = zext i1 %cmp to i32
@@ -60,35 +60,35 @@ define void @slti_beq0(i32 %a) {
 ; MMR6-LABEL: slti_beq0:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $2, %hi(_gp_disp) # <MCInst #[[#MCINST4:]] LUi
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(_gp_disp)>>
 ; MMR6-NEXT:    addiu $2, $2, %lo(_gp_disp) # <MCInst #[[#MCINST5:]] ADDiu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(_gp_disp)>>
 ; MMR6-NEXT:    addu $2, $2, $25 # <MCInst #[[#MCINST6:]] ADDu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG5:]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:T9>>
 ; MMR6-NEXT:    slti $1, $4, -32768 # <MCInst #[[#MCINST7:]] SLTi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6:]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
 ; MMR6-NEXT:    # <MCOperand Imm:-32768>>
 ; MMR6-NEXT:    beqzc $1, $BB2_2 # <MCInst #[[#MCINST8:]] BEQZC_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Expr:$BB2_2>>
 ; MMR6-NEXT:  # %bb.1: # %if.then
 ; MMR6-NEXT:    lw $2, %got(g1)($2) # <MCInst #[[#MCINST9:]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4015,g1)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%got(g1)>>
 ; MMR6-NEXT:    sw16 $4, 0($2) # <MCInst #[[#MCINST10:]] SW16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:0>>
 ; MMR6-NEXT:  $BB2_2: # %if.end
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp slt i32 %a, -32768
   br i1 %cmp, label %if.then, label %if.end
@@ -119,42 +119,42 @@ define void @slti_beq1(i32 %a) {
 ; MMR6-LABEL: slti_beq1:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $2, %hi(_gp_disp) # <MCInst #[[#MCINST4]] LUi
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(_gp_disp)>>
 ; MMR6-NEXT:    addiu $2, $2, %lo(_gp_disp) # <MCInst #[[#MCINST5]] ADDiu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(_gp_disp)>>
 ; MMR6-NEXT:    addu $2, $2, $25 # <MCInst #[[#MCINST6]] ADDu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:T9>>
 ; MMR6-NEXT:    lui $1, 65535 # <MCInst #[[#MCINST11:]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Imm:65535>>
 ; MMR6-NEXT:    ori $1, $1, 32766 # <MCInst #[[#MCINST12:]] ORi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Imm:32766>>
 ; MMR6-NEXT:    slt $1, $1, $4 # <MCInst #[[#MCINST13:]] SLT_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:A0>>
 ; MMR6-NEXT:    bnezc $1, $BB3_2 # <MCInst #[[#MCINST14:]] BNEZC_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Expr:$BB3_2>>
 ; MMR6-NEXT:  # %bb.1: # %if.then
 ; MMR6-NEXT:    lw $2, %got(g1)($2) # <MCInst #[[#MCINST9]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4015,g1)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%got(g1)>>
 ; MMR6-NEXT:    sw16 $4, 0($2) # <MCInst #[[#MCINST10]] SW16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:0>>
 ; MMR6-NEXT:  $BB3_2: # %if.end
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp slt i32 %a, -32769
   br i1 %cmp, label %if.then, label %if.end
@@ -183,35 +183,35 @@ define void @slti_beq2(i32 %a) {
 ; MMR6-LABEL: slti_beq2:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $2, %hi(_gp_disp) # <MCInst #[[#MCINST4]] LUi
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(_gp_disp)>>
 ; MMR6-NEXT:    addiu $2, $2, %lo(_gp_disp) # <MCInst #[[#MCINST5]] ADDiu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(_gp_disp)>>
 ; MMR6-NEXT:    addu $2, $2, $25 # <MCInst #[[#MCINST6]] ADDu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:T9>>
 ; MMR6-NEXT:    slti $1, $4, 32767 # <MCInst #[[#MCINST7]] SLTi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
 ; MMR6-NEXT:    # <MCOperand Imm:32767>>
 ; MMR6-NEXT:    beqzc $1, $BB4_2 # <MCInst #[[#MCINST8]] BEQZC_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Expr:$BB4_2>>
 ; MMR6-NEXT:  # %bb.1: # %if.then
 ; MMR6-NEXT:    lw $2, %got(g1)($2) # <MCInst #[[#MCINST9]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4015,g1)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%got(g1)>>
 ; MMR6-NEXT:    sw16 $4, 0($2) # <MCInst #[[#MCINST10]] SW16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:0>>
 ; MMR6-NEXT:  $BB4_2: # %if.end
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp slt i32 %a, 32767
   br i1 %cmp, label %if.then, label %if.end
@@ -241,39 +241,39 @@ define void @slti_beq3(i32 %a) {
 ; MMR6-LABEL: slti_beq3:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $2, %hi(_gp_disp) # <MCInst #[[#MCINST4]] LUi
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(_gp_disp)>>
 ; MMR6-NEXT:    addiu $2, $2, %lo(_gp_disp) # <MCInst #[[#MCINST5]] ADDiu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(_gp_disp)>>
 ; MMR6-NEXT:    addu $2, $2, $25 # <MCInst #[[#MCINST6]] ADDu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:T9>>
 ; MMR6-NEXT:    addiu $1, $zero, 32767 # <MCInst #[[#MCINST15:]] ADDiu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:ZERO>
 ; MMR6-NEXT:    # <MCOperand Imm:32767>>
 ; MMR6-NEXT:    slt $1, $1, $4 # <MCInst #[[#MCINST13]] SLT_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:A0>>
 ; MMR6-NEXT:    bnezc $1, $BB5_2 # <MCInst #[[#MCINST14]] BNEZC_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Expr:$BB5_2>>
 ; MMR6-NEXT:  # %bb.1: # %if.then
 ; MMR6-NEXT:    lw $2, %got(g1)($2) # <MCInst #[[#MCINST9]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4015,g1)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%got(g1)>>
 ; MMR6-NEXT:    sw16 $4, 0($2) # <MCInst #[[#MCINST10]] SW16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:0>>
 ; MMR6-NEXT:  $BB5_2: # %if.end
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp slt i32 %a, 32768
   br i1 %cmp, label %if.then, label %if.end
@@ -302,35 +302,35 @@ define void @sltiu_beq0(i32 %a) {
 ; MMR6-LABEL: sltiu_beq0:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $2, %hi(_gp_disp) # <MCInst #[[#MCINST4]] LUi
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(_gp_disp)>>
 ; MMR6-NEXT:    addiu $2, $2, %lo(_gp_disp) # <MCInst #[[#MCINST5]] ADDiu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(_gp_disp)>>
 ; MMR6-NEXT:    addu $2, $2, $25 # <MCInst #[[#MCINST6]] ADDu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:T9>>
 ; MMR6-NEXT:    sltiu $1, $4, 32767 # <MCInst #[[#MCINST1]] SLTiu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
 ; MMR6-NEXT:    # <MCOperand Imm:32767>>
 ; MMR6-NEXT:    beqzc $1, $BB6_2 # <MCInst #[[#MCINST8]] BEQZC_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Expr:$BB6_2>>
 ; MMR6-NEXT:  # %bb.1: # %if.then
 ; MMR6-NEXT:    lw $2, %got(g1)($2) # <MCInst #[[#MCINST9]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4015,g1)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%got(g1)>>
 ; MMR6-NEXT:    sw16 $4, 0($2) # <MCInst #[[#MCINST10]] SW16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:0>>
 ; MMR6-NEXT:  $BB6_2: # %if.end
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp ult i32 %a, 32767
   br i1 %cmp, label %if.then, label %if.end
@@ -360,39 +360,39 @@ define void @sltiu_beq1(i32 %a) {
 ; MMR6-LABEL: sltiu_beq1:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $2, %hi(_gp_disp) # <MCInst #[[#MCINST4]] LUi
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(_gp_disp)>>
 ; MMR6-NEXT:    addiu $2, $2, %lo(_gp_disp) # <MCInst #[[#MCINST5]] ADDiu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(_gp_disp)>>
 ; MMR6-NEXT:    addu $2, $2, $25 # <MCInst #[[#MCINST6]] ADDu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:T9>>
 ; MMR6-NEXT:    addiu $1, $zero, 32767 # <MCInst #[[#MCINST15]] ADDiu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG4]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:ZERO>
 ; MMR6-NEXT:    # <MCOperand Imm:32767>>
 ; MMR6-NEXT:    sltu $1, $1, $4 # <MCInst #[[#MCINST3]] SLTu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:A0>>
 ; MMR6-NEXT:    bnezc $1, $BB7_2 # <MCInst #[[#MCINST14]] BNEZC_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Expr:$BB7_2>>
 ; MMR6-NEXT:  # %bb.1: # %if.then
 ; MMR6-NEXT:    lw $2, %got(g1)($2) # <MCInst #[[#MCINST9]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4015,g1)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%got(g1)>>
 ; MMR6-NEXT:    sw16 $4, 0($2) # <MCInst #[[#MCINST10]] SW16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:0>>
 ; MMR6-NEXT:  $BB7_2: # %if.end
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp ult i32 %a, 32768
   br i1 %cmp, label %if.then, label %if.end
@@ -421,35 +421,35 @@ define void @sltiu_beq2(i32 %a) {
 ; MMR6-LABEL: sltiu_beq2:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $2, %hi(_gp_disp) # <MCInst #[[#MCINST4]] LUi
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(_gp_disp)>>
 ; MMR6-NEXT:    addiu $2, $2, %lo(_gp_disp) # <MCInst #[[#MCINST5]] ADDiu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(_gp_disp)>>
 ; MMR6-NEXT:    addu $2, $2, $25 # <MCInst #[[#MCINST6]] ADDu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:T9>>
 ; MMR6-NEXT:    sltiu $1, $4, -32768 # <MCInst #[[#MCINST1]] SLTiu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
 ; MMR6-NEXT:    # <MCOperand Imm:-32768>>
 ; MMR6-NEXT:    beqzc $1, $BB8_2 # <MCInst #[[#MCINST8]] BEQZC_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Expr:$BB8_2>>
 ; MMR6-NEXT:  # %bb.1: # %if.then
 ; MMR6-NEXT:    lw $2, %got(g1)($2) # <MCInst #[[#MCINST9]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4015,g1)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%got(g1)>>
 ; MMR6-NEXT:    sw16 $4, 0($2) # <MCInst #[[#MCINST10]] SW16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:0>>
 ; MMR6-NEXT:  $BB8_2: # %if.end
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp ult i32 %a, -32768
   br i1 %cmp, label %if.then, label %if.end
@@ -480,42 +480,42 @@ define void @sltiu_beq3(i32 %a) {
 ; MMR6-LABEL: sltiu_beq3:
 ; MMR6:       # %bb.0: # %entry
 ; MMR6-NEXT:    lui $2, %hi(_gp_disp) # <MCInst #[[#MCINST4]] LUi
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4024,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%hi(_gp_disp)>>
 ; MMR6-NEXT:    addiu $2, $2, %lo(_gp_disp) # <MCInst #[[#MCINST5]] ADDiu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4027,_gp_disp)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%lo(_gp_disp)>>
 ; MMR6-NEXT:    addu $2, $2, $25 # <MCInst #[[#MCINST6]] ADDu
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG5]]>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:T9>>
 ; MMR6-NEXT:    lui $1, 65535 # <MCInst #[[#MCINST11]] LUi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Imm:65535>>
 ; MMR6-NEXT:    ori $1, $1, 32766 # <MCInst #[[#MCINST12]] ORi_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Imm:32766>>
 ; MMR6-NEXT:    sltu $1, $1, $4 # <MCInst #[[#MCINST3]] SLTu_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
+; MMR6-NEXT:    # <MCOperand Reg:A0>>
 ; MMR6-NEXT:    bnezc $1, $BB9_2 # <MCInst #[[#MCINST14]] BNEZC_MMR6
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG6]]>
+; MMR6-NEXT:    # <MCOperand Reg:AT>
 ; MMR6-NEXT:    # <MCOperand Expr:$BB9_2>>
 ; MMR6-NEXT:  # %bb.1: # %if.then
 ; MMR6-NEXT:    lw $2, %got(g1)($2) # <MCInst #[[#MCINST9]] LW_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; MMR6-NEXT:    # <MCOperand Expr:specifier(4015,g1)>>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
+; MMR6-NEXT:    # <MCOperand Expr:%got(g1)>>
 ; MMR6-NEXT:    sw16 $4, 0($2) # <MCInst #[[#MCINST10]] SW16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; MMR6-NEXT:    # <MCOperand Reg:A0>
+; MMR6-NEXT:    # <MCOperand Reg:V0>
 ; MMR6-NEXT:    # <MCOperand Imm:0>>
 ; MMR6-NEXT:  $BB9_2: # %if.end
 ; MMR6-NEXT:    jrc $ra # <MCInst #[[#MCINST2]] JRC16_MM
-; MMR6-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; MMR6-NEXT:    # <MCOperand Reg:RA>>
 entry:
   %cmp = icmp ult i32 %a, -32769
   br i1 %cmp, label %if.then, label %if.end

--- a/llvm/test/MC/AMDGPU/buffer-op-swz-operand.s
+++ b/llvm/test/MC/AMDGPU/buffer-op-swz-operand.s
@@ -3,18 +3,18 @@
 // CHECK: .amdgcn_target "amdgcn-amd-amdhsa--gfx1100"
 buffer_load_dwordx4 v[0:3], v0, s[0:3], 0, offen offset:4092 slc
 // CHECK: buffer_load_b128 v[0:3], v0, s[0:3], 0 offen offset:4092 slc ; <MCInst #{{[0-9]+}} BUFFER_LOAD_DWORDX4_OFFEN_gfx11
-// CHECK-NEXT: ;  <MCOperand Reg:10104>
-// CHECK-NEXT: ;  <MCOperand Reg:486>
-// CHECK-NEXT: ;  <MCOperand Reg:7754>
+// CHECK-NEXT: ;  <MCOperand Reg:VGPR0_VGPR1_VGPR2_VGPR3>
+// CHECK-NEXT: ;  <MCOperand Reg:VGPR0>
+// CHECK-NEXT: ;  <MCOperand Reg:SGPR0_SGPR1_SGPR2_SGPR3>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:4092>
 // CHECK-NEXT: ;  <MCOperand Imm:2>
 // CHECK-NEXT: ;  <MCOperand Imm:0>>
 buffer_store_dword v0, v1, s[0:3], 0 offen slc
 // CHECK: buffer_store_b32 v0, v1, s[0:3], 0 offen slc ; <MCInst #{{[0-9]+}} BUFFER_STORE_DWORD_OFFEN_gfx11
-// CHECK-NEXT: ;  <MCOperand Reg:486>
-// CHECK-NEXT: ;  <MCOperand Reg:487>
-// CHECK-NEXT: ;  <MCOperand Reg:7754>
+// CHECK-NEXT: ;  <MCOperand Reg:VGPR0>
+// CHECK-NEXT: ;  <MCOperand Reg:VGPR1>
+// CHECK-NEXT: ;  <MCOperand Reg:SGPR0_SGPR1_SGPR2_SGPR3>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:2>
@@ -23,9 +23,9 @@ buffer_store_dword v0, v1, s[0:3], 0 offen slc
 ; tbuffer ops use autogenerate asm parsers
 tbuffer_load_format_xyzw v[0:3], v0, s[0:3], 0 format:[BUF_FMT_32_32_SINT] offen offset:4092 slc
 // CHECK: tbuffer_load_format_xyzw v[0:3], v0, s[0:3], 0 format:[BUF_FMT_32_32_SINT] offen offset:4092 slc ; <MCInst #{{[0-9]+}} TBUFFER_LOAD_FORMAT_XYZW_OFFEN_gfx11
-// CHECK-NEXT: ;  <MCOperand Reg:10104>
-// CHECK-NEXT: ;  <MCOperand Reg:486>
-// CHECK-NEXT: ;  <MCOperand Reg:7754>
+// CHECK-NEXT: ;  <MCOperand Reg:VGPR0_VGPR1_VGPR2_VGPR3>
+// CHECK-NEXT: ;  <MCOperand Reg:VGPR0>
+// CHECK-NEXT: ;  <MCOperand Reg:SGPR0_SGPR1_SGPR2_SGPR3>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:4092>
 // CHECK-NEXT: ;  <MCOperand Imm:49>
@@ -33,9 +33,9 @@ tbuffer_load_format_xyzw v[0:3], v0, s[0:3], 0 format:[BUF_FMT_32_32_SINT] offen
 // CHECK-NEXT: ;  <MCOperand Imm:0>>
 tbuffer_store_d16_format_x v0, v1, s[0:3], 0 format:[BUF_FMT_10_10_10_2_SNORM] offen slc
 // CHECK: tbuffer_store_d16_format_x v0, v1, s[0:3], 0 format:[BUF_FMT_10_10_10_2_SNORM] offen slc ; <MCInst #{{[0-9]+}} TBUFFER_STORE_FORMAT_D16_X_OFFEN_gfx11
-// CHECK-NEXT: ;  <MCOperand Reg:486>
-// CHECK-NEXT: ;  <MCOperand Reg:487>
-// CHECK-NEXT: ;  <MCOperand Reg:7754>
+// CHECK-NEXT: ;  <MCOperand Reg:VGPR0>
+// CHECK-NEXT: ;  <MCOperand Reg:VGPR1>
+// CHECK-NEXT: ;  <MCOperand Reg:SGPR0_SGPR1_SGPR2_SGPR3>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:33>

--- a/llvm/test/MC/Disassembler/ARM/sub-sp-imm-thumb2.txt
+++ b/llvm/test/MC/Disassembler/ARM/sub-sp-imm-thumb2.txt
@@ -6,32 +6,32 @@
 
 # CHECK:      subw sp, sp, #1148
 # CHECK-SAME: <MCInst #{{[0-9]+}} t2SUBspImm12
-# CHECK-NEXT: <MCOperand Reg:[[SP:[0-9]+]]>
-# CHECK-NEXT: <MCOperand Reg:[[SP]]>
+# CHECK-NEXT: <MCOperand Reg:SP>
+# CHECK-NEXT: <MCOperand Reg:SP>
 # CHECK-NEXT: <MCOperand Imm:1148>
 # CHECK-NEXT: <MCOperand Imm:14>
-# CHECK-NEXT: <MCOperand Reg:0>>
+# CHECK-NEXT: <MCOperand Reg:>>
 
 0xad 0xf2 0x7c 0x4d
 
 # CHECK:      sub.w   sp, sp, #1024
 # CHECK-SAME: <MCInst #{{[0-9]+}} t2SUBspImm
-# CHECK-NEXT: <MCOperand Reg:[[SP]]>
-# CHECK-NEXT: <MCOperand Reg:[[SP]]>
+# CHECK-NEXT: <MCOperand Reg:SP>
+# CHECK-NEXT: <MCOperand Reg:SP>
 # CHECK-NEXT: <MCOperand Imm:1024>
 # CHECK-NEXT: <MCOperand Imm:14>
-# CHECK-NEXT: <MCOperand Reg:0>
-# CHECK-NEXT: <MCOperand Reg:0>>
+# CHECK-NEXT: <MCOperand Reg:>
+# CHECK-NEXT: <MCOperand Reg:>>
 
 0xad,0xf5,0x80,0x6d
 
 # CHECK:      subs.w  sp, sp, #1024
 # CHECK-SAME: <MCInst #{{[0-9]+}} t2SUBspImm
-# CHECK-NEXT: <MCOperand Reg:[[SP]]>
-# CHECK-NEXT: <MCOperand Reg:[[SP]]>
+# CHECK-NEXT: <MCOperand Reg:SP>
+# CHECK-NEXT: <MCOperand Reg:SP>
 # CHECK-NEXT: <MCOperand Imm:1024>
 # CHECK-NEXT: <MCOperand Imm:14>
-# CHECK-NEXT: <MCOperand Reg:0>
-# CHECK-NEXT: <MCOperand Reg:3>>
+# CHECK-NEXT: <MCOperand Reg:>
+# CHECK-NEXT: <MCOperand Reg:CPSR>>
 
 0xbd,0xf5,0x80,0x6d

--- a/llvm/test/MC/Lanai/conditional_inst.s
+++ b/llvm/test/MC/Lanai/conditional_inst.s
@@ -7,7 +7,7 @@
     bt %r5
 ! CHECK: encoding: [0xc1,0x00,0x2d,0x00]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} JR{{$}}
-! CHECK-NEXT:  <MCOperand Reg:12>>
+! CHECK-NEXT:  <MCOperand Reg:R5>>
 
 ! BR classes
     bt 0x1234
@@ -27,14 +27,14 @@ jump2:
 ! CHECK: encoding: [0b1110110A,A,A,0x01'A']
 ! CHECK-NEXT: fixup A - offset: 0, value: jump1, kind: FIXUP_LANAI_25
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} BRCC{{$}}
-! CHECK-NEXT: <MCOperand Expr:specifier(0,jump1)>
+! CHECK-NEXT: <MCOperand Expr:jump1>
 ! CHECK-NEXT: <MCOperand Imm:13>
 
     bpl jump2
 ! CHECK: encoding: [0b1110101A,A,A,A]
 ! CHECK-NEXT: fixup A - offset: 0, value: jump2, kind: FIXUP_LANAI_25
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} BRCC{{$}}
-! CHECK-NEXT: <MCOperand Expr:specifier(0,jump2)>
+! CHECK-NEXT: <MCOperand Expr:jump2>
 ! CHECK-NEXT: <MCOperand Imm:10>
 
     bt .
@@ -49,7 +49,7 @@ jump2:
     spl %r19
 ! CHECK: encoding: [0xea,0x4c,0x00,0x02]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} SCC{{$}}
-! CHECK-NEXT: <MCOperand Reg:26>
+! CHECK-NEXT: <MCOperand Reg:R19>
 ! CHECK-NEXT: <MCOperand Imm:10>
 
 ! BRR
@@ -63,15 +63,15 @@ jump2:
   add.ge %r13, %r14, %r18
 ! CHECK: encoding: [0xc9,0x34,0x70,0x06]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} ADD_R
-! CHECK-NEXT:  <MCOperand Reg:25>
-! CHECK-NEXT:  <MCOperand Reg:20>
-! CHECK-NEXT:  <MCOperand Reg:21>
+! CHECK-NEXT:  <MCOperand Reg:R18>
+! CHECK-NEXT:  <MCOperand Reg:R13>
+! CHECK-NEXT:  <MCOperand Reg:R14>
 ! CHECK-NEXT:  <MCOperand Imm:12>>
 
   add.f %r13, %r14, %r18
 ! CHECK: encoding: [0xc9,0x36,0x70,0x00]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} ADD_F_R
-! CHECK-NEXT:  <MCOperand Reg:25>
-! CHECK-NEXT:  <MCOperand Reg:20>
-! CHECK-NEXT:  <MCOperand Reg:21>
+! CHECK-NEXT:  <MCOperand Reg:R18>
+! CHECK-NEXT:  <MCOperand Reg:R13>
+! CHECK-NEXT:  <MCOperand Reg:R14>
 ! CHECK-NEXT:  <MCOperand Imm:0>>

--- a/llvm/test/MC/Lanai/memory.s
+++ b/llvm/test/MC/Lanai/memory.s
@@ -7,88 +7,88 @@
     ld [%r7], %r6
 ! CHECK: encoding: [0x83,0x1c,0x00,0x00]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:0>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
     ld [%r6], %r6
 ! CHECK: encoding: [0x83,0x18,0x00,0x00]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:13>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R6>
 ! CHECK-NEXT: <MCOperand Imm:0>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
      st %r6, [%r7]
 ! CHECK: encoding: [0x93,0x1c,0x00,0x00]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} SW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:0>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
     ld 0x123[%r7*], %r6
 ! CHECK: encoding: [0x83,0x1d,0x01,0x23]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:291>
 ! CHECK-NEXT: <MCOperand Imm:128>
 
     ld [%r7--], %r6
 ! CHECK: encoding: [0x83,0x1d,0xff,0xfc]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:-4>
 ! CHECK-NEXT: <MCOperand Imm:128>
 
     ld 0x123[%r7], %r6
 ! CHECK: encoding: [0x83,0x1e,0x01,0x23]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:291>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
     ld 0x123[*%r7], %r6
 ! CHECK: encoding: [0x83,0x1f,0x01,0x23]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:291>
 ! CHECK-NEXT: <MCOperand Imm:64>
 
     ld [--%r7], %r6
 ! CHECK: encoding: [0x83,0x1f,0xff,0xfc]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:-4>
 ! CHECK-NEXT: <MCOperand Imm:64>
 
     st %r6, [%r7++]
 ! CHECK: encoding: [0x93,0x1d,0x00,0x04]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} SW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:4>
 ! CHECK-NEXT: <MCOperand Imm:128>
 
     st.h %r6, [%r7++]
 ! CHECK: encoding: [0xf3,0x1f,0x24,0x02]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} STH_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:2>
 ! CHECK-NEXT: <MCOperand Imm:128>>
 
     ld.b [--%r7], %r6
 ! CHECK: encoding: [0xf3,0x1f,0x4f,0xff]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDBs_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:13>
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R6>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:-1>
 ! CHECK-NEXT: <MCOperand Imm:64>>
 
@@ -96,31 +96,31 @@
     ld [0x7fff], %r7
 ! CHECK: encoding: [0x83,0x82,0x7f,0xff]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:14>
-! CHECK-NEXT: <MCOperand Reg:7>
+! CHECK-NEXT: <MCOperand Reg:R7>
+! CHECK-NEXT: <MCOperand Reg:R0>
 ! CHECK-NEXT: <MCOperand Imm:32767>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
     ld [0x8000], %r7
 ! CHECK: encoding: [0xf3,0x80,0x80,0x00]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDADDR{{$}}
-! CHECK-NEXT: <MCOperand Reg:14>
+! CHECK-NEXT: <MCOperand Reg:R7>
 ! CHECK-NEXT: <MCOperand Imm:32768>
 
 ! Negative RM value
     ld [0xfffffe8c], %pc
 ! CHECK: encoding: [0x81,0x02,0xfe,0x8c]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:2>
-! CHECK-NEXT: <MCOperand Reg:7>
+! CHECK-NEXT: <MCOperand Reg:PC>
+! CHECK-NEXT: <MCOperand Reg:R0>
 ! CHECK-NEXT: <MCOperand Imm:-372>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
     ld [-372], %pc
 ! CHECK: encoding: [0x81,0x02,0xfe,0x8c]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:2>
-! CHECK-NEXT: <MCOperand Reg:7>
+! CHECK-NEXT: <MCOperand Reg:PC>
+! CHECK-NEXT: <MCOperand Reg:R0>
 ! CHECK-NEXT: <MCOperand Imm:-372>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
@@ -128,57 +128,57 @@
     ld %r9[%r12*], %r20
 ! CHECK: encoding: [0xaa,0x31,0x48,0x02]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RR{{$}}
-! CHECK-NEXT: <MCOperand Reg:27>
-! CHECK-NEXT: <MCOperand Reg:19>
-! CHECK-NEXT: <MCOperand Reg:16>
+! CHECK-NEXT: <MCOperand Reg:R20>
+! CHECK-NEXT: <MCOperand Reg:R12>
+! CHECK-NEXT: <MCOperand Reg:R9>
 ! CHECK-NEXT: <MCOperand Imm:128>
 
     ld %r9[%r12], %r20
 ! CHECK: encoding: [0xaa,0x32,0x48,0x02]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RR{{$}}
-! CHECK-NEXT: <MCOperand Reg:27>
-! CHECK-NEXT: <MCOperand Reg:19>
-! CHECK-NEXT: <MCOperand Reg:16>
+! CHECK-NEXT: <MCOperand Reg:R20>
+! CHECK-NEXT: <MCOperand Reg:R12>
+! CHECK-NEXT: <MCOperand Reg:R9>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
     ld [%r12 sub %r9], %r20
 ! CHECK: encoding: [0xaa,0x32,0x4a,0x02]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RR{{$}}
-! CHECK-NEXT: <MCOperand Reg:27>
-! CHECK-NEXT: <MCOperand Reg:19>
-! CHECK-NEXT: <MCOperand Reg:16>
+! CHECK-NEXT: <MCOperand Reg:R20>
+! CHECK-NEXT: <MCOperand Reg:R12>
+! CHECK-NEXT: <MCOperand Reg:R9>
 ! CHECK-NEXT: <MCOperand Imm:2>
 
     ld %r9[*%r12], %r20
 ! CHECK: encoding: [0xaa,0x33,0x48,0x02]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDW_RR{{$}}
-! CHECK-NEXT: <MCOperand Reg:27>
-! CHECK-NEXT: <MCOperand Reg:19>
-! CHECK-NEXT: <MCOperand Reg:16>
+! CHECK-NEXT: <MCOperand Reg:R20>
+! CHECK-NEXT: <MCOperand Reg:R12>
+! CHECK-NEXT: <MCOperand Reg:R9>
 ! CHECK-NEXT: <MCOperand Imm:64>
 
     st %r20, %r9[*%r12]
 ! CHECK: encoding: [0xba,0x33,0x48,0x02]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} SW_RR{{$}}
-! CHECK-NEXT: <MCOperand Reg:27>
-! CHECK-NEXT: <MCOperand Reg:19>
-! CHECK-NEXT: <MCOperand Reg:16>
+! CHECK-NEXT: <MCOperand Reg:R20>
+! CHECK-NEXT: <MCOperand Reg:R12>
+! CHECK-NEXT: <MCOperand Reg:R9>
 ! CHECK-NEXT: <MCOperand Imm:64>
 
     ld.b [%r12 sub %r9], %r20
 ! CHECK: encoding: [0xaa,0x32,0x4a,0x04]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDBs_RR{{$}}
-! CHECK-NEXT: <MCOperand Reg:27>
-! CHECK-NEXT: <MCOperand Reg:19>
-! CHECK-NEXT: <MCOperand Reg:16>
+! CHECK-NEXT: <MCOperand Reg:R20>
+! CHECK-NEXT: <MCOperand Reg:R12>
+! CHECK-NEXT: <MCOperand Reg:R9>
 ! CHECK-NEXT: <MCOperand Imm:2>
 
     uld.h [%r12 sub %r9], %r20
 ! CHECK: encoding: [0xaa,0x32,0x4a,0x01]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDHz_RR{{$}}
-! CHECK-NEXT: <MCOperand Reg:27>
-! CHECK-NEXT: <MCOperand Reg:19>
-! CHECK-NEXT: <MCOperand Reg:16>
+! CHECK-NEXT: <MCOperand Reg:R20>
+! CHECK-NEXT: <MCOperand Reg:R12>
+! CHECK-NEXT: <MCOperand Reg:R9>
 ! CHECK-NEXT: <MCOperand Imm:2>
 
 
@@ -186,32 +186,32 @@
     st.b %r3, [%r6]
 ! CHECK: encoding: [0xf1,0x9b,0x60,0x00]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} STB_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:10>
-! CHECK-NEXT: <MCOperand Reg:13>
+! CHECK-NEXT: <MCOperand Reg:R3>
+! CHECK-NEXT: <MCOperand Reg:R6>
 ! CHECK-NEXT: <MCOperand Imm:0>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
     st.b %r3, 1[%r6*]
 ! CHECK: encoding: [0xf1,0x9b,0x64,0x01]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} STB_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:10>
-! CHECK-NEXT: <MCOperand Reg:13>
+! CHECK-NEXT: <MCOperand Reg:R3>
+! CHECK-NEXT: <MCOperand Reg:R6>
 ! CHECK-NEXT: <MCOperand Imm:1>
 ! CHECK-NEXT: <MCOperand Imm:128>
 
     st.b %r3, 1[%r6]
 ! CHECK: encoding: [0xf1,0x9b,0x68,0x01]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} STB_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:10>
-! CHECK-NEXT: <MCOperand Reg:13>
+! CHECK-NEXT: <MCOperand Reg:R3>
+! CHECK-NEXT: <MCOperand Reg:R6>
 ! CHECK-NEXT: <MCOperand Imm:1>
 ! CHECK-NEXT: <MCOperand Imm:0>
 
     st.b %r3, 1[*%r6]
 ! CHECK: encoding: [0xf1,0x9b,0x6c,0x01]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} STB_RI{{$}}
-! CHECK-NEXT: <MCOperand Reg:10>
-! CHECK-NEXT: <MCOperand Reg:13>
+! CHECK-NEXT: <MCOperand Reg:R3>
+! CHECK-NEXT: <MCOperand Reg:R6>
 ! CHECK-NEXT: <MCOperand Imm:1>
 ! CHECK-NEXT: <MCOperand Imm:64>
 
@@ -219,13 +219,13 @@
     st %r30, [0x1234]
 ! CHECK: encoding: [0xff,0x01,0x12,0x34]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} STADDR{{$}}
-! CHECK-NEXT: <MCOperand Reg:37>
+! CHECK-NEXT: <MCOperand Reg:R30>
 ! CHECK-NEXT: <MCOperand Imm:4660>
 
     ld [0xfe8c], %pc
 ! CHECK: encoding: [0xf1,0x00,0xfe,0x8c]
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} LDADDR{{$}}
-! CHECK-NEXT: <MCOperand Reg:2>
+! CHECK-NEXT: <MCOperand Reg:PC>
 ! CHECK-NEXT: <MCOperand Imm:65164>
 
 ! SLI class
@@ -233,15 +233,15 @@
 ! CHECK: encoding: [0x02,0x01,A,A]
 ! CHECK-NEXT: fixup A - offset: 0, value: hi(x), kind: FIXUP_LANAI_HI16{{$}}
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} ADD_I_HI
-! CHECK-NEXT: <MCOperand Reg:11>
-! CHECK-NEXT: <MCOperand Reg:7>
-! CHECK-NEXT: <MCOperand Expr:specifier(1,x)>
+! CHECK-NEXT: <MCOperand Reg:R4>
+! CHECK-NEXT: <MCOperand Reg:R0>
+! CHECK-NEXT: <MCOperand Expr:hi(x)>
 
     mov hi(l+4), %r7
 ! CHECK: encoding: [0x03,0x81,A,A]
 ! CHECK-NEXT: fixup A - offset: 0, value: hi(l)+4, kind: FIXUP_LANAI_HI16{{$}}
 ! CHECK-NEXT: <MCInst #{{[0-9]+}} ADD_I_HI
-! CHECK-NEXT: <MCOperand Reg:14>
-! CHECK-NEXT: <MCOperand Reg:7>
-! CHECK-NEXT: <MCOperand Expr:specifier(1,l)+4>
+! CHECK-NEXT: <MCOperand Reg:R7>
+! CHECK-NEXT: <MCOperand Reg:R0>
+! CHECK-NEXT: <MCOperand Expr:hi(l)+4>
 

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/asm-show-inst.ll.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/asm-show-inst.ll.expected
@@ -7,16 +7,16 @@ define i8 @add_i8(i8 %a) nounwind {
 ; VERBOSE-LABEL: add_i8:
 ; VERBOSE:       # %bb.0:
 ; VERBOSE-NEXT:    movzbl {{[0-9]+}}(%esp), %eax # <MCInst #[[#MCINST1:]] MOVZX32rm8
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG1:]]>
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG2:]]>
+; VERBOSE-NEXT:    # <MCOperand Reg:EAX>
+; VERBOSE-NEXT:    # <MCOperand Reg:ESP>
 ; VERBOSE-NEXT:    # <MCOperand Imm:1>
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG3:]]>
+; VERBOSE-NEXT:    # <MCOperand Reg:>
 ; VERBOSE-NEXT:    # <MCOperand Imm:4>
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; VERBOSE-NEXT:    # <MCOperand Reg:>>
 ; VERBOSE-NEXT:    addb $2, %al # <MCInst #[[#MCINST2:]] ADD8i8
 ; VERBOSE-NEXT:    # <MCOperand Imm:2>>
 ; VERBOSE-NEXT:    retl # <MCInst #[[#MCINST3:]] RET32
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG4:]]>>
+; VERBOSE-NEXT:    # <MCOperand Reg:AL>>
 ;
 ; CHECK-LABEL: add_i8:
 ; CHECK:       # %bb.0:
@@ -31,18 +31,18 @@ define i32 @add_i32(i32 %a) nounwind {
 ; VERBOSE-LABEL: add_i32:
 ; VERBOSE:       # %bb.0:
 ; VERBOSE-NEXT:    movl {{[0-9]+}}(%esp), %eax # <MCInst #[[#MCINST4:]] MOV32rm
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG2]]>
+; VERBOSE-NEXT:    # <MCOperand Reg:EAX>
+; VERBOSE-NEXT:    # <MCOperand Reg:ESP>
 ; VERBOSE-NEXT:    # <MCOperand Imm:1>
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG3]]>
+; VERBOSE-NEXT:    # <MCOperand Reg:>
 ; VERBOSE-NEXT:    # <MCOperand Imm:4>
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG3]]>>
+; VERBOSE-NEXT:    # <MCOperand Reg:>>
 ; VERBOSE-NEXT:    addl $2, %eax # <MCInst #[[#MCINST5:]] ADD32ri8
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG1]]>
+; VERBOSE-NEXT:    # <MCOperand Reg:EAX>
+; VERBOSE-NEXT:    # <MCOperand Reg:EAX>
 ; VERBOSE-NEXT:    # <MCOperand Imm:2>>
 ; VERBOSE-NEXT:    retl # <MCInst #[[#MCINST3]] RET32
-; VERBOSE-NEXT:    # <MCOperand Reg:[[#MCREG1]]>>
+; VERBOSE-NEXT:    # <MCOperand Reg:EAX>>
 ;
 ; CHECK-LABEL: add_i32:
 ; CHECK:       # %bb.0:


### PR DESCRIPTION
Passing the context to `Inst.dump_pretty()` allows printing symbolic
register names instead of `<MCOperand Reg:1234>` in the output.
I plan to use this in a future RVY test cases where we have register
class with the same name in assembly syntax, but different underlying
register enum values. Printing the name of the enum value makes it
easier to test that we selected the correct register.
