### PR TITLE
[HLSL] Add the DXC matrix orientation flags

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -826,6 +826,8 @@ def err_drv_target_variant_invalid : Error<
 
 def err_drv_invalid_directx_shader_module : Error<
   "invalid profile : %0">;
+def err_drv_dxc_invalid_matrix_layout : Error<
+  "cannot specify /Zpr and /Zpc together">;
 def err_drv_dxc_missing_target_profile : Error<
   "target profile option (-T) is missing">;
 def err_drv_hlsl_unsupported_target : Error<

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9603,6 +9603,8 @@ class DXCJoinedOrSeparate<string name> : Option<["/", "-"], name,
   KIND_JOINED_OR_SEPARATE>, Group<dxc_Group>,
   Visibility<[DXCOption]>;
 
+def dxc_col_major : DXCFlag<"Zpc">, HelpText<"Pack matrices in column-major order">;
+def dxc_row_major : DXCFlag<"Zpr">, HelpText<"Pack matrices in row-major order">;
 def dxc_no_stdinc : DXCFlag<"hlsl-no-stdinc">,
   HelpText<"HLSL only. Disables all standard includes containing non-native compiler types and functions.">;
 def dxc_Fo : DXCJoinedOrSeparate<"Fo">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3723,6 +3723,10 @@ static void RenderHLSLOptions(const ArgList &Args, ArgStringList &CmdArgs,
   if (!Args.hasArg(options::OPT_dxc_no_stdinc) &&
       !Args.hasArg(options::OPT_nostdinc))
     CmdArgs.push_back("-finclude-default-header");
+  if (Args.hasArg(options::OPT_dxc_col_major))
+    CmdArgs.push_back("-fmatrix-memory-layout=column-major");
+  if (Args.hasArg(options::OPT_dxc_row_major))
+    CmdArgs.push_back("-fmatrix-memory-layout=row-major");
 }
 
 static void RenderOpenACCOptions(const Driver &D, const ArgList &Args,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3709,6 +3709,7 @@ static void RenderHLSLOptions(const ArgList &Args, ArgStringList &CmdArgs,
       options::OPT_disable_llvm_passes,
       options::OPT_fnative_half_type,
       options::OPT_fnative_int16_type,
+      options::OPT_fmatrix_memory_layout_EQ,
       options::OPT_hlsl_entrypoint,
       options::OPT_fdx_rootsignature_define,
       options::OPT_fdx_rootsignature_version,
@@ -3723,10 +3724,6 @@ static void RenderHLSLOptions(const ArgList &Args, ArgStringList &CmdArgs,
   if (!Args.hasArg(options::OPT_dxc_no_stdinc) &&
       !Args.hasArg(options::OPT_nostdinc))
     CmdArgs.push_back("-finclude-default-header");
-  if (Args.hasArg(options::OPT_dxc_col_major))
-    CmdArgs.push_back("-fmatrix-memory-layout=column-major");
-  if (Args.hasArg(options::OPT_dxc_row_major))
-    CmdArgs.push_back("-fmatrix-memory-layout=row-major");
 }
 
 static void RenderOpenACCOptions(const Driver &D, const ArgList &Args,

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -412,6 +412,10 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
 
   const OptTable &Opts = getDriver().getOpts();
 
+  if (Args.hasArg(options::OPT_dxc_col_major) &&
+      Args.hasArg(options::OPT_dxc_row_major))
+    getDriver().Diag(diag::err_drv_dxc_invalid_matrix_layout);
+
   for (Arg *A : Args) {
     if (A->getOption().getID() == options::OPT_dxil_validator_version) {
       StringRef ValVerStr = A->getValue();

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -510,6 +510,20 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
       A->claim();
       continue;
     }
+    if (A->getOption().getID() == options::OPT_dxc_col_major) {
+      DAL->AddSeparateArg(nullptr,
+                          Opts.getOption(options::OPT_fmatrix_memory_layout_EQ),
+                          "column-major");
+      A->claim();
+      continue;
+    }
+    if (A->getOption().getID() == options::OPT_dxc_row_major) {
+      DAL->AddSeparateArg(nullptr,
+                          Opts.getOption(options::OPT_fmatrix_memory_layout_EQ),
+                          "row-major");
+      A->claim();
+      continue;
+    }
 
     DAL->append(A);
   }

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -511,16 +511,16 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
       continue;
     }
     if (A->getOption().getID() == options::OPT_dxc_col_major) {
-      DAL->AddSeparateArg(nullptr,
-                          Opts.getOption(options::OPT_fmatrix_memory_layout_EQ),
-                          "column-major");
+      DAL->AddJoinedArg(nullptr,
+                        Opts.getOption(options::OPT_fmatrix_memory_layout_EQ),
+                        "column-major");
       A->claim();
       continue;
     }
     if (A->getOption().getID() == options::OPT_dxc_row_major) {
-      DAL->AddSeparateArg(nullptr,
-                          Opts.getOption(options::OPT_fmatrix_memory_layout_EQ),
-                          "row-major");
+      DAL->AddJoinedArg(nullptr,
+                        Opts.getOption(options::OPT_fmatrix_memory_layout_EQ),
+                        "row-major");
       A->claim();
       continue;
     }

--- a/clang/test/Driver/hlsl_matrix_pack_order.hlsl
+++ b/clang/test/Driver/hlsl_matrix_pack_order.hlsl
@@ -1,0 +1,8 @@
+// RUN: %clang_dxc -T lib_6_7  -Zpr -### %s 2>&1 | FileCheck %s  --check-prefix=CHECK-ROW-MAJOR
+// CHECK-ROW-MAJOR:  -fmatrix-memory-layout=row-major
+
+// RUN: %clang_dxc -T lib_6_7  -Zpc -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-COL-MAJOR
+// CHECK-COL-MAJOR:  -fmatrix-memory-layout=column-major
+
+// RUN: not  %clang_dxc  -Tlib_6_7 -Zpr -Zpc -fcgl -Fo - %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-MISMATCH-MAJOR
+// CHECK-MISMATCH-MAJOR: cannot specify /Zpr and /Zpc together


### PR DESCRIPTION
fixes #58676

- Make /Zpr and /Zpc turn on the -fmatrix-memory-layout= row-major and column-major flags
- Add the new DXC driver flags to Options.td
- Error in the HLSL toolchain when  both flags are specified
- Add the new error diagnostic to DiagnosticDriverKinds.td
- propogate the flag via the Clang toolchain