### PR TITLE
[InstSimplify] Ignore mask when combinining vp.reverse(vp.reverse).

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -7306,10 +7306,9 @@ static Value *simplifyIntrinsic(CallBase *Call, Value *Callee,
     Value *EVL = Call->getArgOperand(2);
 
     Value *X;
-    // vp.reverse(vp.reverse(X)) == X (with all ones mask and matching EVL)
-    if (match(Mask, m_AllOnes()) &&
-        match(Vec, m_Intrinsic<Intrinsic::experimental_vp_reverse>(
-                       m_Value(X), m_AllOnes(), m_Specific(EVL))))
+    // vp.reverse(vp.reverse(X)) == X (mask doesn't matter)
+    if (match(Vec, m_Intrinsic<Intrinsic::experimental_vp_reverse>(
+                       m_Value(X), m_Value(), m_Specific(EVL))))
       return X;
 
     // vp.reverse(splat(X)) -> splat(X) (regardless of mask and EVL)

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -7302,7 +7302,6 @@ static Value *simplifyIntrinsic(CallBase *Call, Value *Callee,
   }
   case Intrinsic::experimental_vp_reverse: {
     Value *Vec = Call->getArgOperand(0);
-    Value *Mask = Call->getArgOperand(1);
     Value *EVL = Call->getArgOperand(2);
 
     Value *X;

--- a/llvm/test/Transforms/InstSimplify/vp-reverse.ll
+++ b/llvm/test/Transforms/InstSimplify/vp-reverse.ll
@@ -68,3 +68,12 @@ define <vscale x 4 x i32> @rev_of_splat2(i32 %a, <vscale x 4 x i1> %m, i32 %evl)
   %rev = tail call <vscale x 4 x i32> @llvm.experimental.vp.reverse(<vscale x 4 x i32> %a.vec, <vscale x 4 x i1> %m, i32 %evl)
   ret <vscale x 4 x i32> %rev
 }
+
+define <vscale x 4 x i32> @rev_of_rev_diffmask(<vscale x 4 x i32> %a, <vscale x 4 x i1> %mask1, <vscale x 4 x i1> %mask2, i32 %evl) {
+; CHECK-LABEL: @rev_of_rev_diffmask(
+; CHECK-NEXT:    ret <vscale x 4 x i32> [[RES:%.*]]
+;
+  %a.rev = tail call <vscale x 4 x i32> @llvm.experimental.vp.reverse(<vscale x 4 x i32> %a, <vscale x 4 x i1> %mask1, i32 %evl)
+  %res = tail call <vscale x 4 x i32> @llvm.experimental.vp.reverse(<vscale x 4 x i32> %a.rev, <vscale x 4 x i1> %mask2, i32 %evl)
+  ret <vscale x 4 x i32> %res
+}


### PR DESCRIPTION
The mask doesn't really affect the reverse. It only poisons the masked off elements in the results. It should be ok to ignore the mask if we can eliminate the pair.

I don't have a specific use case for this, but it matches what I had implemented in our downstream before the current upstream implementation. Submitting upstream so I can remove eliminate the delta in my downstream.