### PR TITLE
[OCaml] Try to fix library dependencies

### DIFF
--- a/llvm/cmake/modules/AddOCaml.cmake
+++ b/llvm/cmake/modules/AddOCaml.cmake
@@ -57,9 +57,12 @@ function(add_ocaml_library name)
                   "-ccopt" "-Wl,-rpath,\\$CAMLORIGIN/../.."
                   ${ocaml_pkgs})
 
+  set(ocaml_dep_outputs)
   foreach( ocaml_dep ${ARG_OCAMLDEP} )
     get_target_property(dep_ocaml_flags "ocaml_${ocaml_dep}" OCAML_FLAGS)
     list(APPEND ocaml_flags ${dep_ocaml_flags})
+    # Add dependency on the dependent module's .cmi file
+    list(APPEND ocaml_dep_outputs "${LLVM_LIBRARY_DIR}/ocaml/llvm/${ocaml_dep}.cmi")
   endforeach()
 
   if( NOT BUILD_SHARED_LIBS )
@@ -157,7 +160,7 @@ function(add_ocaml_library name)
     OUTPUT ${ocaml_outputs}
     COMMAND "${OCAMLFIND}" "ocamlmklib" "-ocamlcflags" "-bin-annot"
       "-o" "${name}" ${ocaml_flags} ${ocaml_params}
-    DEPENDS ${ocaml_inputs} ${c_outputs}
+    DEPENDS ${ocaml_inputs} ${c_outputs} ${ocaml_dep_outputs}
     COMMENT "Building OCaml library ${name}"
     VERBATIM)
 

--- a/llvm/cmake/modules/AddOCaml.cmake
+++ b/llvm/cmake/modules/AddOCaml.cmake
@@ -57,12 +57,9 @@ function(add_ocaml_library name)
                   "-ccopt" "-Wl,-rpath,\\$CAMLORIGIN/../.."
                   ${ocaml_pkgs})
 
-  set(ocaml_dep_outputs)
   foreach( ocaml_dep ${ARG_OCAMLDEP} )
     get_target_property(dep_ocaml_flags "ocaml_${ocaml_dep}" OCAML_FLAGS)
     list(APPEND ocaml_flags ${dep_ocaml_flags})
-    # Add dependency on the dependent module's .cmi file
-    list(APPEND ocaml_dep_outputs "${LLVM_LIBRARY_DIR}/ocaml/llvm/${ocaml_dep}.cmi")
   endforeach()
 
   if( NOT BUILD_SHARED_LIBS )
@@ -160,7 +157,7 @@ function(add_ocaml_library name)
     OUTPUT ${ocaml_outputs}
     COMMAND "${OCAMLFIND}" "ocamlmklib" "-ocamlcflags" "-bin-annot"
       "-o" "${name}" ${ocaml_flags} ${ocaml_params}
-    DEPENDS ${ocaml_inputs} ${c_outputs} ${ocaml_dep_outputs}
+    DEPENDS ${ocaml_inputs} ${c_outputs}
     COMMENT "Building OCaml library ${name}"
     VERBATIM)
 


### PR DESCRIPTION
Whenever I try to change anything in the OCaml bindings, I run into errors like this when running tests:

    File "/home/npopov/repos/llvm-project/build/test/Bindings/OCaml/Output/debuginfo.ml.tmp/Testsuite.ml", line 1:
    Warning 70 [missing-mli]: Cannot find interface file.

    File "/home/npopov/repos/llvm-project/build/test/Bindings/OCaml/Output/debuginfo.ml.tmp/debuginfo.ml", line 1:
    Error: The files "/home/npopov/repos/llvm-project/build/lib/ocaml/llvm/llvm.cmi"
           and "/home/npopov/repos/llvm-project/build/lib/ocaml/llvm/llvm_debuginfo.cmi"
           make inconsistent assumptions over interface "Llvm"

The only reliable way of getting rid of these I have found is to do an `rm -rf build` and just rebuild everything.

The root cause of this issue is that we currently add target-dependencies between ocaml modules, but we don't have file-level dependencies. This means that everything gets built in the correct order, but targets don't get rebuilt if a dependency is changed.

To fix this, add file-level dependencies to the custom command. These are generated via a target property that stores the ocaml outputs of the target.