### PR TITLE
[SystemZ] Implement ctor/dtor emission via @@SQINIT and .xtor sections

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -331,6 +331,10 @@ public:
                                       const TargetMachine &TM) const override;
   MCSection *getSectionForLSDA(const Function &F, const MCSymbol &FnSym,
                                const TargetMachine &TM) const override;
+  MCSection *getStaticCtorSection(unsigned Priority,
+                                  const MCSymbol *KeySym) const override;
+  MCSection *getStaticDtorSection(unsigned Priority,
+                                  const MCSymbol *KeySym) const override;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -331,10 +331,8 @@ public:
                                       const TargetMachine &TM) const override;
   MCSection *getSectionForLSDA(const Function &F, const MCSymbol &FnSym,
                                const TargetMachine &TM) const override;
-  MCSection *getStaticCtorSection(unsigned Priority,
-                                  const MCSymbol *KeySym) const override;
-  MCSection *getStaticDtorSection(unsigned Priority,
-                                  const MCSymbol *KeySym) const override;
+  MCSection *getStaticXtorSection(unsigned Priority,
+                                  const MCSymbol *KeySym) const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -331,8 +331,7 @@ public:
                                       const TargetMachine &TM) const override;
   MCSection *getSectionForLSDA(const Function &F, const MCSymbol &FnSym,
                                const TargetMachine &TM) const override;
-  MCSection *getStaticXtorSection(unsigned Priority,
-                                  const MCSymbol *KeySym) const;
+  MCSection *getStaticXtorSection(unsigned Priority) const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_TARGETLOWERINGOBJECTFILEIMPL_H
 #define LLVM_CODEGEN_TARGETLOWERINGOBJECTFILEIMPL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/BinaryFormat/XCOFF.h"
 #include "llvm/MC/MCExpr.h"
@@ -31,7 +32,7 @@ class MCSymbol;
 class Module;
 class TargetMachine;
 
-class TargetLoweringObjectFileELF : public TargetLoweringObjectFile {
+class LLVM_ABI TargetLoweringObjectFileELF : public TargetLoweringObjectFile {
   bool UseInitArray = false;
   mutable unsigned NextUniqueID = 1;  // ID 0 is reserved for execute-only sections
   SmallPtrSet<GlobalObject *, 2> Used;
@@ -130,7 +131,7 @@ public:
   MCSection *getSectionForCommandLines() const override;
 };
 
-class TargetLoweringObjectFileMachO : public TargetLoweringObjectFile {
+class LLVM_ABI TargetLoweringObjectFileMachO : public TargetLoweringObjectFile {
 public:
   TargetLoweringObjectFileMachO();
   ~TargetLoweringObjectFileMachO() override = default;
@@ -180,7 +181,7 @@ public:
   MCSection *getSectionForCommandLines() const override;
 };
 
-class TargetLoweringObjectFileCOFF : public TargetLoweringObjectFile {
+class LLVM_ABI TargetLoweringObjectFileCOFF : public TargetLoweringObjectFile {
   mutable unsigned NextUniqueID = 0;
   const TargetMachine *TM = nullptr;
 
@@ -225,7 +226,7 @@ public:
                                    Align &Alignment) const override;
 };
 
-class TargetLoweringObjectFileWasm : public TargetLoweringObjectFile {
+class LLVM_ABI TargetLoweringObjectFileWasm : public TargetLoweringObjectFile {
   mutable unsigned NextUniqueID = 0;
   SmallPtrSet<GlobalObject *, 2> Used;
 
@@ -251,7 +252,7 @@ public:
                                   const MCSymbol *KeySym) const override;
 };
 
-class TargetLoweringObjectFileXCOFF : public TargetLoweringObjectFile {
+class LLVM_ABI TargetLoweringObjectFileXCOFF : public TargetLoweringObjectFile {
 public:
   TargetLoweringObjectFileXCOFF() = default;
   ~TargetLoweringObjectFileXCOFF() override = default;
@@ -315,7 +316,7 @@ public:
                                const TargetMachine &TM) const override;
 };
 
-class TargetLoweringObjectFileGOFF : public TargetLoweringObjectFile {
+class LLVM_ABI TargetLoweringObjectFileGOFF : public TargetLoweringObjectFile {
   std::string DefaultRootSDName;
   std::string DefaultADAPRName;
 

--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_CODEGEN_TARGETLOWERINGOBJECTFILEIMPL_H
 #define LLVM_CODEGEN_TARGETLOWERINGOBJECTFILEIMPL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/BinaryFormat/XCOFF.h"
 #include "llvm/MC/MCExpr.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
 
 namespace llvm {

--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -17,7 +17,6 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/BinaryFormat/XCOFF.h"
 #include "llvm/MC/MCExpr.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
 
 namespace llvm {
@@ -32,7 +31,7 @@ class MCSymbol;
 class Module;
 class TargetMachine;
 
-class LLVM_ABI TargetLoweringObjectFileELF : public TargetLoweringObjectFile {
+class TargetLoweringObjectFileELF : public TargetLoweringObjectFile {
   bool UseInitArray = false;
   mutable unsigned NextUniqueID = 1;  // ID 0 is reserved for execute-only sections
   SmallPtrSet<GlobalObject *, 2> Used;
@@ -131,7 +130,7 @@ public:
   MCSection *getSectionForCommandLines() const override;
 };
 
-class LLVM_ABI TargetLoweringObjectFileMachO : public TargetLoweringObjectFile {
+class TargetLoweringObjectFileMachO : public TargetLoweringObjectFile {
 public:
   TargetLoweringObjectFileMachO();
   ~TargetLoweringObjectFileMachO() override = default;
@@ -181,7 +180,7 @@ public:
   MCSection *getSectionForCommandLines() const override;
 };
 
-class LLVM_ABI TargetLoweringObjectFileCOFF : public TargetLoweringObjectFile {
+class TargetLoweringObjectFileCOFF : public TargetLoweringObjectFile {
   mutable unsigned NextUniqueID = 0;
   const TargetMachine *TM = nullptr;
 
@@ -226,7 +225,7 @@ public:
                                    Align &Alignment) const override;
 };
 
-class LLVM_ABI TargetLoweringObjectFileWasm : public TargetLoweringObjectFile {
+class TargetLoweringObjectFileWasm : public TargetLoweringObjectFile {
   mutable unsigned NextUniqueID = 0;
   SmallPtrSet<GlobalObject *, 2> Used;
 
@@ -252,7 +251,7 @@ public:
                                   const MCSymbol *KeySym) const override;
 };
 
-class LLVM_ABI TargetLoweringObjectFileXCOFF : public TargetLoweringObjectFile {
+class TargetLoweringObjectFileXCOFF : public TargetLoweringObjectFile {
 public:
   TargetLoweringObjectFileXCOFF() = default;
   ~TargetLoweringObjectFileXCOFF() override = default;
@@ -316,7 +315,7 @@ public:
                                const TargetMachine &TM) const override;
 };
 
-class LLVM_ABI TargetLoweringObjectFileGOFF : public TargetLoweringObjectFile {
+class TargetLoweringObjectFileGOFF : public TargetLoweringObjectFile {
   std::string DefaultRootSDName;
   std::string DefaultADAPRName;
 

--- a/llvm/include/llvm/MC/MCGOFFAttributes.h
+++ b/llvm/include/llvm/MC/MCGOFFAttributes.h
@@ -94,6 +94,7 @@ constexpr StringLiteral CLASS_CODE = "C_CODE64";
 constexpr StringLiteral CLASS_WSA = "C_WSA64";
 constexpr StringLiteral CLASS_DATA = "C_DATA64";
 constexpr StringLiteral CLASS_PPA2 = "C_@@QPPA2";
+constexpr StringLiteral CLASS_SINIT = "C_@@SQINIT";
 
 } // namespace GOFF
 } // namespace llvm

--- a/llvm/include/llvm/MC/MCSectionGOFF.h
+++ b/llvm/include/llvm/MC/MCSectionGOFF.h
@@ -27,13 +27,6 @@ namespace llvm {
 class MCExpr;
 
 class LLVM_ABI MCSectionGOFF final : public MCSection {
-public:
-  enum XtorType { NotXtor, CtorType, DtorType };
-
-private:
-  // ctor/dtor section related - i.e. C_@@S[Q]INIT
-  enum XtorType XtorSectionType = NotXtor;
-
   // Parent of this section. Implies that the parent is emitted first.
   MCSectionGOFF *Parent;
 
@@ -122,10 +115,6 @@ public:
   bool requiresNonZeroLength() const { return RequiresNonZeroLength; }
 
   void setName(StringRef SectionName) { Name = SectionName; }
-
-  bool isXtorSection() const { return XtorSectionType != NotXtor; }
-  void setXtorSectionType(XtorType Value) { XtorSectionType = Value; }
-  XtorType getXtorSectionType() const { return XtorSectionType; }
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/MC/MCSectionGOFF.h
+++ b/llvm/include/llvm/MC/MCSectionGOFF.h
@@ -27,6 +27,13 @@ namespace llvm {
 class MCExpr;
 
 class LLVM_ABI MCSectionGOFF final : public MCSection {
+public:
+  enum XtorType { NotXtor, CtorType, DtorType };
+
+private:
+  // ctor/dtor section related - i.e. C_@@S[Q]INIT
+  enum XtorType XtorSectionType = NotXtor;
+
   // Parent of this section. Implies that the parent is emitted first.
   MCSectionGOFF *Parent;
 
@@ -115,6 +122,10 @@ public:
   bool requiresNonZeroLength() const { return RequiresNonZeroLength; }
 
   void setName(StringRef SectionName) { Name = SectionName; }
+
+  bool isXtorSection() const { return XtorSectionType != NotXtor; }
+  void setXtorSectionType(XtorType Value) { XtorSectionType = Value; }
+  XtorType getXtorSectionType() const { return XtorSectionType; }
 };
 } // end namespace llvm
 

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2865,7 +2865,6 @@ MCSection *TargetLoweringObjectFileGOFF::SelectSectionForGlobal(
 
 static MCSectionGOFF *getStaticStructorSectionGOFF(MCContext &Ctx,
                                                    const MCSection *TextSection,
-                                                   bool IsCtor,
                                                    unsigned Priority) {
   // xl compilers on z/OS support priorities from min-int to max-int, with
   // sinit as source priority 0. For clang, sinit has source priority 65535.
@@ -2898,12 +2897,10 @@ static MCSectionGOFF *getStaticStructorSectionGOFF(MCContext &Ctx,
 
 MCSection *TargetLoweringObjectFileGOFF::getStaticCtorSection(
     unsigned Priority, const MCSymbol *KeySym) const {
-  return getStaticStructorSectionGOFF(getContext(), TextSection, true,
-                                      Priority);
+  return getStaticStructorSectionGOFF(getContext(), TextSection, Priority);
 }
 
 MCSection *TargetLoweringObjectFileGOFF::getStaticDtorSection(
     unsigned Priority, const MCSymbol *KeySym) const {
-  return getStaticStructorSectionGOFF(getContext(), TextSection, false,
-                                      Priority);
+  return getStaticStructorSectionGOFF(getContext(), TextSection, Priority);
 }

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2795,10 +2795,6 @@ void TargetLoweringObjectFileGOFF::getModuleMetadata(Module &M) {
   TextLD->setWeak(false);
   TextLD->setADA(ADAPR);
   TextSection->setBeginSymbol(TextLD);
-  // Initialize the label for the ADA section.
-  MCSymbolGOFF *ADASym = static_cast<MCSymbolGOFF *>(
-      getContext().getOrCreateSymbol(ADAPR->getName()));
-  ADAPR->setBeginSymbol(ADASym);
 }
 
 MCSection *TargetLoweringObjectFileGOFF::getExplicitSectionGlobal(

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2895,12 +2895,7 @@ static MCSectionGOFF *getStaticStructorSectionGOFF(MCContext &Ctx,
   return Xtor;
 }
 
-MCSection *TargetLoweringObjectFileGOFF::getStaticCtorSection(
-    unsigned Priority, const MCSymbol *KeySym) const {
-  return getStaticStructorSectionGOFF(getContext(), TextSection, Priority);
-}
-
-MCSection *TargetLoweringObjectFileGOFF::getStaticDtorSection(
+MCSection *TargetLoweringObjectFileGOFF::getStaticXtorSection(
     unsigned Priority, const MCSymbol *KeySym) const {
   return getStaticStructorSectionGOFF(getContext(), TextSection, Priority);
 }

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2863,8 +2863,8 @@ MCSection *TargetLoweringObjectFileGOFF::SelectSectionForGlobal(
   return TextSection;
 }
 
-MCSection *TargetLoweringObjectFileGOFF::getStaticXtorSection(
-    unsigned Priority) const {
+MCSection *
+TargetLoweringObjectFileGOFF::getStaticXtorSection(unsigned Priority) const {
   // XL C/C++ compilers on z/OS support priorities from min-int to max-int, with
   // sinit as source priority 0. For clang, sinit has source priority 65535.
   // For GOFF, the priority sortkey field is an unsigned value. So, we

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2795,6 +2795,10 @@ void TargetLoweringObjectFileGOFF::getModuleMetadata(Module &M) {
   TextLD->setWeak(false);
   TextLD->setADA(ADAPR);
   TextSection->setBeginSymbol(TextLD);
+  // Initialize the label for the ADA section.
+  MCSymbolGOFF *ADASym = static_cast<MCSymbolGOFF *>(
+      getContext().getOrCreateSymbol(ADAPR->getName()));
+  ADAPR->setBeginSymbol(ADASym);
 }
 
 MCSection *TargetLoweringObjectFileGOFF::getExplicitSectionGlobal(
@@ -2859,10 +2863,9 @@ MCSection *TargetLoweringObjectFileGOFF::SelectSectionForGlobal(
   return TextSection;
 }
 
-static MCSectionGOFF *getStaticStructorSectionGOFF(MCContext &Ctx,
-                                                   const MCSection *TextSection,
-                                                   unsigned Priority) {
-  // xl compilers on z/OS support priorities from min-int to max-int, with
+MCSection *TargetLoweringObjectFileGOFF::getStaticXtorSection(
+    unsigned Priority) const {
+  // XL C/C++ compilers on z/OS support priorities from min-int to max-int, with
   // sinit as source priority 0. For clang, sinit has source priority 65535.
   // For GOFF, the priority sortkey field is an unsigned value. So, we
   // add min-int to get sorting to work properly but also subtract the
@@ -2875,6 +2878,7 @@ static MCSectionGOFF *getStaticStructorSectionGOFF(MCContext &Ctx,
   if (Priority != ClangDefaultSinitPriority)
     Name = llvm::Twine(Name).concat(".").concat(llvm::utostr(Priority)).str();
 
+  MCContext &Ctx = getContext();
   MCSectionGOFF *SInit = Ctx.getGOFFSection(
       SectionKind::getMetadata(), GOFF::CLASS_SINIT,
       GOFF::EDAttr{false, GOFF::ESD_RMODE_64, GOFF::ESD_NS_Parts,
@@ -2889,9 +2893,4 @@ static MCSectionGOFF *getStaticStructorSectionGOFF(MCContext &Ctx,
                    GOFF::ESD_BSC_Section, Prio},
       SInit);
   return Xtor;
-}
-
-MCSection *TargetLoweringObjectFileGOFF::getStaticXtorSection(
-    unsigned Priority, const MCSymbol *KeySym) const {
-  return getStaticStructorSectionGOFF(getContext(), TextSection, Priority);
 }

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2795,6 +2795,10 @@ void TargetLoweringObjectFileGOFF::getModuleMetadata(Module &M) {
   TextLD->setWeak(false);
   TextLD->setADA(ADAPR);
   TextSection->setBeginSymbol(TextLD);
+  // Initialize the label for the ADA section.
+  MCSymbolGOFF *ADASym = static_cast<MCSymbolGOFF *>(
+      getContext().getOrCreateSymbol(ADAPR->getName()));
+  ADAPR->setBeginSymbol(ADASym);
 }
 
 MCSection *TargetLoweringObjectFileGOFF::getExplicitSectionGlobal(
@@ -2857,4 +2861,49 @@ MCSection *TargetLoweringObjectFileGOFF::SelectSectionForGlobal(
                                        ED);
   }
   return TextSection;
+}
+
+static MCSectionGOFF *getStaticStructorSectionGOFF(MCContext &Ctx,
+                                                   const MCSection *TextSection,
+                                                   bool IsCtor,
+                                                   unsigned Priority) {
+  // xl compilers on z/OS support priorities from min-int to max-int, with
+  // sinit as source priority 0. For clang, sinit has source priority 65535.
+  // For GOFF, the priority sortkey field is an unsigned value. So, we
+  // add min-int to get sorting to work properly but also subtract the
+  // clang sinit (65535) value so internally xl sinit and clang sinit have
+  // the same unsigned GOFF priority sortkey field value (i.e. 0x80000000).
+  static constexpr const uint32_t ClangDefaultSinitPriority = 65535;
+  uint32_t Prio = Priority + (0x80000000 - ClangDefaultSinitPriority);
+
+  std::string Name(".xtor");
+  if (Priority != ClangDefaultSinitPriority)
+    Name = llvm::Twine(Name).concat(".").concat(llvm::utostr(Priority)).str();
+
+  MCSectionGOFF *SInit = Ctx.getGOFFSection(
+      SectionKind::getMetadata(), GOFF::CLASS_SINIT,
+      GOFF::EDAttr{false, GOFF::ESD_RMODE_64, GOFF::ESD_NS_Parts,
+                   GOFF::ESD_TS_ByteOriented, GOFF::ESD_BA_Merge,
+                   GOFF::ESD_LB_Initial, GOFF::ESD_RQ_0,
+                   GOFF::ESD_ALIGN_Doubleword},
+      static_cast<const MCSectionGOFF *>(TextSection)->getParent());
+
+  MCSectionGOFF *Xtor = Ctx.getGOFFSection(
+      SectionKind::getData(), Name,
+      GOFF::PRAttr{true, GOFF::ESD_EXE_DATA, GOFF::ESD_LT_XPLink,
+                   GOFF::ESD_BSC_Section, Prio},
+      SInit);
+  return Xtor;
+}
+
+MCSection *TargetLoweringObjectFileGOFF::getStaticCtorSection(
+    unsigned Priority, const MCSymbol *KeySym) const {
+  return getStaticStructorSectionGOFF(getContext(), TextSection, true,
+                                      Priority);
+}
+
+MCSection *TargetLoweringObjectFileGOFF::getStaticDtorSection(
+    unsigned Priority, const MCSymbol *KeySym) const {
+  return getStaticStructorSectionGOFF(getContext(), TextSection, false,
+                                      Priority);
 }

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1028,8 +1028,8 @@ void SystemZAsmPrinter::emitXXStructorList(const DataLayout &DL,
   const TargetLoweringObjectFileGOFF &Obj =
       static_cast<const TargetLoweringObjectFileGOFF &>(getObjFileLowering());
   for (Structor &S : Structors) {
-    MCSectionGOFF *Section = static_cast<MCSectionGOFF *>(
-        Obj.getStaticXtorSection(S.Priority));
+    MCSectionGOFF *Section =
+        static_cast<MCSectionGOFF *>(Obj.getStaticXtorSection(S.Priority));
     OutStreamer->switchSection(Section);
     if (OutStreamer->getCurrentSection() != OutStreamer->getPreviousSection())
       emitAlignment(Align);

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1025,11 +1025,11 @@ void SystemZAsmPrinter::emitXXStructorList(const DataLayout &DL,
     return;
 
   const Align Align = llvm::Align(4);
-  const TargetLoweringObjectFile &Obj = getObjFileLowering();
+  const TargetLoweringObjectFileGOFF &Obj =
+      static_cast<const TargetLoweringObjectFileGOFF &>(getObjFileLowering());
   for (Structor &S : Structors) {
     MCSectionGOFF *Section = static_cast<MCSectionGOFF *>(
-        IsCtor ? Obj.getStaticCtorSection(S.Priority, nullptr)
-               : Obj.getStaticDtorSection(S.Priority, nullptr));
+        Obj.getStaticXtorSection(S.Priority, nullptr));
     OutStreamer->switchSection(Section);
     if (OutStreamer->getCurrentSection() != OutStreamer->getPreviousSection())
       emitAlignment(Align);
@@ -1050,8 +1050,7 @@ void SystemZAsmPrinter::emitXXStructorList(const DataLayout &DL,
     ADAFuncRefExpr = MCBinaryExpr::createAdd(
         MCSpecifierExpr::create(MCSymbolRefExpr::create(ADASym, OutContext),
                                 SystemZ::S_QCon, OutContext),
-        MCConstantExpr::create(ADATable.insert(Symbol, SlotKind).second, Ctx),
-        Ctx);
+        MCConstantExpr::create(ADATable.insert(Symbol, SlotKind), Ctx), Ctx);
 
     emitInt32(XtorPriority);
     if (IsCtor) {

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1020,8 +1020,8 @@ void SystemZAsmPrinter::emitMachineConstantPoolValue(
 // Emit the ctor or dtor list taking into account the init priority.
 void SystemZAsmPrinter::emitXXStructorList(const DataLayout &DL,
                                            const Constant *List, bool IsCtor) {
-  if (TM.getTargetTriple().isOSBinFormatGOFF())
-    AsmPrinter::emitXXStructorList(DL, List, IsCtor);
+  if (!TM.getTargetTriple().isOSBinFormatGOFF())
+    return AsmPrinter::emitXXStructorList(DL, List, IsCtor);
 
   SmallVector<Structor, 8> Structors;
   preprocessXXStructorList(DL, List, Structors);
@@ -1639,14 +1639,16 @@ void SystemZAsmPrinter::emitPPA1(MCSymbol *FnEndSym) {
 }
 
 void SystemZAsmPrinter::emitStartOfAsmFile(Module &M) {
-  if (TM.getTargetTriple().isOSzOS())
+  if (TM.getTargetTriple().isOSzOS()) {
+    ADASym = getObjFileLowering().getADASection()->getBeginSymbol();
+
     emitPPA2(M);
+  }
+
   AsmPrinter::emitStartOfAsmFile(M);
 }
 
 void SystemZAsmPrinter::emitPPA2(Module &M) {
-  ADASym = getObjFileLowering().getADASection()->getBeginSymbol();
-
   OutStreamer->pushSection();
   OutStreamer->switchSection(getObjFileLowering().getTextSection(),
                              GOFF::SK_PPA2);

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1047,6 +1047,10 @@ void SystemZAsmPrinter::emitXXStructorList(const DataLayout &DL,
     auto &Ctx = OutStreamer->getContext();
     const MCExpr *ADAFuncRefExpr;
     unsigned SlotKind = SystemZII::MO_ADA_DIRECT_FUNC_DESC;
+    const MCSymbol *ADASym = Section->getBeginSymbol();
+    if (!ADASym)
+      ADASym = Ctx.getOrCreateSymbol(Section->getName());
+
     ADAFuncRefExpr = MCBinaryExpr::createAdd(
         MCSpecifierExpr::create(MCSymbolRefExpr::create(ADASym, OutContext),
                                 SystemZ::S_QCon, OutContext),
@@ -1632,12 +1636,8 @@ void SystemZAsmPrinter::emitPPA1(MCSymbol *FnEndSym) {
 }
 
 void SystemZAsmPrinter::emitStartOfAsmFile(Module &M) {
-  if (TM.getTargetTriple().isOSzOS()) {
-    ADASym = getObjFileLowering().getADASection()->getBeginSymbol();
-
+  if (TM.getTargetTriple().isOSzOS())
     emitPPA2(M);
-  }
-
   AsmPrinter::emitStartOfAsmFile(M);
 }
 

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1057,8 +1057,7 @@ void SystemZAsmPrinter::emitXXStructorList(const DataLayout &DL,
         static_cast<MCSectionGOFF *>(Obj.getADASection());
     assert(ADASection && "ADA section must exist for GOFF targets!");
     const MCSymbol *ADASym = ADASection->getBeginSymbol();
-    if (!ADASym)
-      ADASym = Ctx.getOrCreateSymbol(ADASection->getName());
+    assert(ADASym && "ADA symbol should already be set!");
 
     ADAFuncRefExpr = MCBinaryExpr::createAdd(
         MCSpecifierExpr::create(MCSymbolRefExpr::create(ADASym, OutContext),

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
@@ -31,6 +31,7 @@ private:
   MCSymbol *CurrentFnPPA1Sym;     // PPA1 Symbol.
   MCSymbol *CurrentFnEPMarkerSym; // Entry Point Marker.
   MCSymbol *PPA2Sym;
+  MCSymbol *ADASym;
 
   SystemZTargetStreamer *getTargetStreamer() {
     MCTargetStreamer *TS = OutStreamer->getTargetStreamer();
@@ -101,13 +102,15 @@ private:
 public:
   SystemZAsmPrinter(TargetMachine &TM, std::unique_ptr<MCStreamer> Streamer)
       : AsmPrinter(TM, std::move(Streamer), ID), CurrentFnPPA1Sym(nullptr),
-        CurrentFnEPMarkerSym(nullptr), PPA2Sym(nullptr),
+        CurrentFnEPMarkerSym(nullptr), PPA2Sym(nullptr), ADASym(nullptr),
         ADATable(TM.getPointerSize(0)) {}
 
   // Override AsmPrinter.
   StringRef getPassName() const override { return "SystemZ Assembly Printer"; }
   void emitInstruction(const MachineInstr *MI) override;
   void emitMachineConstantPoolValue(MachineConstantPoolValue *MCPV) override;
+  void emitXXStructorList(const DataLayout &DL, const Constant *List,
+                          bool IsCtor) override;
   void emitEndOfAsmFile(Module &M) override;
   bool PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
                        const char *ExtraCode, raw_ostream &OS) override;

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
@@ -31,7 +31,6 @@ private:
   MCSymbol *CurrentFnPPA1Sym;     // PPA1 Symbol.
   MCSymbol *CurrentFnEPMarkerSym; // Entry Point Marker.
   MCSymbol *PPA2Sym;
-  MCSymbol *ADASym;
 
   SystemZTargetStreamer *getTargetStreamer() {
     MCTargetStreamer *TS = OutStreamer->getTargetStreamer();
@@ -102,7 +101,7 @@ private:
 public:
   SystemZAsmPrinter(TargetMachine &TM, std::unique_ptr<MCStreamer> Streamer)
       : AsmPrinter(TM, std::move(Streamer), ID), CurrentFnPPA1Sym(nullptr),
-        CurrentFnEPMarkerSym(nullptr), PPA2Sym(nullptr), ADASym(nullptr),
+        CurrentFnEPMarkerSym(nullptr), PPA2Sym(nullptr),
         ADATable(TM.getPointerSize(0)) {}
 
   // Override AsmPrinter.

--- a/llvm/test/CodeGen/SystemZ/zos_sinit.ll
+++ b/llvm/test/CodeGen/SystemZ/zos_sinit.ll
@@ -6,12 +6,10 @@
 
 ; Check for presence of C_@@SQINIT:
 ; CHECK: 	.xtor.22
-; CHECK: 	DC AD(cfuncctor)
 ; CHECK: 	DC XL4'7FFF0017'
 ; Check direct relocation and low bit on ctor.
 ; CHECK:        DC AD(QD(stdin#S)+XL8'0')
 ; CHECK: 	DC XL8'0000000000000000'
-; CHECK:        DC AD(cfuncdtor)
 ; CHECK:        DC XL4'7FFF0017'
 ; CHECK:        DC XL8'0000000000000000'
 ; Check direct relocation and low bit on dtor.

--- a/llvm/test/CodeGen/SystemZ/zos_sinit.ll
+++ b/llvm/test/CodeGen/SystemZ/zos_sinit.ll
@@ -8,12 +8,12 @@
 ; CHECK: 	.xtor.22
 ; CHECK: 	DC XL4'7FFF0017'
 ; Check direct relocation and low bit on ctor.
-; CHECK:        DC AD(QD(.xtor.22)+XL8'0')
+; CHECK:        DC AD(QD(stdin#S)+XL8'0')
 ; CHECK: 	DC XL8'0000000000000000'
 ; CHECK:        DC XL4'7FFF0017'
 ; CHECK:        DC XL8'0000000000000000'
 ; Check direct relocation and low bit on dtor.
-; CHECK:        DC AD(QD(.xtor.22)+XL8'16')
+; CHECK:        DC AD(QD(stdin#S)+XL8'16')
 
 ; Check for function descriptors in ADA section:
 ; CHECK:        * Offset 0 function descriptor of cfuncctor

--- a/llvm/test/CodeGen/SystemZ/zos_sinit.ll
+++ b/llvm/test/CodeGen/SystemZ/zos_sinit.ll
@@ -1,0 +1,36 @@
+; RUN: llc -emit-gnuas-syntax-on-zos=false < %s -mtriple=s390x-ibm-zos | \
+; RUN: FileCheck --check-prefixes=CHECK %s
+
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 22, ptr @cfuncctor, ptr null }]
+@llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 22, ptr @cfuncdtor, ptr null }]
+
+; Check for presence of C_@@SQINIT:
+; CHECK: 	.xtor.22
+; CHECK: 	DC AD(cfuncctor)
+; CHECK: 	DC XL4'7FFF0017'
+; Check direct relocation and low bit on ctor.
+; CHECK:        DC AD(QD(stdin#S)+XL8'0')
+; CHECK: 	DC XL8'0000000000000000'
+; CHECK:        DC AD(cfuncdtor)
+; CHECK:        DC XL4'7FFF0017'
+; CHECK:        DC XL8'0000000000000000'
+; Check direct relocation and low bit on dtor.
+; CHECK:        DC AD(QD(stdin#S)+XL8'16')
+
+; Check for function descriptors in ADA section:
+; CHECK:        * Offset 0 function descriptor of cfuncctor
+; CHECK:        DC RD(cfuncctor)
+; CHECK:        DC VD(cfuncctor)
+; CHECK:        * Offset 16 function descriptor of cfuncdtor
+; CHECK:        DC RD(cfuncdtor)
+; CHECK:        DC VD(cfuncdtor)
+
+define hidden void @cfuncctor() {
+entry:
+  ret void
+}
+
+define hidden void @cfuncdtor() {
+entry:
+  ret void
+}

--- a/llvm/test/CodeGen/SystemZ/zos_sinit.ll
+++ b/llvm/test/CodeGen/SystemZ/zos_sinit.ll
@@ -8,12 +8,12 @@
 ; CHECK: 	.xtor.22
 ; CHECK: 	DC XL4'7FFF0017'
 ; Check direct relocation and low bit on ctor.
-; CHECK:        DC AD(QD(stdin#S)+XL8'0')
+; CHECK:        DC AD(QD(.xtor.22)+XL8'0')
 ; CHECK: 	DC XL8'0000000000000000'
 ; CHECK:        DC XL4'7FFF0017'
 ; CHECK:        DC XL8'0000000000000000'
 ; Check direct relocation and low bit on dtor.
-; CHECK:        DC AD(QD(stdin#S)+XL8'16')
+; CHECK:        DC AD(QD(.xtor.22)+XL8'16')
 
 ; Check for function descriptors in ADA section:
 ; CHECK:        * Offset 0 function descriptor of cfuncctor


### PR DESCRIPTION
This patch implements support for constructors/destructors by introducing the
`@@SQINIT` section and emitting `.xtor.<priority>` sections within the SystemZ
AsmPrinter and in the GOFF object lowering layer. 