### PR TITLE
[sanitizer_common] child_stdin_fd_ should only be set on posix_spawn path

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
@@ -176,6 +176,10 @@ bool SymbolizerProcess::StartSymbolizerSubprocess() {
       internal_close(outfd[1]);
       return false;
     }
+
+    // We intentionally hold on to the read-end so that we don't get a SIGPIPE
+    child_stdin_fd_ = outfd[0];
+
 #  else   // SANITIZER_APPLE
     UNIMPLEMENTED();
 #  endif  // SANITIZER_APPLE
@@ -191,9 +195,6 @@ bool SymbolizerProcess::StartSymbolizerSubprocess() {
 
   input_fd_ = infd[0];
   output_fd_ = outfd[1];
-
-  // We intentionally hold on to the read-end so that we don't get a SIGPIPE
-  child_stdin_fd_ = outfd[0];
 
   CHECK_GT(pid, 0);
 


### PR DESCRIPTION
#170809 added the child_stdin_fd_ field on SymbolizerProcess to allow the parent process to hold on to the read in of the child's stdin pipe. This was to avoid SIGPIPE.

However, the `StartSubprocess` path still closes the stdin fd in the parent here:
https://github.com/llvm/llvm-project/blob/7f5ed91684c808444ede24eb01ad9af73b5806e5/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp#L525-L535

This could cause a double-close of this fd (problematic in the case of fd reuse).

This moves the `child_stdin_fd_` field to only be initialized on the posix_spawn path. This should ensure #170809 only truly affects Darwin.