### PR TITLE
Update hash value constant for std::monostate

### DIFF
--- a/libcxx/include/__variant/monostate.h
+++ b/libcxx/include/__variant/monostate.h
@@ -55,7 +55,7 @@ struct hash<monostate> {
 #  endif
 
   inline _LIBCPP_HIDE_FROM_ABI size_t operator()(const monostate&) const noexcept {
-    return 66740831; // return a fundamentally attractive random value.
+    return 66743015; // return a fundamentally attractive random value.
   }
 };
 


### PR DESCRIPTION
This changes the "fundamentally attractive" random value to align with the 2022 CODATA gravitational constant. Still the same - just slightly more accurate.