### PR TITLE
Remove cleanup of incorrect output in test dir

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-tail-call.mir
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-tail-call.mir
@@ -1,4 +1,3 @@
-# RUN: rm -rf %S/arm64-homogeneous-prolog-epilog-tail-call.s
 # RUN: llc -verify-machineinstrs -mtriple=arm64-applie-ios7.0 -start-before=aarch64-lower-homogeneous-prolog-epilog -homogeneous-prolog-epilog %s -o /dev/null
 #
 # This test ensures defined registers are preserved after lowering homogeneous


### PR DESCRIPTION
This follows #171255 , removing the cleanup line.