### PR TITLE
[clang-tidy] Fix documentation in `modernize-avoid-c-style-cast`

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/google/readability-casting.rst
@@ -10,3 +10,5 @@ for more information.
 Finds usages of C-style casts.
 
 https://google.github.io/styleguide/cppguide.html#Casting
+
+Corresponding cpplint.py check name: `readability/casting`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-c-style-cast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-c-style-cast.rst
@@ -3,6 +3,7 @@
 modernize-avoid-c-style-cast
 ============================
 
+Finds usages of C-style casts.
 
 C-style casts can perform a variety of different conversions (``const_cast``,
 ``static_cast``, ``reinterpret_cast``, or a combination). This makes them


### PR DESCRIPTION
Related discussion: https://github.com/llvm/llvm-project/pull/171058#discussion_r2602100364