### PR TITLE
[AArch64] Make IFUNC opt-in rather than opt-out.

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -770,7 +770,7 @@ public:
   bool isOSGlibc() const {
     return (getOS() == Triple::Linux || getOS() == Triple::KFreeBSD ||
             getOS() == Triple::Hurd) &&
-           !isAndroid() && !isMusl();
+           !isAndroid() && !isMusl() && getEnvironment() != Triple::PAuthTest;
   }
 
   /// Tests whether the OS is AIX.

--- a/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-reloc.ll
@@ -176,19 +176,19 @@
 @g = external global i32
 @g.ref.ia.65536 = constant ptr ptrauth (ptr @g, i32 0, i64 65536)
 
-;--- err-disc-elf.ll
+;--- err-disc-gnu.ll
 
-; RUN: not llc < err-disc-elf.ll -mtriple aarch64-elf -mattr=+pauth 2>&1 \
-; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-DISC-ELF
-; RUN: not llc < err-disc-elf.ll -mtriple aarch64-elf -mattr=+pauth \
+; RUN: not llc < err-disc-gnu.ll -mtriple aarch64-linux-gnu -mattr=+pauth 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-DISC-GNU
+; RUN: not llc < err-disc-gnu.ll -mtriple aarch64-linux-gnu -mattr=+pauth \
 ; RUN:   -global-isel -verify-machineinstrs -global-isel-abort=1 2>&1 \
-; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-DISC-ELF
+; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-DISC-GNU
 
 @g = external global i32
 
 @ds = external global i8
-; CHECK-ERR-DISC-ELF-NOT: error: AArch64 PAC Discriminator '65537' out of range [0, 0xFFFF]
+; CHECK-ERR-DISC-GNU-NOT: error: AArch64 PAC Discriminator '65537' out of range [0, 0xFFFF]
 @g.ref.da.65537 = constant ptr ptrauth (ptr @g, i32 2, i64 65537, ptr @g.ref.da.65537, ptr @ds)
 
-; CHECK-ERR-DISC-ELF: error: AArch64 PAC Discriminator '65538' out of range [0, 0xFFFF]
+; CHECK-ERR-DISC-GNU: error: AArch64 PAC Discriminator '65538' out of range [0, 0xFFFF]
 @g.ref.da.65538 = constant ptr ptrauth (ptr @g, i32 2, i64 65538, ptr null, ptr @ds)


### PR DESCRIPTION
IFUNCs require loader support, so for arbitrary environments, the safe assumption is to assume that they are not supported. In particular, aarch64-linux-pauthtest may be used with musl, and was wrongly detected as supporting IFUNCs.

With IFUNC support now being detected more reliably, this also removes the check for PAuth support. If both are supported, either would work.