### PR TITLE
[libc++] Make basic_string::npos inline

### DIFF
--- a/libcxx/.clang-format
+++ b/libcxx/.clang-format
@@ -49,7 +49,6 @@ AttributeMacros: [
                   '_LIBCPP_REQUIRES_CAPABILITY',
                   '_LIBCPP_SCOPED_LOCKABLE',
                   '_LIBCPP_STANDALONE_DEBUG',
-                  '_LIBCPP_TEMPLATE_DATA_VIS',
                   '_LIBCPP_TRY_ACQUIRE_CAPABILITY',
                   '_LIBCPP_TRY_ACQUIRE_SHARED_CAPABILITY',
                   '_LIBCPP_USING_IF_EXISTS',

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -217,7 +217,6 @@ typedef __char32_t char32_t;
 #    endif
 
 #    define _LIBCPP_HIDDEN
-#    define _LIBCPP_TEMPLATE_DATA_VIS
 #    define _LIBCPP_NAMESPACE_VISIBILITY
 
 #  else
@@ -229,7 +228,6 @@ typedef __char32_t char32_t;
 #    endif
 
 #    define _LIBCPP_HIDDEN _LIBCPP_VISIBILITY("hidden")
-#    define _LIBCPP_TEMPLATE_DATA_VIS _LIBCPP_VISIBILITY("default")
 #    define _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_VISIBILITY("default")
 #    define _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS _LIBCPP_VISIBILITY("default")
 #    define _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS

--- a/libcxx/include/__string/extern_template_lists.h
+++ b/libcxx/include/__string/extern_template_lists.h
@@ -68,7 +68,6 @@
     Func(int basic_string<CharT>::compare(size_type, size_type, const value_type*) const)                              \
     Func(int basic_string<CharT>::compare(size_type, size_type, const value_type*, size_type) const)                   \
     Func(int basic_string<CharT>::compare(size_type, size_type, const basic_string&, size_type, size_type) const)      \
-    Func(const basic_string<CharT>::size_type basic_string<CharT>::npos)                                               \
 
 #define _LIBCPP_STRING_V1_EXTERN_TEMPLATE_LIST(Func, CharT)                                                            \
   _LIBCPP_STRING_COMMON_EXTERN_TEMPLATE_LIST(Func, CharT)                                                              \

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -971,7 +971,7 @@ private:
   }
 
 public:
-  _LIBCPP_TEMPLATE_DATA_VIS static const size_type npos = -1;
+  static inline const size_type npos = -1;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string()
       _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
@@ -3898,10 +3898,6 @@ stoull(const wstring& __str, size_t* __idx = nullptr, int __base = 10);
 [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI wstring to_wstring(double __val);
 [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI wstring to_wstring(long double __val);
 #  endif // _LIBCPP_HAS_WIDE_CHARACTERS
-
-template <class _CharT, class _Traits, class _Allocator>
-_LIBCPP_TEMPLATE_DATA_VIS const typename basic_string<_CharT, _Traits, _Allocator>::size_type
-    basic_string<_CharT, _Traits, _Allocator>::npos;
 
 template <class _CharT, class _Allocator>
 struct __string_hash : public __unary_function<basic_string<_CharT, char_traits<_CharT>, _Allocator>, size_t> {

--- a/libcxx/src/string.cpp
+++ b/libcxx/src/string.cpp
@@ -53,8 +53,18 @@ void basic_string<_CharT, _Traits, _Allocator>::__init(const value_type* __s, si
   __annotate_new(__sz);
 }
 
+// We provide the external 'npos' instantiation for backwards compatibility. However, that was never provided on COFF
+// platforms, so we only provide it on non-coff platforms.
+#  ifdef _LIBCPP_OBJECT_FORMAT_COFF
+#    define STRING_NPOS(CharT) static_assert(true)
+#  else
+#    define STRING_NPOS(CharT)                                                                                         \
+      template _LIBCPP_EXPORTED_FROM_ABI const basic_string<CharT>::size_type basic_string<CharT>::npos
+#  endif
+
 #  define STRING_LEGACY_API(CharT)                                                                                     \
-    template _LIBCPP_EXPORTED_FROM_ABI void basic_string<CharT>::__init(const value_type*, size_type, size_type)
+    template _LIBCPP_EXPORTED_FROM_ABI void basic_string<CharT>::__init(const value_type*, size_type, size_type);      \
+    STRING_NPOS(CharT)
 
 STRING_LEGACY_API(char);
 #  if _LIBCPP_HAS_WIDE_CHARACTERS


### PR DESCRIPTION
`basic_string::npos` should almost never be used in a way that takes the address of the variable, so we can just make it `inline`. This removes the only use of `_LIBCPP_TEMPLATE_DATA_VIS`.