### PR TITLE
[InstCombine] Turn Add into Or even when undef

### DIFF
--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -126,7 +126,8 @@ LLVM_ABI void adjustKnownFPClassForSelectArm(KnownFPClass &Known, Value *Cond,
 /// Return true if LHS and RHS have no common bits set.
 LLVM_ABI bool haveNoCommonBitsSet(const WithCache<const Value *> &LHSCache,
                                   const WithCache<const Value *> &RHSCache,
-                                  const SimplifyQuery &SQ);
+                                  const SimplifyQuery &SQ,
+                                  bool CheckNoUndef = true);
 
 /// Return true if the given value is known to have exactly one bit set when
 /// defined. For vectors return true if every element is known to be a power

--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -123,11 +123,26 @@ LLVM_ABI void adjustKnownFPClassForSelectArm(KnownFPClass &Known, Value *Cond,
                                              const SimplifyQuery &Q,
                                              unsigned Depth = 0);
 
+enum class NoCommonBitsSetResult {
+  /// Not known to have no common set bits.
+  Unknown,
+
+  /// Known to have no common set bits only if undef values are ignored.
+  OnlyIfUndefIgnored,
+
+  /// Known to have no common set bits.
+  Known,
+};
+
+/// Return how strongly LHS and RHS are known to have no common set bits.
+LLVM_ABI NoCommonBitsSetResult getNoCommonBitsSetResult(
+    const WithCache<const Value *> &LHSCache,
+    const WithCache<const Value *> &RHSCache, const SimplifyQuery &SQ);
+
 /// Return true if LHS and RHS have no common bits set.
 LLVM_ABI bool haveNoCommonBitsSet(const WithCache<const Value *> &LHSCache,
                                   const WithCache<const Value *> &RHSCache,
-                                  const SimplifyQuery &SQ,
-                                  bool CheckNoUndef = true);
+                                  const SimplifyQuery &SQ);
 
 /// Return true if the given value is known to have exactly one bit set when
 /// defined. For vectors return true if every element is known to be a power

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -179,19 +179,20 @@ KnownBits llvm::computeKnownBits(const Value *V, const APInt &DemandedElts,
 }
 
 static bool haveNoCommonBitsSetSpecialCases(const Value *LHS, const Value *RHS,
-                                            const SimplifyQuery &SQ) {
+                                            const SimplifyQuery &SQ,
+                                            bool CheckNoUndef) {
   // Look for an inverted mask: (X & ~M) op (Y & M).
   {
     Value *M;
     if (match(LHS, m_c_And(m_Not(m_Value(M)), m_Value())) &&
         match(RHS, m_c_And(m_Specific(M), m_Value())) &&
-        isGuaranteedNotToBeUndef(M, SQ.AC, SQ.CxtI, SQ.DT))
+        (!CheckNoUndef || isGuaranteedNotToBeUndef(M, SQ.AC, SQ.CxtI, SQ.DT)))
       return true;
   }
 
   // X op (Y & ~X)
   if (match(RHS, m_c_And(m_Not(m_Specific(LHS)), m_Value())) &&
-      isGuaranteedNotToBeUndef(LHS, SQ.AC, SQ.CxtI, SQ.DT))
+      (!CheckNoUndef || isGuaranteedNotToBeUndef(LHS, SQ.AC, SQ.CxtI, SQ.DT)))
     return true;
 
   // X op ((X & Y) ^ Y) -- this is the canonical form of the previous pattern
@@ -199,15 +200,15 @@ static bool haveNoCommonBitsSetSpecialCases(const Value *LHS, const Value *RHS,
   Value *Y;
   if (match(RHS,
             m_c_Xor(m_c_And(m_Specific(LHS), m_Value(Y)), m_Deferred(Y))) &&
-      isGuaranteedNotToBeUndef(LHS, SQ.AC, SQ.CxtI, SQ.DT) &&
-      isGuaranteedNotToBeUndef(Y, SQ.AC, SQ.CxtI, SQ.DT))
+      (!CheckNoUndef || isGuaranteedNotToBeUndef(LHS, SQ.AC, SQ.CxtI, SQ.DT)) &&
+      (!CheckNoUndef || isGuaranteedNotToBeUndef(Y, SQ.AC, SQ.CxtI, SQ.DT)))
     return true;
 
   // Peek through extends to find a 'not' of the other side:
   // (ext Y) op ext(~Y)
   if (match(LHS, m_ZExtOrSExt(m_Value(Y))) &&
       match(RHS, m_ZExtOrSExt(m_Not(m_Specific(Y)))) &&
-      isGuaranteedNotToBeUndef(Y, SQ.AC, SQ.CxtI, SQ.DT))
+      (!CheckNoUndef || isGuaranteedNotToBeUndef(Y, SQ.AC, SQ.CxtI, SQ.DT)))
     return true;
 
   // Look for: (A & B) op ~(A | B)
@@ -215,8 +216,8 @@ static bool haveNoCommonBitsSetSpecialCases(const Value *LHS, const Value *RHS,
     Value *A, *B;
     if (match(LHS, m_And(m_Value(A), m_Value(B))) &&
         match(RHS, m_Not(m_c_Or(m_Specific(A), m_Specific(B)))) &&
-        isGuaranteedNotToBeUndef(A, SQ.AC, SQ.CxtI, SQ.DT) &&
-        isGuaranteedNotToBeUndef(B, SQ.AC, SQ.CxtI, SQ.DT))
+        (!CheckNoUndef || isGuaranteedNotToBeUndef(A, SQ.AC, SQ.CxtI, SQ.DT)) &&
+        (!CheckNoUndef || isGuaranteedNotToBeUndef(B, SQ.AC, SQ.CxtI, SQ.DT)))
       return true;
   }
 
@@ -238,7 +239,7 @@ static bool haveNoCommonBitsSetSpecialCases(const Value *LHS, const Value *RHS,
 
 bool llvm::haveNoCommonBitsSet(const WithCache<const Value *> &LHSCache,
                                const WithCache<const Value *> &RHSCache,
-                               const SimplifyQuery &SQ) {
+                               const SimplifyQuery &SQ, bool CheckNoUndef) {
   const Value *LHS = LHSCache.getValue();
   const Value *RHS = RHSCache.getValue();
 
@@ -247,8 +248,8 @@ bool llvm::haveNoCommonBitsSet(const WithCache<const Value *> &LHSCache,
   assert(LHS->getType()->isIntOrIntVectorTy() &&
          "LHS and RHS should be integers");
 
-  if (haveNoCommonBitsSetSpecialCases(LHS, RHS, SQ) ||
-      haveNoCommonBitsSetSpecialCases(RHS, LHS, SQ))
+  if (haveNoCommonBitsSetSpecialCases(LHS, RHS, SQ, CheckNoUndef) ||
+      haveNoCommonBitsSetSpecialCases(RHS, LHS, SQ, CheckNoUndef))
     return true;
 
   return KnownBits::haveNoCommonBitsSet(LHSCache.getKnownBits(SQ),

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -178,47 +178,54 @@ KnownBits llvm::computeKnownBits(const Value *V, const APInt &DemandedElts,
       SimplifyQuery(DL, DT, AC, safeCxtI(V, CxtI), UseInstrInfo), Depth);
 }
 
-static bool haveNoCommonBitsSetSpecialCases(const Value *LHS, const Value *RHS,
-                                            const SimplifyQuery &SQ,
-                                            bool CheckNoUndef) {
+static NoCommonBitsSetResult
+haveNoCommonBitsSetSpecialCases(const Value *LHS, const Value *RHS,
+                                const SimplifyQuery &SQ) {
   // Look for an inverted mask: (X & ~M) op (Y & M).
   {
     Value *M;
     if (match(LHS, m_c_And(m_Not(m_Value(M)), m_Value())) &&
-        match(RHS, m_c_And(m_Specific(M), m_Value())) &&
-        (!CheckNoUndef || isGuaranteedNotToBeUndef(M, SQ.AC, SQ.CxtI, SQ.DT)))
-      return true;
+        match(RHS, m_c_And(m_Specific(M), m_Value())))
+      return isGuaranteedNotToBeUndef(M, SQ.AC, SQ.CxtI, SQ.DT)
+                 ? NoCommonBitsSetResult::Known
+                 : NoCommonBitsSetResult::OnlyIfUndefIgnored;
   }
 
   // X op (Y & ~X)
-  if (match(RHS, m_c_And(m_Not(m_Specific(LHS)), m_Value())) &&
-      (!CheckNoUndef || isGuaranteedNotToBeUndef(LHS, SQ.AC, SQ.CxtI, SQ.DT)))
-    return true;
+  if (match(RHS, m_c_And(m_Not(m_Specific(LHS)), m_Value())))
+    return isGuaranteedNotToBeUndef(LHS, SQ.AC, SQ.CxtI, SQ.DT)
+               ? NoCommonBitsSetResult::Known
+               : NoCommonBitsSetResult::OnlyIfUndefIgnored;
 
   // X op ((X & Y) ^ Y) -- this is the canonical form of the previous pattern
   // for constant Y.
   Value *Y;
   if (match(RHS,
-            m_c_Xor(m_c_And(m_Specific(LHS), m_Value(Y)), m_Deferred(Y))) &&
-      (!CheckNoUndef || isGuaranteedNotToBeUndef(LHS, SQ.AC, SQ.CxtI, SQ.DT)) &&
-      (!CheckNoUndef || isGuaranteedNotToBeUndef(Y, SQ.AC, SQ.CxtI, SQ.DT)))
-    return true;
+            m_c_Xor(m_c_And(m_Specific(LHS), m_Value(Y)), m_Deferred(Y)))) {
+    bool IsNoUndef = isGuaranteedNotToBeUndef(LHS, SQ.AC, SQ.CxtI, SQ.DT) &&
+                     isGuaranteedNotToBeUndef(Y, SQ.AC, SQ.CxtI, SQ.DT);
+    return IsNoUndef ? NoCommonBitsSetResult::Known
+                     : NoCommonBitsSetResult::OnlyIfUndefIgnored;
+  }
 
   // Peek through extends to find a 'not' of the other side:
   // (ext Y) op ext(~Y)
   if (match(LHS, m_ZExtOrSExt(m_Value(Y))) &&
-      match(RHS, m_ZExtOrSExt(m_Not(m_Specific(Y)))) &&
-      (!CheckNoUndef || isGuaranteedNotToBeUndef(Y, SQ.AC, SQ.CxtI, SQ.DT)))
-    return true;
+      match(RHS, m_ZExtOrSExt(m_Not(m_Specific(Y)))))
+    return isGuaranteedNotToBeUndef(Y, SQ.AC, SQ.CxtI, SQ.DT)
+               ? NoCommonBitsSetResult::Known
+               : NoCommonBitsSetResult::OnlyIfUndefIgnored;
 
   // Look for: (A & B) op ~(A | B)
   {
     Value *A, *B;
     if (match(LHS, m_And(m_Value(A), m_Value(B))) &&
-        match(RHS, m_Not(m_c_Or(m_Specific(A), m_Specific(B)))) &&
-        (!CheckNoUndef || isGuaranteedNotToBeUndef(A, SQ.AC, SQ.CxtI, SQ.DT)) &&
-        (!CheckNoUndef || isGuaranteedNotToBeUndef(B, SQ.AC, SQ.CxtI, SQ.DT)))
-      return true;
+        match(RHS, m_Not(m_c_Or(m_Specific(A), m_Specific(B))))) {
+      bool IsNoUndef = isGuaranteedNotToBeUndef(A, SQ.AC, SQ.CxtI, SQ.DT) &&
+                       isGuaranteedNotToBeUndef(B, SQ.AC, SQ.CxtI, SQ.DT);
+      return IsNoUndef ? NoCommonBitsSetResult::Known
+                       : NoCommonBitsSetResult::OnlyIfUndefIgnored;
+    }
   }
 
   // Look for: (X << V) op (Y >> (BitWidth - V))
@@ -231,15 +238,16 @@ static bool haveNoCommonBitsSetSpecialCases(const Value *LHS, const Value *RHS,
          (match(RHS, m_LShr(m_Value(), m_Sub(m_APInt(R), m_Value(V)))) &&
           match(LHS, m_Shl(m_Value(), m_Specific(V))))) &&
         R->uge(LHS->getType()->getScalarSizeInBits()))
-      return true;
+      return NoCommonBitsSetResult::Known;
   }
 
-  return false;
+  return NoCommonBitsSetResult::Unknown;
 }
 
-bool llvm::haveNoCommonBitsSet(const WithCache<const Value *> &LHSCache,
+NoCommonBitsSetResult
+llvm::getNoCommonBitsSetResult(const WithCache<const Value *> &LHSCache,
                                const WithCache<const Value *> &RHSCache,
-                               const SimplifyQuery &SQ, bool CheckNoUndef) {
+                               const SimplifyQuery &SQ) {
   const Value *LHS = LHSCache.getValue();
   const Value *RHS = RHSCache.getValue();
 
@@ -248,12 +256,32 @@ bool llvm::haveNoCommonBitsSet(const WithCache<const Value *> &LHSCache,
   assert(LHS->getType()->isIntOrIntVectorTy() &&
          "LHS and RHS should be integers");
 
-  if (haveNoCommonBitsSetSpecialCases(LHS, RHS, SQ, CheckNoUndef) ||
-      haveNoCommonBitsSetSpecialCases(RHS, LHS, SQ, CheckNoUndef))
-    return true;
+  NoCommonBitsSetResult Result = haveNoCommonBitsSetSpecialCases(LHS, RHS, SQ);
+  if (Result == NoCommonBitsSetResult::Known)
+    return NoCommonBitsSetResult::Known;
 
-  return KnownBits::haveNoCommonBitsSet(LHSCache.getKnownBits(SQ),
-                                        RHSCache.getKnownBits(SQ));
+  NoCommonBitsSetResult CommuteResult =
+      haveNoCommonBitsSetSpecialCases(RHS, LHS, SQ);
+  if (CommuteResult == NoCommonBitsSetResult::Known)
+    return NoCommonBitsSetResult::Known;
+
+  if (KnownBits::haveNoCommonBitsSet(LHSCache.getKnownBits(SQ),
+                                     RHSCache.getKnownBits(SQ)))
+    return NoCommonBitsSetResult::Known;
+
+  if (Result == NoCommonBitsSetResult::OnlyIfUndefIgnored ||
+      CommuteResult == NoCommonBitsSetResult::OnlyIfUndefIgnored)
+    return NoCommonBitsSetResult::OnlyIfUndefIgnored;
+
+  return NoCommonBitsSetResult::Unknown;
+}
+
+bool llvm::haveNoCommonBitsSet(const WithCache<const Value *> &LHSCache,
+                               const WithCache<const Value *> &RHSCache,
+                               const SimplifyQuery &SQ) {
+  NoCommonBitsSetResult Result =
+      getNoCommonBitsSetResult(LHSCache, RHSCache, SQ);
+  return Result == NoCommonBitsSetResult::Known;
 }
 
 bool llvm::isOnlyUsedInZeroComparison(const Instruction *I) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1768,6 +1768,9 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   WithCache<const Value *> LHSCache(LHS), RHSCache(RHS);
   if (haveNoCommonBitsSet(LHSCache, RHSCache, SQ.getWithInstruction(&I)))
     return BinaryOperator::CreateDisjointOr(LHS, RHS);
+  if (haveNoCommonBitsSet(LHSCache, RHSCache, SQ.getWithInstruction(&I),
+                          /*CheckNoUndef=*/false))
+    return BinaryOperator::CreateOr(LHS, RHS);
 
   if (Instruction *Ext = narrowMathIfNoOverflow(I))
     return Ext;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1766,11 +1766,15 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
 
   // A+B --> A|B iff A and B have no bits set in common.
   WithCache<const Value *> LHSCache(LHS), RHSCache(RHS);
-  if (haveNoCommonBitsSet(LHSCache, RHSCache, SQ.getWithInstruction(&I)))
+  switch (
+      getNoCommonBitsSetResult(LHSCache, RHSCache, SQ.getWithInstruction(&I))) {
+  case NoCommonBitsSetResult::Known:
     return BinaryOperator::CreateDisjointOr(LHS, RHS);
-  if (haveNoCommonBitsSet(LHSCache, RHSCache, SQ.getWithInstruction(&I),
-                          /*CheckNoUndef=*/false))
+  case NoCommonBitsSetResult::OnlyIfUndefIgnored:
     return BinaryOperator::CreateOr(LHS, RHS);
+  case NoCommonBitsSetResult::Unknown:
+    break;
+  }
 
   if (Instruction *Ext = narrowMathIfNoOverflow(I))
     return Ext;

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -1998,9 +1998,7 @@ define i8 @add_like_or_disjoint(i8 %x) {
 
 define i8 @add_and_xor(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_and_xor(
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X:%.*]], -1
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[XOR]]
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[AND]], [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %xor = xor i8 %x, -1
@@ -2049,9 +2047,7 @@ define i8 @add_and_xor_wrong_op(i8 %x, i8 %y, i8 %z) {
 define i8 @add_and_xor_commuted1(i8 %x, i8 %_y) {
 ; CHECK-LABEL: @add_and_xor_commuted1(
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X:%.*]], -1
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[XOR]]
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[AND]], [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X:%.*]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %y = udiv i8 42, %_y ; thwart complexity-based canonicalization
@@ -2077,9 +2073,7 @@ define i8 @add_and_xor_commuted1_noundef(i8 noundef %x, i8 %_y) {
 define i8 @add_and_xor_commuted2(i8 %_x, i8 %y) {
 ; CHECK-LABEL: @add_and_xor_commuted2(
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X]], -1
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[XOR]]
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X]], [[AND]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
@@ -2106,9 +2100,7 @@ define i8 @add_and_xor_commuted3(i8 %_x, i8 %_y) {
 ; CHECK-LABEL: @add_and_xor_commuted3(
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X]], -1
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[XOR]]
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[X]], [[AND]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X]], [[Y]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
@@ -2140,7 +2132,7 @@ define i8 @add_and_xor_extra_use(i8 %x, i8 %y) {
 ; CHECK-NEXT:    call void @use(i8 [[XOR]])
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[XOR]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[AND]], [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %xor = xor i8 %x, -1
@@ -2170,9 +2162,7 @@ define i8 @add_and_xor_extra_use_noundef(i8 noundef %x, i8 %y) {
 
 define i8 @add_xor_and_const(i8 %x) {
 ; CHECK-LABEL: @add_xor_and_const(
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X:%.*]], 42
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 42
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X:%.*]], 42
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %and = and i8 %x, 42
@@ -2209,8 +2199,7 @@ define i8 @add_xor_and_var(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_xor_and_var(
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %and = and i8 %x, %y
@@ -2268,8 +2257,7 @@ define i8 @add_xor_and_var_commuted1(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_xor_and_var_commuted1(
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %and = and i8 %y, %x
@@ -2299,8 +2287,7 @@ define i8 @add_xor_and_var_commuted2(i8 %_x, i8 %_y) {
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X]], [[Y]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[Y]], [[AND]]
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[XOR]], [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
@@ -2335,8 +2322,7 @@ define i8 @add_xor_and_var_commuted3(i8 %x, i8 %_y) {
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[X:%.*]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[Y]], [[AND]]
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %y = udiv i8 42, %_y ; thwart complexity-based canonicalization
@@ -2368,8 +2354,7 @@ define i8 @add_xor_and_var_commuted4(i8 %_x, i8 %y) {
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X]], [[Y:%.*]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X]], [[XOR]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X]], [[Y]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
@@ -2402,8 +2387,7 @@ define i8 @add_xor_and_var_commuted5(i8 %_x, i8 %_y) {
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[X]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[X]], [[XOR]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X]], [[Y]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
@@ -2439,8 +2423,7 @@ define i8 @add_xor_and_var_commuted6(i8 %_x, i8 %_y) {
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X]], [[Y]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[Y]], [[AND]]
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[X]], [[XOR]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X]], [[Y]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
@@ -2476,8 +2459,7 @@ define i8 @add_xor_and_var_commuted7(i8 %_x, i8 %_y) {
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[X]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[Y]], [[AND]]
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[X]], [[XOR]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X]], [[Y]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
@@ -2513,7 +2495,7 @@ define i8 @add_xor_and_var_extra_use(i8 %x, i8 %y) {
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
 ; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
 ; CHECK-NEXT:    call void @use(i8 [[XOR]])
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
   %and = and i8 %x, %y
@@ -3307,11 +3289,7 @@ define <vscale x 1 x i32> @add_to_or_scalable(<vscale x 1 x i32> %in) {
 
 define i5 @zext_zext_not(i3 %x) {
 ; CHECK-LABEL: @zext_zext_not(
-; CHECK-NEXT:    [[ZX:%.*]] = zext i3 [[X:%.*]] to i5
-; CHECK-NEXT:    [[NOTX:%.*]] = xor i3 [[X]], -1
-; CHECK-NEXT:    [[ZNOTX:%.*]] = zext i3 [[NOTX]] to i5
-; CHECK-NEXT:    [[R:%.*]] = add nuw nsw i5 [[ZX]], [[ZNOTX]]
-; CHECK-NEXT:    ret i5 [[R]]
+; CHECK-NEXT:    ret i5 7
 ;
   %zx = zext i3 %x to i5
   %notx = xor i3 %x, -1
@@ -3333,11 +3311,7 @@ define i5 @zext_zext_not_noundef(i3 noundef %x) {
 
 define <2 x i5> @zext_zext_not_commute(<2 x i3> %x) {
 ; CHECK-LABEL: @zext_zext_not_commute(
-; CHECK-NEXT:    [[ZX:%.*]] = zext <2 x i3> [[X:%.*]] to <2 x i5>
-; CHECK-NEXT:    [[NOTX:%.*]] = xor <2 x i3> [[X]], <i3 -1, i3 poison>
-; CHECK-NEXT:    [[ZNOTX:%.*]] = zext <2 x i3> [[NOTX]] to <2 x i5>
-; CHECK-NEXT:    [[R:%.*]] = add nuw nsw <2 x i5> [[ZNOTX]], [[ZX]]
-; CHECK-NEXT:    ret <2 x i5> [[R]]
+; CHECK-NEXT:    ret <2 x i5> splat (i5 7)
 ;
   %zx = zext <2 x i3> %x to <2 x i5>
   %notx = xor <2 x i3> %x, <i3 -1, i3 poison>
@@ -3359,11 +3333,7 @@ define <2 x i5> @zext_zext_not_commute_noundef(<2 x i3> noundef %x) {
 
 define i9 @sext_sext_not(i3 %x) {
 ; CHECK-LABEL: @sext_sext_not(
-; CHECK-NEXT:    [[SX:%.*]] = sext i3 [[X:%.*]] to i9
-; CHECK-NEXT:    [[NOTX:%.*]] = xor i3 [[X]], -1
-; CHECK-NEXT:    [[SNOTX:%.*]] = sext i3 [[NOTX]] to i9
-; CHECK-NEXT:    [[R:%.*]] = add nsw i9 [[SX]], [[SNOTX]]
-; CHECK-NEXT:    ret i9 [[R]]
+; CHECK-NEXT:    ret i9 -1
 ;
   %sx = sext i3 %x to i9
   %notx = xor i3 %x, -1
@@ -3387,10 +3357,7 @@ define i8 @sext_sext_not_commute(i3 %x) {
 ; CHECK-LABEL: @sext_sext_not_commute(
 ; CHECK-NEXT:    [[SX:%.*]] = sext i3 [[X:%.*]] to i8
 ; CHECK-NEXT:    call void @use(i8 [[SX]])
-; CHECK-NEXT:    [[NOTX:%.*]] = xor i3 [[X]], -1
-; CHECK-NEXT:    [[SNOTX:%.*]] = sext i3 [[NOTX]] to i8
-; CHECK-NEXT:    [[R:%.*]] = add nsw i8 [[SNOTX]], [[SX]]
-; CHECK-NEXT:    ret i8 [[R]]
+; CHECK-NEXT:    ret i8 -1
 ;
 
   %sx = sext i3 %x to i8
@@ -3421,7 +3388,7 @@ define i5 @zext_sext_not(i4 %x) {
 ; CHECK-NEXT:    [[ZX:%.*]] = zext i4 [[X:%.*]] to i5
 ; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
 ; CHECK-NEXT:    [[SNOTX:%.*]] = sext i4 [[NOTX]] to i5
-; CHECK-NEXT:    [[R:%.*]] = add i5 [[ZX]], [[SNOTX]]
+; CHECK-NEXT:    [[R:%.*]] = or i5 [[ZX]], [[SNOTX]]
 ; CHECK-NEXT:    ret i5 [[R]]
 ;
   %zx = zext i4 %x to i5
@@ -3453,7 +3420,7 @@ define i8 @zext_sext_not_commute(i4 %x) {
 ; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
 ; CHECK-NEXT:    [[SNOTX:%.*]] = sext i4 [[NOTX]] to i8
 ; CHECK-NEXT:    call void @use(i8 [[SNOTX]])
-; CHECK-NEXT:    [[R:%.*]] = add nsw i8 [[SNOTX]], [[ZX]]
+; CHECK-NEXT:    [[R:%.*]] = or i8 [[SNOTX]], [[ZX]]
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %zx = zext i4 %x to i8
@@ -3489,7 +3456,7 @@ define i9 @sext_zext_not(i4 %x) {
 ; CHECK-NEXT:    [[SX:%.*]] = sext i4 [[X:%.*]] to i9
 ; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
 ; CHECK-NEXT:    [[ZNOTX:%.*]] = zext i4 [[NOTX]] to i9
-; CHECK-NEXT:    [[R:%.*]] = add nsw i9 [[SX]], [[ZNOTX]]
+; CHECK-NEXT:    [[R:%.*]] = or i9 [[SX]], [[ZNOTX]]
 ; CHECK-NEXT:    ret i9 [[R]]
 ;
   %sx = sext i4 %x to i9
@@ -3519,7 +3486,7 @@ define i9 @sext_zext_not_commute(i4 %x) {
 ; CHECK-NEXT:    [[SX:%.*]] = sext i4 [[X:%.*]] to i9
 ; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
 ; CHECK-NEXT:    [[ZNOTX:%.*]] = zext i4 [[NOTX]] to i9
-; CHECK-NEXT:    [[R:%.*]] = add nsw i9 [[ZNOTX]], [[SX]]
+; CHECK-NEXT:    [[R:%.*]] = or i9 [[ZNOTX]], [[SX]]
 ; CHECK-NEXT:    ret i9 [[R]]
 ;
   %sx = sext i4 %x to i9

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -1996,8 +1996,21 @@ define i8 @add_like_or_disjoint(i8 %x) {
   ret i8 %r
 }
 
-define i8 @add_and_xor(i8 noundef %x, i8 %y) {
+define i8 @add_and_xor(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_and_xor(
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X:%.*]], -1
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[XOR]]
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[AND]], [[X]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %xor = xor i8 %x, -1
+  %and = and i8 %xor, %y
+  %add = add i8 %and, %x
+  ret i8 %add
+}
+
+define i8 @add_and_xor_noundef(i8 noundef %x, i8 %y) {
+; CHECK-LABEL: @add_and_xor_noundef(
 ; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
@@ -2033,8 +2046,23 @@ define i8 @add_and_xor_wrong_op(i8 %x, i8 %y, i8 %z) {
   ret i8 %add
 }
 
-define i8 @add_and_xor_commuted1(i8 noundef %x, i8 %_y) {
+define i8 @add_and_xor_commuted1(i8 %x, i8 %_y) {
 ; CHECK-LABEL: @add_and_xor_commuted1(
+; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X:%.*]], -1
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[XOR]]
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[AND]], [[X]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %y = udiv i8 42, %_y ; thwart complexity-based canonicalization
+  %xor = xor i8 %x, -1
+  %and = and i8 %y, %xor
+  %add = add i8 %and, %x
+  ret i8 %add
+}
+
+define i8 @add_and_xor_commuted1_noundef(i8 noundef %x, i8 %_y) {
+; CHECK-LABEL: @add_and_xor_commuted1_noundef(
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X:%.*]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
@@ -2046,8 +2074,23 @@ define i8 @add_and_xor_commuted1(i8 noundef %x, i8 %_y) {
   ret i8 %add
 }
 
-define i8 @add_and_xor_commuted2(i8 noundef %_x, i8 %y) {
+define i8 @add_and_xor_commuted2(i8 %_x, i8 %y) {
 ; CHECK-LABEL: @add_and_xor_commuted2(
+; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X]], -1
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[XOR]]
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X]], [[AND]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
+  %xor = xor i8 %x, -1
+  %and = and i8 %xor, %y
+  %add = add i8 %x, %and
+  ret i8 %add
+}
+
+define i8 @add_and_xor_commuted2_noundef(i8 noundef %_x, i8 %y) {
+; CHECK-LABEL: @add_and_xor_commuted2_noundef(
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
 ; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X]], [[Y:%.*]]
 ; CHECK-NEXT:    ret i8 [[ADD]]
@@ -2059,8 +2102,25 @@ define i8 @add_and_xor_commuted2(i8 noundef %_x, i8 %y) {
   ret i8 %add
 }
 
-define i8 @add_and_xor_commuted3(i8 noundef %_x, i8 %_y) {
+define i8 @add_and_xor_commuted3(i8 %_x, i8 %_y) {
 ; CHECK-LABEL: @add_and_xor_commuted3(
+; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
+; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X]], -1
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[XOR]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[X]], [[AND]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
+  %y = udiv i8 42, %_y ; thwart complexity-based canonicalization
+  %xor = xor i8 %x, -1
+  %and = and i8 %y, %xor
+  %add = add i8 %x, %and
+  ret i8 %add
+}
+
+define i8 @add_and_xor_commuted3_noundef(i8 noundef %_x, i8 %_y) {
+; CHECK-LABEL: @add_and_xor_commuted3_noundef(
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X]], [[Y]]
@@ -2074,8 +2134,25 @@ define i8 @add_and_xor_commuted3(i8 noundef %_x, i8 %_y) {
   ret i8 %add
 }
 
-define i8 @add_and_xor_extra_use(i8 noundef %x, i8 %y) {
+define i8 @add_and_xor_extra_use(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_and_xor_extra_use(
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X:%.*]], -1
+; CHECK-NEXT:    call void @use(i8 [[XOR]])
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[XOR]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[AND]], [[X]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %xor = xor i8 %x, -1
+  call void @use(i8 %xor)
+  %and = and i8 %xor, %y
+  call void @use(i8 %and)
+  %add = add i8 %and, %x
+  ret i8 %add
+}
+
+define i8 @add_and_xor_extra_use_noundef(i8 noundef %x, i8 %y) {
+; CHECK-LABEL: @add_and_xor_extra_use_noundef(
 ; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[X:%.*]], -1
 ; CHECK-NEXT:    call void @use(i8 [[XOR]])
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[XOR]]
@@ -2091,8 +2168,21 @@ define i8 @add_and_xor_extra_use(i8 noundef %x, i8 %y) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_const(i8 noundef %x) {
+define i8 @add_xor_and_const(i8 %x) {
 ; CHECK-LABEL: @add_xor_and_const(
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X:%.*]], 42
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 42
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %and = and i8 %x, 42
+  %xor = xor i8 %and, 42
+  %add = add i8 %xor, %x
+  ret i8 %add
+}
+
+define i8 @add_xor_and_const_noundef(i8 noundef %x) {
+; CHECK-LABEL: @add_xor_and_const_noundef(
 ; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[X:%.*]], 42
 ; CHECK-NEXT:    ret i8 [[ADD]]
 ;
@@ -2115,8 +2205,23 @@ define i8 @add_xor_and_const_wrong_const(i8 %x) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_var(i8 noundef %x, i8 noundef %y) {
+define i8 @add_xor_and_var(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_xor_and_var(
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %and = and i8 %x, %y
+  call void @use(i8 %and)
+  %xor = xor i8 %and, %y
+  %add = add i8 %xor, %x
+  ret i8 %add
+}
+
+define i8 @add_xor_and_var_noundef(i8 noundef %x, i8 noundef %y) {
+; CHECK-LABEL: @add_xor_and_var_noundef(
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
 ; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X]]
@@ -2159,8 +2264,23 @@ define i8 @add_xor_and_var_wrong_op2(i8 %x, i8 %y, i8 %z) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_var_commuted1(i8 noundef %x, i8 noundef %y) {
+define i8 @add_xor_and_var_commuted1(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_xor_and_var_commuted1(
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[X:%.*]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %and = and i8 %y, %x
+  call void @use(i8 %and)
+  %xor = xor i8 %and, %y
+  %add = add i8 %xor, %x
+  ret i8 %add
+}
+
+define i8 @add_xor_and_var_commuted1_noundef(i8 noundef %x, i8 noundef %y) {
+; CHECK-LABEL: @add_xor_and_var_commuted1_noundef(
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
 ; CHECK-NEXT:    [[ADD:%.*]] = or i8 [[Y]], [[X]]
@@ -2173,8 +2293,27 @@ define i8 @add_xor_and_var_commuted1(i8 noundef %x, i8 noundef %y) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_var_commuted2(i8 noundef %_x, i8 noundef %_y) {
+define i8 @add_xor_and_var_commuted2(i8 %_x, i8 %_y) {
 ; CHECK-LABEL: @add_xor_and_var_commuted2(
+; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
+; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X]], [[Y]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[Y]], [[AND]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[XOR]], [[X]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
+  %y = udiv i8 42, %_y ; thwart complexity-based canonicalization
+  %and = and i8 %x, %y
+  call void @use(i8 %and)
+  %xor = xor i8 %y, %and
+  %add = add i8 %xor, %x
+  ret i8 %add
+}
+
+define i8 @add_xor_and_var_commuted2_noundef(i8 noundef %_x, i8 noundef %_y) {
+; CHECK-LABEL: @add_xor_and_var_commuted2_noundef(
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X]], [[Y]]
@@ -2191,8 +2330,25 @@ define i8 @add_xor_and_var_commuted2(i8 noundef %_x, i8 noundef %_y) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_var_commuted3(i8 noundef %x, i8 noundef %_y) {
+define i8 @add_xor_and_var_commuted3(i8 %x, i8 %_y) {
 ; CHECK-LABEL: @add_xor_and_var_commuted3(
+; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[X:%.*]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[Y]], [[AND]]
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %y = udiv i8 42, %_y ; thwart complexity-based canonicalization
+  %and = and i8 %y, %x
+  call void @use(i8 %and)
+  %xor = xor i8 %y, %and
+  %add = add i8 %xor, %x
+  ret i8 %add
+}
+
+define i8 @add_xor_and_var_commuted3_noundef(i8 noundef %x, i8 noundef %_y) {
+; CHECK-LABEL: @add_xor_and_var_commuted3_noundef(
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[X:%.*]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
@@ -2207,8 +2363,25 @@ define i8 @add_xor_and_var_commuted3(i8 noundef %x, i8 noundef %_y) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_var_commuted4(i8 noundef %_x, i8 noundef %y) {
+define i8 @add_xor_and_var_commuted4(i8 %_x, i8 %y) {
 ; CHECK-LABEL: @add_xor_and_var_commuted4(
+; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X]], [[Y:%.*]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X]], [[XOR]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
+  %and = and i8 %x, %y
+  call void @use(i8 %and)
+  %xor = xor i8 %and, %y
+  %add = add i8 %x, %xor
+  ret i8 %add
+}
+
+define i8 @add_xor_and_var_commuted4_noundef(i8 noundef %_x, i8 noundef %y) {
+; CHECK-LABEL: @add_xor_and_var_commuted4_noundef(
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X]], [[Y:%.*]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
@@ -2223,8 +2396,27 @@ define i8 @add_xor_and_var_commuted4(i8 noundef %_x, i8 noundef %y) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_var_commuted5(i8 noundef %_x, i8 noundef %_y) {
+define i8 @add_xor_and_var_commuted5(i8 %_x, i8 %_y) {
 ; CHECK-LABEL: @add_xor_and_var_commuted5(
+; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
+; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[X]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[X]], [[XOR]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
+  %y = udiv i8 42, %_y ; thwart complexity-based canonicalization
+  %and = and i8 %y, %x
+  call void @use(i8 %and)
+  %xor = xor i8 %and, %y
+  %add = add i8 %x, %xor
+  ret i8 %add
+}
+
+define i8 @add_xor_and_var_commuted5_noundef(i8 noundef %_x, i8 noundef %_y) {
+; CHECK-LABEL: @add_xor_and_var_commuted5_noundef(
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[X]]
@@ -2241,8 +2433,27 @@ define i8 @add_xor_and_var_commuted5(i8 noundef %_x, i8 noundef %_y) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_var_commuted6(i8 noundef %_x, i8 noundef %_y) {
+define i8 @add_xor_and_var_commuted6(i8 %_x, i8 %_y) {
 ; CHECK-LABEL: @add_xor_and_var_commuted6(
+; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
+; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X]], [[Y]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[Y]], [[AND]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[X]], [[XOR]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
+  %y = udiv i8 42, %_y ; thwart complexity-based canonicalization
+  %and = and i8 %x, %y
+  call void @use(i8 %and)
+  %xor = xor i8 %y, %and
+  %add = add i8 %x, %xor
+  ret i8 %add
+}
+
+define i8 @add_xor_and_var_commuted6_noundef(i8 noundef %_x, i8 noundef %_y) {
+; CHECK-LABEL: @add_xor_and_var_commuted6_noundef(
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X]], [[Y]]
@@ -2259,8 +2470,27 @@ define i8 @add_xor_and_var_commuted6(i8 noundef %_x, i8 noundef %_y) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_var_commuted7(i8 noundef %_x, i8 noundef %_y) {
+define i8 @add_xor_and_var_commuted7(i8 %_x, i8 %_y) {
 ; CHECK-LABEL: @add_xor_and_var_commuted7(
+; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
+; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[X]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[Y]], [[AND]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i8 [[X]], [[XOR]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %x = udiv i8 42, %_x ; thwart complexity-based canonicalization
+  %y = udiv i8 42, %_y ; thwart complexity-based canonicalization
+  %and = and i8 %y, %x
+  call void @use(i8 %and)
+  %xor = xor i8 %y, %and
+  %add = add i8 %x, %xor
+  ret i8 %add
+}
+
+define i8 @add_xor_and_var_commuted7_noundef(i8 noundef %_x, i8 noundef %_y) {
+; CHECK-LABEL: @add_xor_and_var_commuted7_noundef(
 ; CHECK-NEXT:    [[X:%.*]] = udiv i8 42, [[_X:%.*]]
 ; CHECK-NEXT:    [[Y:%.*]] = udiv i8 42, [[_Y:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[Y]], [[X]]
@@ -2277,8 +2507,25 @@ define i8 @add_xor_and_var_commuted7(i8 noundef %_x, i8 noundef %_y) {
   ret i8 %add
 }
 
-define i8 @add_xor_and_var_extra_use(i8 noundef %x, i8 noundef %y) {
+define i8 @add_xor_and_var_extra_use(i8 %x, i8 %y) {
 ; CHECK-LABEL: @add_xor_and_var_extra_use(
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    call void @use(i8 [[AND]])
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
+; CHECK-NEXT:    call void @use(i8 [[XOR]])
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[XOR]], [[X]]
+; CHECK-NEXT:    ret i8 [[ADD]]
+;
+  %and = and i8 %x, %y
+  call void @use(i8 %and)
+  %xor = xor i8 %and, %y
+  call void @use(i8 %xor)
+  %add = add i8 %xor, %x
+  ret i8 %add
+}
+
+define i8 @add_xor_and_var_extra_use_noundef(i8 noundef %x, i8 noundef %y) {
+; CHECK-LABEL: @add_xor_and_var_extra_use_noundef(
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    call void @use(i8 [[AND]])
 ; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], [[Y]]
@@ -3058,8 +3305,23 @@ define <vscale x 1 x i32> @add_to_or_scalable(<vscale x 1 x i32> %in) {
   ret <vscale x 1 x i32> %add
 }
 
-define i5 @zext_zext_not(i3 noundef %x) {
+define i5 @zext_zext_not(i3 %x) {
 ; CHECK-LABEL: @zext_zext_not(
+; CHECK-NEXT:    [[ZX:%.*]] = zext i3 [[X:%.*]] to i5
+; CHECK-NEXT:    [[NOTX:%.*]] = xor i3 [[X]], -1
+; CHECK-NEXT:    [[ZNOTX:%.*]] = zext i3 [[NOTX]] to i5
+; CHECK-NEXT:    [[R:%.*]] = add nuw nsw i5 [[ZX]], [[ZNOTX]]
+; CHECK-NEXT:    ret i5 [[R]]
+;
+  %zx = zext i3 %x to i5
+  %notx = xor i3 %x, -1
+  %znotx = zext i3 %notx to i5
+  %r = add i5 %zx, %znotx
+  ret i5 %r
+}
+
+define i5 @zext_zext_not_noundef(i3 noundef %x) {
+; CHECK-LABEL: @zext_zext_not_noundef(
 ; CHECK-NEXT:    ret i5 7
 ;
   %zx = zext i3 %x to i5
@@ -3069,8 +3331,23 @@ define i5 @zext_zext_not(i3 noundef %x) {
   ret i5 %r
 }
 
-define <2 x i5> @zext_zext_not_commute(<2 x i3> noundef %x) {
+define <2 x i5> @zext_zext_not_commute(<2 x i3> %x) {
 ; CHECK-LABEL: @zext_zext_not_commute(
+; CHECK-NEXT:    [[ZX:%.*]] = zext <2 x i3> [[X:%.*]] to <2 x i5>
+; CHECK-NEXT:    [[NOTX:%.*]] = xor <2 x i3> [[X]], <i3 -1, i3 poison>
+; CHECK-NEXT:    [[ZNOTX:%.*]] = zext <2 x i3> [[NOTX]] to <2 x i5>
+; CHECK-NEXT:    [[R:%.*]] = add nuw nsw <2 x i5> [[ZNOTX]], [[ZX]]
+; CHECK-NEXT:    ret <2 x i5> [[R]]
+;
+  %zx = zext <2 x i3> %x to <2 x i5>
+  %notx = xor <2 x i3> %x, <i3 -1, i3 poison>
+  %znotx = zext <2 x i3> %notx to <2 x i5>
+  %r = add <2 x i5> %znotx, %zx
+  ret <2 x i5> %r
+}
+
+define <2 x i5> @zext_zext_not_commute_noundef(<2 x i3> noundef %x) {
+; CHECK-LABEL: @zext_zext_not_commute_noundef(
 ; CHECK-NEXT:    ret <2 x i5> splat (i5 7)
 ;
   %zx = zext <2 x i3> %x to <2 x i5>
@@ -3080,8 +3357,23 @@ define <2 x i5> @zext_zext_not_commute(<2 x i3> noundef %x) {
   ret <2 x i5> %r
 }
 
-define i9 @sext_sext_not(i3 noundef %x) {
+define i9 @sext_sext_not(i3 %x) {
 ; CHECK-LABEL: @sext_sext_not(
+; CHECK-NEXT:    [[SX:%.*]] = sext i3 [[X:%.*]] to i9
+; CHECK-NEXT:    [[NOTX:%.*]] = xor i3 [[X]], -1
+; CHECK-NEXT:    [[SNOTX:%.*]] = sext i3 [[NOTX]] to i9
+; CHECK-NEXT:    [[R:%.*]] = add nsw i9 [[SX]], [[SNOTX]]
+; CHECK-NEXT:    ret i9 [[R]]
+;
+  %sx = sext i3 %x to i9
+  %notx = xor i3 %x, -1
+  %snotx = sext i3 %notx to i9
+  %r = add i9 %sx, %snotx
+  ret i9 %r
+}
+
+define i9 @sext_sext_not_noundef(i3 noundef %x) {
+; CHECK-LABEL: @sext_sext_not_noundef(
 ; CHECK-NEXT:    ret i9 -1
 ;
   %sx = sext i3 %x to i9
@@ -3091,8 +3383,26 @@ define i9 @sext_sext_not(i3 noundef %x) {
   ret i9 %r
 }
 
-define i8 @sext_sext_not_commute(i3 noundef %x) {
+define i8 @sext_sext_not_commute(i3 %x) {
 ; CHECK-LABEL: @sext_sext_not_commute(
+; CHECK-NEXT:    [[SX:%.*]] = sext i3 [[X:%.*]] to i8
+; CHECK-NEXT:    call void @use(i8 [[SX]])
+; CHECK-NEXT:    [[NOTX:%.*]] = xor i3 [[X]], -1
+; CHECK-NEXT:    [[SNOTX:%.*]] = sext i3 [[NOTX]] to i8
+; CHECK-NEXT:    [[R:%.*]] = add nsw i8 [[SNOTX]], [[SX]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+
+  %sx = sext i3 %x to i8
+  call void @use(i8 %sx)
+  %notx = xor i3 %x, -1
+  %snotx = sext i3 %notx to i8
+  %r = add i8 %snotx, %sx
+  ret i8 %r
+}
+
+define i8 @sext_sext_not_commute_noundef(i3 noundef %x) {
+; CHECK-LABEL: @sext_sext_not_commute_noundef(
 ; CHECK-NEXT:    [[SX:%.*]] = sext i3 [[X:%.*]] to i8
 ; CHECK-NEXT:    call void @use(i8 [[SX]])
 ; CHECK-NEXT:    ret i8 -1
@@ -3106,8 +3416,23 @@ define i8 @sext_sext_not_commute(i3 noundef %x) {
   ret i8 %r
 }
 
-define i5 @zext_sext_not(i4 noundef %x) {
+define i5 @zext_sext_not(i4 %x) {
 ; CHECK-LABEL: @zext_sext_not(
+; CHECK-NEXT:    [[ZX:%.*]] = zext i4 [[X:%.*]] to i5
+; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
+; CHECK-NEXT:    [[SNOTX:%.*]] = sext i4 [[NOTX]] to i5
+; CHECK-NEXT:    [[R:%.*]] = add i5 [[ZX]], [[SNOTX]]
+; CHECK-NEXT:    ret i5 [[R]]
+;
+  %zx = zext i4 %x to i5
+  %notx = xor i4 %x, -1
+  %snotx = sext i4 %notx to i5
+  %r = add i5 %zx, %snotx
+  ret i5 %r
+}
+
+define i5 @zext_sext_not_noundef(i4 noundef %x) {
+; CHECK-LABEL: @zext_sext_not_noundef(
 ; CHECK-NEXT:    [[ZX:%.*]] = zext i4 [[X:%.*]] to i5
 ; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
 ; CHECK-NEXT:    [[SNOTX:%.*]] = sext i4 [[NOTX]] to i5
@@ -3121,8 +3446,27 @@ define i5 @zext_sext_not(i4 noundef %x) {
   ret i5 %r
 }
 
-define i8 @zext_sext_not_commute(i4 noundef %x) {
+define i8 @zext_sext_not_commute(i4 %x) {
 ; CHECK-LABEL: @zext_sext_not_commute(
+; CHECK-NEXT:    [[ZX:%.*]] = zext i4 [[X:%.*]] to i8
+; CHECK-NEXT:    call void @use(i8 [[ZX]])
+; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
+; CHECK-NEXT:    [[SNOTX:%.*]] = sext i4 [[NOTX]] to i8
+; CHECK-NEXT:    call void @use(i8 [[SNOTX]])
+; CHECK-NEXT:    [[R:%.*]] = add nsw i8 [[SNOTX]], [[ZX]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %zx = zext i4 %x to i8
+  call void @use(i8 %zx)
+  %notx = xor i4 %x, -1
+  %snotx = sext i4 %notx to i8
+  call void @use(i8 %snotx)
+  %r = add i8 %snotx, %zx
+  ret i8 %r
+}
+
+define i8 @zext_sext_not_commute_noundef(i4 noundef %x) {
+; CHECK-LABEL: @zext_sext_not_commute_noundef(
 ; CHECK-NEXT:    [[ZX:%.*]] = zext i4 [[X:%.*]] to i8
 ; CHECK-NEXT:    call void @use(i8 [[ZX]])
 ; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
@@ -3140,8 +3484,23 @@ define i8 @zext_sext_not_commute(i4 noundef %x) {
   ret i8 %r
 }
 
-define i9 @sext_zext_not(i4 noundef %x) {
+define i9 @sext_zext_not(i4 %x) {
 ; CHECK-LABEL: @sext_zext_not(
+; CHECK-NEXT:    [[SX:%.*]] = sext i4 [[X:%.*]] to i9
+; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
+; CHECK-NEXT:    [[ZNOTX:%.*]] = zext i4 [[NOTX]] to i9
+; CHECK-NEXT:    [[R:%.*]] = add nsw i9 [[SX]], [[ZNOTX]]
+; CHECK-NEXT:    ret i9 [[R]]
+;
+  %sx = sext i4 %x to i9
+  %notx = xor i4 %x, -1
+  %znotx = zext i4 %notx to i9
+  %r = add i9 %sx, %znotx
+  ret i9 %r
+}
+
+define i9 @sext_zext_not_noundef(i4 noundef %x) {
+; CHECK-LABEL: @sext_zext_not_noundef(
 ; CHECK-NEXT:    [[SX:%.*]] = sext i4 [[X:%.*]] to i9
 ; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
 ; CHECK-NEXT:    [[ZNOTX:%.*]] = zext i4 [[NOTX]] to i9
@@ -3155,8 +3514,23 @@ define i9 @sext_zext_not(i4 noundef %x) {
   ret i9 %r
 }
 
-define i9 @sext_zext_not_commute(i4 noundef %x) {
+define i9 @sext_zext_not_commute(i4 %x) {
 ; CHECK-LABEL: @sext_zext_not_commute(
+; CHECK-NEXT:    [[SX:%.*]] = sext i4 [[X:%.*]] to i9
+; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
+; CHECK-NEXT:    [[ZNOTX:%.*]] = zext i4 [[NOTX]] to i9
+; CHECK-NEXT:    [[R:%.*]] = add nsw i9 [[ZNOTX]], [[SX]]
+; CHECK-NEXT:    ret i9 [[R]]
+;
+  %sx = sext i4 %x to i9
+  %notx = xor i4 %x, -1
+  %znotx = zext i4 %notx to i9
+  %r = add i9 %znotx, %sx
+  ret i9 %r
+}
+
+define i9 @sext_zext_not_commute_noundef(i4 noundef %x) {
+; CHECK-LABEL: @sext_zext_not_commute_noundef(
 ; CHECK-NEXT:    [[SX:%.*]] = sext i4 [[X:%.*]] to i9
 ; CHECK-NEXT:    [[NOTX:%.*]] = xor i4 [[X]], -1
 ; CHECK-NEXT:    [[ZNOTX:%.*]] = zext i4 [[NOTX]] to i9

--- a/llvm/test/Transforms/InstCombine/masked-merge-add.ll
+++ b/llvm/test/Transforms/InstCombine/masked-merge-add.ll
@@ -21,7 +21,7 @@ define i32 @p(i32 %x, i32 %y, i32 %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    [[RET:%.*]] = or i32 [[AND]], [[AND1]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %and = and i32 %x, %m
@@ -51,7 +51,7 @@ define <2 x i32> @p_splatvec(<2 x i32> %x, <2 x i32> %y, <2 x i32> %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and <2 x i32> [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor <2 x i32> [[M]], splat (i32 -1)
 ; CHECK-NEXT:    [[AND1:%.*]] = and <2 x i32> [[Y:%.*]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add <2 x i32> [[AND]], [[AND1]]
+; CHECK-NEXT:    [[RET:%.*]] = or <2 x i32> [[AND]], [[AND1]]
 ; CHECK-NEXT:    ret <2 x i32> [[RET]]
 ;
   %and = and <2 x i32> %x, %m
@@ -230,7 +230,7 @@ define i32 @p_commutative0(i32 %x, i32 %y, i32 %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    [[RET:%.*]] = or i32 [[AND]], [[AND1]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %and = and i32 %m, %x ; swapped order
@@ -261,7 +261,7 @@ define i32 @p_commutative1(i32 %x, i32 %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    [[RET:%.*]] = or i32 [[AND]], [[AND1]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %y = call i32 @gen32()
@@ -294,7 +294,7 @@ define i32 @p_commutative2(i32 %x, i32 %y, i32 %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND1]], [[AND]]
+; CHECK-NEXT:    [[RET:%.*]] = or i32 [[AND1]], [[AND]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %and = and i32 %x, %m
@@ -325,7 +325,7 @@ define i32 @p_commutative3(i32 %x, i32 %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    [[RET:%.*]] = or i32 [[AND]], [[AND1]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %y = call i32 @gen32()
@@ -358,7 +358,7 @@ define i32 @p_commutative4(i32 %x, i32 %y, i32 %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND1]], [[AND]]
+; CHECK-NEXT:    [[RET:%.*]] = or i32 [[AND1]], [[AND]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %and = and i32 %m, %x ; swapped order
@@ -389,7 +389,7 @@ define i32 @p_commutative5(i32 %x, i32 %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND1]], [[AND]]
+; CHECK-NEXT:    [[RET:%.*]] = or i32 [[AND1]], [[AND]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %y = call i32 @gen32()
@@ -423,7 +423,7 @@ define i32 @p_commutative6(i32 %x, i32 %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND1]], [[AND]]
+; CHECK-NEXT:    [[RET:%.*]] = or i32 [[AND1]], [[AND]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %y = call i32 @gen32()
@@ -477,7 +477,7 @@ define i32 @n0_oneuse(i32 %x, i32 %y, i32 %m) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
-; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    [[RET:%.*]] = or i32 [[AND]], [[AND1]]
 ; CHECK-NEXT:    call void @use32(i32 [[AND]])
 ; CHECK-NEXT:    call void @use32(i32 [[NEG]])
 ; CHECK-NEXT:    call void @use32(i32 [[AND1]])

--- a/llvm/test/Transforms/InstCombine/masked-merge-add.ll
+++ b/llvm/test/Transforms/InstCombine/masked-merge-add.ll
@@ -16,8 +16,23 @@
 ; Most basic positive tests
 ; ============================================================================ ;
 
-define i32 @p(i32 %x, i32 %y, i32 noundef %m) {
+define i32 @p(i32 %x, i32 %y, i32 %m) {
 ; CHECK-LABEL: @p(
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %and = and i32 %x, %m
+  %neg = xor i32 %m, -1
+  %and1 = and i32 %neg, %y
+  %ret = add i32 %and, %and1
+  ret i32 %ret
+}
+
+define i32 @p_noundef(i32 %x, i32 %y, i32 noundef %m) {
+; CHECK-LABEL: @p_noundef(
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
@@ -31,8 +46,23 @@ define i32 @p(i32 %x, i32 %y, i32 noundef %m) {
   ret i32 %ret
 }
 
-define <2 x i32> @p_splatvec(<2 x i32> %x, <2 x i32> %y, <2 x i32> noundef %m) {
+define <2 x i32> @p_splatvec(<2 x i32> %x, <2 x i32> %y, <2 x i32> %m) {
 ; CHECK-LABEL: @p_splatvec(
+; CHECK-NEXT:    [[AND:%.*]] = and <2 x i32> [[X:%.*]], [[M:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor <2 x i32> [[M]], splat (i32 -1)
+; CHECK-NEXT:    [[AND1:%.*]] = and <2 x i32> [[Y:%.*]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add <2 x i32> [[AND]], [[AND1]]
+; CHECK-NEXT:    ret <2 x i32> [[RET]]
+;
+  %and = and <2 x i32> %x, %m
+  %neg = xor <2 x i32> %m, <i32 -1, i32 -1>
+  %and1 = and <2 x i32> %neg, %y
+  %ret = add <2 x i32> %and, %and1
+  ret <2 x i32> %ret
+}
+
+define <2 x i32> @p_splatvec_noundef(<2 x i32> %x, <2 x i32> %y, <2 x i32> noundef %m) {
+; CHECK-LABEL: @p_splatvec_noundef(
 ; CHECK-NEXT:    [[AND:%.*]] = and <2 x i32> [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor <2 x i32> [[M]], splat (i32 -1)
 ; CHECK-NEXT:    [[AND1:%.*]] = and <2 x i32> [[Y:%.*]], [[NEG]]
@@ -195,8 +225,23 @@ define <3 x i32> @p_constmask2_vec_undef(<3 x i32> %x, <3 x i32> %y) {
 ; Used to make sure that the IR complexity sorting does not interfere.
 declare i32 @gen32()
 
-define i32 @p_commutative0(i32 %x, i32 %y, i32 noundef %m) {
+define i32 @p_commutative0(i32 %x, i32 %y, i32 %m) {
 ; CHECK-LABEL: @p_commutative0(
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %and = and i32 %m, %x ; swapped order
+  %neg = xor i32 %m, -1
+  %and1 = and i32 %neg, %y
+  %ret = add i32 %and, %and1
+  ret i32 %ret
+}
+
+define i32 @p_commutative0_noundef(i32 %x, i32 %y, i32 noundef %m) {
+; CHECK-LABEL: @p_commutative0_noundef(
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
@@ -210,12 +255,29 @@ define i32 @p_commutative0(i32 %x, i32 %y, i32 noundef %m) {
   ret i32 %ret
 }
 
-define i32 @p_commutative1(i32 %x, i32 noundef %m) {
+define i32 @p_commutative1(i32 %x, i32 %m) {
 ; CHECK-LABEL: @p_commutative1(
 ; CHECK-NEXT:    [[Y:%.*]] = call i32 @gen32()
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %y = call i32 @gen32()
+  %and = and i32 %x, %m
+  %neg = xor i32 %m, -1
+  %and1 = and i32 %y, %neg; swapped order
+  %ret = add i32 %and, %and1
+  ret i32 %ret
+}
+
+define i32 @p_commutative1_noundef(i32 %x, i32 noundef %m) {
+; CHECK-LABEL: @p_commutative1_noundef(
+; CHECK-NEXT:    [[Y:%.*]] = call i32 @gen32()
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
 ; CHECK-NEXT:    [[RET:%.*]] = or disjoint i32 [[AND]], [[AND1]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
@@ -227,8 +289,23 @@ define i32 @p_commutative1(i32 %x, i32 noundef %m) {
   ret i32 %ret
 }
 
-define i32 @p_commutative2(i32 %x, i32 %y, i32 noundef %m) {
+define i32 @p_commutative2(i32 %x, i32 %y, i32 %m) {
 ; CHECK-LABEL: @p_commutative2(
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND1]], [[AND]]
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %and = and i32 %x, %m
+  %neg = xor i32 %m, -1
+  %and1 = and i32 %neg, %y
+  %ret = add i32 %and1, %and ; swapped order
+  ret i32 %ret
+}
+
+define i32 @p_commutative2_noundef(i32 %x, i32 %y, i32 noundef %m) {
+; CHECK-LABEL: @p_commutative2_noundef(
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
@@ -242,12 +319,29 @@ define i32 @p_commutative2(i32 %x, i32 %y, i32 noundef %m) {
   ret i32 %ret
 }
 
-define i32 @p_commutative3(i32 %x, i32 noundef %m) {
+define i32 @p_commutative3(i32 %x, i32 %m) {
 ; CHECK-LABEL: @p_commutative3(
 ; CHECK-NEXT:    [[Y:%.*]] = call i32 @gen32()
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %y = call i32 @gen32()
+  %and = and i32 %m, %x ; swapped order
+  %neg = xor i32 %m, -1
+  %and1 = and i32 %y, %neg; swapped order
+  %ret = add i32 %and, %and1
+  ret i32 %ret
+}
+
+define i32 @p_commutative3_noundef(i32 %x, i32 noundef %m) {
+; CHECK-LABEL: @p_commutative3_noundef(
+; CHECK-NEXT:    [[Y:%.*]] = call i32 @gen32()
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
 ; CHECK-NEXT:    [[RET:%.*]] = or disjoint i32 [[AND]], [[AND1]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
@@ -259,8 +353,23 @@ define i32 @p_commutative3(i32 %x, i32 noundef %m) {
   ret i32 %ret
 }
 
-define i32 @p_commutative4(i32 %x, i32 %y, i32 noundef %m) {
+define i32 @p_commutative4(i32 %x, i32 %y, i32 %m) {
 ; CHECK-LABEL: @p_commutative4(
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND1]], [[AND]]
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %and = and i32 %m, %x ; swapped order
+  %neg = xor i32 %m, -1
+  %and1 = and i32 %neg, %y
+  %ret = add i32 %and1, %and ; swapped order
+  ret i32 %ret
+}
+
+define i32 @p_commutative4_noundef(i32 %x, i32 %y, i32 noundef %m) {
+; CHECK-LABEL: @p_commutative4_noundef(
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
@@ -274,8 +383,25 @@ define i32 @p_commutative4(i32 %x, i32 %y, i32 noundef %m) {
   ret i32 %ret
 }
 
-define i32 @p_commutative5(i32 %x, i32 noundef %m) {
+define i32 @p_commutative5(i32 %x, i32 %m) {
 ; CHECK-LABEL: @p_commutative5(
+; CHECK-NEXT:    [[Y:%.*]] = call i32 @gen32()
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND1]], [[AND]]
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %y = call i32 @gen32()
+  %and = and i32 %x, %m
+  %neg = xor i32 %m, -1
+  %and1 = and i32 %y, %neg; swapped order
+  %ret = add i32 %and1, %and ; swapped order
+  ret i32 %ret
+}
+
+define i32 @p_commutative5_noundef(i32 %x, i32 noundef %m) {
+; CHECK-LABEL: @p_commutative5_noundef(
 ; CHECK-NEXT:    [[Y:%.*]] = call i32 @gen32()
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
@@ -291,8 +417,25 @@ define i32 @p_commutative5(i32 %x, i32 noundef %m) {
   ret i32 %ret
 }
 
-define i32 @p_commutative6(i32 %x, i32 noundef %m) {
+define i32 @p_commutative6(i32 %x, i32 %m) {
 ; CHECK-LABEL: @p_commutative6(
+; CHECK-NEXT:    [[Y:%.*]] = call i32 @gen32()
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND1]], [[AND]]
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %y = call i32 @gen32()
+  %and = and i32 %m, %x ; swapped order
+  %neg = xor i32 %m, -1
+  %and1 = and i32 %y, %neg; swapped order
+  %ret = add i32 %and1, %and ; swapped order
+  ret i32 %ret
+}
+
+define i32 @p_commutative6_noundef(i32 %x, i32 noundef %m) {
+; CHECK-LABEL: @p_commutative6_noundef(
 ; CHECK-NEXT:    [[Y:%.*]] = call i32 @gen32()
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[M:%.*]], [[X:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
@@ -329,8 +472,29 @@ define i32 @p_constmask_commutative(i32 %x, i32 %y) {
 
 declare void @use32(i32)
 
-define i32 @n0_oneuse(i32 %x, i32 %y, i32 noundef %m) {
+define i32 @n0_oneuse(i32 %x, i32 %y, i32 %m) {
 ; CHECK-LABEL: @n0_oneuse(
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
+; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]
+; CHECK-NEXT:    [[RET:%.*]] = add i32 [[AND]], [[AND1]]
+; CHECK-NEXT:    call void @use32(i32 [[AND]])
+; CHECK-NEXT:    call void @use32(i32 [[NEG]])
+; CHECK-NEXT:    call void @use32(i32 [[AND1]])
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %and = and i32 %x, %m
+  %neg = xor i32 %m, -1
+  %and1 = and i32 %neg, %y
+  %ret = add i32 %and, %and1
+  call void @use32(i32 %and)
+  call void @use32(i32 %neg)
+  call void @use32(i32 %and1)
+  ret i32 %ret
+}
+
+define i32 @n0_oneuse_noundef(i32 %x, i32 %y, i32 noundef %m) {
+; CHECK-LABEL: @n0_oneuse_noundef(
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], [[M:%.*]]
 ; CHECK-NEXT:    [[NEG:%.*]] = xor i32 [[M]], -1
 ; CHECK-NEXT:    [[AND1:%.*]] = and i32 [[Y:%.*]], [[NEG]]

--- a/llvm/test/Transforms/InstCombine/pr53357.ll
+++ b/llvm/test/Transforms/InstCombine/pr53357.ll
@@ -3,8 +3,24 @@
 ; RUN: opt < %s -passes=instcombine -S | FileCheck %s
 
 ; (x & y) + ~(x | y)
-define i32 @src(i32 noundef %0, i32 noundef %1) {
+define i32 @src(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src(
+; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP1:%.*]], [[TMP0:%.*]]
+; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP1]], [[TMP0]]
+; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
+; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP5]], [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP6]]
+;
+  %3 = and i32 %1, %0
+  %4 = or i32 %1, %0
+  %5 = xor i32 %4, -1
+  %6 = add i32 %3, %5
+  ret i32 %6
+}
+
+; (x & y) + ~(x | y) where x and y are noundef
+define i32 @src_noundef(i32 noundef %0, i32 noundef %1) {
+; CHECK-LABEL: @src_noundef(
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
 ; CHECK-NEXT:    ret i32 [[TMP4]]
@@ -17,8 +33,24 @@ define i32 @src(i32 noundef %0, i32 noundef %1) {
 }
 
 ; vector version of src
-define <2 x i32> @src_vec(<2 x i32> noundef %0, <2 x i32> noundef %1) {
+define <2 x i32> @src_vec(<2 x i32> %0, <2 x i32> %1) {
 ; CHECK-LABEL: @src_vec(
+; CHECK-NEXT:    [[TMP5:%.*]] = and <2 x i32> [[TMP1:%.*]], [[TMP0:%.*]]
+; CHECK-NEXT:    [[TMP3:%.*]] = or <2 x i32> [[TMP1]], [[TMP0]]
+; CHECK-NEXT:    [[TMP4:%.*]] = xor <2 x i32> [[TMP3]], splat (i32 -1)
+; CHECK-NEXT:    [[TMP6:%.*]] = add <2 x i32> [[TMP5]], [[TMP4]]
+; CHECK-NEXT:    ret <2 x i32> [[TMP6]]
+;
+  %3 = and <2 x i32> %1, %0
+  %4 = or  <2 x i32> %1, %0
+  %5 = xor <2 x i32> %4, <i32 -1, i32 -1>
+  %6 = add <2 x i32> %3, %5
+  ret <2 x i32> %6
+}
+
+; vector version of src_noundef
+define <2 x i32> @src_vec_noundef(<2 x i32> noundef %0, <2 x i32> noundef %1) {
+; CHECK-LABEL: @src_vec_noundef(
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor <2 x i32> [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor <2 x i32> [[TMP3]], splat (i32 -1)
 ; CHECK-NEXT:    ret <2 x i32> [[TMP4]]
@@ -31,8 +63,24 @@ define <2 x i32> @src_vec(<2 x i32> noundef %0, <2 x i32> noundef %1) {
 }
 
 ; vector version of src with poison values
-define <2 x i32> @src_vec_poison(<2 x i32> noundef %0, <2 x i32> noundef %1) {
+define <2 x i32> @src_vec_poison(<2 x i32> %0, <2 x i32> %1) {
 ; CHECK-LABEL: @src_vec_poison(
+; CHECK-NEXT:    [[TMP3:%.*]] = and <2 x i32> [[TMP1:%.*]], [[TMP0:%.*]]
+; CHECK-NEXT:    [[TMP6:%.*]] = or <2 x i32> [[TMP1]], [[TMP0]]
+; CHECK-NEXT:    [[TMP5:%.*]] = xor <2 x i32> [[TMP6]], <i32 -1, i32 poison>
+; CHECK-NEXT:    [[TMP4:%.*]] = add <2 x i32> [[TMP3]], [[TMP5]]
+; CHECK-NEXT:    ret <2 x i32> [[TMP4]]
+;
+  %3 = and <2 x i32> %1, %0
+  %4 = or  <2 x i32> %1, %0
+  %5 = xor <2 x i32> %4, <i32 -1, i32 poison>
+  %6 = add <2 x i32> %3, %5
+  ret <2 x i32> %6
+}
+
+; vector version of src_noundef with poison values
+define <2 x i32> @src_vec_poison_noundef(<2 x i32> noundef %0, <2 x i32> noundef %1) {
+; CHECK-LABEL: @src_vec_poison_noundef(
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor <2 x i32> [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor <2 x i32> [[TMP3]], splat (i32 -1)
 ; CHECK-NEXT:    ret <2 x i32> [[TMP4]]
@@ -45,8 +93,24 @@ define <2 x i32> @src_vec_poison(<2 x i32> noundef %0, <2 x i32> noundef %1) {
 }
 
 ; (x & y) + ~(y | x)
-define i32 @src2(i32 noundef %0, i32 noundef %1) {
+define i32 @src2(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src2(
+; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP1:%.*]], [[TMP0:%.*]]
+; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP0]], [[TMP1]]
+; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
+; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP5]], [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP6]]
+;
+  %3 = and i32 %1, %0
+  %4 = or i32 %0, %1
+  %5 = xor i32 %4, -1
+  %6 = add i32 %3, %5
+  ret i32 %6
+}
+
+; (x & y) + ~(y | x) where x and y are noundef
+define i32 @src2_noundef(i32 noundef %0, i32 noundef %1) {
+; CHECK-LABEL: @src2_noundef(
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
 ; CHECK-NEXT:    ret i32 [[TMP4]]
@@ -59,8 +123,25 @@ define i32 @src2(i32 noundef %0, i32 noundef %1) {
 }
 
 ; (x & y) + (~x & ~y)
-define i32 @src3(i32 noundef %0, i32 noundef %1) {
+define i32 @src3(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src3(
+; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP1:%.*]], [[TMP0:%.*]]
+; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP0]], [[TMP1]]
+; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
+; CHECK-NEXT:    [[TMP5:%.*]] = add i32 [[TMP6]], [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  %3 = and i32 %1, %0
+  %4 = xor i32 %0, -1
+  %5 = xor i32 %1, -1
+  %6 = and i32 %4, %5
+  %7 = add i32 %3, %6
+  ret i32 %7
+}
+
+; (x & y) + (~x & ~y) where x and y are noundef
+define i32 @src3_noundef(i32 noundef %0, i32 noundef %1) {
+; CHECK-LABEL: @src3_noundef(
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
 ; CHECK-NEXT:    ret i32 [[TMP4]]
@@ -74,8 +155,24 @@ define i32 @src3(i32 noundef %0, i32 noundef %1) {
 }
 
 ; ~(x | y) + (y & x)
-define i32 @src4(i32 noundef %0, i32 noundef %1) {
+define i32 @src4(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src4(
+; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP0:%.*]], [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP1]], [[TMP0]]
+; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
+; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP5]], [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP6]]
+;
+  %3 = and i32 %0, %1
+  %4 = or i32 %1, %0
+  %5 = xor i32 %4, -1
+  %6 = add i32 %3, %5
+  ret i32 %6
+}
+
+; ~(x | y) + (y & x) where x and y are noundef
+define i32 @src4_noundef(i32 noundef %0, i32 noundef %1) {
+; CHECK-LABEL: @src4_noundef(
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP0:%.*]], [[TMP1:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
 ; CHECK-NEXT:    ret i32 [[TMP4]]
@@ -88,8 +185,24 @@ define i32 @src4(i32 noundef %0, i32 noundef %1) {
 }
 
 ; ~(x | y) + (x & y)
-define i32 @src5(i32 noundef %0, i32 noundef %1) {
+define i32 @src5(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src5(
+; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP1:%.*]], [[TMP0:%.*]]
+; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
+; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP1]], [[TMP0]]
+; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP5]], [[TMP4]]
+; CHECK-NEXT:    ret i32 [[TMP6]]
+;
+  %3 = or i32 %1, %0
+  %4 = xor i32 %3, -1
+  %5 = and i32 %1, %0
+  %6 = add i32 %4, %5
+  ret i32 %6
+}
+
+; ~(x | y) + (x & y) where x and y are noundef
+define i32 @src5_noundef(i32 noundef %0, i32 noundef %1) {
+; CHECK-LABEL: @src5_noundef(
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
 ; CHECK-NEXT:    ret i32 [[TMP4]]

--- a/llvm/test/Transforms/InstCombine/pr53357.ll
+++ b/llvm/test/Transforms/InstCombine/pr53357.ll
@@ -5,11 +5,9 @@
 ; (x & y) + ~(x | y)
 define i32 @src(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src(
-; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP1:%.*]], [[TMP0:%.*]]
-; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP1]], [[TMP0]]
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
-; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP5]], [[TMP4]]
-; CHECK-NEXT:    ret i32 [[TMP6]]
+; CHECK-NEXT:    ret i32 [[TMP4]]
 ;
   %3 = and i32 %1, %0
   %4 = or i32 %1, %0
@@ -35,11 +33,9 @@ define i32 @src_noundef(i32 noundef %0, i32 noundef %1) {
 ; vector version of src
 define <2 x i32> @src_vec(<2 x i32> %0, <2 x i32> %1) {
 ; CHECK-LABEL: @src_vec(
-; CHECK-NEXT:    [[TMP5:%.*]] = and <2 x i32> [[TMP1:%.*]], [[TMP0:%.*]]
-; CHECK-NEXT:    [[TMP3:%.*]] = or <2 x i32> [[TMP1]], [[TMP0]]
+; CHECK-NEXT:    [[TMP3:%.*]] = xor <2 x i32> [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor <2 x i32> [[TMP3]], splat (i32 -1)
-; CHECK-NEXT:    [[TMP6:%.*]] = add <2 x i32> [[TMP5]], [[TMP4]]
-; CHECK-NEXT:    ret <2 x i32> [[TMP6]]
+; CHECK-NEXT:    ret <2 x i32> [[TMP4]]
 ;
   %3 = and <2 x i32> %1, %0
   %4 = or  <2 x i32> %1, %0
@@ -65,10 +61,8 @@ define <2 x i32> @src_vec_noundef(<2 x i32> noundef %0, <2 x i32> noundef %1) {
 ; vector version of src with poison values
 define <2 x i32> @src_vec_poison(<2 x i32> %0, <2 x i32> %1) {
 ; CHECK-LABEL: @src_vec_poison(
-; CHECK-NEXT:    [[TMP3:%.*]] = and <2 x i32> [[TMP1:%.*]], [[TMP0:%.*]]
-; CHECK-NEXT:    [[TMP6:%.*]] = or <2 x i32> [[TMP1]], [[TMP0]]
-; CHECK-NEXT:    [[TMP5:%.*]] = xor <2 x i32> [[TMP6]], <i32 -1, i32 poison>
-; CHECK-NEXT:    [[TMP4:%.*]] = add <2 x i32> [[TMP3]], [[TMP5]]
+; CHECK-NEXT:    [[TMP3:%.*]] = xor <2 x i32> [[TMP1:%.*]], [[TMP0:%.*]]
+; CHECK-NEXT:    [[TMP4:%.*]] = xor <2 x i32> [[TMP3]], splat (i32 -1)
 ; CHECK-NEXT:    ret <2 x i32> [[TMP4]]
 ;
   %3 = and <2 x i32> %1, %0
@@ -95,11 +89,9 @@ define <2 x i32> @src_vec_poison_noundef(<2 x i32> noundef %0, <2 x i32> noundef
 ; (x & y) + ~(y | x)
 define i32 @src2(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src2(
-; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP1:%.*]], [[TMP0:%.*]]
-; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP0]], [[TMP1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
-; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP5]], [[TMP4]]
-; CHECK-NEXT:    ret i32 [[TMP6]]
+; CHECK-NEXT:    ret i32 [[TMP4]]
 ;
   %3 = and i32 %1, %0
   %4 = or i32 %0, %1
@@ -125,11 +117,9 @@ define i32 @src2_noundef(i32 noundef %0, i32 noundef %1) {
 ; (x & y) + (~x & ~y)
 define i32 @src3(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src3(
-; CHECK-NEXT:    [[TMP6:%.*]] = and i32 [[TMP1:%.*]], [[TMP0:%.*]]
-; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP0]], [[TMP1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
-; CHECK-NEXT:    [[TMP5:%.*]] = add i32 [[TMP6]], [[TMP4]]
-; CHECK-NEXT:    ret i32 [[TMP5]]
+; CHECK-NEXT:    ret i32 [[TMP4]]
 ;
   %3 = and i32 %1, %0
   %4 = xor i32 %0, -1
@@ -157,11 +147,9 @@ define i32 @src3_noundef(i32 noundef %0, i32 noundef %1) {
 ; ~(x | y) + (y & x)
 define i32 @src4(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src4(
-; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP0:%.*]], [[TMP1:%.*]]
-; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP1]], [[TMP0]]
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP0:%.*]], [[TMP1:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
-; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP5]], [[TMP4]]
-; CHECK-NEXT:    ret i32 [[TMP6]]
+; CHECK-NEXT:    ret i32 [[TMP4]]
 ;
   %3 = and i32 %0, %1
   %4 = or i32 %1, %0
@@ -187,11 +175,9 @@ define i32 @src4_noundef(i32 noundef %0, i32 noundef %1) {
 ; ~(x | y) + (x & y)
 define i32 @src5(i32 %0, i32 %1) {
 ; CHECK-LABEL: @src5(
-; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP1:%.*]], [[TMP0:%.*]]
+; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1:%.*]], [[TMP0:%.*]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], -1
-; CHECK-NEXT:    [[TMP5:%.*]] = and i32 [[TMP1]], [[TMP0]]
-; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP5]], [[TMP4]]
-; CHECK-NEXT:    ret i32 [[TMP6]]
+; CHECK-NEXT:    ret i32 [[TMP4]]
 ;
   %3 = or i32 %1, %0
   %4 = xor i32 %3, -1

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -3128,9 +3128,11 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
 
     const DataLayout &DL = M->getDataLayout();
     EXPECT_FALSE(haveNoCommonBitsSet(LHS, RHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(LHS, RHS, DL));
     EXPECT_FALSE(haveNoCommonBitsSet(RHS, LHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(RHS, LHS, DL));
   }
   {
     // Check for an inverted mask: (X & ~M) op (Y & M) where M is noundef.
@@ -3149,9 +3151,11 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
 
     const DataLayout &DL = M->getDataLayout();
     EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(LHS, RHS, DL));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(RHS, LHS, DL));
   }
   {
     // Check for (A & B) and ~(A | B)
@@ -3174,16 +3178,20 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
     auto *LHS = findInstructionByNameOrNull(F, "LHS");
     auto *RHS = findInstructionByNameOrNull(F, "RHS");
     EXPECT_FALSE(haveNoCommonBitsSet(LHS, RHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(LHS, RHS, DL));
     EXPECT_FALSE(haveNoCommonBitsSet(RHS, LHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(RHS, LHS, DL));
 
     auto *LHS2 = findInstructionByNameOrNull(F, "LHS2");
     auto *RHS2 = findInstructionByNameOrNull(F, "RHS2");
     EXPECT_FALSE(haveNoCommonBitsSet(LHS2, RHS2, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(LHS2, RHS2, DL));
     EXPECT_FALSE(haveNoCommonBitsSet(RHS2, LHS2, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(RHS2, LHS2, DL));
   }
   {
     // Check for (A & B) and ~(A | B) where A and B are noundef
@@ -3206,16 +3214,20 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
     auto *LHS = findInstructionByNameOrNull(F, "LHS");
     auto *RHS = findInstructionByNameOrNull(F, "RHS");
     EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(LHS, RHS, DL));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(RHS, LHS, DL));
 
     auto *LHS2 = findInstructionByNameOrNull(F, "LHS2");
     auto *RHS2 = findInstructionByNameOrNull(F, "RHS2");
     EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(LHS2, RHS2, DL));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(RHS2, LHS2, DL));
   }
   {
     // Check for (A & B) and ~(A | B) in vector version
@@ -3238,16 +3250,20 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
     auto *LHS = findInstructionByNameOrNull(F, "LHS");
     auto *RHS = findInstructionByNameOrNull(F, "RHS");
     EXPECT_FALSE(haveNoCommonBitsSet(LHS, RHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(LHS, RHS, DL));
     EXPECT_FALSE(haveNoCommonBitsSet(RHS, LHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(RHS, LHS, DL));
 
     auto *LHS2 = findInstructionByNameOrNull(F, "LHS2");
     auto *RHS2 = findInstructionByNameOrNull(F, "RHS2");
     EXPECT_FALSE(haveNoCommonBitsSet(LHS2, RHS2, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(LHS2, RHS2, DL));
     EXPECT_FALSE(haveNoCommonBitsSet(RHS2, LHS2, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::OnlyIfUndefIgnored,
+              getNoCommonBitsSetResult(RHS2, LHS2, DL));
   }
   {
     // Check for (A & B) and ~(A | B) in vector version where A and B are
@@ -3271,16 +3287,20 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
     auto *LHS = findInstructionByNameOrNull(F, "LHS");
     auto *RHS = findInstructionByNameOrNull(F, "RHS");
     EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(LHS, RHS, DL));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(RHS, LHS, DL));
 
     auto *LHS2 = findInstructionByNameOrNull(F, "LHS2");
     auto *RHS2 = findInstructionByNameOrNull(F, "RHS2");
     EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(LHS2, RHS2, DL));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL));
-    EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_EQ(NoCommonBitsSetResult::Known,
+              getNoCommonBitsSetResult(RHS2, LHS2, DL));
   }
 }
 

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -3114,6 +3114,27 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
   {
     // Check for an inverted mask: (X & ~M) op (Y & M).
     auto M = parseModule(R"(
+  define i32 @test(i32 %X, i32 %Y, i32 %M) {
+    %1 = xor i32 %M, -1
+    %LHS = and i32 %1, %X
+    %RHS = and i32 %Y, %M
+    %Ret = add i32 %LHS, %RHS
+    ret i32 %Ret
+  })");
+
+    auto *F = M->getFunction("test");
+    auto *LHS = findInstructionByNameOrNull(F, "LHS");
+    auto *RHS = findInstructionByNameOrNull(F, "RHS");
+
+    const DataLayout &DL = M->getDataLayout();
+    EXPECT_FALSE(haveNoCommonBitsSet(LHS, RHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_FALSE(haveNoCommonBitsSet(RHS, LHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
+  }
+  {
+    // Check for an inverted mask: (X & ~M) op (Y & M) where M is noundef.
+    auto M = parseModule(R"(
   define i32 @test(i32 %X, i32 %Y, i32 noundef %M) {
     %1 = xor i32 %M, -1
     %LHS = and i32 %1, %X
@@ -3128,10 +3149,44 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
 
     const DataLayout &DL = M->getDataLayout();
     EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
   }
   {
     // Check for (A & B) and ~(A | B)
+    auto M = parseModule(R"(
+  define void @test(i32 %A, i32 %B) {
+    %LHS = and i32 %A, %B
+    %or = or i32 %A, %B
+    %RHS = xor i32 %or, -1
+
+    %LHS2 = and i32 %B, %A
+    %or2 = or i32 %A, %B
+    %RHS2 = xor i32 %or2, -1
+
+    ret void
+  })");
+
+    auto *F = M->getFunction("test");
+    const DataLayout &DL = M->getDataLayout();
+
+    auto *LHS = findInstructionByNameOrNull(F, "LHS");
+    auto *RHS = findInstructionByNameOrNull(F, "RHS");
+    EXPECT_FALSE(haveNoCommonBitsSet(LHS, RHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_FALSE(haveNoCommonBitsSet(RHS, LHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
+
+    auto *LHS2 = findInstructionByNameOrNull(F, "LHS2");
+    auto *RHS2 = findInstructionByNameOrNull(F, "RHS2");
+    EXPECT_FALSE(haveNoCommonBitsSet(LHS2, RHS2, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_FALSE(haveNoCommonBitsSet(RHS2, LHS2, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL, /*CheckNoUndef=*/false));
+  }
+  {
+    // Check for (A & B) and ~(A | B) where A and B are noundef
     auto M = parseModule(R"(
   define void @test(i32 noundef %A, i32 noundef %B) {
     %LHS = and i32 %A, %B
@@ -3151,15 +3206,52 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
     auto *LHS = findInstructionByNameOrNull(F, "LHS");
     auto *RHS = findInstructionByNameOrNull(F, "RHS");
     EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
 
     auto *LHS2 = findInstructionByNameOrNull(F, "LHS2");
     auto *RHS2 = findInstructionByNameOrNull(F, "RHS2");
     EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL, /*CheckNoUndef=*/false));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL, /*CheckNoUndef=*/false));
   }
   {
     // Check for (A & B) and ~(A | B) in vector version
+    auto M = parseModule(R"(
+  define void @test(<2 x i32> %A, <2 x i32> %B) {
+    %LHS = and <2 x i32> %A, %B
+    %or = or <2 x i32> %A, %B
+    %RHS = xor <2 x i32> %or, <i32 -1, i32 -1>
+
+    %LHS2 = and <2 x i32> %B, %A
+    %or2 = or <2 x i32> %A, %B
+    %RHS2 = xor <2 x i32> %or2, <i32 -1, i32 -1>
+
+    ret void
+  })");
+
+    auto *F = M->getFunction("test");
+    const DataLayout &DL = M->getDataLayout();
+
+    auto *LHS = findInstructionByNameOrNull(F, "LHS");
+    auto *RHS = findInstructionByNameOrNull(F, "RHS");
+    EXPECT_FALSE(haveNoCommonBitsSet(LHS, RHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
+    EXPECT_FALSE(haveNoCommonBitsSet(RHS, LHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
+
+    auto *LHS2 = findInstructionByNameOrNull(F, "LHS2");
+    auto *RHS2 = findInstructionByNameOrNull(F, "RHS2");
+    EXPECT_FALSE(haveNoCommonBitsSet(LHS2, RHS2, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL, /*CheckNoUndef=*/false));
+    EXPECT_FALSE(haveNoCommonBitsSet(RHS2, LHS2, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL, /*CheckNoUndef=*/false));
+  }
+  {
+    // Check for (A & B) and ~(A | B) in vector version where A and B are
+    // noundef
     auto M = parseModule(R"(
   define void @test(<2 x i32> noundef %A, <2 x i32> noundef %B) {
     %LHS = and <2 x i32> %A, %B
@@ -3179,12 +3271,16 @@ TEST_F(ValueTrackingTest, HaveNoCommonBitsSet) {
     auto *LHS = findInstructionByNameOrNull(F, "LHS");
     auto *RHS = findInstructionByNameOrNull(F, "RHS");
     EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS, RHS, DL, /*CheckNoUndef=*/false));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS, LHS, DL, /*CheckNoUndef=*/false));
 
     auto *LHS2 = findInstructionByNameOrNull(F, "LHS2");
     auto *RHS2 = findInstructionByNameOrNull(F, "RHS2");
     EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(LHS2, RHS2, DL, /*CheckNoUndef=*/false));
     EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL));
+    EXPECT_TRUE(haveNoCommonBitsSet(RHS2, LHS2, DL, /*CheckNoUndef=*/false));
   }
 }
 


### PR DESCRIPTION
Since 03d4a9d94da30590ebfc444cf13a8763f47b7bb9, Add is turned into DisjointOr, and since 5c3496ff33ce8e4cc6f8c18edd7ae5fc65d23fdf, Add isn't turned into DisjointOr when undef.  However, Add can still be turned into Or even when undef.

This patch restores the transformation behavior we had in LLVM 17, while continuing to generate DisjointOr when possible.

Alive2: https://alive2.llvm.org/ce/z/ZT0ZFj