### PR TITLE
[clang-doc] Align indentation in templates

### DIFF
--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -11,10 +11,10 @@
     <meta charset="utf-8"/>
     <title>{{Name}}</title>
     {{#Stylesheets}}
-        <link rel="stylesheet" type="text/css" href="{{.}}"/>
+    <link rel="stylesheet" type="text/css" href="{{.}}"/>
     {{/Stylesheets}}
     {{#Scripts}}
-        <script src="{{.}}"></script>
+    <script src="{{.}}"></script>
     {{/Scripts}}
     {{! Highlight.js dependency for syntax highlighting }}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
@@ -22,176 +22,176 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/cpp.min.js"></script>
 </head>
 <body>
-<nav class="navbar">
-    <div class="navbar__container">
-        {{#ProjectName}}
+    <nav class="navbar">
+        <div class="navbar__container">
+            {{#ProjectName}}
             <div class="navbar__logo">
                 {{ProjectName}}
             </div>
-        {{/ProjectName}}
-        <div class="navbar__menu">
-            <ul class="navbar__links">
-                <li class="navbar__item">
-                    <a href="/" class="navbar__link">Namespace</a>
-                </li>
-                <li class="navbar__item">
-                    <a href="/" class="navbar__link">Class</a>
-                </li>
-            </ul>
+            {{/ProjectName}}
+            <div class="navbar__menu">
+                <ul class="navbar__links">
+                    <li class="navbar__item">
+                        <a href="/" class="navbar__link">Namespace</a>
+                    </li>
+                    <li class="navbar__item">
+                        <a href="/" class="navbar__link">Class</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
-<main>
-    <div class="container">
-        <div class="sidebar">
-            <h2>{{TagType}} {{Name}}</h2>
-            <ul>
-                {{#HasPublicMembers}}
-                <li class="sidebar-section">
-                    <a class="sidebar-item" href="#PublicMembers">Public Members</a>
-                </li>
-                <li>
-                    <ul>
-                        {{#PublicMembers}}
-                        <li class="sidebar-item-container">
-                            <a class="sidebar-item" href="#{{Name}}">{{Name}}</a>
-                        </li>
-                        {{/PublicMembers}}
-                    </ul>
-                </li>
-                {{/HasPublicMembers}}
-                {{#ProtectedMembers}}
-                <li class="sidebar-section">
-                    <a class="sidebar-item" href="#PublicMethods">Protected Members</a>
-                </li>
-                <li>
-                    <ul>
-                        {{#Obj}}
+    </nav>
+    <main>
+        <div class="container">
+            <div class="sidebar">
+                <h2>{{TagType}} {{Name}}</h2>
+                <ul>
+                    {{#HasPublicMembers}}
+                    <li class="sidebar-section">
+                        <a class="sidebar-item" href="#PublicMembers">Public Members</a>
+                    </li>
+                    <li>
+                        <ul>
+                            {{#PublicMembers}}
                             <li class="sidebar-item-container">
                                 <a class="sidebar-item" href="#{{Name}}">{{Name}}</a>
                             </li>
+                            {{/PublicMembers}}
+                        </ul>
+                    </li>
+                    {{/HasPublicMembers}}
+                    {{#ProtectedMembers}}
+                    <li class="sidebar-section">
+                        <a class="sidebar-item" href="#PublicMethods">Protected Members</a>
+                    </li>
+                    <li>
+                        <ul>
+                            {{#Obj}}
+                            <li class="sidebar-item-container">
+                                <a class="sidebar-item" href="#{{Name}}">{{Name}}</a>
+                            </li>
+                            {{/Obj}}
+                        </ul>
+                    </li>
+                    {{/ProtectedMembers}}
+                    {{#HasPublicFunctions}}
+                    <li class="sidebar-section">
+                        <a class="sidebar-item" href="#PublicMethods">Public Method</a>
+                    </li>
+                    <li>
+                        <ul>
+                            {{#PublicFunctions}}
+                            <li class="sidebar-item-container">
+                                <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
+                            </li>
+                            {{/PublicFunctions}}
+                        </ul>
+                    </li>
+                    {{/HasPublicFunctions}}
+                    {{#ProtectedFunction}}
+                    <li class="sidebar-section">
+                        <a class="sidebar-item" href="#ProtectedFunction">Protected Method</a>
+                    </li>
+                    <li>
+                        <ul>
+                            {{#Obj}}
+                            <li class="sidebar-item-container">
+                                <a class="sidebar-item" href="#{{ID}}">{{Name}}</a>
+                            </li>
+                            {{/Obj}}
+                        </ul>
+                    </li>
+                    {{/ProtectedFunction}}
+                    {{#Enums}}
+                    <li class="sidebar-section">
+                        <a class="sidebar-item" href="#Enums">Enums</a>
+                    </li>
+                    <li>
+                        <ul>
+                            {{#Obj}}
+                            <li class="sidebar-item-container">
+                                <a class="sidebar-item" href="#{{USR}}">{{EnumName}}</a>
+                            </li>
+                            {{/Obj}}
+                        </ul>
+                    </li>
+                    {{/Enums}}
+                    {{#Typedef}}
+                    <li class="sidebar-section">Typedef</li>
+                    {{/Typedef}}
+                    {{#Record}}
+                    <li class="sidebar-section">
+                        <a class="sidebar-item" href="#Classes">Inner Classes</a>
+                    </li>
+                    <li>
+                        <ul>
+                            {{#Links}}
+                            <li class="sidebar-item-container">
+                                <a class="sidebar-item" href="#{{ID}}">{{Name}}</a>
+                            </li>
+                            {{/Links}}
+                        </ul>
+                    </li>
+                    {{/Record}}
+                </ul>
+            </div>
+            <div class="resizer" id="resizer"></div>
+            <div class="content">
+                <section class="hero section-container">
+                    <div class="hero__title">
+                        <h1 class="hero__title-large">{{TagType}} {{Name}}</h1>
+                        <p>Defined at line {{Location.LineNumber}} of file {{Location.Filename}}</p>
+                        {{#Description}}
+                        <div class="hero__subtitle">
+                            {{>Comments}}
+                        </div>
+                        {{/Description}}
+                    </div>
+                </section>
+                {{#HasPublicMembers}}
+                <section id="PublicMembers" class="section-container">
+                    <h2>Public Members</h2>
+                    <div>
+                        {{#PublicMembers}}
+                        <div id="{{Name}}" class="delimiter-container">
+                            <pre><code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code></pre>
+                            {{#MemberComments}}
+                            <div>
+                                {{>Comments}}
+                            </div>
+                            {{/MemberComments}}
+                        </div>
+                        {{/PublicMembers}}
+                    </div>
+                </section>
+                {{/HasPublicMembers}}
+                {{#ProtectedMembers}}
+                <section id="ProtectedMembers" class="section-container">
+                    <h2>Protected Members</h2>
+                    <div>
+                        {{#Obj}}
+                        <div id="{{Name}}" class="delimiter-container">
+                            <pre><code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code></pre>
+                            {{#MemberComments}}
+                            <div>
+                                {{>Comments}}
+                            </div>
+                            {{/MemberComments}}
+                        </div>
                         {{/Obj}}
-                    </ul>
-                </li>
+                    </div>
+                </section>
                 {{/ProtectedMembers}}
                 {{#HasPublicFunctions}}
-                <li class="sidebar-section">
-                    <a class="sidebar-item" href="#PublicMethods">Public Method</a>
-                </li>
-                <li>
-                    <ul>
+                <section id="PublicMethods" class="section-container">
+                    <h2>Public Methods</h2>
+                    <div>
                         {{#PublicFunctions}}
-                        <li class="sidebar-item-container">
-                            <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
-                        </li>
+                        {{>FunctionPartial}}
                         {{/PublicFunctions}}
-                    </ul>
-                </li>
-                {{/HasPublicFunctions}}
-                {{#ProtectedFunction}}
-                <li class="sidebar-section">
-                    <a class="sidebar-item" href="#ProtectedFunction">Protected Method</a>
-                </li>
-                <li>
-                    <ul>
-                        {{#Obj}}
-                        <li class="sidebar-item-container">
-                            <a class="sidebar-item" href="#{{ID}}">{{Name}}</a>
-                        </li>
-                        {{/Obj}}
-                    </ul>
-                </li>
-                {{/ProtectedFunction}}
-                {{#Enums}}
-                <li class="sidebar-section">
-                    <a class="sidebar-item" href="#Enums">Enums</a>
-                </li>
-                <li>
-                    <ul>
-                        {{#Obj}}
-                        <li class="sidebar-item-container">
-                            <a class="sidebar-item" href="#{{USR}}">{{EnumName}}</a>
-                        </li>
-                        {{/Obj}}
-                    </ul>
-                </li>
-                {{/Enums}}
-                {{#Typedef}}
-                <li class="sidebar-section">Typedef</li>
-                {{/Typedef}}
-                {{#Record}}
-                <li class="sidebar-section">
-                    <a class="sidebar-item" href="#Classes">Inner Classes</a>
-                </li>
-                <li>
-                    <ul>
-                        {{#Links}}
-                        <li class="sidebar-item-container">
-                            <a class="sidebar-item" href="#{{ID}}">{{Name}}</a>
-                        </li>
-                        {{/Links}}
-                    </ul>
-                </li>
-                {{/Record}}
-            </ul>
-        </div>
-        <div class="resizer" id="resizer"></div>
-        <div class="content">
-            <section class="hero section-container">
-                <div class="hero__title">
-                    <h1 class="hero__title-large">{{TagType}} {{Name}}</h1>
-                    <p>Defined at line {{Location.LineNumber}} of file {{Location.Filename}}</p>
-                    {{#Description}}
-                    <div class="hero__subtitle">
-                        {{>Comments}}
                     </div>
-                    {{/Description}}
-                </div>
-            </section>
-            {{#HasPublicMembers}}
-            <section id="PublicMembers" class="section-container">
-                <h2>Public Members</h2>
-                <div>
-                    {{#PublicMembers}}
-                    <div id="{{Name}}" class="delimiter-container">
-                        <pre><code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code></pre>
-                        {{#MemberComments}}
-                        <div>
-                            {{>Comments}}
-                        </div>
-                        {{/MemberComments}}
-                    </div>
-                    {{/PublicMembers}}
-                </div>
-            </section>    
-            {{/HasPublicMembers}}
-            {{#ProtectedMembers}}
-            <section id="ProtectedMembers" class="section-container">
-                <h2>Protected Members</h2>
-                <div>
-                    {{#Obj}}
-                    <div id="{{Name}}" class="delimiter-container">
-                        <pre><code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code></pre>
-                        {{#MemberComments}}
-                        <div>
-                            {{>Comments}}
-                        </div>
-                        {{/MemberComments}}
-                    </div>
-                    {{/Obj}}
-                </div>
-            </section>
-            {{/ProtectedMembers}}
-            {{#HasPublicFunctions}}
-            <section id="PublicMethods" class="section-container">
-                <h2>Public Methods</h2>
-                <div>
-                    {{#PublicFunctions}}
-                    {{>FunctionPartial}}
-                    {{/PublicFunctions}}
-                </div>
-            </section>
-            {{/PublicFunctions}}
+                </section>
+                {{/PublicFunctions}}
                 {{#ProtectedFunction}}
                 <li class="sidebar-section">
                     <a class="sidebar-item" href="#ProtectedFunction">Protected Method</a>
@@ -204,35 +204,37 @@
                     {{/Obj}}
                 </ul>
                 {{/ProtectedFunction}}
-            {{#Enums}}
-            <section id="Enums" class="section-container">
-                <h2>Enumerations</h2>
-                <div>
-                    {{#Obj}}
-{{>EnumPartial}}
-                    {{/Obj}}
-                </div>
-            </section>
-            {{/Enums}}
-            {{#Record}}
-            <section id="Classes" class="section-container">
-                <h2>Inner Classes</h2>
-                <ul class="class-container">
-                    {{#Links}}
-                    <li id="{{ID}}" style="max-height: 40px;">
-<a href="{{Link}}"><pre><code class="language-cpp code-clang-doc" >class {{Name}}</code></pre></a>
-                    </li>
-                    {{/Links}}
-                </ul>
-            </section>
-            {{/Record}}
-            {{#Typedef}}
-            <section class="section-container">
-                <h2 id="Enums">Enums</h2>
-            </section>
-            {{/Typedef}}
+                {{#Enums}}
+                <section id="Enums" class="section-container">
+                    <h2>Enumerations</h2>
+                    <div>
+                        {{#Obj}}
+                        {{>EnumPartial}}
+                        {{/Obj}}
+                    </div>
+                </section>
+                {{/Enums}}
+                {{#Record}}
+                <section id="Classes" class="section-container">
+                    <h2>Inner Classes</h2>
+                    <ul class="class-container">
+                        {{#Links}}
+                        <li id="{{ID}}" style="max-height: 40px;">
+                            <a href="{{Link}}">
+                                <pre><code class="language-cpp code-clang-doc" >class {{Name}}</code></pre>
+                            </a>
+                        </li>
+                        {{/Links}}
+                    </ul>
+                </section>
+                {{/Record}}
+                {{#Typedef}}
+                <section class="section-container">
+                    <h2 id="Enums">Enums</h2>
+                </section>
+                {{/Typedef}}
+            </div>
         </div>
-    </div>
-</main>
+    </main>
 </body>
 </html>

--- a/clang-tools-extra/clang-doc/assets/namespace-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/namespace-template.mustache
@@ -7,104 +7,103 @@
 }}
 <!DOCTYPE html>
 <html lang="en-US">
-    <head>
-        <meta charset="utf-8"/>
-        <title>{{NamespaceTitle}}</title>
-        {{#Stylesheets}}
-        <link rel="stylesheet" type="text/css" href="{{.}}"/>
-        {{/Stylesheets}}
-        {{#Scripts}}
-        <script src="{{.}}"></script>
-        {{/Scripts}}
-        {{! Highlight.js dependency for syntax highlighting }}
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/cpp.min.js"></script>
-    </head>
-    <body>
-        <nav class="navbar">
-            <div class="navbar__container">
-                {{#ProjectName}}
-                <div class="navbar__logo">
-                    {{ProjectName}}
-                </div>
-                {{/ProjectName}}
-                <div class="navbar__menu">
-                    <ul class="navbar__links">
-                        <li class="navbar__item">
-                            <a href="/" class="navbar__link">Namespace</a>
-                        </li>
-                        <li class="navbar__item">
-                            <a href="/" class="navbar__link">Class</a>
-                        </li>
-                    </ul>
-                </div>
+<head>
+    <meta charset="utf-8"/>
+    <title>{{NamespaceTitle}}</title>
+    {{#Stylesheets}}
+    <link rel="stylesheet" type="text/css" href="{{.}}"/>
+    {{/Stylesheets}}
+    {{#Scripts}}
+    <script src="{{.}}"></script>
+    {{/Scripts}}
+    {{! Highlight.js dependency for syntax highlighting }}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/cpp.min.js"></script>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="navbar__container">
+            {{#ProjectName}}
+            <div class="navbar__logo">
+                {{ProjectName}}
             </div>
-        </nav>
-        <main>
-            <div class="container">
-                <div class="sidebar">
-                    <h2>{{RecordType}} {{Name}}</h2>
-                    <ul>
-                        {{#HasEnums}}
-                        <li class="sidebar-section">
-                            <a class="sidebar-item" href="#Enums">Enums</a>
-                        </li>
-                        <li>
-                            <ul>
-                                {{#Enums}}
-                                <li class="sidebar-item-container">
-                                    <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
-                                </li>
-                                {{/Enums}}
-                            </ul>
-                        </li>
-                        {{/HasEnums}}
-                        {{#HasRecords}}
-                        <li class="sidebar-section">
-                            <a class="sidebar-item" href="#Classes">Inner Classes</a>
-                        </li>
-                        <li>
-                            <ul>
-                                {{#Records}}
-                                <li class="sidebar-item-container">
-                                    <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
-                                </li>
-                                {{/Records}}
-                            </ul>
-                        </li>
-                        {{/HasRecrods}}
-                    </ul>
-                </div>
-                <div class="resizer" id="resizer"></div>
-                <div class="content">
+            {{/ProjectName}}
+            <div class="navbar__menu">
+                <ul class="navbar__links">
+                    <li class="navbar__item">
+                        <a href="/" class="navbar__link">Namespace</a>
+                    </li>
+                    <li class="navbar__item">
+                        <a href="/" class="navbar__link">Class</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <main>
+        <div class="container">
+            <div class="sidebar">
+                <h2>{{RecordType}} {{Name}}</h2>
+                <ul>
                     {{#HasEnums}}
-                    <section id="Enums" class="section-container">
-                        <h2>Enumerations</h2>
-                        <div>
+                    <li class="sidebar-section">
+                        <a class="sidebar-item" href="#Enums">Enums</a>
+                    </li>
+                    <li>
+                        <ul>
                             {{#Enums}}
-                            {{>EnumPartial}}
-                            {{/Enums}}
-                        </div>
-                    </section>
-                    {{/HasEnums}}
-
-                    {{#HasRecords}}
-                    <section id="Classes" class="section-container">
-                        <h2>Inner Classes</h2>
-                        <ul class="class-container">
-                        {{#Records}}
-                            <li id="{{USR}}" style="max-height: 40px;">
-                                <a href="{{DocumentationFileName}}.html">
-                                    <pre><code class="language-cpp code-clang-doc">class {{Name}}</code></pre>
-                                </a>
+                            <li class="sidebar-item-container">
+                                <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
                             </li>
-                        {{/Records}}
+                            {{/Enums}}
                         </ul>
-                    </section>
+                    </li>
+                    {{/HasEnums}}
+                    {{#HasRecords}}
+                    <li class="sidebar-section">
+                        <a class="sidebar-item" href="#Classes">Inner Classes</a>
+                    </li>
+                    <li>
+                        <ul>
+                            {{#Records}}
+                            <li class="sidebar-item-container">
+                                <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
+                            </li>
+                            {{/Records}}
+                        </ul>
+                    </li>
                     {{/HasRecords}}
-                </div>
+                </ul>
             </div>
-        </main>
-    </body>
+            <div class="resizer" id="resizer"></div>
+            <div class="content">
+                {{#HasEnums}}
+                <section id="Enums" class="section-container">
+                    <h2>Enumerations</h2>
+                    <div>
+                        {{#Enums}}
+                        {{>EnumPartial}}
+                        {{/Enums}}
+                    </div>
+                </section>
+                {{/HasEnums}}
+                {{#HasRecords}}
+                <section id="Classes" class="section-container">
+                    <h2>Inner Classes</h2>
+                    <ul class="class-container">
+                        {{#Records}}
+                        <li id="{{USR}}" style="max-height: 40px;">
+                            <a href="{{DocumentationFileName}}.html">
+                                <pre><code class="language-cpp code-clang-doc">class {{Name}}</code></pre>
+                            </a>
+                        </li>
+                        {{/Records}}
+                    </ul>
+                </section>
+                {{/HasRecords}}
+            </div>
+        </div>
+    </main>
+</body>
 </html>

--- a/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
@@ -25,7 +25,6 @@ namespace MyNamespace {
 // CHECK-GLOBAL-NEXT:                </div>
 // CHECK-GLOBAL-NEXT:                <div class="resizer" id="resizer"></div>
 // CHECK-GLOBAL-NEXT:                <div class="content">
-// CHECK-GLOBAL-EMPTY:
 // CHECK-GLOBAL-NEXT:                </div>
 // CHECK-GLOBAL-NEXT:            </div>
 // CHECK-GLOBAL-NEXT:        </main>


### PR DESCRIPTION
Indentation was inconsistent between the namespace and class templates.
This patch assumes that `<body>` is not indented.