### PR TITLE
[NFC][SPIRV] Fix breakage introduced by #170798

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -115,18 +115,19 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
                            v4s1, v4s8, v4s16, v4s32, v4s64};
 
   auto allScalarsAndVectors = {
-      s1,   s8,   s16,   s32,   s64,   v2s1,  v2s8,  v2s16,  v2s32,  v2s64,
-      v3s1, v3s8, v3s16, v3s32, v3s64, v4s1,  v4s8,  v4s16,  v4s32,  v4s64,
-      v8s1, v8s8, v8s16, v8s32, v8s64, v16s1, v16s8, v16s16, v16s32, v16s64};
+      s1,    s8,   s16,  s32,   s64,   s128,  v2s1,  v2s8,  v2s16,  v2s32,
+      v2s64, v3s1, v3s8, v3s16, v3s32, v3s64, v4s1,  v4s8,  v4s16,  v4s32,
+      v4s64, v8s1, v8s8, v8s16, v8s32, v8s64, v16s1, v16s8, v16s16, v16s32,
+      v16s64};
 
-  auto allIntScalarsAndVectors = {s8,    s16,   s32,   s64,    v2s8,   v2s16,
-                                  v2s32, v2s64, v3s8,  v3s16,  v3s32,  v3s64,
-                                  v4s8,  v4s16, v4s32, v4s64,  v8s8,   v8s16,
-                                  v8s32, v8s64, v16s8, v16s16, v16s32, v16s64};
+  auto allIntScalarsAndVectors = {
+      s8,    s16,   s32,    s64,    s128,  v2s8,  v2s16, v2s32, v2s64, v3s8,
+      v3s16, v3s32, v3s64,  v4s8,   v4s16, v4s32, v4s64, v8s8,  v8s16, v8s32,
+      v8s64, v16s8, v16s16, v16s32, v16s64};
 
   auto allBoolScalarsAndVectors = {s1, v2s1, v3s1, v4s1, v8s1, v16s1};
 
-  auto allIntScalars = {s8, s16, s32, s64};
+  auto allIntScalars = {s8, s16, s32, s64, s128};
 
   auto allFloatScalarsAndF16Vector2AndVector4s = {s16, s32, s64, v2s16, v4s16};
 

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -115,15 +115,15 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
                            v4s1, v4s8, v4s16, v4s32, v4s64};
 
   auto allScalarsAndVectors = {
-      s1,    s8,   s16,  s32,   s64,   s128,  v2s1,  v2s8,  v2s16,  v2s32,
-      v2s64, v3s1, v3s8, v3s16, v3s32, v3s64, v4s1,  v4s8,  v4s16,  v4s32,
-      v4s64, v8s1, v8s8, v8s16, v8s32, v8s64, v16s1, v16s8, v16s16, v16s32,
-      v16s64};
+      s1,    s8,    s16,   s32,   s64,    s128,   v2s1,  v2s8,
+      v2s16, v2s32, v2s64, v3s1,  v3s8,   v3s16,  v3s32, v3s64,
+      v4s1,  v4s8,  v4s16, v4s32, v4s64,  v8s1,   v8s8,  v8s16,
+      v8s32, v8s64, v16s1, v16s8, v16s16, v16s32, v16s64};
 
   auto allIntScalarsAndVectors = {
-      s8,    s16,   s32,    s64,    s128,  v2s8,  v2s16, v2s32, v2s64, v3s8,
-      v3s16, v3s32, v3s64,  v4s8,   v4s16, v4s32, v4s64, v8s8,  v8s16, v8s32,
-      v8s64, v16s8, v16s16, v16s32, v16s64};
+      s8,    s16,   s32,   s64,   s128,   v2s8,   v2s16, v2s32, v2s64,
+      v3s8,  v3s16, v3s32, v3s64, v4s8,   v4s16,  v4s32, v4s64, v8s8,
+      v8s16, v8s32, v8s64, v16s8, v16s16, v16s32, v16s64};
 
   auto allBoolScalarsAndVectors = {s1, v2s1, v3s1, v4s1, v8s1, v16s1};
 

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -388,11 +388,11 @@ static SPIRVType *propagateSPIRVType(MachineInstr *MI, SPIRVGlobalRegistry *GR,
 
 // To support current approach and limitations wrt. bit width here we widen a
 // scalar register with a bit width greater than 1 to valid sizes and cap it to
-// 64 width.
+// 128 width.
 static unsigned widenBitWidthToNextPow2(unsigned BitWidth) {
   if (BitWidth == 1)
     return 1; // No need to widen 1-bit values
-  return std::min(std::max(1u << Log2_32_Ceil(BitWidth), 8u), 64u);
+  return std::min(std::max(1u << Log2_32_Ceil(BitWidth), 8u), 128u);
 }
 
 static void widenScalarType(Register Reg, MachineRegisterInfo &MRI) {


### PR DESCRIPTION
Adding support for i128 missed a few quirks of legalisation, which were masked previously by early erroring out on bitwidth > 64. i128 uses should be legal, we decide whether or not the resulting module is viable (i.e. if the required extensions are present) in the ModuleAnalysis pass.