### PR TITLE
[X86] Trap instructions don't need side effects

### DIFF
--- a/llvm/lib/Target/X86/X86InstrSystem.td
+++ b/llvm/lib/Target/X86/X86InstrSystem.td
@@ -21,7 +21,7 @@ def RDTSCP : I<0x01, MRM_F9, (outs), (ins), "rdtscp", []>, TB;
 
 // CPU flow control instructions
 
-let mayLoad = 1, mayStore = 0, hasSideEffects = 1, isTrap = 1 in {
+let mayLoad = 1, mayStore = 0, hasSideEffects = 0, isTrap = 1 in {
   def TRAP    : I<0x0B, RawFrm, (outs), (ins), "ud2", [(trap)]>, TB;
 
   def UD1Wm   : I<0xB9, MRMSrcMem, (outs), (ins GR16:$src1, i16mem:$src2),

--- a/llvm/test/tools/llvm-mca/X86/AlderlakeP/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/AlderlakeP/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      7     0.33    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      2     0.20                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      7     0.33    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.25    *             U     ud2
+# CHECK-NEXT:  1      100   0.25    *                   ud2
 # CHECK-NEXT:  144    100   35.50                 U     wrmsr
 # CHECK-NEXT:  3      2     0.60                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      13    0.50    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/Atom/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Atom/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      1     1.00    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.50                        testq	%rsi, %rdi
 # CHECK-NEXT:  1      1     1.00    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.50    *             U     ud2
+# CHECK-NEXT:  1      100   0.50    *                   ud2
 # CHECK-NEXT:  1      202   101.00                U     wrmsr
 # CHECK-NEXT:  1      2     1.00                        xaddb	%bl, %cl
 # CHECK-NEXT:  1      3     1.50    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.33                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.33    *             U     ud2
+# CHECK-NEXT:  1      100   0.33    *                   ud2
 # CHECK-NEXT:  1      100   0.33                  U     wrmsr
 # CHECK-NEXT:  3      2     1.00                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      8     1.00    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      5     1.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     1.00                        testq	%rsi, %rdi
 # CHECK-NEXT:  1      5     1.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.50    *             U     ud2
+# CHECK-NEXT:  1      100   0.50    *                   ud2
 # CHECK-NEXT:  1      100   0.50                  U     wrmsr
 # CHECK-NEXT:  2      1     1.00                        xaddb	%bl, %cl
 # CHECK-NEXT:  4      6     20.00   *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/Broadwell/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Broadwell/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.25                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.25    *             U     ud2
+# CHECK-NEXT:  1      100   0.25    *                   ud2
 # CHECK-NEXT:  1      100   0.25                  U     wrmsr
 # CHECK-NEXT:  3      2     0.75                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      7     1.00    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      4     1.00    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.50                        testq	%rsi, %rdi
 # CHECK-NEXT:  1      4     1.00    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.50    *             U     ud2
+# CHECK-NEXT:  1      100   0.50    *                   ud2
 # CHECK-NEXT:  1      100   0.50                  U     wrmsr
 # CHECK-NEXT:  3      2     1.50                        xaddb	%bl, %cl
 # CHECK-NEXT:  4      11    1.50    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/Generic/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Generic/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.33                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.33    *             U     ud2
+# CHECK-NEXT:  1      100   0.33    *                   ud2
 # CHECK-NEXT:  1      100   0.33                  U     wrmsr
 # CHECK-NEXT:  3      2     1.00                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      8     1.00    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/Haswell/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Haswell/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.25                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.25    *             U     ud2
+# CHECK-NEXT:  1      100   0.25    *                   ud2
 # CHECK-NEXT:  1      100   0.25                  U     wrmsr
 # CHECK-NEXT:  3      2     0.75                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      8     1.00    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/IceLakeServer/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/IceLakeServer/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.25                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.25    *             U     ud2
+# CHECK-NEXT:  1      100   0.25    *                   ud2
 # CHECK-NEXT:  1      100   0.25                  U     wrmsr
 # CHECK-NEXT:  3      2     0.75                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      7     0.50    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/LunarlakeP/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/LunarlakeP/resources-x86_64.s
@@ -1873,7 +1873,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      7     0.33    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      2     0.17                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      7     0.33    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.17    *             U     ud2
+# CHECK-NEXT:  1      100   0.17    *                   ud2
 # CHECK-NEXT:  144    100   21.00                 U     wrmsr
 # CHECK-NEXT:  3      2     0.50                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      13    0.50    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/SLM/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/SLM/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      4     1.00    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.50                        testq	%rsi, %rdi
 # CHECK-NEXT:  1      4     1.00    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   1.00    *             U     ud2
+# CHECK-NEXT:  1      100   1.00    *                   ud2
 # CHECK-NEXT:  1      100   1.00                  U     wrmsr
 # CHECK-NEXT:  3      3     1.50                        xaddb	%bl, %cl
 # CHECK-NEXT:  1      4     2.00    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/SandyBridge/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/SandyBridge/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.33                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.33    *             U     ud2
+# CHECK-NEXT:  1      100   0.33    *                   ud2
 # CHECK-NEXT:  1      100   0.33                  U     wrmsr
 # CHECK-NEXT:  3      2     1.00                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      8     1.00    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/SapphireRapids/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/SapphireRapids/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      7     0.33    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      2     0.20                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      7     0.33    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.25    *             U     ud2
+# CHECK-NEXT:  1      100   0.25    *                   ud2
 # CHECK-NEXT:  144    100   35.50                 U     wrmsr
 # CHECK-NEXT:  3      2     0.60                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      13    0.50    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/SkylakeClient/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeClient/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.25                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.25    *             U     ud2
+# CHECK-NEXT:  1      100   0.25    *                   ud2
 # CHECK-NEXT:  1      100   0.25                  U     wrmsr
 # CHECK-NEXT:  3      2     0.75                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      7     1.00    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/SkylakeServer/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeServer/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.25                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      6     0.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.25    *             U     ud2
+# CHECK-NEXT:  1      100   0.25    *                   ud2
 # CHECK-NEXT:  1      100   0.25                  U     wrmsr
 # CHECK-NEXT:  3      2     0.75                        xaddb	%bl, %cl
 # CHECK-NEXT:  5      7     1.00    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/Znver1/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver1/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      5     0.50    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.25                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      5     0.50    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.25    *             U     ud2
+# CHECK-NEXT:  1      100   0.25    *                   ud2
 # CHECK-NEXT:  1      100   0.25                  U     wrmsr
 # CHECK-NEXT:  1      1     0.25                        xaddb	%bl, %cl
 # CHECK-NEXT:  1      100   0.25    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/Znver2/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver2/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  2      5     0.33    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.25                        testq	%rsi, %rdi
 # CHECK-NEXT:  2      5     0.33    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  1      100   0.25    *             U     ud2
+# CHECK-NEXT:  1      100   0.25    *                   ud2
 # CHECK-NEXT:  1      100   0.25                  U     wrmsr
 # CHECK-NEXT:  1      1     0.25                        xaddb	%bl, %cl
 # CHECK-NEXT:  1      100   0.25    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/Znver3/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      5     0.33    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.25                        testq	%rsi, %rdi
 # CHECK-NEXT:  1      5     0.33    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  100    100   25.00   *             U     ud2
+# CHECK-NEXT:  100    100   25.00   *                   ud2
 # CHECK-NEXT:  100    100   25.00                 U     wrmsr
 # CHECK-NEXT:  2      0     2.00                        xaddb	%bl, %cl
 # CHECK-NEXT:  1      5     0.67    *      *            xaddb	%bl, (%rcx)

--- a/llvm/test/tools/llvm-mca/X86/Znver4/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver4/resources-x86_64.s
@@ -1876,7 +1876,7 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      5     0.33    *                   testq	$7, (%rax)
 # CHECK-NEXT:  1      1     0.25                        testq	%rsi, %rdi
 # CHECK-NEXT:  1      5     0.33    *                   testq	%rsi, (%rax)
-# CHECK-NEXT:  100    100   25.00   *             U     ud2
+# CHECK-NEXT:  100    100   25.00   *                   ud2
 # CHECK-NEXT:  100    100   25.00                 U     wrmsr
 # CHECK-NEXT:  2      0     2.00                        xaddb	%bl, %cl
 # CHECK-NEXT:  1      5     0.67    *      *            xaddb	%bl, (%rcx)


### PR DESCRIPTION
TargetSelectionDAG.td defines *trap with SDNPSideEffect to indicate that the pattern has side effects that are not otherwise modelled. TableGen requires that when a pattern has side effects, the corresponding instructions do too. However, that does not take into account that instructions have more fine-grained flags, and what is a side effect on the pattern need not be a side effect on the instruction.

Specifically, this commit modifies TableGen to permit patterns with side effects to map to instructions with hasSideEffects = 0, isTrap = 1. This is never inferred: the TableGen change only permits behaviour that was previously rejected. Anything that TableGen previously permitted continues to be treated exactly the same, to ensure there are no unexpected effects on other targets.

The X86 trap instructions are modified to make use of this new option.