### PR TITLE
[HLSL][Matrix] Support row and column indexing modes for MatrixSubscriptExpr

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -2485,7 +2485,7 @@ RValue CodeGenFunction::EmitLoadOfLValue(LValue LV, SourceLocation Loc) {
       bool IsMatrixRowMajor = getLangOpts().getDefaultMatrixMemoryLayout() ==
                               LangOptions::MatrixMemoryLayout::MatrixRowMajor;
       llvm::Value *EltIndex =
-          MB.createIndex(Row, ColIdx, NumRows, NumCols, IsMatrixRowMajor);
+          MB.CreateIndex(Row, ColIdx, NumRows, NumCols, IsMatrixRowMajor);
       llvm::Value *Elt = Builder.CreateExtractElement(MatrixVec, EltIndex);
       llvm::Value *Lane = llvm::ConstantInt::get(Builder.getInt32Ty(), Col);
       Result = Builder.CreateInsertElement(Result, Elt, Lane);
@@ -2739,7 +2739,7 @@ void CodeGenFunction::EmitStoreThroughLValue(RValue Src, LValue Dst,
         bool IsMatrixRowMajor = getLangOpts().getDefaultMatrixMemoryLayout() ==
                                 LangOptions::MatrixMemoryLayout::MatrixRowMajor;
         llvm::Value *EltIndex =
-            MB.createIndex(Row, ColIdx, NumRows, NumCols, IsMatrixRowMajor);
+            MB.CreateIndex(Row, ColIdx, NumRows, NumCols, IsMatrixRowMajor);
         llvm::Value *Lane = llvm::ConstantInt::get(Builder.getInt32Ty(), Col);
         llvm::Value *NewElt = Builder.CreateExtractElement(RowVal, Lane);
         MatrixVec = Builder.CreateInsertElement(MatrixVec, NewElt, EltIndex);
@@ -4989,7 +4989,7 @@ LValue CodeGenFunction::EmitMatrixSubscriptExpr(const MatrixSubscriptExpr *E) {
   bool IsMatrixRowMajor = getLangOpts().getDefaultMatrixMemoryLayout() ==
                           LangOptions::MatrixMemoryLayout::MatrixRowMajor;
   llvm::Value *FinalIdx =
-      MB.createIndex(RowIdx, ColIdx, NumRows, NumCols, IsMatrixRowMajor);
+      MB.CreateIndex(RowIdx, ColIdx, NumRows, NumCols, IsMatrixRowMajor);
 
   return LValue::MakeMatrixElt(
       MaybeConvertMatrixAddress(Base.getAddress(), *this), FinalIdx,

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2138,7 +2138,7 @@ Value *ScalarExprEmitter::VisitMatrixSingleSubscriptExpr(
     Value *ColVal = llvm::ConstantInt::get(RowIdx->getType(), Col);
     bool IsMatrixRowMajor = CGF.getLangOpts().getDefaultMatrixMemoryLayout() ==
                             LangOptions::MatrixMemoryLayout::MatrixRowMajor;
-    Value *EltIdx = MB.createIndex(RowIdx, ColVal, NumRows, NumColumns,
+    Value *EltIdx = MB.CreateIndex(RowIdx, ColVal, NumRows, NumColumns,
                                    IsMatrixRowMajor, "matrix_row_idx");
     Value *Elt =
         Builder.CreateExtractElement(FlatMatrix, EltIdx, "matrix_elem");
@@ -2165,7 +2165,7 @@ Value *ScalarExprEmitter::VisitMatrixSubscriptExpr(MatrixSubscriptExpr *E) {
   unsigned NumRows = MatrixTy->getNumRows();
   bool IsMatrixRowMajor = CGF.getLangOpts().getDefaultMatrixMemoryLayout() ==
                           LangOptions::MatrixMemoryLayout::MatrixRowMajor;
-  Idx = MB.createIndex(RowIdx, ColumnIdx, NumRows, NumCols, IsMatrixRowMajor);
+  Idx = MB.CreateIndex(RowIdx, ColumnIdx, NumRows, NumCols, IsMatrixRowMajor);
 
   if (CGF.CGM.getCodeGenOpts().OptimizationLevel > 0)
     MB.CreateIndexAssumption(Idx, MatrixTy->getNumElementsFlattened());

--- a/clang/test/CodeGen/matrix-type-indexing.c
+++ b/clang/test/CodeGen/matrix-type-indexing.c
@@ -1,0 +1,60 @@
+// RUN: %clang_cc1 -fenable-matrix -fmatrix-memory-layout=row-major -triple x86_64-apple-darwin %s -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefixes=CHECK,ROW-CHECK
+// RUN: %clang_cc1 -fenable-matrix -fmatrix-memory-layout=column-major -triple x86_64-apple-darwin %s -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefixes=CHECK,COL-CHECK
+// RUN: %clang_cc1 -fenable-matrix -triple x86_64-apple-darwin %s -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefixes=CHECK,COL-CHECK
+
+typedef float fx2x3_t __attribute__((matrix_type(2, 3)));
+ float Out[6];
+
+ fx2x3_t gM;
+
+void binaryOpMatrixSubscriptExpr(int index, fx2x3_t M) {
+    // CHECK-LABEL: binaryOpMatrixSubscriptExpr
+    // CHECK: %row = alloca i32, align 4
+    // CHECK: %col = alloca i32, align 4
+    // CHECK: [[row_load:%.*]] = load i32, ptr %row, align 4
+    // CHECK-NEXT: [[row_load_zext:%.*]] = zext i32 [[row_load]] to i64
+    // CHECK-NEXT: [[col_load:%.*]] = load i32, ptr %col, align 4
+    // CHECK-NEXT: [[col_load_zext:%.*]] = zext i32 [[col_load]] to i64
+    // COL-CHECK-NEXT: [[col_offset:%.*]] = mul i64 [[col_load_zext]], 2
+    // COL-CHECK-NEXT: [[col_major_index:%.*]] = add i64 [[col_offset]], [[row_load_zext]]
+    // ROW-CHECK-NEXT: [[row_offset:%.*]] = mul i64 [[row_load_zext]], 3
+    // ROW-CHECK-NEXT: [[row_major_index:%.*]] = add i64 [[row_offset]], [[col_load_zext]]
+    // CHECK-NEXT: [[matrix_as_vec:%.*]] = load <6 x float>, ptr %M.addr, align 4
+    // COL-CHECK-NEXT: %matrixext = extractelement <6 x float> [[matrix_as_vec]], i64 [[col_major_index]]
+    // ROW-CHECK-NEXT: %matrixext = extractelement <6 x float> [[matrix_as_vec]], i64 [[row_major_index]]
+    const unsigned int COLS = 3;
+    unsigned int row = index / COLS;
+    unsigned int col = index % COLS;
+    Out[index] = M[row][col];
+}
+
+float returnMatrixSubscriptExpr(int row, int col, fx2x3_t M) {
+    // CHECK-LABEL: returnMatrixSubscriptExpr
+    // CHECK: [[row_load:%.*]] = load i32, ptr [[row_ptr:%.*]], align 4
+    // CHECK-NEXT: [[row_load_sext:%.*]] = sext i32 [[row_load]] to i64
+    // CHECK-NEXT: [[col_load:%.*]] = load i32, ptr [[col_ptr:%.*]], align 4
+    // CHECK-NEXT: [[col_load_sext:%.*]] = sext i32 [[col_load]] to i64
+    // COL-CHECK-NEXT: [[col_offset:%.*]] = mul i64 [[col_load_sext]], 2
+    // COL-CHECK-NEXT: [[col_major_index:%.*]] = add i64 [[col_offset]], [[row_load_sext]]
+    // ROW-CHECK-NEXT: [[row_offset:%.*]] = mul i64 [[row_load_sext]], 3
+    // ROW-CHECK-NEXT: [[row_major_index:%.*]] = add i64 [[row_offset]], [[col_load_sext]]
+    // CHECK-NEXT: [[matrix_as_vec:%.*]] = load <6 x float>, ptr %M.addr, align 4
+    // COL-CHECK-NEXT: [[matrix_after_extract:%.*]] = extractelement <6 x float> [[matrix_as_vec]], i64 [[col_major_index]]
+    // ROW-CHECK-NEXT: [[matrix_after_extract:%.*]] = extractelement <6 x float> [[matrix_as_vec]], i64 [[row_major_index]]
+    // CHECK-NEXT: ret float [[matrix_after_extract]]
+    return M[row][col];
+}
+
+void storeAtMatrixSubscriptExpr(int row, int col, float value) {
+    // CHECK-LABEL: storeAtMatrixSubscriptExpr
+    // CHECK: [[value_load:%.*]] = load float, ptr [[value_ptr:%.*]], align 4
+    // ROW-CHECK: [[row_offset:%.*]] = mul i64 [[row_load:%.*]], 3
+    // ROW-CHECK-NEXT: [[row_major_index:%.*]] = add i64 [[row_offset]], [[col_load:%.*]]
+    // COL-CHECK: [[col_offset:%.*]] = mul i64 [[col_load:%.*]], 2
+    // COL-CHECK-NEXT: [[col_major_index:%.*]] = add i64 [[col_offset]], [[row_load:%.*]]
+    // CHECK-NEXT: [[matrix_as_vec:%.*]] = load <6 x float>, ptr @gM, align 4
+    // ROW-CHECK-NEXT: [[matrix_after_insert:%.*]] = insertelement <6 x float> [[matrix_as_vec]], float [[value_load]], i64 [[row_major_index]]
+    // COL-CHECK-NEXT: [[matrix_after_insert:%.*]] = insertelement <6 x float> [[matrix_as_vec]], float [[value_load]], i64 [[col_major_index]]
+    // CHECK-NEXT: store <6 x float> [[matrix_after_insert]], ptr @gM, align 4
+    gM[row][col] = value;
+}

--- a/clang/test/CodeGenCXX/matrix-type-indexing.cpp
+++ b/clang/test/CodeGenCXX/matrix-type-indexing.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -fenable-matrix  -fmatrix-memory-layout=column-major -triple x86_64-apple-darwin %s -emit-llvm -disable-llvm-passes -o - -std=c++11 | FileCheck %s
+// RUN: %clang_cc1 -fenable-matrix -triple x86_64-apple-darwin %s -emit-llvm -disable-llvm-passes -o - -std=c++11 | FileCheck %s
+
+ typedef float fx2x3_t __attribute__((matrix_type(2, 3)));
+ float Out[6];
+
+void binaryOpMatrixSubscriptExpr(int index, fx2x3_t M) {
+    // CHECK-LABEL: binaryOpMatrixSubscriptExpr
+    // CHECK: %row = alloca i32, align 4
+    // CHECK: %col = alloca i32, align 4
+    // CHECK: [[row_load:%.*]] = load i32, ptr %row, align 4
+    // CHECK-NEXT: [[row_load_zext:%.*]] = zext i32 [[row_load]] to i64
+    // CHECK-NEXT: [[col_load:%.*]] = load i32, ptr %col, align 4
+    // CHECK-NEXT: [[col_load_zext:%.*]] = zext i32 [[col_load]] to i64
+    // CHECK-NEXT: [[col_offset:%.*]] = mul i64 [[col_load_zext]], 2
+    // CHECK-NEXT: [[col_major_index:%.*]] = add i64 [[col_offset]], [[row_load_zext]]
+    // CHECK-NEXT: [[matrix_as_vec:%.*]] = load <6 x float>, ptr %M.addr, align 4
+    // CHECK-NEXT: %matrixext = extractelement <6 x float> [[matrix_as_vec]], i64 [[col_major_index]]
+    const unsigned int COLS = 3;
+    unsigned int row = index / COLS;
+    unsigned int col = index % COLS;
+    Out[index] = M[row][col];
+}
+
+float returnMatrixSubscriptExpr(int row, int col, fx2x3_t M) {
+    // CHECK-LABEL: returnMatrixSubscriptExpr
+    // CHECK: [[row_load:%.*]] = load i32, ptr %row.addr, align 4
+    // CHECK-NEXT: [[row_load_sext:%.*]] = sext i32 [[row_load]] to i64
+    // CHECK-NEXT: [[col_load:%.*]] = load i32, ptr %col.addr, align 4
+    // CHECK-NEXT: [[col_load_sext:%.*]] = sext i32 [[col_load]] to i64
+    // CHECK-NEXT: [[col_offset:%.*]] = mul i64 [[col_load_sext]], 2
+    // CHECK-NEXT: [[col_major_index:%.*]] = add i64 [[col_offset]], [[row_load_sext]]
+    // CHECK-NEXT: [[matrix_as_vec:%.*]] = load <6 x float>, ptr %M.addr, align 4
+    // CHECK-NEXT: %matrixext = extractelement <6 x float> [[matrix_as_vec]], i64 [[col_major_index]]
+    return M[row][col];
+}

--- a/clang/test/CodeGenHLSL/BasicFeatures/matrix-type-indexing.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/matrix-type-indexing.hlsl
@@ -1,0 +1,52 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=row-major -o - | FileCheck %s --check-prefixes=CHECK,ROW-CHECK
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=column-major -o - | FileCheck %s --check-prefixes=CHECK,COL-CHECK
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefixes=CHECK,COL-CHECK
+
+RWBuffer<int> Out : register(u1);
+half2x3 gM;
+
+
+void binaryOpMatrixSubscriptExpr(int index, half2x3 M) {
+    // CHECK-LABEL: binaryOpMatrixSubscriptExpr
+    // CHECK: %row = alloca i32, align 4
+    // CHECK: %col = alloca i32, align 4
+    // CHECK: [[row_load:%.*]] = load i32, ptr %row, align 4
+    // CHECK-NEXT: [[col_load:%.*]] = load i32, ptr %col, align 4
+    // ROW-CHECK-NEXT: [[row_offset:%.*]] = mul i32 [[row_load]], 3
+    // ROW-CHECK-NEXT: [[row_major_index:%.*]] = add i32 [[row_offset]], [[col_load]]
+    // COL-CHECK-NEXT: [[col_offset:%.*]] = mul i32 [[col_load]], 2
+    // COL-CHECK-NEXT: [[col_major_index:%.*]] = add i32 [[col_offset]], [[row_load]]
+    // CHECK-NEXT: [[matrix_as_vec:%.*]] = load <6 x half>, ptr %M.addr, align 2
+    // ROW-CHECK-NEXT: %matrixext = extractelement <6 x half> [[matrix_as_vec]], i32 [[row_major_index]]
+    // COL-CHECK-NEXT: %matrixext = extractelement <6 x half> [[matrix_as_vec]], i32 [[col_major_index]]
+    const uint COLS = 3;
+    uint row = index / COLS;
+    uint col = index % COLS;
+    Out[index] = M[row][col];
+}
+
+half returnMatrixSubscriptExpr(int row, int col, half2x3 M) {
+    // CHECK-LABEL: returnMatrixSubscriptExpr
+    // ROW-CHECK: [[row_offset:%.*]] = mul i32 [[row_load:%.*]], 3
+    // ROW-CHECK-NEXT: [[row_major_index:%.*]] = add i32 [[row_offset]], [[col_load:%.*]]
+    // COL-CHECK: [[col_offset:%.*]] = mul i32 [[col_load:%.*]], 2
+    // COL-CHECK-NEXT: [[col_major_index:%.*]] = add i32 [[col_offset]], [[row_load:%.*]]
+    // CHECK-NEXT: [[matrix_as_vec:%.*]] = load <6 x half>, ptr %M.addr, align 2
+    // ROW-CHECK-NEXT: %matrixext = extractelement <6 x half> [[matrix_as_vec]], i32 [[row_major_index]]
+    // COL-CHECK-NEXT: %matrixext = extractelement <6 x half> [[matrix_as_vec]], i32 [[col_major_index]]
+    return M[row][col];
+}
+
+void storeAtMatrixSubscriptExpr(int row, int col, half value) {
+    // CHECK-LABEL: storeAtMatrixSubscriptExpr
+    // CHECK: [[value_load:%.*]] = load half, ptr [[value_ptr:%.*]], align 2
+    // ROW-CHECK: [[row_offset:%.*]] = mul i32 [[row_load:%.*]], 3
+    // ROW-CHECK-NEXT: [[row_major_index:%.*]] = add i32 [[row_offset]], [[col_load:%.*]]
+    // COL-CHECK: [[col_offset:%.*]] = mul i32 [[col_load:%.*]], 2
+    // COL-CHECK-NEXT: [[col_major_index:%.*]] = add i32 [[col_offset]], [[row_load:%.*]]
+    // CHECK-NEXT: [[matrix_as_vec:%.*]] = load <6 x half>, ptr addrspace(2) @gM, align 2
+    // ROW-CHECK-NEXT: [[matrix_after_insert:%.*]] = insertelement <6 x half> [[matrix_as_vec]], half [[value_load]], i32 [[row_major_index]]
+    // COL-CHECK-NEXT: [[matrix_after_insert:%.*]] = insertelement <6 x half> [[matrix_as_vec]], half [[value_load]], i32 [[col_major_index]]
+    // CHECK-NEXT: store <6 x half> [[matrix_after_insert]], ptr addrspace(2) @gM, align 2
+    gM[row][col] = value;
+}

--- a/llvm/include/llvm/IR/MatrixBuilder.h
+++ b/llvm/include/llvm/IR/MatrixBuilder.h
@@ -238,7 +238,10 @@ public:
     else
       B.CreateAssumption(Cmp);
   }
-  Value *createIndex(Value *RowIdx, Value *ColumnIdx, unsigned NumRows,
+  /// Compute the index to access the element at (\p RowIdx, \p ColumnIdx) from
+  /// a matrix with \p NumRows or \p NumCols embedded in a vector depending
+  /// on matrix major ordering.
+  Value *CreateIndex(Value *RowIdx, Value *ColumnIdx, unsigned NumRows,
                      unsigned NumCols, bool IsMatrixRowMajor = false,
                      Twine const &Name = "") {
     unsigned MaxWidth = std::max(RowIdx->getType()->getScalarSizeInBits(),
@@ -248,23 +251,23 @@ public:
     ColumnIdx = B.CreateZExt(ColumnIdx, IntTy);
     if (IsMatrixRowMajor) {
       Value *NumColsV = B.getIntN(MaxWidth, NumCols);
-      return createRowMajorIndex(RowIdx, ColumnIdx, NumColsV, Name);
+      return CreateRowMajorIndex(RowIdx, ColumnIdx, NumColsV, Name);
     }
     Value *NumRowsV = B.getIntN(MaxWidth, NumRows);
-    return createColumnMajorIndex(RowIdx, ColumnIdx, NumRowsV, Name);
+    return CreateColumnMajorIndex(RowIdx, ColumnIdx, NumRowsV, Name);
   }
 
 private:
   /// Compute the index to access the element at (\p RowIdx, \p ColumnIdx) from
   /// a matrix with \p NumRows embedded in a vector.
-  Value *createColumnMajorIndex(Value *RowIdx, Value *ColumnIdx,
+  Value *CreateColumnMajorIndex(Value *RowIdx, Value *ColumnIdx,
                                 Value *NumRowsV, Twine const &Name) {
     return B.CreateAdd(B.CreateMul(ColumnIdx, NumRowsV), RowIdx);
   }
 
   /// Compute the index to access the element at (\p RowIdx, \p ColumnIdx) from
   /// a matrix with \p NumCols embedded in a vector.
-  Value *createRowMajorIndex(Value *RowIdx, Value *ColumnIdx, Value *NumColsV,
+  Value *CreateRowMajorIndex(Value *RowIdx, Value *ColumnIdx, Value *NumColsV,
                              Twine const &Name) {
     return B.CreateAdd(B.CreateMul(RowIdx, NumColsV), ColumnIdx);
   }

--- a/llvm/include/llvm/IR/MatrixBuilder.h
+++ b/llvm/include/llvm/IR/MatrixBuilder.h
@@ -241,8 +241,8 @@ public:
 
   /// Compute the index to access the element at (\p RowIdx, \p ColumnIdx) from
   /// a matrix with \p NumRows embedded in a vector.
-  Value *CreateIndex(Value *RowIdx, Value *ColumnIdx, unsigned NumRows,
-                     Twine const &Name = "") {
+  Value *createColumnMajorIndex(Value *RowIdx, Value *ColumnIdx,
+                                unsigned NumRows, Twine const &Name = "") {
     unsigned MaxWidth = std::max(RowIdx->getType()->getScalarSizeInBits(),
                                  ColumnIdx->getType()->getScalarSizeInBits());
     Type *IntTy = IntegerType::get(RowIdx->getType()->getContext(), MaxWidth);
@@ -250,6 +250,19 @@ public:
     ColumnIdx = B.CreateZExt(ColumnIdx, IntTy);
     Value *NumRowsV = B.getIntN(MaxWidth, NumRows);
     return B.CreateAdd(B.CreateMul(ColumnIdx, NumRowsV), RowIdx);
+  }
+
+  /// Compute the index to access the element at (\p RowIdx, \p ColumnIdx) from
+  /// a matrix with \p NumCols embedded in a vector.
+  Value *createRowMajorIndex(Value *RowIdx, Value *ColumnIdx, unsigned NumCols,
+                             Twine const &Name = "") {
+    unsigned MaxWidth = std::max(RowIdx->getType()->getScalarSizeInBits(),
+                                 ColumnIdx->getType()->getScalarSizeInBits());
+    Type *IntTy = IntegerType::get(RowIdx->getType()->getContext(), MaxWidth);
+    RowIdx = B.CreateZExt(RowIdx, IntTy);
+    ColumnIdx = B.CreateZExt(ColumnIdx, IntTy);
+    Value *NumColsV = B.getIntN(MaxWidth, NumCols);
+    return B.CreateAdd(B.CreateMul(RowIdx, NumColsV), ColumnIdx);
   }
 };
 


### PR DESCRIPTION
fixes #167617

In DXC HLSL supports different indexing modes via codegen for its equivalent of the MatrixSubscriptExpr when the /Zpr and /Zpc flags are used see: https://godbolt.org/z/bz5Y5WG36.

This change modifies EmitMatrixSubscriptExpr to consider the MatrixRowMajor/MatrixColMajor Layout flags before generating an index.

Similarly it introduces `createRowMajorIndex` and
`createColumnMajorIndex` in `MatrixBuilder.h` for use in `VisitMatrixSubscriptExpr`.