### PR TITLE
[RISCV] Fix wrong use of SiFiveP400GetVLMAX in RISCVSchedSiFiveP600

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSiFiveP600.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFiveP600.td
@@ -48,7 +48,7 @@ class SiFiveP600GetVLMAX<string mx, int sew> {
 }
 
 class SiFiveP600StridedLdStLatency<string mx, int sew> {
-  defvar VL = SiFiveP400GetVLMAX<mx, sew>.val;
+  defvar VL = SiFiveP600GetVLMAX<mx, sew>.val;
   int val = !cond(
     !eq(VL, 2):  13,
     !eq(VL, 4):  18,


### PR DESCRIPTION
There is no difference of functionality and I believe this is a
copy-paste mistake. :-)
