### PR TITLE
[lldb-dap] enable TestDAP_module on linux

### DIFF
--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -7,8 +7,6 @@ from lldbsuite.test.lldbtest import *
 import lldbdap_testcase
 import re
 
-# Flakey in Github CI runs, see https://github.com/llvm/llvm-project/issues/137660.
-@skipIfLinux
 class TestDAP_module(lldbdap_testcase.DAPTestCaseBase):
     def run_test(self, symbol_basename, expect_debug_info_size):
         program_basename = "a.out.stripped"


### PR DESCRIPTION
The issue was fixed in https://github.com/llvm/llvm-project/pull/163821