### PR TITLE
[Flang-rt] Implement same behavior as -O3 for zero-length arrays

### DIFF
--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -366,7 +366,7 @@ RT_API_ATTRS int AssignTicket::Begin(WorkQueue &workQueue) {
                                    "assignment to unallocated allocatable",
           to_.rank(), from_->rank());
     }
-  } else if (!to_.IsAllocated()) {
+  } else if (!to_.IsAllocated() && to_.Elements()) {
     workQueue.terminator().Crash(
         "Assign: left-hand side variable is neither allocated nor allocatable");
   }


### PR DESCRIPTION
This PR addresses an issue of incorrect code where an unallocated array is passed to a routine as a zero-length array.  When compiling such a code with -O3, the assignment is ignored, but -O0 chokes in flang-rt due to an allocation check condition in the original code. Adding the extra condition makes the behavior consistent with -O3.