### PR TITLE
[clang-tidy] Add missing Modernize module to Google module link libs

### DIFF
--- a/clang-tools-extra/clang-tidy/google/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/google/CMakeLists.txt
@@ -24,6 +24,7 @@ add_clang_library(clangTidyGoogleModule STATIC
 
   LINK_LIBS
   clangTidy
+  clangTidyModernizeModule
   clangTidyReadabilityModule
   clangTidyUtils
 


### PR DESCRIPTION
Fixes failures in https://github.com/llvm/llvm-project/pull/171058#issuecomment-3631809933