### PR TITLE
[lldb] fix a problem in the ValueObject::GetExpressionPath method

### DIFF
--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -2144,9 +2144,8 @@ void ValueObject::GetExpressionPath(Stream &s,
     const bool pointeeOfParentTypeIsArray =
         parentType.GetPointeeType().IsArrayType(nullptr, nullptr, nullptr);
     if (parentTypeIsPointer && pointeeOfParentTypeIsArray) {
-      s.PutCString("(*");
       parent->GetExpressionPath(s, epformat);
-      s.PutCString(")");
+      s.PutCString("[0]");
       s.PutCString(GetName().GetCString());
       return;
     }

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -2139,20 +2139,15 @@ void ValueObject::GetExpressionPath(Stream &s,
   ValueObject *parent = GetParent();
 
   if (parent) {
-    const lldb_private::CompilerType parentType = parent->GetCompilerType();
-    const bool parentTypeIsPointer = parentType.IsPointerType();
-    const bool pointeeOfParentTypeIsArray =
-        parentType.GetPointeeType().IsArrayType(nullptr, nullptr, nullptr);
-    if (parentTypeIsPointer && pointeeOfParentTypeIsArray) {
-      parent->GetExpressionPath(s, epformat);
+    parent->GetExpressionPath(s, epformat);
+    const CompilerType parentType = parent->GetCompilerType();
+    if (parentType.IsPointerType() &&
+        parentType.GetPointeeType().IsArrayType(nullptr, nullptr, nullptr)) {
       s.PutCString("[0]");
       s.PutCString(GetName().GetCString());
       return;
     }
   }
-
-  if (parent)
-    parent->GetExpressionPath(s, epformat);
 
   // if we are a deref_of_parent just because we are synthetic array members
   // made up to allow ptr[%d] syntax to work in variable printing, then add our

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -2138,6 +2138,20 @@ void ValueObject::GetExpressionPath(Stream &s,
 
   ValueObject *parent = GetParent();
 
+  if (parent) {
+    lldb_private::CompilerType parentType = parent->GetCompilerType();
+    const bool parentTypeIsPointer = parentType.IsPointerType();
+    const bool pointeeOfParentTypeIsArray =
+        parentType.GetPointeeType().IsArrayType(nullptr, nullptr, nullptr);
+    if (parentTypeIsPointer && pointeeOfParentTypeIsArray) {
+      s.PutCString("(*");
+      parent->GetExpressionPath(s, epformat);
+      s.PutCString(")");
+      s.PutCString(GetName().GetCString());
+      return;
+    }
+  }
+
   if (parent)
     parent->GetExpressionPath(s, epformat);
 

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -2143,6 +2143,12 @@ void ValueObject::GetExpressionPath(Stream &s,
     const CompilerType parentType = parent->GetCompilerType();
     if (parentType.IsPointerType() &&
         parentType.GetPointeeType().IsArrayType(nullptr, nullptr, nullptr)) {
+      // When the parent is a pointer to an array, then we have to:
+      // - follow the expression path of the parent with "[0]"
+      //   (that will indicate dereferencing the pointer to the array)
+      // - and then follow that with this ValueObject's name
+      //   (which will be something like "[i]" to indicate
+      //    the i-th element of the array)
       s.PutCString("[0]");
       s.PutCString(GetName().GetCString());
       return;

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -2139,7 +2139,7 @@ void ValueObject::GetExpressionPath(Stream &s,
   ValueObject *parent = GetParent();
 
   if (parent) {
-    lldb_private::CompilerType parentType = parent->GetCompilerType();
+    const lldb_private::CompilerType parentType = parent->GetCompilerType();
     const bool parentTypeIsPointer = parentType.IsPointerType();
     const bool pointeeOfParentTypeIsArray =
         parentType.GetPointeeType().IsArrayType(nullptr, nullptr, nullptr);

--- a/lldb/test/API/python_api/value/get_expr_path/Makefile
+++ b/lldb/test/API/python_api/value/get_expr_path/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/python_api/value/get_expr_path/TestValueAPIGetExpressionPath.py
+++ b/lldb/test/API/python_api/value/get_expr_path/TestValueAPIGetExpressionPath.py
@@ -1,0 +1,50 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class ValueAPIGetExpressionPath(TestBase):
+    def test(self):
+        self.build()
+
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "Break at this line", lldb.SBFileSpec("main.c")
+        )
+        frame = thread.GetFrameAtIndex(0)
+
+        self.assertEqual(frame.FindVariable("foo").get_expr_path(), "foo")
+        for i in range(2):
+            self.assertEqual(
+                frame.FindVariable("foo").GetChildAtIndex(i).get_expr_path(),
+                f"foo[{i}]",
+            )
+            for j in range(3):
+                self.assertEqual(
+                    frame.FindVariable("foo")
+                    .GetChildAtIndex(i)
+                    .GetChildAtIndex(j)
+                    .get_expr_path(),
+                    f"foo[{i}][{j}]",
+                )
+                for k in range(4):
+                    self.assertEqual(
+                        frame.FindVariable("foo")
+                        .GetChildAtIndex(i)
+                        .GetChildAtIndex(j)
+                        .GetChildAtIndex(k)
+                        .get_expr_path(),
+                        f"foo[{i}][{j}][{k}]",
+                    )
+        self.assertEqual(frame.FindVariable("bar").get_expr_path(), "bar")
+        for j in range(3):
+            self.assertEqual(
+                frame.FindVariable("bar").GetChildAtIndex(j).get_expr_path(), f"(*bar)[{j}]"
+            )
+            for k in range(4):
+                self.assertEqual(
+                    frame.FindVariable("bar")
+                    .GetChildAtIndex(j)
+                    .GetChildAtIndex(k)
+                    .get_expr_path(),
+                    f"(*bar)[{j}][{k}]",
+                )

--- a/lldb/test/API/python_api/value/get_expr_path/TestValueAPIGetExpressionPath.py
+++ b/lldb/test/API/python_api/value/get_expr_path/TestValueAPIGetExpressionPath.py
@@ -38,7 +38,8 @@ class ValueAPIGetExpressionPath(TestBase):
         self.assertEqual(frame.FindVariable("bar").get_expr_path(), "bar")
         for j in range(3):
             self.assertEqual(
-                frame.FindVariable("bar").GetChildAtIndex(j).get_expr_path(), f"(*bar)[{j}]"
+                frame.FindVariable("bar").GetChildAtIndex(j).get_expr_path(),
+                f"(*bar)[{j}]",
             )
             for k in range(4):
                 self.assertEqual(

--- a/lldb/test/API/python_api/value/get_expr_path/TestValueAPIGetExpressionPath.py
+++ b/lldb/test/API/python_api/value/get_expr_path/TestValueAPIGetExpressionPath.py
@@ -39,7 +39,7 @@ class ValueAPIGetExpressionPath(TestBase):
         for j in range(3):
             self.assertEqual(
                 frame.FindVariable("bar").GetChildAtIndex(j).get_expr_path(),
-                f"(*bar)[{j}]",
+                f"bar[0][{j}]",
             )
             for k in range(4):
                 self.assertEqual(
@@ -47,5 +47,5 @@ class ValueAPIGetExpressionPath(TestBase):
                     .GetChildAtIndex(j)
                     .GetChildAtIndex(k)
                     .get_expr_path(),
-                    f"(*bar)[{j}][{k}]",
+                    f"bar[0][{j}][{k}]",
                 )

--- a/lldb/test/API/python_api/value/get_expr_path/main.c
+++ b/lldb/test/API/python_api/value/get_expr_path/main.c
@@ -1,0 +1,5 @@
+int main() {
+  int foo[2][3][4];
+  int (*bar)[3][4] = foo;
+  return 0; // Break at this line
+}


### PR DESCRIPTION
Consider the following program:
```
int main() {
  int foo[2][3][4];
  int (*bar)[3][4] = foo;
  return 0;
}
```
If we:
- compile this program
- launch an LLDB debugging session
- launch the process and let it stop at the `return 0;` statement
then the following LLDB command:
```
(lldb) script lldb.frame.FindVariable("bar").GetChildAtIndex(0).get_expr_path()
```
will produce the following output:
```
bar->[0]
```
What we were expecting:
- a valid expression in the C programming language
- that would allow us (in the scope of the `main` function) access the appropriate object.

What we've got is a string that does not represent a valid expression in the C programming language.

This pull-request proposes a fix to this problem.