### PR TITLE
[lldb] Fix capitalization in ambiguous command error

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -3702,12 +3702,10 @@ CommandInterpreter::ResolveCommandImpl(std::string &command_line,
           done = static_cast<bool>(cmd_obj);
         } else {
           StreamString error_msg;
-          error_msg.Printf("Ambiguous command '%s'. Possible matches:\n",
+          error_msg.Printf("ambiguous command '%s'. Possible matches:\n",
                            next_word.c_str());
-
-          for (uint32_t i = 0; i < num_matches; ++i) {
+          for (uint32_t i = 0; i < num_matches; ++i)
             error_msg.Printf("\t%s\n", matches.GetStringAtIndex(i));
-          }
           result.AppendError(error_msg.GetString());
         }
       } else {

--- a/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
+++ b/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
@@ -41,7 +41,7 @@ class AbbreviationsTestCase(TestBase):
         # "pl" could be "platform" or "plugin".
         command_interpreter.ResolveCommand("pl", result)
         self.assertFalse(result.Succeeded())
-        self.assertTrue(result.GetError().startswith("error: Ambiguous command"))
+        self.assertTrue(result.GetError().startswith("error: ambiguous command"))
 
         # Make sure an unabbreviated command is not mangled.
         command_interpreter.ResolveCommand(

--- a/lldb/test/API/functionalities/ambigous_commands/TestAmbiguousCommands.py
+++ b/lldb/test/API/functionalities/ambigous_commands/TestAmbiguousCommands.py
@@ -24,7 +24,7 @@ class AmbiguousCommandTestCase(TestBase):
         self.assertFalse(result.Succeeded())
         self.assertEqual(
             result.GetError(),
-            "error: Ambiguous command 'co'. Possible matches:\n\tcommand\n\tcontinue\n\tcorefile\n",
+            "error: ambiguous command 'co'. Possible matches:\n\tcommand\n\tcontinue\n\tcorefile\n",
         )
 
         command_interpreter.HandleCommand("command unalias continue", result)

--- a/lldb/test/API/functionalities/wrong_commands/TestWrongCommands.py
+++ b/lldb/test/API/functionalities/wrong_commands/TestWrongCommands.py
@@ -18,7 +18,7 @@ class UnknownCommandTestCase(TestBase):
         command_interpreter.HandleCommand("g", result)
         self.assertFalse(result.Succeeded())
         self.assertRegex(
-            result.GetError(), "error: Ambiguous command 'g'. Possible matches:"
+            result.GetError(), "error: ambiguous command 'g'. Possible matches:"
         )
         self.assertRegex(result.GetError(), "gui")
         self.assertRegex(result.GetError(), "gdb-remote")


### PR DESCRIPTION
We follow LLVM's style guide for diagnostics, which instructs to start the first sentence with a lowercase letter, and finish the last sentence without a period, if it would end in one otherwise.