### PR TITLE
[clang][ExprConstant] Fix error on static constexpr symbol in dllimport function

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -2407,12 +2407,11 @@ static bool CheckLValueConstantExpression(EvalInfo &Info, SourceLocation Loc,
         return false;
 
       // A dllimport variable never acts like a constant, unless we're
-      // evaluating a value for use only in name mangling, and unless we're a
+      // evaluating a value for use only in name mangling, and unless it's a
       // static local. For the latter case, we'd still need to evaluate the
       // constant expression in case we're inside a (inlined) function.
       if (!isForManglingOnly(Kind) && Var->hasAttr<DLLImportAttr>() &&
           !Var->isStaticLocal())
-        // FIXME: Diagnostic!
         return false;
 
       // In CUDA/HIP device compilation, only device side variables have

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -2407,8 +2407,11 @@ static bool CheckLValueConstantExpression(EvalInfo &Info, SourceLocation Loc,
         return false;
 
       // A dllimport variable never acts like a constant, unless we're
-      // evaluating a value for use only in name mangling.
-      if (!isForManglingOnly(Kind) && Var->hasAttr<DLLImportAttr>())
+      // evaluating a value for use only in name mangling, and unless we're a
+      // static local. For the latter case, we'd still need to evaluate the
+      // constant expression in case we're inside a (inlined) function.
+      if (!isForManglingOnly(Kind) && Var->hasAttr<DLLImportAttr>() &&
+          !Var->isStaticLocal())
         // FIXME: Diagnostic!
         return false;
 

--- a/clang/test/SemaCXX/dllimport.cpp
+++ b/clang/test/SemaCXX/dllimport.cpp
@@ -1527,37 +1527,33 @@ template <typename T> struct ExpliciallySpecializedClassTemplate {};
 template <> struct __declspec(dllimport) ExpliciallySpecializedClassTemplate<int> { void f() {} };
 
 // Function-local static constexpr in dllimport function (or class).
-struct DLLImportFuncWithConstexprStatic {
 #if defined(GNU)
 // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
 #endif
-  __declspec(dllimport) static const int *func() {
-    static constexpr int value = 42;
-    static constexpr const int *p = &value;
-    static_assert(*p == 42, "");
-    return p;
-  }
-};
-const int* (*pFunc)() = &DLLImportFuncWithConstexprStatic::func;
+__declspec(dllimport) inline const int *dLLImportFuncWithConstexprStatic() {
+  static constexpr int value = 42;
+  static constexpr const int *p = &value;
+  static_assert(*p == 42, "");
+  return p;
+}
+const int* (*pFunc)() = &dLLImportFuncWithConstexprStatic;
 bool UsedDLLImportFuncWithConstexprStatic() {
-  return pFunc() == DLLImportFuncWithConstexprStatic::func();
+  return pFunc() == dLLImportFuncWithConstexprStatic();
 }
 
 #if !defined(PS)
-struct DLLImportInlineFuncWithConstexprStatic {
 #if defined(GNU)
   // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
 #endif
-  __declspec(dllimport) __forceinline static const int* funcForceInline() {
-    static constexpr int value = 42;
-    static constexpr const int* p = &value;
-    static_assert(*p == 42, "");
-    return p;
-  }
-};
-const int* (*pFuncForceInline)() = &DLLImportInlineFuncWithConstexprStatic::funcForceInline;
+__declspec(dllimport) __forceinline const int* dLLImportInlineFuncWithConstexprStatic() {
+  static constexpr int value = 42;
+  static constexpr const int* p = &value;
+  static_assert(*p == 42, "");
+  return p;
+}
+const int* (*pFuncForceInline)() = &dLLImportInlineFuncWithConstexprStatic;
 bool UsedDLLImportInlineFuncWithConstexprStatic() {
-  return pFuncForceInline() == DLLImportInlineFuncWithConstexprStatic::funcForceInline();
+  return pFuncForceInline() == dLLImportInlineFuncWithConstexprStatic();
 }
 #endif // !PS
 

--- a/clang/test/SemaCXX/dllimport.cpp
+++ b/clang/test/SemaCXX/dllimport.cpp
@@ -1528,15 +1528,10 @@ template <> struct __declspec(dllimport) ExpliciallySpecializedClassTemplate<int
 
 // Function-local static constexpr in dllimport function (or class).
 struct DLLImportFuncWithConstexprStatic {
+#if defined(GNU)
+// expected-warning@+2{{'dllimport' attribute ignored on inline function}}
+#endif
   __declspec(dllimport) static const int *func() {
-    // expected-warning@-1{{'dllimport' attribute ignored on inline function}}
-    static constexpr int value = 42;
-    static constexpr const int *p = &value;
-    static_assert(*p == 42, "");
-    return p;
-  }
-  __declspec(dllimport) __forceinline static const int *funcForceInline() {
-    // expected-warning@-1{{'dllimport' attribute ignored on inline function}}
     static constexpr int value = 42;
     static constexpr const int *p = &value;
     static_assert(*p == 42, "");
@@ -1544,10 +1539,27 @@ struct DLLImportFuncWithConstexprStatic {
   }
 };
 const int* (*pFunc)() = &DLLImportFuncWithConstexprStatic::func;
-const int* (*pFuncForceInline)() = &DLLImportFuncWithConstexprStatic::funcForceInline;
 bool UsedDLLImportFuncWithConstexprStatic() {
-  return pFunc() == DLLImportFuncWithConstexprStatic::func() && pFuncForceInline() == DLLImportFuncWithConstexprStatic::funcForceInline();
+  return pFunc() == DLLImportFuncWithConstexprStatic::func();
 }
+
+#if !defined(PS)
+struct DLLImportInlineFuncWithConstexprStatic {
+#if defined(GNU)
+  // expected-warning@+2{{'dllimport' attribute ignored on inline function}}
+#endif
+  __declspec(dllimport) __forceinline static const int* funcForceInline() {
+    static constexpr int value = 42;
+    static constexpr const int* p = &value;
+    static_assert(*p == 42, "");
+    return p;
+  }
+};
+const int* (*pFuncForceInline)() = &DLLImportInlineFuncWithConstexprStatic::funcForceInline;
+bool UsedDLLImportInlineFuncWithConstexprStatic() {
+  return pFuncForceInline() == DLLImportInlineFuncWithConstexprStatic::funcForceInline();
+}
+#endif // !PS
 
 //===----------------------------------------------------------------------===//
 // Classes with template base classes

--- a/clang/test/SemaCXX/dllimport.cpp
+++ b/clang/test/SemaCXX/dllimport.cpp
@@ -1526,6 +1526,28 @@ template <typename T> struct __declspec(dllimport) PartiallySpecializedClassTemp
 template <typename T> struct ExpliciallySpecializedClassTemplate {};
 template <> struct __declspec(dllimport) ExpliciallySpecializedClassTemplate<int> { void f() {} };
 
+// Function-local static constexpr in dllimport function (or class).
+struct DLLImportFuncWithConstexprStatic {
+  __declspec(dllimport) static const int *func() {
+    // expected-warning@-1{{'dllimport' attribute ignored on inline function}}
+    static constexpr int value = 42;
+    static constexpr const int *p = &value;
+    static_assert(*p == 42, "");
+    return p;
+  }
+  __declspec(dllimport) __forceinline static const int *funcForceInline() {
+    // expected-warning@-1{{'dllimport' attribute ignored on inline function}}
+    static constexpr int value = 42;
+    static constexpr const int *p = &value;
+    static_assert(*p == 42, "");
+    return p;
+  }
+};
+const int* (*pFunc)() = &DLLImportFuncWithConstexprStatic::func;
+const int* (*pFuncForceInline)() = &DLLImportFuncWithConstexprStatic::funcForceInline;
+bool UsedDLLImportFuncWithConstexprStatic() {
+  return pFunc() == DLLImportFuncWithConstexprStatic::func() && pFuncForceInline() == DLLImportFuncWithConstexprStatic::funcForceInline();
+}
 
 //===----------------------------------------------------------------------===//
 // Classes with template base classes


### PR DESCRIPTION
Consider the following:
```
struct A {
    __declspec(dllimport) __forceinline
    static const int* foo() {
        static constexpr int var = 42;
        static constexpr const int* p = &var;
        static_assert(*p == 42, "");
        return p;
    }
};

const int* (*pfoo)() = &A::foo;

int main() {
    return pfoo() == A::foo();
}
```
With clang-cl, this generates an error:
```
> clang-cl /c C:\src\git\test\test.cpp
C:\src\git\test\test.cpp(5,37): error: constexpr variable 'p' must be initialized by a constant expression
    5 |         static constexpr const int* p = &var;
      |                                     ^   ~~~~
C:\src\git\test\test.cpp(6,23): error: static assertion expression is not an integral constant expression
    6 |         static_assert(*p == 42, "");
      |                       ^~~~~~~~
C:\src\git\test\test.cpp(6,24): note: initializer of 'p' is not a constant expression
    6 |         static_assert(*p == 42, "");
      |                        ^
C:\src\git\test\test.cpp(5,37): note: declared here
    5 |         static constexpr const int* p = &var;
      |                                     ^
2 errors generated.
```
MSVC cl.exe does not generate such error with the same snippet.

The problem here is that the static variable 'var' inherits the dllimport attribute, and the const-init evaluation for 'p' is rejected because of the dllimport attribute.

I think it's fine to accept the example above since the body of the function will be discarded anyway; and the inlined version of the function will contain a reference to the imported function-static symbol, like MSVC does:
```
> cl.exe /c test.cpp /Ox
...
> dumpbin /disasm test.obj
Microsoft (R) COFF/PE Dumper Version 14.44.35222.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file test.obj

File Type: COFF OBJECT

main:
  0000000000000000: 48 83 EC 28        sub         rsp,28h
  0000000000000004: FF 15 00 00 00 00  call        qword ptr [?pfoo@@3P6APEBHXZEA]
  000000000000000A: 48 8B 0D 00 00 00  mov         rcx,qword ptr [__imp_?p@?1??foo@A@@SAPEBHXZ@4QEBHEB]
                    00
  0000000000000011: 33 D2              xor         edx,edx
  0000000000000013: 48 3B 01           cmp         rax,qword ptr [rcx]
  0000000000000016: 0F 94 C2           sete        dl
  0000000000000019: 8B C2              mov         eax,edx
  000000000000001B: 48 83 C4 28        add         rsp,28h
  000000000000001F: C3                 ret

??__Epfoo@@YAXXZ (void __cdecl `dynamic initializer for 'pfoo''(void)):
  0000000000000000: 48 8B 05 00 00 00  mov         rax,qword ptr [__imp_?foo@A@@SAPEBHXZ]
                    00
  0000000000000007: 48 89 05 00 00 00  mov         qword ptr [?pfoo@@3P6APEBHXZEA],rax
                    00
  000000000000000E: C3                 ret

> clang-cl.exe /c test.cpp /Ox

> dumpbin /disasm test.obj
Microsoft (R) COFF/PE Dumper Version 14.44.35222.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file test.obj

File Type: COFF OBJECT

main:
  0000000000000000: 48 83 EC 28        sub         rsp,28h
  0000000000000004: FF 15 00 00 00 00  call        qword ptr [?pfoo@@3P6APEBHXZEA]
  000000000000000A: 31 C9              xor         ecx,ecx
  000000000000000C: 48 3B 05 00 00 00  cmp         rax,qword ptr [__imp_?var@?1??foo@A@@SAPEBHXZ@4HB]
                    00
  0000000000000013: 0F 94 C1           sete        cl
  0000000000000016: 89 C8              mov         eax,ecx
  0000000000000018: 48 83 C4 28        add         rsp,28h
  000000000000001C: C3                 ret
  000000000000001D: 0F 1F 00           nop         dword ptr [rax]
_GLOBAL__sub_I_test.cpp:
  0000000000000020: 48 8B 05 00 00 00  mov         rax,qword ptr [__imp_?foo@A@@SAPEBHXZ]
                    00
  0000000000000027: 48 89 05 00 00 00  mov         qword ptr [?pfoo@@3P6APEBHXZEA],rax
                    00
  000000000000002E: C3                 ret
```
Thanks to @jfmarquis for crafting a reproducer.