### PR TITLE
[BOLT] Fix pacret-synchronous-unwind.cpp test

### DIFF
--- a/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
+++ b/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
@@ -11,10 +11,11 @@
 // RUN: -fno-asynchronous-unwind-tables \
 // RUN: %s -o %t.exe -Wl,-q
 // RUN: llvm-bolt %t.exe -o %t.bolt | FileCheck %s --check-prefix=CHECK
-//
-// CHECK: PointerAuthCFIAnalyzer ran on 3 functions. Ignored
-// CHECK-NOT: 0 functions (0.00%) because of CFI inconsistencies
-// CHECK-SAME: 1 functions (33.33%) because of CFI inconsistencies
+
+// Number of functions with .cfi-negate-ra-state in the binary is
+// platform-dependent.
+// CHECK: PointerAuthCFIAnalyzer ran on {{[0-9]}} functions.
+// CHECK: Ignored 1 functions ({{[0-9.]+}}%) because of CFI inconsistencies
 // CHECK-NEXT: BOLT-WARNING: PointerAuthCFIAnalyzer only supports asynchronous
 // CHECK-SAME: unwind tables. For C compilers, see -fasynchronous-unwind-tables.
 

--- a/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
+++ b/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
@@ -14,7 +14,7 @@
 
 // Number of functions with .cfi-negate-ra-state in the binary is
 // platform-dependent.
-// CHECK: PointerAuthCFIAnalyzer ran on {{[0-9]}} functions.
+// CHECK: PointerAuthCFIAnalyzer ran on {{[0-9]+}} functions.
 // CHECK: Ignored 1 functions ({{[0-9.]+}}%) because of CFI inconsistencies
 // CHECK-NEXT: BOLT-WARNING: PointerAuthCFIAnalyzer only supports asynchronous
 // CHECK-SAME: unwind tables. For C compilers, see -fasynchronous-unwind-tables.

--- a/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
+++ b/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
@@ -15,7 +15,7 @@
 // Number of functions with .cfi-negate-ra-state in the binary is
 // platform-dependent.
 // CHECK: PointerAuthCFIAnalyzer ran on {{[0-9]+}} functions.
-// CHECK: Ignored 1 functions ({{[0-9.]+}}%) because of CFI inconsistencies
+// CHECK: Ignored {{[0-9]}} functions ({{[0-9.]+}}%) because of CFI inconsistencies
 // CHECK-NEXT: BOLT-WARNING: PointerAuthCFIAnalyzer only supports asynchronous
 // CHECK-SAME: unwind tables. For C compilers, see -fasynchronous-unwind-tables.
 

--- a/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
+++ b/bolt/test/runtime/AArch64/pacret-synchronous-unwind.cpp
@@ -14,10 +14,12 @@
 
 // Number of functions with .cfi-negate-ra-state in the binary is
 // platform-dependent.
-// CHECK: PointerAuthCFIAnalyzer ran on {{[0-9]+}} functions.
-// CHECK: Ignored {{[0-9]}} functions ({{[0-9.]+}}%) because of CFI inconsistencies
-// CHECK-NEXT: BOLT-WARNING: PointerAuthCFIAnalyzer only supports asynchronous
-// CHECK-SAME: unwind tables. For C compilers, see -fasynchronous-unwind-tables.
+// CHECK: BOLT-INFO: PointerAuthCFIAnalyzer ran on {{[0-9]+}} functions.
+// CHECK-SAME: Ignored {{[0-9]}} functions ({{[0-9.]+}}%) because of CFI
+// CHECK-SAME: inconsistencies
+// CHECK-NEXT: BOLT-WARNING: PointerAuthCFIAnalyzer only supports
+// CHECK-SAME: asynchronous unwind tables. For C compilers, see
+// CHECK-SAME: -fasynchronous-unwind-tables.
 
 #include <cstdio>
 #include <stdexcept>


### PR DESCRIPTION
The test case build a binary from C++, and checks for the number of
functions the PointerAuthCFIFixup pass runs on.
This can change based on the platform. To account for this, the patch
changes the number to a regex.

The test failed when running on RHEL 9.