### PR TITLE
[mlir][bufferization][NFC] Add convenience overload for `buildBufferDeallocationPipeline`

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/Pipelines/Passes.h
+++ b/mlir/include/mlir/Dialect/Bufferization/Pipelines/Passes.h
@@ -47,6 +47,7 @@ struct BufferDeallocationPipelineOptions
 /// One-Shot bufferization pass.
 void buildBufferDeallocationPipeline(
     OpPassManager &pm, const BufferDeallocationPipelineOptions &options);
+void buildBufferDeallocationPipeline(OpPassManager &pm);
 
 /// Registers all pipelines for the `bufferization` dialect. Currently,
 /// this includes only the "buffer-deallocation-pipeline".

--- a/mlir/lib/Dialect/Bufferization/Pipelines/BufferizationPipelines.cpp
+++ b/mlir/lib/Dialect/Bufferization/Pipelines/BufferizationPipelines.cpp
@@ -17,6 +17,10 @@
 // Pipeline implementation.
 //===----------------------------------------------------------------------===//
 
+void mlir::bufferization::buildBufferDeallocationPipeline(OpPassManager &pm) {
+  buildBufferDeallocationPipeline(pm, BufferDeallocationPipelineOptions());
+}
+
 void mlir::bufferization::buildBufferDeallocationPipeline(
     OpPassManager &pm, const BufferDeallocationPipelineOptions &options) {
   memref::ExpandReallocPassOptions expandAllocPassOptions{
@@ -44,5 +48,7 @@ void mlir::bufferization::registerBufferizationPipelines() {
       "The default pipeline for automatically inserting deallocation "
       "operations after one-shot bufferization. Deallocation operations "
       "(except `memref.realloc`) may not be present already.",
-      buildBufferDeallocationPipeline);
+      [](OpPassManager &pm, const BufferDeallocationPipelineOptions &options) {
+        buildBufferDeallocationPipeline(pm, options);
+      });
 }


### PR DESCRIPTION
Add an overload that does not take any options and uses the default options instead.
