### PR TITLE
[X86] Return instructions don't need side effects

### DIFF
--- a/llvm/lib/Target/X86/X86InstrControl.td
+++ b/llvm/lib/Target/X86/X86InstrControl.td
@@ -18,7 +18,7 @@
 //
 // The X86retglue return instructions are variadic because we may add ST0 and
 // ST1 arguments when returning values on the x87 stack.
-let isTerminator = 1, isReturn = 1, isBarrier = 1,
+let isTerminator = 1, isReturn = 1, isBarrier = 1, hasSideEffects = 0,
     hasCtrlDep = 1, FPForm = SpecialFP, SchedRW = [WriteJumpLd] in {
   def RET32  : I   <0xC3, RawFrm, (outs), (ins variable_ops),
                     "ret{l}", []>, OpSize32, Requires<[Not64BitMode]>;

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/stmxcsr-ldmxcsr.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/stmxcsr-ldmxcsr.s
@@ -34,7 +34,7 @@ retq
 # CHECK-NEXT:  1      4     1.00    *                   andl	-4(%rsp), %eax
 # CHECK-NEXT:  1      1     1.00           *            movl	%eax, -8(%rsp)
 # CHECK-NEXT:  1      3     1.00    *      *      U     ldmxcsr	-8(%rsp)
-# CHECK-NEXT:  1      4     1.00                  U     retq
+# CHECK-NEXT:  1      4     1.00                        retq
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - JALU0

--- a/llvm/test/tools/llvm-mca/X86/Haswell/stmxcsr-ldmxcsr.s
+++ b/llvm/test/tools/llvm-mca/X86/Haswell/stmxcsr-ldmxcsr.s
@@ -34,7 +34,7 @@ retq
 # CHECK-NEXT:  2      6     0.50    *                   andl	-4(%rsp), %eax
 # CHECK-NEXT:  1      1     1.00           *            movl	%eax, -8(%rsp)
 # CHECK-NEXT:  3      7     1.00    *      *      U     ldmxcsr	-8(%rsp)
-# CHECK-NEXT:  3      7     1.00                  U     retq
+# CHECK-NEXT:  3      7     1.00                        retq
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - HWDivider


### PR DESCRIPTION
Their effects are modelled through isReturn = 1 already.