### PR TITLE
[AArch64][NFC] add isTRNMask improvements to isZIPMask

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -31792,12 +31792,12 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
   unsigned OperandOrder;
   if (isZIPMask(ShuffleMask, VT.getVectorNumElements(), WhichResult,
                 OperandOrder) &&
-      WhichResult == 0)
-    return convertFromScalableVector(
-        DAG, VT,
-        DAG.getNode(AArch64ISD::ZIP1, DL, ContainerVT,
-                    OperandOrder == 0 ? Op1 : Op2,
-                    OperandOrder == 0 ? Op2 : Op1));
+      WhichResult == 0) {
+    SDValue ZIP = DAG.getNode(AArch64ISD::ZIP1, DL, ContainerVT,
+                              OperandOrder == 0 ? Op1 : Op2,
+                              OperandOrder == 0 ? Op2 : Op1);
+    return convertFromScalableVector(DAG, VT, ZIP);
+  }
 
   if (isTRNMask(ShuffleMask, VT.getVectorNumElements(), WhichResult,
                 OperandOrder)) {
@@ -31847,12 +31847,12 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
 
     if (isZIPMask(ShuffleMask, VT.getVectorNumElements(), WhichResult,
                   OperandOrder) &&
-        WhichResult != 0)
-      return convertFromScalableVector(
-          DAG, VT,
-          DAG.getNode(AArch64ISD::ZIP2, DL, ContainerVT,
-                      OperandOrder == 0 ? Op1 : Op2,
-                      OperandOrder == 0 ? Op2 : Op1));
+        WhichResult != 0) {
+      SDValue ZIP = DAG.getNode(AArch64ISD::ZIP2, DL, ContainerVT,
+                                OperandOrder == 0 ? Op1 : Op2,
+                                OperandOrder == 0 ? Op2 : Op1);
+      return convertFromScalableVector(DAG, VT, ZIP);
+    }
 
     if (isUZPMask(ShuffleMask, VT.getVectorNumElements(), WhichResult)) {
       unsigned Opc = (WhichResult == 0) ? AArch64ISD::UZP1 : AArch64ISD::UZP2;

--- a/llvm/lib/Target/AArch64/AArch64PerfectShuffle.h
+++ b/llvm/lib/Target/AArch64/AArch64PerfectShuffle.h
@@ -6631,43 +6631,44 @@ inline bool isZIPMask(ArrayRef<int> M, unsigned NumElts,
   if (NumElts % 2 != 0)
     return false;
 
-  // "Variant" refers to the distinction bwetween zip1 and zip2, while
-  // "Order" refers to sequence of input registers (matching vs flipped).
-  bool Variant0Order0 = true; // WhichResultOut = 0, OperandOrderOut = 0
-  bool Variant1Order0 = true; // WhichResultOut = 1, OperandOrderOut = 0
-  bool Variant0Order1 = true; // WhichResultOut = 0, OperandOrderOut = 1
-  bool Variant1Order1 = true; // WhichResultOut = 1, OperandOrderOut = 1
+  // "Result" corresponds to "WhichResultOut", selecting between zip1 and zip2.
+  // "Order" corresponds to "OperandOrderOut", selecting the order of operands
+  // for the instruction (flipped or not).
+  bool Result0Order0 = true; // WhichResultOut = 0, OperandOrderOut = 0
+  bool Result1Order0 = true; // WhichResultOut = 1, OperandOrderOut = 0
+  bool Result0Order1 = true; // WhichResultOut = 0, OperandOrderOut = 1
+  bool Result1Order1 = true; // WhichResultOut = 1, OperandOrderOut = 1
   // Check all elements match.
   for (unsigned i = 0; i != NumElts; i += 2) {
     if (M[i] >= 0) {
       unsigned EvenElt = (unsigned)M[i];
       if (EvenElt != i / 2)
-        Variant0Order0 = false;
+        Result0Order0 = false;
       if (EvenElt != NumElts / 2 + i / 2)
-        Variant1Order0 = false;
+        Result1Order0 = false;
       if (EvenElt != NumElts + i / 2)
-        Variant0Order1 = false;
+        Result0Order1 = false;
       if (EvenElt != NumElts + NumElts / 2 + i / 2)
-        Variant1Order1 = false;
+        Result1Order1 = false;
     }
     if (M[i + 1] >= 0) {
       unsigned OddElt = (unsigned)M[i + 1];
       if (OddElt != NumElts + i / 2)
-        Variant0Order0 = false;
+        Result0Order0 = false;
       if (OddElt != NumElts + NumElts / 2 + i / 2)
-        Variant1Order0 = false;
+        Result1Order0 = false;
       if (OddElt != i / 2)
-        Variant0Order1 = false;
+        Result0Order1 = false;
       if (OddElt != NumElts / 2 + i / 2)
-        Variant1Order1 = false;
+        Result1Order1 = false;
     }
   }
 
-  if (Variant0Order0 + Variant1Order0 + Variant0Order1 + Variant1Order1 != 1)
+  if (Result0Order0 + Result1Order0 + Result0Order1 + Result1Order1 != 1)
     return false;
 
-  WhichResultOut = (Variant0Order0 || Variant0Order1) ? 0 : 1;
-  OperandOrderOut = (Variant0Order0 || Variant1Order0) ? 0 : 1;
+  WhichResultOut = (Result0Order0 || Result0Order1) ? 0 : 1;
+  OperandOrderOut = (Result0Order0 || Result1Order0) ? 0 : 1;
   return true;
 }
 


### PR DESCRIPTION
Some [ideas for improvement](https://github.com/llvm/llvm-project/pull/169858#pullrequestreview-3525357470) came up during review of recent changes to `isTRNMask`.
This PR applies them also to `isZIPMask`, which is implemented almost identically.