### PR TITLE
[Flang][Pass]Disable memory intrinsics expansions

### DIFF
--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -42,9 +42,11 @@
 #include "clang/Driver/DriverDiagnostic.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Analysis/RuntimeLibcallInfo.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
+#include "llvm/CodeGen/LibcallLoweringInfo.h"
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
 #include "llvm/IR/LLVMRemarkStreamer.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -902,6 +904,9 @@ static void generateMachineCodeOrAssemblyImpl(clang::DiagnosticsEngine &diags,
   llvm::TargetLibraryInfoImpl *tlii =
       llvm::driver::createTLII(triple, codeGenOpts.getVecLib());
   codeGenPasses.add(new llvm::TargetLibraryInfoWrapperPass(*tlii));
+  codeGenPasses.add(new llvm::RuntimeLibraryInfoWrapper(
+      triple, tm.Options.ExceptionModel, tm.Options.FloatABIType,
+      tm.Options.EABIVersion, tm.Options.MCOptions.ABIName, tm.Options.VecLib));
 
   llvm::CodeGenFileType cgft = (act == BackendActionTy::Backend_EmitAssembly)
                                    ? llvm::CodeGenFileType::AssemblyFile
@@ -1009,6 +1014,14 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
   llvm::TargetLibraryInfoImpl *tlii =
       llvm::driver::createTLII(triple, opts.getVecLib());
   fam.registerPass([&] { return llvm::TargetLibraryAnalysis(*tlii); });
+  mam.registerPass([&] {
+    return llvm::RuntimeLibraryAnalysis(
+        triple, targetMachine->Options.ExceptionModel,
+        targetMachine->Options.FloatABIType, targetMachine->Options.EABIVersion,
+        targetMachine->Options.MCOptions.ABIName,
+        targetMachine->Options.VecLib);
+  });
+  mam.registerPass([&] { return llvm::LibcallLoweringModuleAnalysis(); });
 
   // Register all the basic analyses with the managers.
   pb.registerModuleAnalyses(mam);

--- a/flang/test/Lower/memory-intrinsics-expansion.F90
+++ b/flang/test/Lower/memory-intrinsics-expansion.F90
@@ -1,0 +1,33 @@
+! REQUIRES:  aarch64-registered-target
+
+! RUN: %flang_fc1 -S -O1 %s -triple aarch64-linux-gnu -mllvm -debug-pass=Structure -o %t_O0 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -S -O2 %s -triple aarch64-linux-gnu -mllvm -debug-pass=Structure -o %t_O2 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -S -O3 %s -triple aarch64-linux-gnu -mllvm -debug-pass=Structure -o %t_O3 2>&1 | FileCheck %s
+! RUN: FileCheck --input-file=%t_O0 --check-prefix=CALL %s
+! RUN: FileCheck --input-file=%t_O2 --check-prefix=CALL %s
+! RUN: FileCheck --input-file=%t_O3 --check-prefix=CALL %s
+
+! CHECK: Target Library Information
+! CHECK: Runtime Library Function Analysis
+! CHECK: Library Function Lowering Analysis
+
+! CALL: {{callq|bl}} memcpy
+program memcpy_test
+  implicit none
+  integer, parameter :: n = 100
+  real :: a(n), b(n)
+  integer :: i
+
+  ! Initialize array a
+  do i = 1, n
+    a(i) = real(i)
+  end do
+
+  ! Array assignment - this should generate memcpy
+  b = a
+
+  ! Use array b to prevent optimization
+  print *, b(1), b(n)
+
+end program memcpy_test
+


### PR DESCRIPTION
Patch disables memory intrinsics expansion, enabled by default in
https://github.com/llvm/llvm-project/pull/168622. This patch does the
same in clang, but not in flang.

The expansion causes massive perf regressions, up to 2x times in
fortran code.
