### PR TITLE
[mlir][DialectUtils][NFC] Add helper for matching zero int/float values

### DIFF
--- a/mlir/include/mlir/Dialect/Utils/StaticValueUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/StaticValueUtils.h
@@ -24,8 +24,15 @@
 
 namespace mlir {
 
-/// Return true if `v` is an IntegerAttr with value `0`.
+/// Return "true" if `v` is an integer value/attribute with constant value `0`.
 bool isZeroInteger(OpFoldResult v);
+
+/// Return "true" if `v` is a float value/attribute with constant value `0.0`.
+bool isZeroFloat(OpFoldResult v);
+
+/// Return "true" if `v` is an integer/float value/attribute with constant
+/// value zero.
+bool isZeroIntegerOrFloat(OpFoldResult v);
 
 /// Return true if `v` is an IntegerAttr with value `1`.
 bool isOneInteger(OpFoldResult v);

--- a/mlir/lib/Dialect/Linalg/Transforms/FoldAddIntoDest.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/FoldAddIntoDest.cpp
@@ -21,7 +21,7 @@ static bool isDefinedAsZero(Value val) {
 
   // Check whether val is a constant scalar / vector splat / tensor splat float
   // or integer zero.
-  if (matchPattern(val, m_AnyZeroFloat()) || matchPattern(val, m_Zero()))
+  if (isZeroIntegerOrFloat(val))
     return true;
 
   return TypeSwitch<Operation *, bool>(val.getDefiningOp())

--- a/mlir/lib/Dialect/Utils/StaticValueUtils.cpp
+++ b/mlir/lib/Dialect/Utils/StaticValueUtils.cpp
@@ -19,6 +19,19 @@ namespace mlir {
 
 bool isZeroInteger(OpFoldResult v) { return isConstantIntValue(v, 0); }
 
+bool isZeroFloat(OpFoldResult v) {
+  if (auto attr = dyn_cast<Attribute>(v)) {
+    if (auto floatAttr = dyn_cast<FloatAttr>(attr))
+      return floatAttr.getValue().isZero();
+    return false;
+  }
+  return matchPattern(cast<Value>(v), m_AnyZeroFloat());
+}
+
+bool isZeroIntegerOrFloat(OpFoldResult v) {
+  return isZeroInteger(v) || isZeroFloat(v);
+}
+
 bool isOneInteger(OpFoldResult v) { return isConstantIntValue(v, 1); }
 
 std::tuple<SmallVector<OpFoldResult>, SmallVector<OpFoldResult>,


### PR DESCRIPTION
Add a convenience helper similar to `isZeroInteger` that works for integers and floats.
