### PR TITLE
[BOLT] Exclude BOLT injected functions from AssignSections. NFCI

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -735,11 +735,12 @@ private:
     Symbols.push_back(BC.Ctx->getOrCreateSymbol(Name));
   }
 
-  /// This constructor is used to create an injected function
+  /// This constructor is used to create an injected function, i.e. a function
+  /// that didn't originate in the input file.
   BinaryFunction(const std::string &Name, BinaryContext &BC, bool IsSimple)
       : Address(0), Size(0), BC(BC), IsSimple(IsSimple),
-        CodeSectionName(buildCodeSectionName(Name, BC)),
-        ColdCodeSectionName(buildColdCodeSectionName(Name, BC)),
+        CodeSectionName(BC.getInjectedCodeSectionName()),
+        ColdCodeSectionName(BC.getInjectedColdCodeSectionName()),
         FunctionNumber(++Count) {
     Symbols.push_back(BC.Ctx->getOrCreateSymbol(Name));
     IsInjected = true;

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2598,6 +2598,10 @@ BinaryContext::createInstructionPatch(uint64_t Address,
   PBF->addBasicBlock()->addInstructions(Instructions);
   PBF->setIsPatch(true);
 
+  // Patch functions have to be emitted each into their unique section.
+  PBF->setCodeSectionName(
+      BinaryFunction::buildCodeSectionName(PBF->getOneName(), *this));
+
   // Don't create symbol table entry if the name wasn't specified.
   if (Name.str().empty())
     PBF->setAnonymous(true);

--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -1276,13 +1276,6 @@ Error SimplifyRODataLoads::runOnFunctions(BinaryContext &BC) {
 }
 
 Error AssignSections::runOnFunctions(BinaryContext &BC) {
-  for (BinaryFunction *Function : BC.getInjectedBinaryFunctions()) {
-    if (!Function->isPatch()) {
-      Function->setCodeSectionName(BC.getInjectedCodeSectionName());
-      Function->setColdCodeSectionName(BC.getInjectedColdCodeSectionName());
-    }
-  }
-
   // In non-relocation mode functions have pre-assigned section names.
   if (!BC.HasRelocations)
     return Error::success();


### PR DESCRIPTION
Assign output sections for injected functions explicitly, and don't reassign in AssignSections pass.

This change is a prerequisite for further PRs where veneer functions are created as injected functions and their code section depends on their placement.