### PR TITLE
[MLIR][Bytecode] Use consistent types for resolveEntry

### DIFF
--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -1320,8 +1320,9 @@ LogicalResult AttrTypeReader::initialize(
 }
 
 template <typename T>
-T AttrTypeReader::resolveEntry(SmallVectorImpl<Entry<T>> &entries, size_t index,
-                               StringRef entryType, uint64_t depth) {
+T AttrTypeReader::resolveEntry(SmallVectorImpl<Entry<T>> &entries,
+                               uint64_t index, StringRef entryType,
+                               uint64_t depth) {
   if (index >= entries.size()) {
     emitError(fileLoc) << "invalid " << entryType << " index: " << index;
     return {};


### PR DESCRIPTION
uint64_t and size_t are not the same across all platforms. This was causing build failures when building this file for wasm:

llvm-project/mlir/lib/Bytecode/Reader/BytecodeReader.cpp:1323:19: error: out-of-line definition of 'resolveEntry' does not match any declaration in '(anonymous namespace)::AttrTypeReader'
 1323 | T AttrTypeReader::resolveEntry(SmallVectorImpl<Entry<T>> &entries, size_t index,
      |                   ^~~~~~~~~~~~
third_party/llvm/llvm-project/mlir/lib/Bytecode/Reader/BytecodeReader.cpp:851:7: note: AttrTypeReader defined here
  851 | class AttrTypeReader {
      |       ^~~~~~~~~~~~~~
1 error generated.

Use uint64_t everywhere to ensure portability.