### PR TITLE
Fix test outputting to test dir

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-tail-call.mir
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-tail-call.mir
@@ -1,4 +1,5 @@
-# RUN: llc -verify-machineinstrs -mtriple=arm64-applie-ios7.0 -start-before=aarch64-lower-homogeneous-prolog-epilog -homogeneous-prolog-epilog %s
+# RUN: rm -rf %S/arm64-homogeneous-prolog-epilog-tail-call.s
+# RUN: llc -verify-machineinstrs -mtriple=arm64-applie-ios7.0 -start-before=aarch64-lower-homogeneous-prolog-epilog -homogeneous-prolog-epilog %s -o /dev/null
 #
 # This test ensures defined registers are preserved after lowering homogeneous
 # epilog into helper calls. Without the fix, the verifier would complain about


### PR DESCRIPTION
The test introduced in #171118 has `llc` inadvertently producing an output into the same dir as the test file itself. Most build bots don't clean up the local git repo, which is assumed to not be written by build + test, and patch on top (for build performance reasons), which means the produced output from the aforementioned PR is treated as a test from here onwards, by all bots. Since it's missing `RUN` lines, we get errors, for example  https://lab.llvm.org/buildbot/#/builders/108/builds/20674

This patch fixes the `llc` line and also removes the `.s`. This avoids all bot maintainers go restart their bots. Then, the cleanup is removed in #171256.