### PR TITLE
[BOLT][docs] Document commands to identify BOLT-ed binaries

### DIFF
--- a/bolt/README.md
+++ b/bolt/README.md
@@ -209,18 +209,17 @@ have extra sections with `bolt` in their name.
 
 You can use `readelf` to find these:
 ```
-$ llvm-readelf -S <your-binary> | grep bolt
+$ readelf -S <your-binary> | grep bolt
   [11] .bolt.org.eh_frame PROGBITS <...>
 <...>
   [39] .note.bolt_info   NOTE <...>
 ```
 The note can be displayed with:
 ```
-$ llvm-readelf -n <your-binary>
-<...>
-Displaying notes found in: .note.bolt_info
+$ readelf -p .note.bolt_info <your-binary>
+String dump of section '.note.bolt_info':
   <...>
-    Version: BOLT revision: <...>
+  [    10]  BOLT revision: <...>
 ```
 
 ## License

--- a/bolt/README.md
+++ b/bolt/README.md
@@ -202,6 +202,27 @@ $ merge-fdata *.fdata > combined.fdata
 Use `combined.fdata` for **Step 3** above to generate a universally optimized
 binary.
 
+## Identifying a Binary Modified By BOLT
+
+A binary that has been modified by BOLT will include a `bolt_info` note and may
+have extra sections with `bolt` in their name.
+
+You can use `readelf` to find these:
+```
+$ llvm-readelf -S <your-binary> | grep bolt
+  [11] .bolt.org.eh_frame PROGBITS <...>
+<...>
+  [39] .note.bolt_info   NOTE <...>
+```
+The note can be displayed with:
+```
+$ llvm-readelf -n <your-binary>
+<...>
+Displaying notes found in: .note.bolt_info
+  <...>
+    Version: BOLT revision: <...>
+```
+
 ## License
 
 BOLT is licensed under the [Apache License v2.0 with LLVM Exceptions](./LICENSE.TXT).


### PR DESCRIPTION
These have been useful to me in the past and I don't see any docs referencing the `bolt_info` note either.

There is a test checking that it is emitted, so I assume it's something we are ok with people looking for.