### PR TITLE
[clang-tidy][NFC] Refactor `readability-redundant-control-flow`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
@@ -38,7 +38,7 @@ static bool isLocationInMacroExpansion(const SourceManager &SM,
 
 void RedundantControlFlowCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
-      functionDecl(isDefinition(), returns(voidType()),
+      functionDecl(returns(voidType()),
                    hasBody(compoundStmt(hasFinalStmt(
                        returnStmt(unless(has(expr()))).bind("stmt"))))),
       this);

--- a/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
@@ -24,10 +24,10 @@ AST_MATCHER_P(CompoundStmt, hasFinalStmt, StatementMatcher, InnerMatcher) {
 
 } // namespace
 
-static const char *const RedundantReturnDiag =
+static constexpr StringRef RedundantReturnDiag =
     "redundant return statement at the end "
     "of a function with a void return type";
-static const char *const RedundantContinueDiag =
+static constexpr StringRef RedundantContinueDiag =
     "redundant continue statement at the "
     "end of loop statement";
 

--- a/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
@@ -46,15 +46,14 @@ void RedundantControlFlowCheck::registerMatchers(MatchFinder *Finder) {
 void RedundantControlFlowCheck::check(const MatchFinder::MatchResult &Result) {
   const auto &RedundantStmt = *Result.Nodes.getNodeAs<Stmt>("stmt");
   const SourceRange StmtRange = RedundantStmt.getSourceRange();
-  const SourceManager &SM = *Result.SourceManager;
 
   if (StmtRange.getBegin().isMacroID())
     return;
 
   const auto RemovedRange = CharSourceRange::getCharRange(
       StmtRange.getBegin(),
-      Lexer::findLocationAfterToken(StmtRange.getEnd(), tok::semi, SM,
-                                    getLangOpts(),
+      Lexer::findLocationAfterToken(StmtRange.getEnd(), tok::semi,
+                                    *Result.SourceManager, getLangOpts(),
                                     /*SkipTrailingWhitespaceAndNewLine=*/true));
 
   diag(StmtRange.getBegin(), isa<ReturnStmt>(RedundantStmt)

--- a/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.cpp
@@ -31,11 +31,6 @@ static constexpr StringRef RedundantContinueDiag =
     "redundant continue statement at the "
     "end of loop statement";
 
-static bool isLocationInMacroExpansion(const SourceManager &SM,
-                                       SourceLocation Loc) {
-  return SM.isMacroBodyExpansion(Loc) || SM.isMacroArgExpansion(Loc);
-}
-
 void RedundantControlFlowCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       functionDecl(returns(voidType()),
@@ -53,7 +48,7 @@ void RedundantControlFlowCheck::check(const MatchFinder::MatchResult &Result) {
   const SourceRange StmtRange = RedundantStmt.getSourceRange();
   const SourceManager &SM = *Result.SourceManager;
 
-  if (isLocationInMacroExpansion(SM, StmtRange.getBegin()))
+  if (StmtRange.getBegin().isMacroID())
     return;
 
   const auto RemovedRange = CharSourceRange::getCharRange(

--- a/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/RedundantControlFlowCheck.h
@@ -30,19 +30,6 @@ public:
   std::optional<TraversalKind> getCheckTraversalKind() const override {
     return TK_IgnoreUnlessSpelledInSource;
   }
-
-private:
-  void
-  checkRedundantReturn(const ast_matchers::MatchFinder::MatchResult &Result,
-                       const CompoundStmt *Block);
-
-  void
-  checkRedundantContinue(const ast_matchers::MatchFinder::MatchResult &Result,
-                         const CompoundStmt *Block);
-
-  void issueDiagnostic(const ast_matchers::MatchFinder::MatchResult &Result,
-                       const CompoundStmt *Block, const SourceRange &StmtRange,
-                       const char *Diag);
 };
 
 } // namespace clang::tidy::readability


### PR DESCRIPTION
This is probably easiest to review commit-by-commit.

Besides simplifying the code, this refactor should also make it more efficient: instead of using the `hasAnySubstatement` matcher to find blocks we're interested in, which requires looking through every substatement, this PR introduces a custom `hasFinalStmt` matcher which only checks the last substatement.