### PR TITLE
[LLVM][AArch64] Remove hasNoSchedulingInfo from SVE pseudo instructions.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedA320.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedA320.td
@@ -639,7 +639,7 @@ def : InstRW<[CortexA320Write<2, CortexA320UnitVALU>], (instregex "^PTRUES_[BHSD
 def : InstRW<[CortexA320Write<2, CortexA320UnitVALU>], (instregex "^PFIRST_B", "^PNEXT_[BHSD]")>;
 
 // Predicate test
-def : InstRW<[CortexA320Write<2, CortexA320UnitVALU>], (instrs PTEST_PP)>;
+def : InstRW<[CortexA320Write<2, CortexA320UnitVALU>], (instrs PTEST_PP, PTEST_PP_ANY, PTEST_PP_FIRST)>;
 
 // Predicate transpose
 def : InstRW<[CortexA320Write<2, CortexA320UnitVALU>], (instregex "^TRN[12]_PPP_[BHSDQ]")>;

--- a/llvm/lib/Target/AArch64/AArch64SchedA510.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedA510.td
@@ -617,7 +617,7 @@ def : InstRW<[CortexA510Write<2, CortexA510UnitVALU0>], (instregex "^PTRUES_[BHS
 def : InstRW<[CortexA510Write<2, CortexA510UnitVALU0>], (instregex "^PFIRST_B", "^PNEXT_[BHSD]")>;
 
 // Predicate test
-def : InstRW<[CortexA510Write<2, CortexA510UnitVALU0>], (instrs PTEST_PP)>;
+def : InstRW<[CortexA510Write<2, CortexA510UnitVALU0>], (instrs PTEST_PP, PTEST_PP_ANY, PTEST_PP_FIRST)>;
 
 // Predicate transpose
 def : InstRW<[CortexA510Write<2, CortexA510UnitVALU0>], (instregex "^TRN[12]_PPP_[BHSDQ]")>;

--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseN2.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseN2.td
@@ -1625,7 +1625,7 @@ def : InstRW<[N2Write_3c_1M], (instregex "^PTRUES_[BHSD]$")>;
 def : InstRW<[N2Write_3c_1M], (instregex "^PFIRST_B$", "^PNEXT_[BHSD]$")>;
 
 // Predicate test
-def : InstRW<[N2Write_1c_1M], (instrs PTEST_PP)>;
+def : InstRW<[N2Write_1c_1M], (instrs PTEST_PP, PTEST_PP_ANY, PTEST_PP_FIRST)>;
 
 // Predicate transpose
 def : InstRW<[N2Write_2c_1M], (instregex "^TRN[12]_PPP_[BHSDQ]$")>;

--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseN3.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseN3.td
@@ -1715,7 +1715,7 @@ def : InstRW<[N3Write_0or2c_1M], (instregex "^PTRUES_[BHSD]")>;
 def : InstRW<[N3Write_2c_1M], (instregex "^PFIRST_B$", "^PNEXT_[BHSD]$")>;
 
 // Predicate test
-def : InstRW<[N3Write_1c_1M], (instrs PTEST_PP)>;
+def : InstRW<[N3Write_1c_1M], (instrs PTEST_PP, PTEST_PP_ANY, PTEST_PP_FIRST)>;
 
 // Predicate transpose
 def : InstRW<[N3Write_2c_1M], (instregex "^TRN[12]_PPP_[BHSDQ]$")>;

--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseV1.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseV1.td
@@ -1481,7 +1481,7 @@ def : InstRW<[V1Write_2c_1M0], (instregex "^REV_PP_[BHSD]$",
 
 // Predicate set/initialize/find next
 // Predicate unpack and widen
-def : InstRW<[V1Write_2c_1M0], (instrs PTEST_PP,
+def : InstRW<[V1Write_2c_1M0], (instrs PTEST_PP, PTEST_PP_ANY, PTEST_PP_FIRST,
                                        PUNPKHI_PP, PUNPKLO_PP)>;
 
 // Predicate select

--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseV2.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseV2.td
@@ -2088,7 +2088,7 @@ def : InstRW<[V2Write_3c_2M], (instregex "^PTRUES_[BHSD]")>;
 def : InstRW<[V2Write_2c_1M], (instregex "^PFIRST_B", "^PNEXT_[BHSD]")>;
 
 // Predicate test
-def : InstRW<[V2Write_1c_1M], (instrs PTEST_PP)>;
+def : InstRW<[V2Write_1c_1M], (instrs PTEST_PP, PTEST_PP_ANY, PTEST_PP_FIRST)>;
 
 // Predicate transpose
 def : InstRW<[V2Write_2c_1M], (instregex "^TRN[12]_PPP_[BHSD]")>;

--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3.td
@@ -2017,7 +2017,7 @@ def : InstRW<[V3Write_2c_1M], (instregex "^PTRUES_[BHSD]")>;
 def : InstRW<[V3Write_2c_1M], (instregex "^PFIRST_B", "^PNEXT_[BHSD]")>;
 
 // Predicate test
-def : InstRW<[V3Write_1c_1M], (instrs PTEST_PP)>;
+def : InstRW<[V3Write_1c_1M], (instrs PTEST_PP, PTEST_PP_ANY, PTEST_PP_FIRST)>;
 
 // Predicate transpose
 def : InstRW<[V3Write_2c_1M], (instregex "^TRN[12]_PPP_[BHSD]")>;

--- a/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3AE.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedNeoverseV3AE.td
@@ -1945,7 +1945,7 @@ def : InstRW<[V3AEWrite_2c_1M], (instregex "^PTRUES_[BHSD]")>;
 def : InstRW<[V3AEWrite_2c_1M], (instregex "^PFIRST_B", "^PNEXT_[BHSD]")>;
 
 // Predicate test
-def : InstRW<[V3AEWrite_1c_1M], (instrs PTEST_PP)>;
+def : InstRW<[V3AEWrite_1c_1M], (instrs PTEST_PP, PTEST_PP_ANY, PTEST_PP_FIRST)>;
 
 // Predicate transpose
 def : InstRW<[V3AEWrite_2c_1M], (instregex "^TRN[12]_PPP_[BHSD]")>;

--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -800,45 +800,43 @@ class SVEInstr2Rev<string name1, string name2, bit name1IsReverseInstr> {
 //
 // Pseudos for destructive operands
 //
-let hasNoSchedulingInfo = 1 in {
-  class PredTwoOpPseudo<string name, ZPRRegOp zprty,
+
+class PredTwoOpPseudo<string name, ZPRRegOp zprty,
+                      FalseLanesEnum flags = FalseLanesNone>
+: SVEPseudo2Instr<name, 0>,
+  Pseudo<(outs zprty:$Zd), (ins PPR3bAny:$Pg, zprty:$Zs1, zprty:$Zs2), []> {
+  let FalseLanes = flags;
+}
+
+class PredTwoOpImmPseudo<string name, ZPRRegOp zprty, Operand immty,
+                         FalseLanesEnum flags = FalseLanesNone>
+: SVEPseudo2Instr<name, 0>,
+  Pseudo<(outs zprty:$Zd), (ins PPR3bAny:$Pg, zprty:$Zs1, immty:$imm), []> {
+  let FalseLanes = flags;
+}
+
+class PredThreeOpPseudo<string name, ZPRRegOp zprty,
                         FalseLanesEnum flags = FalseLanesNone>
-  : SVEPseudo2Instr<name, 0>,
-    Pseudo<(outs zprty:$Zd), (ins PPR3bAny:$Pg, zprty:$Zs1, zprty:$Zs2), []> {
-    let FalseLanes = flags;
-  }
+: SVEPseudo2Instr<name, 0>,
+  Pseudo<(outs zprty:$Zd), (ins PPR3bAny:$Pg, zprty:$Zs1, zprty:$Zs2, zprty:$Zs3), []> {
+  let FalseLanes = flags;
+}
 
-  class PredTwoOpImmPseudo<string name, ZPRRegOp zprty, Operand immty,
-                           FalseLanesEnum flags = FalseLanesNone>
-  : SVEPseudo2Instr<name, 0>,
-    Pseudo<(outs zprty:$Zd), (ins PPR3bAny:$Pg, zprty:$Zs1, immty:$imm), []> {
-    let FalseLanes = flags;
-  }
-
-  class PredThreeOpPseudo<string name, ZPRRegOp zprty,
-                          FalseLanesEnum flags = FalseLanesNone>
-  : SVEPseudo2Instr<name, 0>,
-    Pseudo<(outs zprty:$Zd), (ins PPR3bAny:$Pg, zprty:$Zs1, zprty:$Zs2, zprty:$Zs3), []> {
-    let FalseLanes = flags;
-  }
-
-  class UnpredRegImmPseudo<ZPRRegOp zprty, Operand immty>
-  : SVEPseudo2Instr<NAME, 0>,
-    Pseudo<(outs zprty:$Zd), (ins zprty:$Zs, immty:$imm), []> {
-  }
+class UnpredRegImmPseudo<ZPRRegOp zprty, Operand immty>
+: SVEPseudo2Instr<NAME, 0>,
+  Pseudo<(outs zprty:$Zd), (ins zprty:$Zs, immty:$imm), []> {
 }
 
 //
 // Pseudos for passthru operands
 //
-let hasNoSchedulingInfo = 1 in {
-  class PredOneOpPassthruPseudo<string name, ZPRRegOp zprty,
-                                FalseLanesEnum flags = FalseLanesNone>
-  : SVEPseudo2Instr<name, 0>,
-    Pseudo<(outs zprty:$Zd), (ins zprty:$Passthru, PPR3bAny:$Pg, zprty:$Zs), []> {
-    let FalseLanes = flags;
-    let Constraints = !if(!eq(flags, FalseLanesZero), "$Zd = $Passthru,@earlyclobber $Zd", "");
-  }
+
+class PredOneOpPassthruPseudo<string name, ZPRRegOp zprty,
+                              FalseLanesEnum flags = FalseLanesNone>
+: SVEPseudo2Instr<name, 0>,
+  Pseudo<(outs zprty:$Zd), (ins zprty:$Passthru, PPR3bAny:$Pg, zprty:$Zs), []> {
+  let FalseLanes = flags;
+  let Constraints = !if(!eq(flags, FalseLanesZero), "$Zd = $Passthru,@earlyclobber $Zd", "");
 }
 
 //===----------------------------------------------------------------------===//
@@ -901,7 +899,7 @@ multiclass sve_int_ptest<bits<6> opc, string asm, SDPatternOperator op,
                          SDPatternOperator op_any, SDPatternOperator op_first> {
   def NAME : sve_int_ptest<opc, asm, op>;
 
-  let hasNoSchedulingInfo = 1, isCompare = 1, Defs = [NZCV] in {
+  let isCompare = 1, Defs = [NZCV] in {
   def _ANY : Pseudo<(outs), (ins PPRAny:$Pg, PPR8:$Pn),
                     [(set NZCV, (op_any (nxv16i1 PPRAny:$Pg), (nxv16i1 PPR8:$Pn)))]>,
              PseudoInstExpansion<(!cast<Instruction>(NAME) PPRAny:$Pg, PPR8:$Pn)>;

--- a/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
@@ -103,11 +103,15 @@ void runSVEPseudoTestForCPU(const std::string &CPU) {
 }
 
 // TODO : Add more CPUs that support SVE/SVE2
+TEST(AArch64SVESchedPseudoTesta320, IsCorrect) {
+  runSVEPseudoTestForCPU("cortex-a320");
+}
+
 TEST(AArch64SVESchedPseudoTesta510, IsCorrect) {
   runSVEPseudoTestForCPU("cortex-a510");
 }
 
-TEST(AArch64SVESchedPseudoTestn1, IsCorrect) {
+TEST(AArch64SVESchedPseudoTestn2, IsCorrect) {
   runSVEPseudoTestForCPU("neoverse-n2");
 }
 
@@ -121,6 +125,14 @@ TEST(AArch64SVESchedPseudoTestv1, IsCorrect) {
 
 TEST(AArch64SVESchedPseudoTestv2, IsCorrect) {
   runSVEPseudoTestForCPU("neoverse-v2");
+}
+
+TEST(AArch64SVESchedPseudoTestv3, IsCorrect) {
+  runSVEPseudoTestForCPU("neoverse-v3");
+}
+
+TEST(AArch64SVESchedPseudoTestv3ae, IsCorrect) {
+  runSVEPseudoTestForCPU("neoverse-v3ae");
 }
 
 } // namespace


### PR DESCRIPTION
These should always have the same schediling information as their real instruction counterparts. Removing this property means we'll catch missing entries when building the compiler.