### PR TITLE
[sanitizer_common][test-only] Specify full path for sort executable in popen.cpp

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/popen.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/popen.cpp
@@ -8,7 +8,7 @@
 int main(void) {
   // use a tool that produces different output than input to verify
   // that everything worked correctly
-  FILE *fp = popen("sort", "w");
+  FILE *fp = popen("/usr/bin/sort", "w");
   assert(fp);
 
   // verify that fileno() returns a meaningful descriptor (needed


### PR DESCRIPTION
This test has begun failing on iossim with 'sh: sort: command not found' in the stderr. I believe this may be due to the change to the lit internal shell not having 'sort' in it's path.

This patch adds the full path /usr/bin/sort to work around this.