### PR TITLE
Fix misprint in computeKnownFPClass in GISelValueTracking.cpp

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
@@ -1373,7 +1373,8 @@ void GISelValueTracking::computeKnownFPClass(Register R,
           (KnownLHS.isKnownNeverInfinity() || KnownRHS.isKnownNeverInfinity()))
         Known.knownNot(fcNan);
 
-      if (Opcode == Instruction::FAdd) {
+      if (Opcode == TargetOpcode::G_FADD ||
+          Opcode == TargetOpcode::G_STRICT_FADD) {
         if (KnownLHS.cannotBeOrderedLessThanZero() &&
             KnownRHS.cannotBeOrderedLessThanZero())
           Known.knownNot(KnownFPClass::OrderedLessThanZeroMask);
@@ -1488,7 +1489,7 @@ void GISelValueTracking::computeKnownFPClass(Register R,
                           KnownLHS, Depth + 1);
     }
 
-    if (Opcode == Instruction::FDiv) {
+    if (Opcode == TargetOpcode::G_FDIV) {
       // Only 0/0, Inf/Inf produce NaN.
       if (KnownLHS.isKnownNeverNaN() && KnownRHS.isKnownNeverNaN() &&
           (KnownLHS.isKnownNeverInfinity() ||

--- a/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
@@ -751,6 +751,31 @@ TEST_F(AArch64GISelMITest, TestFPClassFAdd_Zero) {
   EXPECT_EQ(std::nullopt, Known.SignBit);
 }
 
+TEST_F(AArch64GISelMITest, TestFPClassFAdd_NegZero) {
+  StringRef MIRString = R"(
+    %ptr:_(p0) = G_IMPLICIT_DEF
+    %lhs:_(s32) = G_LOAD %ptr(p0) :: (load (s32))    
+    %rhs:_(s32) = G_FCONSTANT float -0.0
+    %fadd:_(s32) = G_FADD %lhs, %rhs
+    %copy_fadd:_(s32) = COPY %fadd
+)";
+
+  setUp(MIRString);
+  if (!TM)
+    GTEST_SKIP();
+
+  Register CopyReg = Copies[Copies.size() - 1];
+  MachineInstr *FinalCopy = MRI->getVRegDef(CopyReg);
+  Register SrcReg = FinalCopy->getOperand(1).getReg();
+
+  GISelValueTracking Info(*MF);
+
+  KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
+
+  EXPECT_EQ(fcAllFlags, Known.KnownFPClasses);
+  EXPECT_EQ(std::nullopt, Known.SignBit);
+}
+
 TEST_F(AArch64GISelMITest, TestFPClassFMul) {
   StringRef MIRString = R"(
     %ptr:_(p0) = G_IMPLICIT_DEF

--- a/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/KnownFPClassTest.cpp
@@ -726,6 +726,31 @@ TEST_F(AArch64GISelMITest, TestFPClassFAdd) {
   EXPECT_EQ(std::nullopt, Known.SignBit);
 }
 
+TEST_F(AArch64GISelMITest, TestFPClassFAdd_Zero) {
+  StringRef MIRString = R"(
+    %ptr:_(p0) = G_IMPLICIT_DEF
+    %lhs:_(s32) = G_LOAD %ptr(p0) :: (load (s32))    
+    %rhs:_(s32) = G_FCONSTANT float 0.0
+    %fadd:_(s32) = G_FADD %lhs, %rhs
+    %copy_fadd:_(s32) = COPY %fadd
+)";
+
+  setUp(MIRString);
+  if (!TM)
+    GTEST_SKIP();
+
+  Register CopyReg = Copies[Copies.size() - 1];
+  MachineInstr *FinalCopy = MRI->getVRegDef(CopyReg);
+  Register SrcReg = FinalCopy->getOperand(1).getReg();
+
+  GISelValueTracking Info(*MF);
+
+  KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
+
+  EXPECT_EQ(fcAllFlags & ~fcNegZero, Known.KnownFPClasses);
+  EXPECT_EQ(std::nullopt, Known.SignBit);
+}
+
 TEST_F(AArch64GISelMITest, TestFPClassFMul) {
   StringRef MIRString = R"(
     %ptr:_(p0) = G_IMPLICIT_DEF
@@ -998,6 +1023,30 @@ TEST_F(AArch64GISelMITest, TestFPClassFDiv) {
 
   EXPECT_EQ(fcPosNormal | fcNan, Known.KnownFPClasses);
   EXPECT_EQ(std::nullopt, Known.SignBit);
+}
+
+TEST_F(AArch64GISelMITest, TestFPClassFDiv_Inf) {
+  StringRef MIRString = R"(
+    %lhs:_(s32) = G_FCONSTANT float 1.0
+    %rhs:_(s32) = G_FCONSTANT float 0.0
+    %fdiv:_(s32) = G_FDIV %lhs, %rhs
+    %copy_fdiv:_(s32) = COPY %fdiv
+)";
+
+  setUp(MIRString);
+  if (!TM)
+    GTEST_SKIP();
+
+  Register CopyReg = Copies[Copies.size() - 1];
+  MachineInstr *FinalCopy = MRI->getVRegDef(CopyReg);
+  Register SrcReg = FinalCopy->getOperand(1).getReg();
+
+  GISelValueTracking Info(*MF);
+
+  KnownFPClass Known = Info.computeKnownFPClass(SrcReg);
+
+  EXPECT_EQ(fcPositive, Known.KnownFPClasses);
+  EXPECT_EQ(false, Known.SignBit);
 }
 
 TEST_F(AArch64GISelMITest, TestFPClassFRem) {


### PR DESCRIPTION
Fix wrong value(from Instruction enum) in conditional and add test check.
Related with
https://github.com/llvm/llvm-project/issues/169959


