### PR TITLE
[lldb] Make TestJitBreakPoint.py use LLVM_TOOLS_DIR

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/jit_loader_rtdyld_elf/TestJitBreakPoint.py
+++ b/lldb/test/API/functionalities/breakpoint/jit_loader_rtdyld_elf/TestJitBreakPoint.py
@@ -5,6 +5,7 @@ Test that pending breakpoints resolve for JITted code with mcjit and rtdyld.
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
+from lldbsuite.test import configuration
 
 
 class TestJitBreakpoint(TestBase):
@@ -20,9 +21,11 @@ class TestJitBreakpoint(TestBase):
     def do_test(self, jit_flag: str):
         self.runCmd("settings set plugin.jit-loader.gdb.enable on")
 
-        clang_path = self.findBuiltClang()
-        self.assertTrue(clang_path, "built clang could not be found")
-        lli_path = os.path.join(os.path.dirname(clang_path), "lli")
+        self.assertIsNotNone(
+            configuration.llvm_tools_dir,
+            "llvm_tools_dir must be set to find lli",
+        )
+        lli_path = os.path.join(os.path.join(configuration.llvm_tools_dir, "lli"))
         self.assertTrue(lldbutil.is_exe(lli_path), f"'{lli_path}' is not an executable")
         self.runCmd(f"target create {lli_path}", CURRENT_EXECUTABLE_SET)
 


### PR DESCRIPTION
This seems the standard way to get the path to such tools within LLVM. Calling findBuiltClang() has some annoying behavior like falling back to CC when it cannot find anything else, which might point to anything or not even be set.

We noticed this with our internal build system as the lli binary is not in the same path as the clang binary.