### PR TITLE
[RISCVInsertVSETVLI] Don't allow getSEW/getLMUL to be called for hasSEWLMULRatioOnly(). NFC

### DIFF
--- a/llvm/include/llvm/TargetParser/RISCVTargetParser.h
+++ b/llvm/include/llvm/TargetParser/RISCVTargetParser.h
@@ -165,8 +165,7 @@ LLVM_ABI void printXSfmmVType(unsigned VType, raw_ostream &OS);
 
 LLVM_ABI unsigned getSEWLMULRatio(unsigned SEW, VLMUL VLMul);
 
-LLVM_ABI std::optional<VLMUL> getSameRatioLMUL(unsigned SEW, VLMUL VLMUL,
-                                               unsigned EEW);
+LLVM_ABI std::optional<VLMUL> getSameRatioLMUL(unsigned Ratio, unsigned EEW);
 } // namespace RISCVVType
 
 } // namespace llvm

--- a/llvm/lib/Target/RISCV/MCA/RISCVCustomBehaviour.cpp
+++ b/llvm/lib/Target/RISCV/MCA/RISCVCustomBehaviour.cpp
@@ -215,7 +215,8 @@ getEEWAndEMUL(unsigned Opcode, RISCVVType::VLMUL LMUL, uint8_t SEW) {
     llvm_unreachable("Could not determine EEW from Opcode");
   }
 
-  auto EMUL = RISCVVType::getSameRatioLMUL(SEW, LMUL, EEW);
+  auto EMUL =
+      RISCVVType::getSameRatioLMUL(RISCVVType::getSEWLMULRatio(SEW, LMUL), EEW);
   if (!EEW)
     llvm_unreachable("Invalid SEW or LMUL for new ratio");
   return std::make_pair(EEW, *EMUL);

--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -607,13 +607,15 @@ public:
     }
   }
 
+  bool hasSEWLMULRatioOnly() const { return SEWLMULRatioOnly; }
+
   unsigned getSEW() const {
-    assert(isValid() && !isUnknown() &&
+    assert(isValid() && !isUnknown() && !hasSEWLMULRatioOnly() &&
            "Can't use VTYPE for uninitialized or unknown");
     return SEW;
   }
   RISCVVType::VLMUL getVLMUL() const {
-    assert(isValid() && !isUnknown() &&
+    assert(isValid() && !isUnknown() && !hasSEWLMULRatioOnly() &&
            "Can't use VTYPE for uninitialized or unknown");
     return VLMul;
   }
@@ -726,8 +728,6 @@ public:
     return RISCVVType::encodeVTYPE(VLMul, SEW, TailAgnostic, MaskAgnostic,
                                    AltFmt);
   }
-
-  bool hasSEWLMULRatioOnly() const { return SEWLMULRatioOnly; }
 
   bool hasSameVTYPE(const VSETVLIInfo &Other) const {
     assert(isValid() && Other.isValid() &&
@@ -1317,8 +1317,8 @@ static VSETVLIInfo adjustIncoming(const VSETVLIInfo &PrevInfo,
 
   if (!Demanded.LMUL && !Demanded.SEWLMULRatio && PrevInfo.isValid() &&
       !PrevInfo.isUnknown()) {
-    if (auto NewVLMul = RISCVVType::getSameRatioLMUL(
-            PrevInfo.getSEW(), PrevInfo.getVLMUL(), Info.getSEW()))
+    if (auto NewVLMul = RISCVVType::getSameRatioLMUL(PrevInfo.getSEWLMULRatio(),
+                                                     Info.getSEW()))
       Info.setVLMul(*NewVLMul);
     Demanded.LMUL = DemandedFields::LMULEqual;
   }
@@ -1371,25 +1371,25 @@ void RISCVInsertVSETVLI::transferBefore(VSETVLIInfo &Info,
   if (Demanded.VLAny || (Demanded.VLZeroness && !EquallyZero))
     Info.setAVL(IncomingInfo);
 
-  Info.setVTYPE(
-      ((Demanded.LMUL || Demanded.SEWLMULRatio) ? IncomingInfo : Info)
-          .getVLMUL(),
-      ((Demanded.SEW || Demanded.SEWLMULRatio) ? IncomingInfo : Info).getSEW(),
-      // Prefer tail/mask agnostic since it can be relaxed to undisturbed later
-      // if needed.
-      (Demanded.TailPolicy ? IncomingInfo : Info).getTailAgnostic() ||
-          IncomingInfo.getTailAgnostic(),
-      (Demanded.MaskPolicy ? IncomingInfo : Info).getMaskAgnostic() ||
-          IncomingInfo.getMaskAgnostic(),
-      (Demanded.AltFmt ? IncomingInfo : Info).getAltFmt(),
-      Demanded.TWiden ? IncomingInfo.getTWiden() : 0);
-
-  // If we only knew the sew/lmul ratio previously, replace the VTYPE but keep
-  // the AVL.
+  // If we only knew the sew/lmul ratio previously, replace the VTYPE.
   if (Info.hasSEWLMULRatioOnly()) {
     VSETVLIInfo RatiolessInfo = IncomingInfo;
     RatiolessInfo.setAVL(Info);
     Info = RatiolessInfo;
+  } else {
+    Info.setVTYPE(
+        ((Demanded.LMUL || Demanded.SEWLMULRatio) ? IncomingInfo : Info)
+            .getVLMUL(),
+        ((Demanded.SEW || Demanded.SEWLMULRatio) ? IncomingInfo : Info)
+            .getSEW(),
+        // Prefer tail/mask agnostic since it can be relaxed to undisturbed
+        // later if needed.
+        (Demanded.TailPolicy ? IncomingInfo : Info).getTailAgnostic() ||
+            IncomingInfo.getTailAgnostic(),
+        (Demanded.MaskPolicy ? IncomingInfo : Info).getMaskAgnostic() ||
+            IncomingInfo.getMaskAgnostic(),
+        (Demanded.AltFmt ? IncomingInfo : Info).getAltFmt(),
+        Demanded.TWiden ? IncomingInfo.getTWiden() : 0);
   }
 }
 

--- a/llvm/lib/TargetParser/RISCVTargetParser.cpp
+++ b/llvm/lib/TargetParser/RISCVTargetParser.cpp
@@ -244,8 +244,7 @@ unsigned getSEWLMULRatio(unsigned SEW, VLMUL VLMul) {
   return (SEW * 8) / LMul;
 }
 
-std::optional<VLMUL> getSameRatioLMUL(unsigned SEW, VLMUL VLMul, unsigned EEW) {
-  unsigned Ratio = RISCVVType::getSEWLMULRatio(SEW, VLMul);
+std::optional<VLMUL> getSameRatioLMUL(unsigned Ratio, unsigned EEW) {
   unsigned EMULFixedPoint = (EEW * 8) / Ratio;
   bool Fractional = EMULFixedPoint < 8;
   unsigned EMUL = Fractional ? 8 / EMULFixedPoint : EMULFixedPoint / 8;

--- a/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
@@ -15,19 +15,25 @@ namespace {
 TEST(RISCVVType, CheckSameRatioLMUL) {
   // Smaller LMUL.
   EXPECT_EQ(RISCVVType::LMUL_1,
-            RISCVVType::getSameRatioLMUL(16, RISCVVType::LMUL_2, 8));
+            RISCVVType::getSameRatioLMUL(
+                RISCVVType::getSEWLMULRatio(16, RISCVVType::LMUL_2), 8));
   EXPECT_EQ(RISCVVType::LMUL_F2,
-            RISCVVType::getSameRatioLMUL(16, RISCVVType::LMUL_1, 8));
+            RISCVVType::getSameRatioLMUL(
+                RISCVVType::getSEWLMULRatio(16, RISCVVType::LMUL_1), 8));
   // Smaller fractional LMUL.
   EXPECT_EQ(RISCVVType::LMUL_F8,
-            RISCVVType::getSameRatioLMUL(16, RISCVVType::LMUL_F4, 8));
+            RISCVVType::getSameRatioLMUL(
+                RISCVVType::getSEWLMULRatio(16, RISCVVType::LMUL_F4), 8));
   // Bigger LMUL.
   EXPECT_EQ(RISCVVType::LMUL_2,
-            RISCVVType::getSameRatioLMUL(8, RISCVVType::LMUL_1, 16));
+            RISCVVType::getSameRatioLMUL(
+                RISCVVType::getSEWLMULRatio(8, RISCVVType::LMUL_1), 16));
   EXPECT_EQ(RISCVVType::LMUL_1,
-            RISCVVType::getSameRatioLMUL(8, RISCVVType::LMUL_F2, 16));
+            RISCVVType::getSameRatioLMUL(
+                RISCVVType::getSEWLMULRatio(8, RISCVVType::LMUL_F2), 16));
   // Bigger fractional LMUL.
   EXPECT_EQ(RISCVVType::LMUL_F2,
-            RISCVVType::getSameRatioLMUL(8, RISCVVType::LMUL_F4, 16));
+            RISCVVType::getSameRatioLMUL(
+                RISCVVType::getSEWLMULRatio(8, RISCVVType::LMUL_F4), 16));
 }
 } // namespace


### PR DESCRIPTION
Refactor some logic in transferBefore to handle hasSEWLMULRatioOnly() before calling getSEW/getLMUL.

Update adjustIncoming to use getSEWLMULRatio(). Update the interface of RISCVVType::getSameRatioLMUL to take the ratio instead of SEW and LMUL. Update the few other callers to call RISCVVType::getSEWLMULRatio first. I can keep the old signature too if reviewers prefer.