### PR TITLE
Fix quoting of CMake parameters in llvm_create_cross_target

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -85,9 +85,9 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
 
   add_custom_command(OUTPUT ${${project_name}_${target_name}_BUILD}/CMakeCache.txt
     COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
-        "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}"
-        "-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}"
-        "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}"
+        -DCMAKE_MAKE_PROGRAM="${CMAKE_MAKE_PROGRAM}"
+        -DCMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER}"
+        -DCMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}"
         ${CROSS_TOOLCHAIN_FLAGS_${target_name}} ${CMAKE_CURRENT_SOURCE_DIR}
         ${CROSS_TOOLCHAIN_FLAGS_${project_name}_${target_name}}
         -DLLVM_TARGET_IS_CROSSCOMPILE_HOST=TRUE


### PR DESCRIPTION
add_custom_command in CMake handles parameters enclosed by quotes and parameters containing quoted parts differently. In the first case the quotes are removed in the executed command line while they are retained for the second case.

Since the entire parameters setting CMAKE_MAKE_PROGRAM, CMAKE_C_COMPILER_LAUNCHER, and CMAKE_CXX_LAUNCHER was enclosed by quotes the recursive CMake call broke when either of these three cmake variables contained spaces.