### PR TITLE
[clang][bytecode][NFC] Remove an outdated comment

### DIFF
--- a/clang/test/AST/ByteCode/new-delete.cpp
+++ b/clang/test/AST/ByteCode/new-delete.cpp
@@ -523,7 +523,6 @@ namespace DeleteRunsDtors {
   static_assert(abc2() == 1);
 }
 
-/// FIXME: There is a slight difference in diagnostics here.
 namespace FaultyDtorCalledByDelete {
   struct InnerFoo {
     int *mem;


### PR DESCRIPTION
Both implementations emit the same diagnostics these days.