### PR TITLE
[lldb] Remove CommandReturnObject::AppendRawError

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -129,8 +129,6 @@ public:
 
   void AppendError(llvm::StringRef in_string);
 
-  void AppendRawError(llvm::StringRef in_string);
-
   void AppendErrorWithFormat(const char *format, ...)
       __attribute__((format(printf, 2, 3)));
 

--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -205,7 +205,7 @@ void CommandObjectMultiword::Execute(const char *args_string,
             .str());
   }
   error_msg.append("\n");
-  result.AppendRawError(error_msg.c_str());
+  result.AppendError(error_msg);
 }
 
 std::string CommandObjectMultiword::GetSubcommandsHintText() {

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -3708,7 +3708,7 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
           for (uint32_t i = 0; i < num_matches; ++i) {
             error_msg.Printf("\t%s\n", matches.GetStringAtIndex(i));
           }
-          result.AppendRawError(error_msg.GetString());
+          result.AppendError(error_msg.GetString());
         }
       } else {
         // We didn't have only one match, otherwise we wouldn't get here.

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -173,15 +173,6 @@ StructuredData::ObjectSP CommandReturnObject::GetErrorData() {
   return Serialize(m_diagnostics);
 }
 
-// Similar to AppendError, but do not prepend 'Status: ' to message, and don't
-// append "\n" to the end of it.
-
-void CommandReturnObject::AppendRawError(llvm::StringRef in_string) {
-  SetStatus(eReturnStatusFailed);
-  assert(!in_string.empty() && "Expected a non-empty error message");
-  GetErrorStream() << in_string;
-}
-
 void CommandReturnObject::SetStatus(ReturnStatus status) { m_status = status; }
 
 ReturnStatus CommandReturnObject::GetStatus() const { return m_status; }

--- a/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
+++ b/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
@@ -41,7 +41,7 @@ class AbbreviationsTestCase(TestBase):
         # "pl" could be "platform" or "plugin".
         command_interpreter.ResolveCommand("pl", result)
         self.assertFalse(result.Succeeded())
-        self.assertTrue(result.GetError().startswith("Ambiguous command"))
+        self.assertTrue(result.GetError().startswith("error: Ambiguous command"))
 
         # Make sure an unabbreviated command is not mangled.
         command_interpreter.ResolveCommand(

--- a/lldb/test/API/functionalities/ambigous_commands/TestAmbiguousCommands.py
+++ b/lldb/test/API/functionalities/ambigous_commands/TestAmbiguousCommands.py
@@ -24,7 +24,7 @@ class AmbiguousCommandTestCase(TestBase):
         self.assertFalse(result.Succeeded())
         self.assertEqual(
             result.GetError(),
-            "Ambiguous command 'co'. Possible matches:\n\tcommand\n\tcontinue\n\tcorefile\n",
+            "error: Ambiguous command 'co'. Possible matches:\n\tcommand\n\tcontinue\n\tcorefile\n",
         )
 
         command_interpreter.HandleCommand("command unalias continue", result)

--- a/lldb/test/API/functionalities/wrong_commands/TestWrongCommands.py
+++ b/lldb/test/API/functionalities/wrong_commands/TestWrongCommands.py
@@ -17,7 +17,9 @@ class UnknownCommandTestCase(TestBase):
 
         command_interpreter.HandleCommand("g", result)
         self.assertFalse(result.Succeeded())
-        self.assertRegex(result.GetError(), "Ambiguous command 'g'. Possible matches:")
+        self.assertRegex(
+            result.GetError(), "error: Ambiguous command 'g'. Possible matches:"
+        )
         self.assertRegex(result.GetError(), "gui")
         self.assertRegex(result.GetError(), "gdb-remote")
         self.assertEqual(1, result.GetError().count("gdb-remote"))

--- a/lldb/test/Shell/Commands/command-wrong-subcommand-error-msg.test
+++ b/lldb/test/Shell/Commands/command-wrong-subcommand-error-msg.test
@@ -4,5 +4,5 @@
 # RUN: not %lldb -b -o 'breakpoint foo' %t.out -o exit 2>&1 | FileCheck %s --check-prefix BP-MSG
 # RUN: not %lldb -b -o 'watchpoint set foo' %t.out -o exit 2>&1 | FileCheck %s --check-prefix WP-MSG
 # CHECK: at main.c:2:21
-# BP-MSG: "foo" is not a valid subcommand of "breakpoint". Valid subcommands are: add, clear, command, delete, disable, and others. Use "help breakpoint" to find out more.
-# WP-MSG: "foo" is not a valid subcommand of "watchpoint set". Valid subcommands are: expression, variable. Use "help watchpoint set" to find out more.
+# BP-MSG: error: "foo" is not a valid subcommand of "breakpoint". Valid subcommands are: add, clear, command, delete, disable, and others. Use "help breakpoint" to find out more.
+# WP-MSG: error: "foo" is not a valid subcommand of "watchpoint set". Valid subcommands are: expression, variable. Use "help watchpoint set" to find out more.


### PR DESCRIPTION
Remove `CommandReturnObject::AppendRawError` and replace its two uses with `AppendError`, which correctly prefixes the message with `error:`. The comment for the method is outdated and the prefixing is clearly desired in both situations.