### PR TITLE
[bazel] Port 24117f75ad9d7bbb439e8e1bd596fdcf0aa8d6e2

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-doc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-doc/BUILD.bazel
@@ -28,7 +28,6 @@ cc_library(
         exclude = [
             "Generators.cpp",
             "HTMLGenerator.cpp",
-            "HTMLMustacheGenerator.cpp",
             "MDGenerator.cpp",
             "YAMLGenerator.cpp",
         ],
@@ -53,7 +52,6 @@ cc_library(
     srcs = [
         "Generators.cpp",
         "HTMLGenerator.cpp",
-        "HTMLMustacheGenerator.cpp",
         "MDGenerator.cpp",
         "YAMLGenerator.cpp",
     ],


### PR DESCRIPTION
This patch removed some source files that were explicitly enumerated in the bazel files. Remove them so that the build passes.