### PR TITLE
[Verifier] Make sure all constexprs in instructions are visited

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2676,6 +2676,9 @@ void Verifier::verifyFunctionMetadata(
 }
 
 void Verifier::visitConstantExprsRecursively(const Constant *EntryC) {
+  if (EntryC->getNumOperands() == 0)
+    return;
+
   if (!ConstantExprVisited.insert(EntryC).second)
     return;
 
@@ -5610,14 +5613,8 @@ void Verifier::visitInstruction(Instruction &I) {
     } else if (isa<InlineAsm>(I.getOperand(i))) {
       Check(CBI && &CBI->getCalledOperandUse() == &I.getOperandUse(i),
             "Cannot take the address of an inline asm!", &I);
-    } else if (auto *CPA = dyn_cast<ConstantPtrAuth>(I.getOperand(i))) {
-      visitConstantExprsRecursively(CPA);
-    } else if (ConstantExpr *CE = dyn_cast<ConstantExpr>(I.getOperand(i))) {
-      if (CE->getType()->isPtrOrPtrVectorTy()) {
-        // If we have a ConstantExpr pointer, we need to see if it came from an
-        // illegal bitcast.
-        visitConstantExprsRecursively(CE);
-      }
+    } else if (auto *C = dyn_cast<Constant>(I.getOperand(i))) {
+      visitConstantExprsRecursively(C);
     }
   }
 

--- a/llvm/test/Assembler/ptrtoaddr-invalid-constexpr.ll
+++ b/llvm/test/Assembler/ptrtoaddr-invalid-constexpr.ll
@@ -51,6 +51,20 @@
 @g = global i32 ptrtoaddr (ptr @g to i32)
 ; DST_NOT_ADDR_SIZE-NEXT: PtrToAddr result must be address width
 ; DST_NOT_ADDR_SIZE-NEXT: i32 ptrtoaddr (ptr @g to i32)
-@g_vec = global <4 x i32> ptrtoaddr (<4 x ptr> <ptr @g, ptr @g, ptr @g, ptr @g> to <4 x i32>)
-; TODO: Verifier.cpp does not visit ConstantVector/ConstantStruct values
-; TODO-DST_NOT_ADDR_SIZE: PtrToAddr result must be address width
+@g_vec = global <4 x i32> ptrtoaddr (<4 x ptr> <ptr @g_vec, ptr @g_vec, ptr @g_vec, ptr @g_vec> to <4 x i32>)
+; DST_NOT_ADDR_SIZE-NEXT: PtrToAddr result must be address width
+; DST_NOT_ADDR_SIZE-NEXT: i32 ptrtoaddr (ptr @g_vec to i32)
+
+;--- dst_not_addr_size_in_inst.ll
+; RUN: not llvm-as %t/dst_not_addr_size_in_inst.ll -o /dev/null 2>&1 | FileCheck -check-prefix=DST_NOT_ADDR_SIZE_IN_INST %s --implicit-check-not="error:"
+; DST_NOT_ADDR_SIZE_IN_INST: PtrToAddr result must be address width
+; DST_NOT_ADDR_SIZE_IN_INST-NEXT: i32 ptrtoaddr (ptr @fn to i32)
+define i32 @fn() {
+    ret i32 ptrtoaddr (ptr @fn to i32)
+}
+
+; DST_NOT_ADDR_SIZE_IN_INST: PtrToAddr result must be address width
+; DST_NOT_ADDR_SIZE_IN_INST-NEXT: i32 ptrtoaddr (ptr @fn2 to i32)
+define <2 x i32> @fn2() {
+    ret <2 x i32> <i32 ptrtoaddr (ptr @fn2 to i32), i32 ptrtoaddr (ptr @fn2 to i32)>
+}


### PR DESCRIPTION
Previously this only happened for constants of some types and missed incorrect ptrtoaddr.