### PR TITLE
[mlir][acc] Fix build error for tiling API return value

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsTiling.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtilsTiling.cpp
@@ -253,7 +253,7 @@ llvm::SmallVector<mlir::acc::LoopOp>
 mlir::acc::uncollapseLoops(mlir::acc::LoopOp origLoop, unsigned tileCount,
                            unsigned collapseCount,
                            mlir::RewriterBase &rewriter) {
-  llvm::SmallVector<mlir::acc::LoopOp, 3> newLoops;
+  llvm::SmallVector<mlir::acc::LoopOp> newLoops;
   llvm::SmallVector<mlir::Value, 3> newIVs;
   mlir::Location loc = origLoop.getLoc();
   llvm::SmallVector<bool> newInclusiveUBs;


### PR DESCRIPTION
The build error looks like:
error: could not convert 'newLoops' from 'SmallVector<[...],3>' to 'SmallVector<[...],6>'
  310 |   return newLoops;

The fix is to remove the explicit size in the local declaration for the SmallVector being returned.