### PR TITLE
[cmake] LLVM_BUILTINS_TARGET='default' should bootstrap builtins without compiler-rt

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -35,7 +35,7 @@ function(get_compiler_rt_path path)
     endif()
   endforeach()
 
-  # If LLVM_BUILTIN_TARGETS is spcified, we still need
+  # If LLVM_BUILTIN_TARGETS is specified, we still need
   # to locate the compiler-rt runtime to be able to build builtins.
   # This supports bootstrapping builtins without compiler-rt.
   if (LLVM_BUILTIN_TARGETS)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -34,6 +34,13 @@ function(get_compiler_rt_path path)
       return()
     endif()
   endforeach()
+
+  # If LLVM_BUILTIN_TARGETS is spcified, we still need
+  # to locate the compiler-rt runtime to be able to build builtins.
+  # This supports bootstrapping builtins without compiler-rt.
+  if (LLVM_BUILTIN_TARGETS)
+    set(${path} "${CMAKE_CURRENT_SOURCE_DIR}/../../compiler-rt" PARENT_SCOPE)
+  endif()
 endfunction()
 
 include(LLVMExternalProjectUtils)


### PR DESCRIPTION
This makes it possible to build just clang + builtins (using just-built clang) with:

```
LLVM_ENABLE_PROJECTS="clang"
LLVM_BUILTIN_TARGETS="default"
```

(No need for `LLVM_ENABLE_RUNTIMES`)

The only thing preventing this from working today is that `get_compiler_rt_path` does not return the path unless the runtime is listed.

rdar://166180263