### PR TITLE
[compiler-rt] Fix usage of `stdin`/`stdout`

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix.h
@@ -68,7 +68,7 @@ uptr internal_waitpid(int pid, int *status, int options);
 
 int internal_fork();
 bool internal_spawn(const char* argv[], const char* envp[], pid_t* pid,
-                    fd_t stdin, fd_t stdout);
+                    fd_t fd_stdin, fd_t fd_stdout);
 
 int internal_sysctl(const int *name, unsigned int namelen, void *oldp,
                     uptr *oldlenp, const void *newp, uptr newlen);


### PR DESCRIPTION
From #170809.

Causes compile errors when `stdin`/`stdout` are #defined in stdio.h.