### PR TITLE
[lldb][docs] Describe how to check enabled features

### DIFF
--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -141,13 +141,13 @@ The output above shows us that this particular copy of LLDB has XML parsing
 
    ``readelf -d`` as used above only shows direct dependencies of the binary.
    Libraries loaded by a library will not be shown. An example of this is Python.
-   ``lldb`` loads ``liblldb`` and it is ``liblldb`` that requires ``libpython``.
+   ``lldb`` requires ``liblldb`` and it is ``liblldb`` that would require ``libpython``.
 
    The same ``readelf`` command can be used on ``liblldb`` to see if it does
    depend on Python.
 
    ``ldd`` will show you the full dependency tree of ``lldb`` but **do not**
-   use it unless you trust the ``lldb`` binary itself. As some versions of
-   ``ldd`` may execute the binary in the process of inspecting it.
+   use it unless you trust the ``lldb`` binary. As some versions of ``ldd`` may
+   execute the binary in the process of inspecting it.
 
-If you are on MacOS, use ``otool -l <path-to-lldb>``.
+On MacOS, use ``otool -l <path-to-lldb>``.

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -137,4 +137,13 @@ For example on Linux you can use the following command:
 The output above shows us that this particular copy of LLDB has XML parsing
 (``libxml2``) and editline (``libedit``) enabled.
 
+.. note::
+
+   ``readelf -d`` as used above only shows direct dependencies of the binary.
+   Libraries loaded by a library will not be shown. An example of this is Python.
+   ``lldb`` loads ``liblldb`` and it is ``liblldb`` that requires ``libpython``.
+
+   The same ``readelf`` command can be used on ``liblldb`` to see if it does
+   depend on Python.
+
 If you are on MacOS, use ``otool -l <path-to-lldb>``.

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -113,8 +113,8 @@ command from within LLDB:
    This feature was added in LLDB 22. If you are using an earlier version, you
    can use one of the methods below.
 
-If your LLDB has Python enabled, you can also use this command to print the
-same information:
+If your LLDB has a scripting langauge enabled, you can also use this command to
+print the same information:
 
 ::
 

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -98,8 +98,8 @@ for any source file and line breakpoints that the IDE set using:
 
    (lldb) breakpoint list --verbose
 
-How Do I Find Out Which Features My Version Of LLDB Has?
---------------------------------------------------------
+How Do I Find Out Which Features My Copy Of LLDB Has?
+-----------------------------------------------------
 
 Some features such as XML parsing are optional and must be enabled when LLDB is
 built. To check which features your copy of LLDB has enabled, use the ``version``

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -120,8 +120,8 @@ same information:
 
    (lldb) script lldb.debugger.GetBuildConfiguration()
 
-This command will fail if Python was not enabled. In that case, you can instead
-check the shared library dependencies of LLDB.
+This command will fail if no scripting langauge is enabled. In that case, you
+can instead check the shared library dependencies of LLDB.
 
 For example on Linux you can use the following command:
 

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -118,7 +118,7 @@ on Linux you can use the following command:
 
 ::
 
-   $ readelf -d ./bin/lldb | grep NEEDED
+   $ readelf -d lldb | grep NEEDED
    0x0000000000000001 (NEEDED)             Shared library: [liblldb.so.22.0git]
    0x0000000000000001 (NEEDED)             Shared library: [libxml2.so.2]
    0x0000000000000001 (NEEDED)             Shared library: [libedit.so.2]

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -98,8 +98,8 @@ for any source file and line breakpoints that the IDE set using:
 
    (lldb) breakpoint list --verbose
 
-How Do I Find Out What Features My Version Of LLDB Has?
--------------------------------------------------------
+How Do I Find Out Which Features My Version Of LLDB Has?
+--------------------------------------------------------
 
 Some features such as XML parsing are optional and must be enabled when LLDB is
 built. To check which features your copy of LLDB has enabled, use the ``version``

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -111,14 +111,23 @@ command from within LLDB:
 
 .. note::
    This feature was added in LLDB 22. If you are using an earlier version, you
-   can use the method below.
+   can use one of the methods below.
 
-Alternatively, you can check the shared library dependencies of LLDB. For example
-on Linux you can use the following command:
+If your LLDB has Python enabled, you can also use this command to print the
+same information:
 
 ::
 
-   $ readelf -d lldb | grep NEEDED
+   (lldb) script lldb.debugger.GetBuildConfiguration()
+
+This command will fail if Python was not enabled. In that case, you can instead
+check the shared library dependencies of LLDB.
+
+For example on Linux you can use the following command:
+
+::
+
+   $ readelf -d <path-to-lldb> | grep NEEDED
    0x0000000000000001 (NEEDED)             Shared library: [liblldb.so.22.0git]
    0x0000000000000001 (NEEDED)             Shared library: [libxml2.so.2]
    0x0000000000000001 (NEEDED)             Shared library: [libedit.so.2]
@@ -127,3 +136,5 @@ on Linux you can use the following command:
 
 The output above shows us that this particular copy of LLDB has XML parsing
 (``libxml2``) and editline (``libedit``) enabled.
+
+If you are on MacOS, use ``otool -l <path-to-lldb>``.

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -97,3 +97,33 @@ for any source file and line breakpoints that the IDE set using:
 ::
 
    (lldb) breakpoint list --verbose
+
+How Do I Find Out What Features My Version Of LLDB Has?
+-------------------------------------------------------
+
+Some features such as XML parsing are optional and must be enabled when LLDB is
+built. To check which features your copy of LLDB has enabled, use the ``version``
+command from within LLDB:
+
+::
+
+   (lldb) version -v
+
+.. note::
+   This feature was added in LLDB 22. If you are using an earlier version, you
+   can use the method below.
+
+Alternatively, you can check the shared library dependencies of LLDB. For example
+on Linux you can use the following command:
+
+::
+
+   $ readelf -d ./bin/lldb | grep NEEDED
+   0x0000000000000001 (NEEDED)             Shared library: [liblldb.so.22.0git]
+   0x0000000000000001 (NEEDED)             Shared library: [libxml2.so.2]
+   0x0000000000000001 (NEEDED)             Shared library: [libedit.so.2]
+   <...>
+   0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+
+The output above shows us that this particular copy of LLDB has XML parsing
+(``libxml2``) and editline (``libedit``) enabled.

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -146,4 +146,8 @@ The output above shows us that this particular copy of LLDB has XML parsing
    The same ``readelf`` command can be used on ``liblldb`` to see if it does
    depend on Python.
 
+   ``ldd`` will show you the full dependency tree of ``lldb`` but **do not**
+   use it unless you trust the ``lldb`` binary itself. As some versions of
+   ``ldd`` may execute the binary in the process of inspecting it.
+
 If you are on MacOS, use ``otool -l <path-to-lldb>``.

--- a/lldb/docs/use/troubleshooting.rst
+++ b/lldb/docs/use/troubleshooting.rst
@@ -120,7 +120,7 @@ print the same information:
 
    (lldb) script lldb.debugger.GetBuildConfiguration()
 
-This command will fail if no scripting langauge is enabled. In that case, you
+This command will fail if no scripting langauge was enabled. In that case, you
 can instead check the shared library dependencies of LLDB.
 
 For example on Linux you can use the following command:
@@ -132,7 +132,6 @@ For example on Linux you can use the following command:
    0x0000000000000001 (NEEDED)             Shared library: [libxml2.so.2]
    0x0000000000000001 (NEEDED)             Shared library: [libedit.so.2]
    <...>
-   0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 
 The output above shows us that this particular copy of LLDB has XML parsing
 (``libxml2``) and editline (``libedit``) enabled.
@@ -142,12 +141,15 @@ The output above shows us that this particular copy of LLDB has XML parsing
    ``readelf -d`` as used above only shows direct dependencies of the binary.
    Libraries loaded by a library will not be shown. An example of this is Python.
    ``lldb`` requires ``liblldb`` and it is ``liblldb`` that would require ``libpython``.
-
    The same ``readelf`` command can be used on ``liblldb`` to see if it does
    depend on Python.
 
    ``ldd`` will show you the full dependency tree of ``lldb`` but **do not**
    use it unless you trust the ``lldb`` binary. As some versions of ``ldd`` may
    execute the binary in the process of inspecting it.
+
+On Windows, use ``dumpbin /dependents <path-to-lldb>``. The same caveat from
+Linux applies to Windows. To find dependencies like Python, you need to run
+``dumpbin`` on ``liblldb.dll`` too.
 
 On MacOS, use ``otool -l <path-to-lldb>``.


### PR DESCRIPTION
This makes use of `version -v` added by #170772,
along with fallback methods for LLDB prior to 22.

1. version --verbose (won't work prior to 22)
2. Scripting to call GetBuildConfiguration (won't work if you don't have a scripting language
3. readelf/other platform's equivalent utility

readelf is recommended for Linux due to security concerns with ldd.

https://man7.org/linux/man-pages/man1/ldd.1.html
"some versions of ldd may attempt to obtain the
dependency information by attempting to directly
execute the program"

The drawback to that is it doesn't show dependencies of dependencies, so I've noted that. People can use ldd if they trust the binary, but I've made it clear how to avoid that and why you should avoid it.