### PR TITLE
[sanitizer_common] Fix SIGPIPE when symbolizer started by StartSubprocess dies

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
@@ -523,9 +523,6 @@ pid_t StartSubprocess(const char *program, const char *const argv[],
                       const char *const envp[], fd_t stdin_fd, fd_t stdout_fd,
                       fd_t stderr_fd) {
   auto file_closer = at_scope_exit([&] {
-    if (stdin_fd != kInvalidFd) {
-      internal_close(stdin_fd);
-    }
     if (stdout_fd != kInvalidFd) {
       internal_close(stdout_fd);
     }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp
@@ -176,10 +176,6 @@ bool SymbolizerProcess::StartSymbolizerSubprocess() {
       internal_close(outfd[1]);
       return false;
     }
-
-    // We intentionally hold on to the read-end so that we don't get a SIGPIPE
-    child_stdin_fd_ = outfd[0];
-
 #  else   // SANITIZER_APPLE
     UNIMPLEMENTED();
 #  endif  // SANITIZER_APPLE
@@ -195,6 +191,8 @@ bool SymbolizerProcess::StartSymbolizerSubprocess() {
 
   input_fd_ = infd[0];
   output_fd_ = outfd[1];
+  // We intentionally hold on to the read-end so that we don't get a SIGPIPE
+  child_stdin_fd_ = outfd[0];
 
   CHECK_GT(pid, 0);
 


### PR DESCRIPTION
It's possible for the sanitized process to get SIGPIPE if the symbolizer dies. To prevent this from happening, #170809 added a field to SymbolizerProcess that can hold the read end of the child's stdin. This keeps the read end of the stdin pipe open for the lifetime of the SymbolizerProcess, which prevents us from getting SIGPIPE.

#170809 only uses this field on the posix_spawn path. This PR makes the change to the StartSubprocess path as well.

This should help mitigate the consequences of #120915