### PR TITLE
[libunwind] Make sure libunwind test dependencies are installed before running tests

### DIFF
--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -336,6 +336,9 @@ if (RUNTIMES_EXECUTE_ONLY_CODE)
   add_compile_definitions(_LIBUNWIND_EXECUTE_ONLY_CODE)
 endif()
 
+add_custom_target(unwind-test-depends
+  COMMENT "Build dependencies required to run the libunwind test suite.")
+
 #===============================================================================
 # Setup Source Code
 #===============================================================================

--- a/libunwind/test/CMakeLists.txt
+++ b/libunwind/test/CMakeLists.txt
@@ -8,56 +8,22 @@ macro(pythonize_bool var)
   endif()
 endmacro()
 
+# Install targets required to run libunwind tests into a temporary location.
+#
+# This ensures that we run the tests against the final installed products, which
+# is closer to what we actually ship than the contents of the build tree.
 set(LIBUNWIND_TESTING_INSTALL_PREFIX "${LIBUNWIND_BINARY_DIR}/test-suite-install")
+set(libunwind_test_suite_install_targets unwind-headers unwind)
 if ("libcxx" IN_LIST LLVM_ENABLE_RUNTIMES)
-  add_custom_target(libunwind-install-cxx-for-testing
-                      DEPENDS cxx-headers
-                              cxx
-                              cxx_experimental
-                              cxx-modules
-                      COMMAND ${CMAKE_COMMAND} -E make_directory "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                      COMMAND "${CMAKE_COMMAND}"
-                              -DCMAKE_INSTALL_COMPONENT=cxx-headers
-                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-                      COMMAND "${CMAKE_COMMAND}"
-                              -DCMAKE_INSTALL_COMPONENT=cxx-modules
-                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-                      COMMAND "${CMAKE_COMMAND}"
-                              -DCMAKE_INSTALL_COMPONENT=cxx
-                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
-  add_dependencies(unwind-test-depends libunwind-install-cxx-for-testing)
-
-  add_custom_target(libunwind-install-cxxabi-for-testing
-                      DEPENDS cxxabi-headers
-                              cxxabi
-                      COMMAND ${CMAKE_COMMAND} -E make_directory "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                      COMMAND "${CMAKE_COMMAND}"
-                              -DCMAKE_INSTALL_COMPONENT=cxxabi-headers
-                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-                      COMMAND "${CMAKE_COMMAND}"
-                              -DCMAKE_INSTALL_COMPONENT=cxxabi
-                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
-  add_dependencies(unwind-test-depends libunwind-install-cxxabi-for-testing)
+  list(APPEND libunwind_test_suite_install_targets cxx-headers cxx cxx_experimental cxx-modules cxxabi-headers cxxabi)
 endif()
-
-add_custom_target(libunwind-install-unwind-for-testing
-  DEPENDS unwind-headers
-          unwind
-  COMMAND ${CMAKE_COMMAND} -E make_directory "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-  COMMAND "${CMAKE_COMMAND}"
-          -DCMAKE_INSTALL_COMPONENT=unwind-headers
-          -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-          -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-  COMMAND "${CMAKE_COMMAND}"
-          -DCMAKE_INSTALL_COMPONENT=unwind
-          -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-          -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
-add_dependencies(unwind-test-depends libunwind-install-unwind-for-testing)
+foreach(target IN LISTS libunwind_test_suite_install_targets)
+  add_custom_target(libunwind-test-suite-install-${target} DEPENDS "${target}"
+                    COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}"
+                                               --prefix "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                                               --component "${target}")
+  add_dependencies(unwind-test-depends libunwind-test-suite-install-${target})
+endforeach()
 
 pythonize_bool(LIBUNWIND_ENABLE_CET)
 pythonize_bool(LIBUNWIND_ENABLE_GCS)

--- a/libunwind/test/CMakeLists.txt
+++ b/libunwind/test/CMakeLists.txt
@@ -9,25 +9,27 @@ macro(pythonize_bool var)
 endmacro()
 
 set(LIBUNWIND_TESTING_INSTALL_PREFIX "${LIBUNWIND_BINARY_DIR}/test-suite-install")
-add_custom_target(libunwind-install-cxx-for-testing
-                    DEPENDS cxx-headers
-                            cxx
-                            cxx_experimental
-                            cxx-modules
-                    COMMAND ${CMAKE_COMMAND} -E make_directory "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                    COMMAND "${CMAKE_COMMAND}"
-                            -DCMAKE_INSTALL_COMPONENT=cxx-headers
-                            -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-                    COMMAND "${CMAKE_COMMAND}"
-                            -DCMAKE_INSTALL_COMPONENT=cxx-modules
-                            -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-                    COMMAND "${CMAKE_COMMAND}"
-                            -DCMAKE_INSTALL_COMPONENT=cxx
-                            -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
-add_dependencies(unwind-test-depends libunwind-install-cxx-for-testing)
+if ("libcxx" IN_LIST LLVM_ENABLE_RUNTIMES)
+  add_custom_target(libunwind-install-cxx-for-testing
+                      DEPENDS cxx-headers
+                              cxx
+                              cxx_experimental
+                              cxx-modules
+                      COMMAND ${CMAKE_COMMAND} -E make_directory "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                      COMMAND "${CMAKE_COMMAND}"
+                              -DCMAKE_INSTALL_COMPONENT=cxx-headers
+                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+                      COMMAND "${CMAKE_COMMAND}"
+                              -DCMAKE_INSTALL_COMPONENT=cxx-modules
+                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+                      COMMAND "${CMAKE_COMMAND}"
+                              -DCMAKE_INSTALL_COMPONENT=cxx
+                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+  add_dependencies(unwind-test-depends libunwind-install-cxx-for-testing)
+endif()
 
 add_custom_target(libunwind-install-unwind-for-testing
   DEPENDS unwind-headers

--- a/libunwind/test/CMakeLists.txt
+++ b/libunwind/test/CMakeLists.txt
@@ -9,6 +9,26 @@ macro(pythonize_bool var)
 endmacro()
 
 set(LIBUNWIND_TESTING_INSTALL_PREFIX "${LIBUNWIND_BINARY_DIR}/test-suite-install")
+add_custom_target(libunwind-install-cxx-for-testing
+                    DEPENDS cxx-headers
+                            cxx
+                            cxx_experimental
+                            cxx-modules
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                    COMMAND "${CMAKE_COMMAND}"
+                            -DCMAKE_INSTALL_COMPONENT=cxx-headers
+                            -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+                    COMMAND "${CMAKE_COMMAND}"
+                            -DCMAKE_INSTALL_COMPONENT=cxx-modules
+                            -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+                    COMMAND "${CMAKE_COMMAND}"
+                            -DCMAKE_INSTALL_COMPONENT=cxx
+                            -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+add_dependencies(unwind-test-depends libunwind-install-cxx-for-testing)
+
 add_custom_target(libunwind-install-unwind-for-testing
   DEPENDS unwind-headers
           unwind
@@ -21,6 +41,7 @@ add_custom_target(libunwind-install-unwind-for-testing
           -DCMAKE_INSTALL_COMPONENT=unwind
           -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
           -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+add_dependencies(unwind-test-depends libunwind-install-unwind-for-testing)
 
 pythonize_bool(LIBUNWIND_ENABLE_CET)
 pythonize_bool(LIBUNWIND_ENABLE_GCS)
@@ -62,4 +83,4 @@ configure_lit_site_cfg(
 
 add_lit_testsuite(check-unwind "Running libunwind tests"
   ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS libunwind-install-unwind-for-testing)
+  DEPENDS unwind-test-depends)

--- a/libunwind/test/CMakeLists.txt
+++ b/libunwind/test/CMakeLists.txt
@@ -29,6 +29,20 @@ if ("libcxx" IN_LIST LLVM_ENABLE_RUNTIMES)
                               -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
                               -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
   add_dependencies(unwind-test-depends libunwind-install-cxx-for-testing)
+
+  add_custom_target(libunwind-install-cxxabi-for-testing
+                      DEPENDS cxxabi-headers
+                              cxxabi
+                      COMMAND ${CMAKE_COMMAND} -E make_directory "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                      COMMAND "${CMAKE_COMMAND}"
+                              -DCMAKE_INSTALL_COMPONENT=cxxabi-headers
+                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
+                      COMMAND "${CMAKE_COMMAND}"
+                              -DCMAKE_INSTALL_COMPONENT=cxxabi
+                              -DCMAKE_INSTALL_PREFIX="${LIBUNWIND_TESTING_INSTALL_PREFIX}"
+                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+  add_dependencies(unwind-test-depends libunwind-install-cxxabi-for-testing)
 endif()
 
 add_custom_target(libunwind-install-unwind-for-testing

--- a/libunwind/test/CMakeLists.txt
+++ b/libunwind/test/CMakeLists.txt
@@ -17,14 +17,11 @@ set(libunwind_test_suite_install_targets unwind-headers unwind)
 if ("libcxx" IN_LIST LLVM_ENABLE_RUNTIMES)
   list(APPEND libunwind_test_suite_install_targets cxx-headers cxx cxx_experimental cxx-modules cxxabi-headers cxxabi)
 endif()
-# Run installation targets serially to avoid race conditions between install targets
-set_property(GLOBAL PROPERTY JOB_POOLS libunwind-test-install-pool=1 APPEND)
 foreach(target IN LISTS libunwind_test_suite_install_targets)
   add_custom_target(libunwind-test-suite-install-${target} DEPENDS "${target}"
                     COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}"
                                                --prefix "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                                               --component "${target}"
-                    JOB_POOL libunwind-test-install-pool)
+                                               --component "${target}")
   add_dependencies(unwind-test-depends libunwind-test-suite-install-${target})
 endforeach()
 

--- a/libunwind/test/CMakeLists.txt
+++ b/libunwind/test/CMakeLists.txt
@@ -17,11 +17,14 @@ set(libunwind_test_suite_install_targets unwind-headers unwind)
 if ("libcxx" IN_LIST LLVM_ENABLE_RUNTIMES)
   list(APPEND libunwind_test_suite_install_targets cxx-headers cxx cxx_experimental cxx-modules cxxabi-headers cxxabi)
 endif()
+# Run installation targets serially to avoid race conditions between install targets
+set_property(GLOBAL PROPERTY JOB_POOLS libunwind-test-install-pool=1 APPEND)
 foreach(target IN LISTS libunwind_test_suite_install_targets)
   add_custom_target(libunwind-test-suite-install-${target} DEPENDS "${target}"
                     COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}"
                                                --prefix "${LIBUNWIND_TESTING_INSTALL_PREFIX}"
-                                               --component "${target}")
+                                               --component "${target}"
+                    JOB_POOL libunwind-test-install-pool)
   add_dependencies(unwind-test-depends libunwind-test-suite-install-${target})
 endforeach()
 


### PR DESCRIPTION
This patch adds an installation step where we install libc++ in a fake installation tree before testing libunwind. This is necessary because some configurations (in particular "generic-merged") require libc++ to be installed, since the libunwind tests are actually linking libc++.so in which libc++abi.a and libunwind.a have been merged.

Without this, we were actually failing to find `libc++.so` to link against and then linking against whatever system library we'd find in the provided search directories. While this happens to work in the current CI configuration, this breaks down when updating to newer build tools.