### PR TITLE
[lldb-vscode] make "integratedTerminal" the default console

### DIFF
--- a/lldb/tools/lldb-dap/extension/package.json
+++ b/lldb/tools/lldb-dap/extension/package.json
@@ -633,7 +633,7 @@
                   "Launch the program inside an external terminal window."
                 ],
                 "description": "Specify where to launch the program: internal console, integrated terminal or external terminal.",
-                "default": "internalConsole"
+                "default": "integratedTerminal"
               },
               "stdio": {
                 "type": "array",


### PR DESCRIPTION
This patch changes the default `console` from `"internalConsole"` to `"integratedTerminal"`. `"internalConsole"` in VSCode does not support sending stdin to the debuggee on any platform, whereas `"integratedTerminal"` does.

This patch fixes https://github.com/llvm/llvm-project/issues/162887.