### PR TITLE
[mlir] Move GET_ATTR/TYPEDEF_CLASSES after declarations

### DIFF
--- a/mlir/test/mlir-tblgen/attrdefs.td
+++ b/mlir/test/mlir-tblgen/attrdefs.td
@@ -4,6 +4,13 @@
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 
+// DECL: namespace test {
+// DECL: class IndexAttr;
+// DECL: class SimpleAAttr;
+// DECL: class CompoundAAttr;
+// DECL: class SingleParameterAttr;
+// DECL: } // namespace test
+
 // DECL: #ifdef GET_ATTRDEF_CLASSES
 // DECL: #undef GET_ATTRDEF_CLASSES
 

--- a/mlir/test/mlir-tblgen/typedefs.td
+++ b/mlir/test/mlir-tblgen/typedefs.td
@@ -4,6 +4,14 @@
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 
+// DECL: namespace test {
+// DECL: class SimpleAType;
+// DECL: class CompoundAType;
+// DECL: class IndexType;
+// DECL: class SingleParameterType;
+// DECL: class IntegerType;
+// DECL: } // namespace test
+
 // DECL: #ifdef GET_TYPEDEF_CLASSES
 // DECL: #undef GET_TYPEDEF_CLASSES
 


### PR DESCRIPTION
Currently, the `GET_ATTRDEF_CLASSES` and `GET_TYPEDEF_CLASSES` macros get introduced at the very top of the generated header for attributes and types, which allows the entire header to be skipped from inclusion when they are not specified. Inside the scope of these macros, the classes are forward-declared in case the attributes / types refer to each other. Example for `BuiltinAttributes.h.inc` (the descriptions of each class are removed for simplicity):

```C++
#ifdef GET_ATTRDEF_CLASSES
#undef GET_ATTRDEF_CLASSES
// Symbols commonly used in the attribute classes below
namespace mlir {
class AsmParser;
class AsmPrinter;
} // namespace mlir

namespace mlir {
class AffineMapAttr;
class ArrayAttr;
class DenseArrayAttr;
// ...
class UnitAttr;
} // namespace mlir

// Attribute classes declarations...
```

The change in this PR proposes to move the macros after the forward-declarations. This allows these declarations to be included separately if desired, which allows them to be used as forward declarations in other parts of the project. The goal of this is to allow MLIR projects to reduce the build time by employing forward declarations where possible, thus reducing the amount of expensive includes. The impact of this change on `BuiltinAttributes.h.inc`:

```C++
namespace mlir {
class AffineMapAttr;
class ArrayAttr;
class DenseArrayAttr;
// ...
class UnitAttr;
} // namespace mlir

#ifdef GET_ATTRDEF_CLASSES
#undef GET_ATTRDEF_CLASSES
// Symbols commonly used in the attribute classes below
namespace mlir {
class AsmParser;
class AsmPrinter;
} // namespace mlir

// Attribute classes declarations...
```

This change is not expected to break the compatibility with the existing code which includes the generated `.h.inc` files. It also exposes the same forward-declaration feature that is available for operations; for example, `BuiltinOps.h.inc`:

```C++
namespace mlir {
class ModuleOp;
} // namespace mlir
namespace mlir {
class UnrealizedConversionCastOp;
} // namespace mlir
#ifdef GET_OP_CLASSES
#undef GET_OP_CLASSES

// Op classes declarations...
```