### PR TITLE
[InstCombine][CmpInstAnalysis] Use consistent spelling and function names. NFC.

### DIFF
--- a/llvm/lib/Analysis/CmpInstAnalysis.cpp
+++ b/llvm/lib/Analysis/CmpInstAnalysis.cpp
@@ -75,7 +75,7 @@ Constant *llvm::getPredForFCmpCode(unsigned Code, Type *OpTy,
 
 std::optional<DecomposedBitTest>
 llvm::decomposeBitTestICmp(Value *LHS, Value *RHS, CmpInst::Predicate Pred,
-                           bool LookThruTrunc, bool AllowNonZeroC,
+                           bool LookThroughTrunc, bool AllowNonZeroC,
                            bool DecomposeAnd) {
   using namespace PatternMatch;
 
@@ -173,7 +173,7 @@ llvm::decomposeBitTestICmp(Value *LHS, Value *RHS, CmpInst::Predicate Pred,
     Result.Pred = ICmpInst::getInversePredicate(Result.Pred);
 
   Value *X;
-  if (LookThruTrunc && match(LHS, m_Trunc(m_Value(X)))) {
+  if (LookThroughTrunc && match(LHS, m_Trunc(m_Value(X)))) {
     Result.X = X;
     Result.Mask = Result.Mask.zext(X->getType()->getScalarSizeInBits());
     Result.C = Result.C.zext(X->getType()->getScalarSizeInBits());
@@ -185,7 +185,7 @@ llvm::decomposeBitTestICmp(Value *LHS, Value *RHS, CmpInst::Predicate Pred,
 }
 
 std::optional<DecomposedBitTest> llvm::decomposeBitTest(Value *Cond,
-                                                        bool LookThruTrunc,
+                                                        bool LookThroughTrunc,
                                                         bool AllowNonZeroC,
                                                         bool DecomposeAnd) {
   using namespace PatternMatch;
@@ -194,7 +194,7 @@ std::optional<DecomposedBitTest> llvm::decomposeBitTest(Value *Cond,
     if (!ICmp->getOperand(0)->getType()->isIntOrIntVectorTy())
       return std::nullopt;
     return decomposeBitTestICmp(ICmp->getOperand(0), ICmp->getOperand(1),
-                                ICmp->getPredicate(), LookThruTrunc,
+                                ICmp->getPredicate(), LookThroughTrunc,
                                 AllowNonZeroC, DecomposeAnd);
   }
   Value *X;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -187,8 +187,8 @@ static unsigned conjugateICmpMask(unsigned Mask) {
 }
 
 // Adapts the external decomposeBitTest for local use.
-static bool decomposeBitTest(Value *Cond, CmpInst::Predicate &Pred,
-                                 Value *&X, Value *&Y, Value *&Z) {
+static bool decomposeBitTest(Value *Cond, CmpInst::Predicate &Pred, Value *&X,
+                             Value *&Y, Value *&Z) {
   auto Res = llvm::decomposeBitTest(Cond, /*LookThroughTrunc=*/true,
                                     /*AllowNonZeroC=*/true);
   if (!Res)

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -3890,7 +3890,7 @@ static std::optional<DecomposedBitMaskMul> matchBitmaskMul(Value *V) {
   // Decompose ((A & N) ? 0 : N * C) into BitMaskMul
   if (match(Op, m_Select(m_Value(Cond), m_APInt(EqZero), m_APInt(NeZero)))) {
     auto ICmpDecompose =
-        decomposeBitTest(Cond, /*LookThruTrunc=*/true,
+        decomposeBitTest(Cond, /*LookThroughTrunc=*/true,
                          /*AllowNonZeroC=*/false, /*DecomposeBitMask=*/true);
     if (!ICmpDecompose.has_value())
       return std::nullopt;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -186,8 +186,8 @@ static unsigned conjugateICmpMask(unsigned Mask) {
   return NewMask;
 }
 
-// Adapts the external decomposeBitTestICmp for local use.
-static bool decomposeBitTestICmp(Value *Cond, CmpInst::Predicate &Pred,
+// Adapts the external decomposeBitTest for local use.
+static bool decomposeBitTest(Value *Cond, CmpInst::Predicate &Pred,
                                  Value *&X, Value *&Y, Value *&Z) {
   auto Res = llvm::decomposeBitTest(Cond, /*LookThroughTrunc=*/true,
                                     /*AllowNonZeroC=*/true);
@@ -220,7 +220,7 @@ getMaskedTypeForICmpPair(Value *&A, Value *&B, Value *&C, Value *&D, Value *&E,
 
   // Check whether the icmp can be decomposed into a bit test.
   Value *L1, *L11, *L12, *L2, *L21, *L22;
-  if (decomposeBitTestICmp(LHS, PredL, L11, L12, L2)) {
+  if (decomposeBitTest(LHS, PredL, L11, L12, L2)) {
     L21 = L22 = L1 = nullptr;
   } else {
     auto *LHSCMP = dyn_cast<ICmpInst>(LHS);
@@ -253,7 +253,7 @@ getMaskedTypeForICmpPair(Value *&A, Value *&B, Value *&C, Value *&D, Value *&E,
     return std::nullopt;
 
   Value *R11, *R12, *R2;
-  if (decomposeBitTestICmp(RHS, PredR, R11, R12, R2)) {
+  if (decomposeBitTest(RHS, PredR, R11, R12, R2)) {
     if (R11 == L11 || R11 == L12 || R11 == L21 || R11 == L22) {
       A = R11;
       D = R12;

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -6290,7 +6290,7 @@ Instruction *InstCombinerImpl::foldICmpWithTrunc(ICmpInst &ICmp) {
 
   // This matches patterns corresponding to tests of the signbit as well as:
   // (trunc X) pred C2 --> (X & Mask) == C
-  if (auto Res = decomposeBitTestICmp(Op0, Op1, Pred, /*WithTrunc=*/true,
+  if (auto Res = decomposeBitTestICmp(Op0, Op1, Pred, /*LookThroughTrunc=*/true,
                                       /*AllowNonZeroC=*/true)) {
     Value *And = Builder.CreateAnd(Res->X, Res->Mask);
     Constant *C = ConstantInt::get(Res->X->getType(), Res->C);


### PR DESCRIPTION
Both `decomposeBitTestICmp` and `decomposeBitTest` have a parameter called `lookThroughTrunc`. This was spelled in full (i.e. `lookThroughTrunc`) in the header (see [here](https://github.com/llvm/llvm-project/blob/f8580c915f0b5205ddc3ae5e8286653ddc1d8d68/llvm/include/llvm/Analysis/CmpInstAnalysis.h#L110) and [here](https://github.com/llvm/llvm-project/blob/f8580c915f0b5205ddc3ae5e8286653ddc1d8d68/llvm/include/llvm/Analysis/CmpInstAnalysis.h#L118)).

However, in the implementation, it's written as
https://github.com/llvm/llvm-project/blob/54b4bd510a8cc90fac3d2071179d1424af894c9c/llvm/lib/Analysis/CmpInstAnalysis.cpp#L78
and
https://github.com/llvm/llvm-project/blob/54b4bd510a8cc90fac3d2071179d1424af894c9c/llvm/lib/Analysis/CmpInstAnalysis.cpp#L188

I opted to convert all instances of `lookThruTrunc` into `lookThroughTrunc` to reduce surprise while reading the code and for conformity.

---

The other change in this PR is the renaming of the wrapper around `decomposeBitTest()`. Even though it was a wrapper around `CmpInstAnalysis.h`'s `decomposeBitTest`, the function was called `decomposeBitTestICmp`. This is quite confusing because such a function _also_ exists in `CmpInstAnalysis.h`, but it is _not_ the one actually being used in `InstCombineAndOrXor.cpp`.