### PR TITLE
[BOLT] Fix typo in adrp/add sequence

### DIFF
--- a/bolt/test/AArch64/safe-icf.s
+++ b/bolt/test/AArch64/safe-icf.s
@@ -52,7 +52,7 @@ bar:
   .type random, %function
 random:
   adrp x8, foo
-  add  x8, x8, :lo12:goo
+  add  x8, x8, :lo12:foo
   br   x8
 #endif
 


### PR DESCRIPTION
RHEL-8 fails to link against a non-existing symbol. ld.lld: error:
relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'goo'