### PR TITLE
[lldb] Stop emitting pointless newline (NFC)

### DIFF
--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -204,7 +204,6 @@ void CommandObjectMultiword::Execute(const char *args_string,
                     " Use \"help " + GetCommandName() + "\" to find out more.")
             .str());
   }
-  error_msg.append("\n");
   result.AppendError(error_msg);
 }
 


### PR DESCRIPTION
AppendError ends up trimming this "\n" from the end of the string, then putting another on on. So there's no reason to keep appending the newline in CommandObjectMultiword::Execute.