### PR TITLE
[clang-tidy] Make `readability-redundant-control-flow` not suggest deleting unrelated lines

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
@@ -71,19 +71,11 @@ void RedundantControlFlowCheck::issueDiagnostic(
   if (isLocationInMacroExpansion(SM, StmtRange.getBegin()))
     return;
 
-  const CompoundStmt::const_reverse_body_iterator Previous =
-      ++Block->body_rbegin();
-  SourceLocation Start;
-  if (Previous != Block->body_rend())
-    Start = Lexer::findLocationAfterToken(
-        cast<Stmt>(*Previous)->getEndLoc(), tok::semi, SM, getLangOpts(),
-        /*SkipTrailingWhitespaceAndNewLine=*/true);
-  if (!Start.isValid())
-    Start = StmtRange.getBegin();
-  auto RemovedRange = CharSourceRange::getCharRange(
-      Start, Lexer::findLocationAfterToken(
-                 StmtRange.getEnd(), tok::semi, SM, getLangOpts(),
-                 /*SkipTrailingWhitespaceAndNewLine=*/true));
+  const auto RemovedRange = CharSourceRange::getCharRange(
+      StmtRange.getBegin(),
+      Lexer::findLocationAfterToken(StmtRange.getEnd(), tok::semi, SM,
+                                    getLangOpts(),
+                                    /*SkipTrailingWhitespaceAndNewLine=*/true));
 
   diag(StmtRange.getBegin(), Diag) << FixItHint::CreateRemoval(RemovedRange);
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -581,6 +581,11 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-casting>` check by fixing false
   negatives when explicitly cast from function pointer.
 
+- Improved :doc:`readability-redundant-control-flow
+  <clang-tidy/checks/readability/redundant-control-flow>` by fixing an issue
+  where the check would sometimes suggest deleting not only a redundant
+  ``return`` or ``continue``, but also unrelated lines preceding it.
+
 - Improved :doc:`readability-uppercase-literal-suffix
   <clang-tidy/checks/readability/uppercase-literal-suffix>` check to recognize
   literal suffixes added in C++23 and C23.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-control-flow.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-control-flow.cpp
@@ -222,3 +222,33 @@ void call_templates() {
   template_loop(10L);
   template_loop(10U);
 }
+
+void dont_delete_lines_before_return_statement() {
+	do {} while (0);
+#ifdef FOO
+#endif
+  return;
+}
+// CHECK-MESSAGES: :[[@LINE-2]]:3: warning: redundant return statement
+// CHECK-FIXES:      void dont_delete_lines_before_return_statement() {
+// CHECK-FIXES-NEXT: 	 do {} while (0);
+// CHECK-FIXES-NEXT: #ifdef FOO
+// CHECK-FIXES-NEXT: #endif
+// CHECK-FIXES-NEXT: }
+
+void dont_delete_lines_before_continue_statement() {
+  for (;;) {
+	  do {} while (0);
+#ifdef BAR
+#endif
+    continue;
+  }
+}
+// CHECK-MESSAGES: :[[@LINE-3]]:5: warning: redundant continue statement
+// CHECK-FIXES:      void dont_delete_lines_before_continue_statement() {
+// CHECK-FIXES-NEXT:   for (;;) {
+// CHECK-FIXES-NEXT: 	   do {} while (0);
+// CHECK-FIXES-NEXT: #ifdef BAR
+// CHECK-FIXES-NEXT: #endif
+// CHECK-FIXES-NEXT:   }
+// CHECK-FIXES-NEXT: }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-control-flow.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-control-flow.cpp
@@ -252,3 +252,23 @@ void dont_delete_lines_before_continue_statement() {
 // CHECK-FIXES-NEXT: #endif
 // CHECK-FIXES-NEXT:   }
 // CHECK-FIXES-NEXT: }
+
+void semicolon_far_from_return() {
+  return
+
+  ;
+}
+// CHECK-MESSAGES: :[[@LINE-4]]:3: warning: redundant return statement at the end of a function with a void return type [readability-redundant-control-flow]
+// CHECK-FIXES:      void semicolon_far_from_return() {
+// CHECK-FIXES-NEXT: }
+
+void semicolon_far_from_continue() {
+  for (int i = 0; i < 20; ++i) {
+    continue
+
+    ;
+  }
+}
+// CHECK-MESSAGES: :[[@LINE-5]]:5: warning: redundant continue statement at the end of loop statement
+// CHECK-FIXES:      for (int i = 0; i < 20; ++i) {
+// CHECK-FIXES-NEXT: }


### PR DESCRIPTION
Closes #171200.