### PR TITLE
[clang-tidy] Moved Multiple Inheritence check from fuchsia to misc module

### DIFF
--- a/clang-tools-extra/clang-tidy/fuchsia/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/fuchsia/CMakeLists.txt
@@ -16,6 +16,7 @@ add_clang_library(clangTidyFuchsiaModule STATIC
   LINK_LIBS
   clangTidy
   clangTidyGoogleModule
+  clangTidyMiscModule
   clangTidyUtils
 
   DEPENDS

--- a/clang-tools-extra/clang-tidy/fuchsia/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/fuchsia/CMakeLists.txt
@@ -7,7 +7,6 @@ add_clang_library(clangTidyFuchsiaModule STATIC
   DefaultArgumentsCallsCheck.cpp
   DefaultArgumentsDeclarationsCheck.cpp
   FuchsiaTidyModule.cpp
-  MultipleInheritanceCheck.cpp
   OverloadedOperatorCheck.cpp
   StaticallyConstructedObjectsCheck.cpp
   TemporaryObjectsCheck.cpp

--- a/clang-tools-extra/clang-tidy/fuchsia/FuchsiaTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/fuchsia/FuchsiaTidyModule.cpp
@@ -10,9 +10,9 @@
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
 #include "../google/UnnamedNamespaceInHeaderCheck.h"
+#include "../misc/MultipleInheritanceCheck.h"
 #include "DefaultArgumentsCallsCheck.h"
 #include "DefaultArgumentsDeclarationsCheck.h"
-#include "MultipleInheritanceCheck.h"
 #include "OverloadedOperatorCheck.h"
 #include "StaticallyConstructedObjectsCheck.h"
 #include "TemporaryObjectsCheck.h"
@@ -34,7 +34,7 @@ public:
         "fuchsia-default-arguments-declarations");
     CheckFactories.registerCheck<google::build::UnnamedNamespaceInHeaderCheck>(
         "fuchsia-header-anon-namespaces");
-    CheckFactories.registerCheck<MultipleInheritanceCheck>(
+    CheckFactories.registerCheck<misc::MultipleInheritanceCheck>(
         "fuchsia-multiple-inheritance");
     CheckFactories.registerCheck<OverloadedOperatorCheck>(
         "fuchsia-overloaded-operator");

--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -28,6 +28,7 @@ add_clang_library(clangTidyMiscModule STATIC
   MisleadingBidirectionalCheck.cpp
   MisleadingIdentifierCheck.cpp
   MisplacedConstCheck.cpp
+  MultipleInheritanceCheck.cpp
   NewDeleteOverloadsCheck.cpp
   NoRecursionCheck.cpp
   NonCopyableObjectsCheck.cpp

--- a/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
@@ -18,6 +18,7 @@
 #include "MisleadingBidirectionalCheck.h"
 #include "MisleadingIdentifierCheck.h"
 #include "MisplacedConstCheck.h"
+#include "MultipleInheritanceCheck.h"
 #include "NewDeleteOverloadsCheck.h"
 #include "NoRecursionCheck.h"
 #include "NonCopyableObjectsCheck.h"
@@ -57,6 +58,8 @@ public:
     CheckFactories.registerCheck<MisleadingIdentifierCheck>(
         "misc-misleading-identifier");
     CheckFactories.registerCheck<MisplacedConstCheck>("misc-misplaced-const");
+    CheckFactories.registerCheck<MultipleInheritanceCheck>(
+        "misc-multiple-inheritance");
     CheckFactories.registerCheck<NewDeleteOverloadsCheck>(
         "misc-new-delete-overloads");
     CheckFactories.registerCheck<NoRecursionCheck>("misc-no-recursion");

--- a/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.cpp
@@ -13,7 +13,7 @@
 using namespace clang;
 using namespace clang::ast_matchers;
 
-namespace clang::tidy::fuchsia {
+namespace clang::tidy::misc {
 
 namespace {
 AST_MATCHER(CXXRecordDecl, hasBases) {
@@ -74,4 +74,4 @@ void MultipleInheritanceCheck::check(const MatchFinder::MatchResult &Result) {
                           "pure virtual is discouraged");
 }
 
-} // namespace clang::tidy::fuchsia
+} // namespace clang::tidy::misc

--- a/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.h
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_FUCHSIA_MULTIPLEINHERITANCECHECK_H
-#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_FUCHSIA_MULTIPLEINHERITANCECHECK_H
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_MULTIPLEINHERITANCECHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_MULTIPLEINHERITANCECHECK_H
 
 #include "../ClangTidyCheck.h"
 
-namespace clang::tidy::fuchsia {
+namespace clang::tidy::misc {
 
 /// Multiple implementation inheritance is discouraged.
 ///
@@ -38,6 +38,6 @@ private:
   llvm::DenseMap<const CXXRecordDecl *, bool> InterfaceMap;
 };
 
-} // namespace clang::tidy::fuchsia
+} // namespace clang::tidy::misc
 
-#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_FUCHSIA_MULTIPLEINHERITANCECHECK_H
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_MULTIPLEINHERITANCECHECK_H

--- a/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/MultipleInheritanceCheck.h
@@ -16,7 +16,7 @@ namespace clang::tidy::misc {
 /// Multiple implementation inheritance is discouraged.
 ///
 /// For the user-facing documentation see:
-/// https://clang.llvm.org/extra/clang-tidy/checks/fuchsia/multiple-inheritance.html
+/// https://clang.llvm.org/extra/clang-tidy/checks/misc/multiple-inheritance.html
 class MultipleInheritanceCheck : public ClangTidyCheck {
 public:
   MultipleInheritanceCheck(StringRef Name, ClangTidyContext *Context)

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -328,6 +328,11 @@ New check aliases
   <clang-tidy/checks/bugprone/copy-constructor-mutates-argument>`
   keeping initial check as an alias to the new one.
 
+- Renamed :doc:`fuchsia-multiple-inheritance <clang-tidy/checks/fuchsia/multiple-inheritance>` to
+  :doc:`misc-multiple-inheritance
+  <clang-tidy/checks/misc/multiple-inheritance>`
+  keeping initial check as an alias to the new one.
+
 - Renamed :doc:`google-readability-casting <clang-tidy/checks/google/readability-casting>` to
   :doc:`modernize-avoid-c-style-cast
   <clang-tidy/checks/modernize/avoid-c-style-cast>`

--- a/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/fuchsia/multiple-inheritance.rst
@@ -3,44 +3,7 @@
 fuchsia-multiple-inheritance
 ============================
 
-Warns if a class inherits from multiple classes that are not pure virtual.
-
-For example, declaring a class that inherits from multiple concrete classes is
-disallowed:
-
-.. code-block:: c++
-
-  class Base_A {
-  public:
-    virtual int foo() { return 0; }
-  };
-
-  class Base_B {
-  public:
-    virtual int bar() { return 0; }
-  };
-
-  // Warning
-  class Bad_Child1 : public Base_A, Base_B {};
-
-A class that inherits from a pure virtual is allowed:
-
-.. code-block:: c++
-
-  class Interface_A {
-  public:
-    virtual int foo() = 0;
-  };
-
-  class Interface_B {
-  public:
-    virtual int bar() = 0;
-  };
-
-  // No warning
-  class Good_Child1 : public Interface_A, Interface_B {
-    virtual int foo() override { return 0; }
-    virtual int bar() override { return 0; }
-  };
+The `fuchsia-multiple-inheritance` check is an alias, please See
+:doc:`misc-multiple-inheritance <../misc/multiple-inheritance>` for details.
 
 See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -222,7 +222,6 @@ Clang-Tidy Checks
    :doc:`darwin-dispatch-once-nonstatic <darwin/dispatch-once-nonstatic>`, "Yes"
    :doc:`fuchsia-default-arguments-calls <fuchsia/default-arguments-calls>`,
    :doc:`fuchsia-default-arguments-declarations <fuchsia/default-arguments-declarations>`, "Yes"
-   :doc:`fuchsia-multiple-inheritance <fuchsia/multiple-inheritance>`,
    :doc:`fuchsia-overloaded-operator <fuchsia/overloaded-operator>`,
    :doc:`fuchsia-statically-constructed-objects <fuchsia/statically-constructed-objects>`,
    :doc:`fuchsia-temporary-objects <fuchsia/temporary-objects>`,
@@ -272,6 +271,7 @@ Clang-Tidy Checks
    :doc:`misc-misleading-bidirectional <misc/misleading-bidirectional>`,
    :doc:`misc-misleading-identifier <misc/misleading-identifier>`,
    :doc:`misc-misplaced-const <misc/misplaced-const>`,
+   :doc:`misc-multiple-inheritance <misc/multiple-inheritance>`,
    :doc:`misc-new-delete-overloads <misc/new-delete-overloads>`,
    :doc:`misc-no-recursion <misc/no-recursion>`,
    :doc:`misc-non-copyable-objects <misc/non-copyable-objects>`,
@@ -584,6 +584,7 @@ Check aliases
    :doc:`cppcoreguidelines-non-private-member-variables-in-classes <cppcoreguidelines/non-private-member-variables-in-classes>`, :doc:`misc-non-private-member-variables-in-classes <misc/non-private-member-variables-in-classes>`,
    :doc:`cppcoreguidelines-use-default-member-init <cppcoreguidelines/use-default-member-init>`, :doc:`modernize-use-default-member-init <modernize/use-default-member-init>`, "Yes"
    :doc:`fuchsia-header-anon-namespaces <fuchsia/header-anon-namespaces>`, :doc:`google-build-namespaces <google/build-namespaces>`,
+   :doc:`fuchsia-multiple-inheritance <fuchsia/multiple-inheritance>`, :doc:`misc-multiple-inheritance <misc/multiple-inheritance>`,
    :doc:`google-readability-braces-around-statements <google/readability-braces-around-statements>`, :doc:`readability-braces-around-statements <readability/braces-around-statements>`, "Yes"
    :doc:`google-readability-casting <google/readability-casting>`, :doc:`modernize-avoid-c-style-cast <modernize/avoid-c-style-cast>`,
    :doc:`google-readability-function-size <google/readability-function-size>`, :doc:`readability-function-size <readability/function-size>`,

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/multiple-inheritance.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/multiple-inheritance.rst
@@ -1,0 +1,49 @@
+.. title:: clang-tidy - misc-multiple-inheritance
+
+misc-multiple-inheritance
+=========================
+
+Warns if a class inherits from multiple classes that are not pure virtual.
+
+For example, declaring a class that inherits from multiple concrete classes is
+disallowed:
+
+.. code-block:: c++
+
+  class Base_A {
+  public:
+    virtual int foo() { return 0; }
+  };
+
+  class Base_B {
+  public:
+    virtual int bar() { return 0; }
+  };
+
+  // Warning
+  class Bad_Child1 : public Base_A, Base_B {};
+
+A class that inherits from a pure virtual is allowed:
+
+.. code-block:: c++
+
+  class Interface_A {
+  public:
+    virtual int foo() = 0;
+  };
+
+  class Interface_B {
+  public:
+    virtual int bar() = 0;
+  };
+
+  // No warning
+  class Good_Child1 : public Interface_A, Interface_B {
+    virtual int foo() override { return 0; }
+    virtual int bar() override { return 0; }
+  };
+
+References
+----------
+
+See the features disallowed in Fuchsia at https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/cxx?hl=en

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/multiple-inheritance.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/multiple-inheritance.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s fuchsia-multiple-inheritance %t
+// RUN: %check_clang_tidy %s misc-multiple-inheritance %t
 
 class Base_A {
 public:
@@ -45,16 +45,16 @@ public:
 class Bad_Child1;
 
 // Inherits from multiple concrete classes.
-// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [fuchsia-multiple-inheritance]
+// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [misc-multiple-inheritance]
 // CHECK-NEXT: class Bad_Child1 : public Base_A, Base_B {};
 class Bad_Child1 : public Base_A, Base_B {};
 
-// CHECK-MESSAGES: [[@LINE+1]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [fuchsia-multiple-inheritance]
+// CHECK-MESSAGES: [[@LINE+1]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [misc-multiple-inheritance]
 class Bad_Child2 : public Base_A, Interface_A_with_member {
   virtual int foo() override { return 0; }
 };
 
-// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [fuchsia-multiple-inheritance]
+// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [misc-multiple-inheritance]
 // CHECK-NEXT: class Bad_Child3 : public Interface_with_A_Parent, Base_B {
 class Bad_Child3 : public Interface_with_A_Parent, Base_B {
   virtual int baz() override { return 0; }
@@ -83,7 +83,7 @@ class Good_Child3 : public Base_A_child, Interface_C, Interface_B {
 
 struct B1 { int x; };
 struct B2 { int x;};
-// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [fuchsia-multiple-inheritance]
+// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [misc-multiple-inheritance]
 // CHECK-NEXT: struct D : B1, B2 {};
 struct D1 : B1, B2 {};
 
@@ -100,7 +100,7 @@ struct D3 : V3, V4 {};
 struct Base3 {};
 struct V5 : virtual Base3 { virtual void f(); };
 struct V6 : virtual Base3 { virtual void g(); };
-// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [fuchsia-multiple-inheritance]
+// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [misc-multiple-inheritance]
 // CHECK-NEXT: struct D4 : V5, V6 {};
 struct D4 : V5, V6 {};
 
@@ -118,7 +118,7 @@ struct Base6 { virtual void f(); };
 struct Base7 { virtual void g(); };
 struct V15 : virtual Base6 { virtual void f() = 0; };
 struct V16 : virtual Base7 { virtual void g() = 0; };
-// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [fuchsia-multiple-inheritance]
+// CHECK-MESSAGES: [[@LINE+2]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [misc-multiple-inheritance]
 // CHECK-NEXT: struct D9 : V15, V16 {};
 struct D9 : V15, V16 {};
 
@@ -159,7 +159,7 @@ namespace N {
 struct S1 { int i; };
 struct S2 { int i; };
 
-// CHECK-MESSAGES: [[@LINE+1]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [fuchsia-multiple-inheritance]
+// CHECK-MESSAGES: [[@LINE+1]]:1: warning: inheriting multiple classes that aren't pure virtual is discouraged [misc-multiple-inheritance]
 struct S3 : S1, S2 {};
 
 } // namespace N


### PR DESCRIPTION
Resolves: [#171136](https://github.com/llvm/llvm-project/issues/171136) 

Referred the issue tagged in the issue mentioned.