### PR TITLE
[libc++][NFC] Assume that __GCC_{CON,DE}STRUCTIVE_SIZE are available

### DIFF
--- a/libcxx/include/__new/interference_size.h
+++ b/libcxx/include/__new/interference_size.h
@@ -20,12 +20,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 17
 
-#  if defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
-
 inline constexpr size_t hardware_destructive_interference_size  = __GCC_DESTRUCTIVE_SIZE;
 inline constexpr size_t hardware_constructive_interference_size = __GCC_CONSTRUCTIVE_SIZE;
-
-#  endif // defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
 
 #endif // _LIBCPP_STD_VER >= 17
 

--- a/libcxx/include/version
+++ b/libcxx/include/version
@@ -343,9 +343,7 @@ __cpp_lib_void_t                                        201411L <type_traits>
 #   define __cpp_lib_filesystem                         201703L
 # endif
 # define __cpp_lib_gcd_lcm                              201606L
-# if defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
-#   define __cpp_lib_hardware_interference_size         201703L
-# endif
+# define __cpp_lib_hardware_interference_size           201703L
 # define __cpp_lib_has_unique_object_representations    201606L
 # define __cpp_lib_hypot                                201603L
 # define __cpp_lib_incomplete_container_elements        201505L

--- a/libcxx/modules/std/new.inc
+++ b/libcxx/modules/std/new.inc
@@ -28,11 +28,9 @@ export namespace std {
   // [ptr.launder], pointer optimization barrier
   using std::launder;
 #if _LIBCPP_STD_VER >= 17
-#  if defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
   // [hardware.interference], hardware interference size
   using std::hardware_constructive_interference_size;
   using std::hardware_destructive_interference_size;
-#  endif
 #endif // _LIBCPP_STD_VER >= 17
 } // namespace std
 

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/new.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/new.version.compile.pass.cpp
@@ -64,17 +64,11 @@
 #    error "__cpp_lib_destroying_delete should not be defined before c++20"
 #  endif
 
-#  if !defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))
-#    ifndef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should be defined in c++17"
-#    endif
-#    if __cpp_lib_hardware_interference_size != 201703L
-#      error "__cpp_lib_hardware_interference_size should have the value 201703L in c++17"
-#    endif
-#  else
-#    ifdef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should not be defined when the requirement '!defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))' is not met!"
-#    endif
+#  ifndef __cpp_lib_hardware_interference_size
+#    error "__cpp_lib_hardware_interference_size should be defined in c++17"
+#  endif
+#  if __cpp_lib_hardware_interference_size != 201703L
+#    error "__cpp_lib_hardware_interference_size should have the value 201703L in c++17"
 #  endif
 
 #  ifndef __cpp_lib_launder
@@ -103,17 +97,11 @@
 #    endif
 #  endif
 
-#  if !defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))
-#    ifndef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should be defined in c++20"
-#    endif
-#    if __cpp_lib_hardware_interference_size != 201703L
-#      error "__cpp_lib_hardware_interference_size should have the value 201703L in c++20"
-#    endif
-#  else
-#    ifdef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should not be defined when the requirement '!defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))' is not met!"
-#    endif
+#  ifndef __cpp_lib_hardware_interference_size
+#    error "__cpp_lib_hardware_interference_size should be defined in c++20"
+#  endif
+#  if __cpp_lib_hardware_interference_size != 201703L
+#    error "__cpp_lib_hardware_interference_size should have the value 201703L in c++20"
 #  endif
 
 #  ifndef __cpp_lib_launder
@@ -142,17 +130,11 @@
 #    endif
 #  endif
 
-#  if !defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))
-#    ifndef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should be defined in c++23"
-#    endif
-#    if __cpp_lib_hardware_interference_size != 201703L
-#      error "__cpp_lib_hardware_interference_size should have the value 201703L in c++23"
-#    endif
-#  else
-#    ifdef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should not be defined when the requirement '!defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))' is not met!"
-#    endif
+#  ifndef __cpp_lib_hardware_interference_size
+#    error "__cpp_lib_hardware_interference_size should be defined in c++23"
+#  endif
+#  if __cpp_lib_hardware_interference_size != 201703L
+#    error "__cpp_lib_hardware_interference_size should have the value 201703L in c++23"
 #  endif
 
 #  ifndef __cpp_lib_launder
@@ -190,17 +172,11 @@
 #    endif
 #  endif
 
-#  if !defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))
-#    ifndef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should be defined in c++26"
-#    endif
-#    if __cpp_lib_hardware_interference_size != 201703L
-#      error "__cpp_lib_hardware_interference_size should have the value 201703L in c++26"
-#    endif
-#  else
-#    ifdef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should not be defined when the requirement '!defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))' is not met!"
-#    endif
+#  ifndef __cpp_lib_hardware_interference_size
+#    error "__cpp_lib_hardware_interference_size should be defined in c++26"
+#  endif
+#  if __cpp_lib_hardware_interference_size != 201703L
+#    error "__cpp_lib_hardware_interference_size should have the value 201703L in c++26"
 #  endif
 
 #  ifndef __cpp_lib_launder

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
@@ -2384,17 +2384,11 @@
 #    error "__cpp_lib_generic_unordered_lookup should not be defined before c++20"
 #  endif
 
-#  if !defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))
-#    ifndef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should be defined in c++17"
-#    endif
-#    if __cpp_lib_hardware_interference_size != 201703L
-#      error "__cpp_lib_hardware_interference_size should have the value 201703L in c++17"
-#    endif
-#  else
-#    ifdef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should not be defined when the requirement '!defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))' is not met!"
-#    endif
+#  ifndef __cpp_lib_hardware_interference_size
+#    error "__cpp_lib_hardware_interference_size should be defined in c++17"
+#  endif
+#  if __cpp_lib_hardware_interference_size != 201703L
+#    error "__cpp_lib_hardware_interference_size should have the value 201703L in c++17"
 #  endif
 
 #  ifndef __cpp_lib_has_unique_object_representations
@@ -3706,17 +3700,11 @@
 #    error "__cpp_lib_generic_unordered_lookup should have the value 201811L in c++20"
 #  endif
 
-#  if !defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))
-#    ifndef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should be defined in c++20"
-#    endif
-#    if __cpp_lib_hardware_interference_size != 201703L
-#      error "__cpp_lib_hardware_interference_size should have the value 201703L in c++20"
-#    endif
-#  else
-#    ifdef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should not be defined when the requirement '!defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))' is not met!"
-#    endif
+#  ifndef __cpp_lib_hardware_interference_size
+#    error "__cpp_lib_hardware_interference_size should be defined in c++20"
+#  endif
+#  if __cpp_lib_hardware_interference_size != 201703L
+#    error "__cpp_lib_hardware_interference_size should have the value 201703L in c++20"
 #  endif
 
 #  ifndef __cpp_lib_has_unique_object_representations
@@ -5220,17 +5208,11 @@
 #    error "__cpp_lib_generic_unordered_lookup should have the value 201811L in c++23"
 #  endif
 
-#  if !defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))
-#    ifndef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should be defined in c++23"
-#    endif
-#    if __cpp_lib_hardware_interference_size != 201703L
-#      error "__cpp_lib_hardware_interference_size should have the value 201703L in c++23"
-#    endif
-#  else
-#    ifdef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should not be defined when the requirement '!defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))' is not met!"
-#    endif
+#  ifndef __cpp_lib_hardware_interference_size
+#    error "__cpp_lib_hardware_interference_size should be defined in c++23"
+#  endif
+#  if __cpp_lib_hardware_interference_size != 201703L
+#    error "__cpp_lib_hardware_interference_size should have the value 201703L in c++23"
 #  endif
 
 #  ifndef __cpp_lib_has_unique_object_representations
@@ -7079,17 +7061,11 @@
 #    error "__cpp_lib_generic_unordered_lookup should have the value 201811L in c++26"
 #  endif
 
-#  if !defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))
-#    ifndef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should be defined in c++26"
-#    endif
-#    if __cpp_lib_hardware_interference_size != 201703L
-#      error "__cpp_lib_hardware_interference_size should have the value 201703L in c++26"
-#    endif
-#  else
-#    ifdef __cpp_lib_hardware_interference_size
-#      error "__cpp_lib_hardware_interference_size should not be defined when the requirement '!defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))' is not met!"
-#    endif
+#  ifndef __cpp_lib_hardware_interference_size
+#    error "__cpp_lib_hardware_interference_size should be defined in c++26"
+#  endif
+#  if __cpp_lib_hardware_interference_size != 201703L
+#    error "__cpp_lib_hardware_interference_size should have the value 201703L in c++26"
 #  endif
 
 #  ifndef __cpp_lib_has_unique_object_representations

--- a/libcxx/utils/generate_feature_test_macro_components.py
+++ b/libcxx/utils/generate_feature_test_macro_components.py
@@ -719,8 +719,6 @@ feature_test_macros = [
         {
             "name": "__cpp_lib_hardware_interference_size",
             "values": {"c++17": 201703},
-            "test_suite_guard": "!defined(_LIBCPP_VERSION) || (defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE))",
-            "libcxx_guard": "defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)",
             "headers": ["new"],
         },
         {


### PR DESCRIPTION
Clang provides these macros since LLVM 19, so we can assume they are available.
