### PR TITLE
[mlir][acc] Add isValidValueUse to OpenACCSupport

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Analysis/OpenACCSupport.cpp
+++ b/mlir/lib/Dialect/OpenACC/Analysis/OpenACCSupport.cpp
@@ -48,5 +48,11 @@ bool OpenACCSupport::isValidSymbolUse(Operation *user, SymbolRefAttr symbol,
   return acc::isValidSymbolUse(user, symbol, definingOpPtr);
 }
 
+bool OpenACCSupport::isValidValueUse(Value v, Region &region) {
+  if (impl)
+    return impl->isValidValueUse(v, region);
+  return false;
+}
+
 } // namespace acc
 } // namespace mlir


### PR DESCRIPTION
Add a new API `isValidValueUse ` to OpenACCSupport. This is used in ACCImplicitData to check value that are already legal in the OpenACC region and do not require implicit clause to be generated. An example would be a CUDA Fortran device variable that is already on the GPU. 