### PR TITLE
llvm: Add missing `LLVM_ABI` annotations

### DIFF
--- a/llvm/include/llvm/CodeGen/LibcallLoweringInfo.h
+++ b/llvm/include/llvm/CodeGen/LibcallLoweringInfo.h
@@ -110,7 +110,7 @@ class LibcallLoweringModuleAnalysis
     : public AnalysisInfoMixin<LibcallLoweringModuleAnalysis> {
 private:
   friend AnalysisInfoMixin<LibcallLoweringModuleAnalysis>;
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 
   LibcallLoweringModuleAnalysisResult LibcallLoweringMap;
 

--- a/llvm/include/llvm/SandboxIR/Constant.h
+++ b/llvm/include/llvm/SandboxIR/Constant.h
@@ -1379,7 +1379,7 @@ public:
   /// the only global-initializer user of the ptrauth signed pointer.
   LLVM_ABI Constant *getAddrDiscriminator() const;
 
-  LLVM_ABI_FOR_TEST Constant *getDeactivationSymbol() const;
+  LLVM_ABI Constant *getDeactivationSymbol() const;
 
   /// Whether there is any non-null address discriminator.
   bool hasAddressDiscriminator() const {

--- a/llvm/include/llvm/SandboxIR/Constant.h
+++ b/llvm/include/llvm/SandboxIR/Constant.h
@@ -1379,7 +1379,7 @@ public:
   /// the only global-initializer user of the ptrauth signed pointer.
   LLVM_ABI Constant *getAddrDiscriminator() const;
 
-  Constant *getDeactivationSymbol() const;
+  LLVM_ABI_FOR_TEST Constant *getDeactivationSymbol() const;
 
   /// Whether there is any non-null address discriminator.
   bool hasAddressDiscriminator() const {

--- a/llvm/include/llvm/Support/Hash.h
+++ b/llvm/include/llvm/Support/Hash.h
@@ -22,14 +22,15 @@ enum class KCFIHashAlgorithm { xxHash64, FNV1a };
 
 /// Parse a KCFI hash algorithm name.
 /// Returns xxHash64 if the name is not recognized.
-KCFIHashAlgorithm parseKCFIHashAlgorithm(StringRef Name);
+LLVM_ABI KCFIHashAlgorithm parseKCFIHashAlgorithm(StringRef Name);
 
 /// Convert a KCFI hash algorithm enum to its string representation.
-StringRef stringifyKCFIHashAlgorithm(KCFIHashAlgorithm Algorithm);
+LLVM_ABI StringRef stringifyKCFIHashAlgorithm(KCFIHashAlgorithm Algorithm);
 
 /// Compute KCFI type ID from mangled type name.
 /// The algorithm can be xxHash64 or FNV-1a.
-uint32_t getKCFITypeID(StringRef MangledTypeName, KCFIHashAlgorithm Algorithm);
+LLVM_ABI uint32_t getKCFITypeID(StringRef MangledTypeName,
+                                KCFIHashAlgorithm Algorithm);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/DebugSSAUpdater.h
+++ b/llvm/include/llvm/Transforms/Utils/DebugSSAUpdater.h
@@ -29,6 +29,7 @@
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/IR/ValueMap.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -342,7 +343,7 @@ class DbgValueRangeTable {
   DenseMap<DebugVariableAggregate, DbgValueDef> OrigSingleLocVariableValueTable;
 
 public:
-  void addVariable(Function *F, DebugVariableAggregate DVA);
+  LLVM_ABI_FOR_TEST void addVariable(Function *F, DebugVariableAggregate DVA);
   bool hasVariableEntry(DebugVariableAggregate DVA) const {
     return OrigVariableValueRangeTable.contains(DVA) ||
            OrigSingleLocVariableValueTable.contains(DVA);


### PR DESCRIPTION
This patch updates various LLVM headers to properly add the `LLVM_ABI` and `LLVM_ABI_FOR_TEST` annotations to build LLVM as a DLL on Windows.

This effort is tracked in #109483.