### PR TITLE
[ARM] computeKnownBitsForTargetNode for VMOVIMM/VMVNIMM Fixes #149276

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -221,6 +221,8 @@ class VectorType;
                                        const SelectionDAG &DAG,
                                        unsigned Depth) const override;
 
+    bool isTargetCanonicalConstantNode(SDValue Op) const override;
+
     bool targetShrinkDemandedConstant(SDValue Op, const APInt &DemandedBits,
                                       const APInt &DemandedElts,
                                       TargetLoweringOpt &TLO) const override;


### PR DESCRIPTION
## Summary

Add `computeKnownBitsForTargetNode` handling for `ARMISD::VMOVIMM` and `ARMISD::VMVNIMM`, following the pattern from #149494 (VORRIMM/VBICIMM).

Also adds `isTargetCanonicalConstantNode` override to mark these nodes as canonical (similar to AArch64 in #148634), preventing infinite loops in `SimplifyDemandedBits`.

Includes unit test coverage in `ARMSelectionDAGTest.cpp`.

## Regression

`fcopysign.ll` generates `vand + vorr` instead of `vbif`/`vbsl`. The code is **functionally correct** but slightly less optimal. This occurs because KnownBits analysis enables earlier optimizations that transform the VBSP pattern before it can be matched.

Fixes #149276