### PR TITLE
[clang-doc] Create a partial for HTML <head> sections

### DIFF
--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -66,10 +66,13 @@ Error HTMLGenerator::setupTemplateFiles(const ClangDocContext &CDCtx) {
       ConvertToNative(CDCtx.MustacheTemplates.lookup("function-template"));
   std::string EnumFilePath =
       ConvertToNative(CDCtx.MustacheTemplates.lookup("enum-template"));
+  std::string HeadFilePath =
+      ConvertToNative(CDCtx.MustacheTemplates.lookup("head-template"));
   std::vector<std::pair<StringRef, StringRef>> Partials = {
       {"Comments", CommentFilePath},
       {"FunctionPartial", FunctionFilePath},
-      {"EnumPartial", EnumFilePath}};
+      {"EnumPartial", EnumFilePath},
+      {"HeadPartial", HeadFilePath}};
 
   if (Error Err = setupTemplate(NamespaceTemplate, NamespaceFilePath, Partials))
     return Err;

--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -7,20 +7,7 @@
 }}
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-    <meta charset="utf-8"/>
-    <title>{{Name}}</title>
-    {{#Stylesheets}}
-    <link rel="stylesheet" type="text/css" href="{{.}}"/>
-    {{/Stylesheets}}
-    {{#Scripts}}
-    <script src="{{.}}"></script>
-    {{/Scripts}}
-    {{! Highlight.js dependency for syntax highlighting }}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/cpp.min.js"></script>
-</head>
+{{>HeadPartial}}
 <body>
     <nav class="navbar">
         <div class="navbar__container">

--- a/clang-tools-extra/clang-doc/assets/head-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/head-template.mustache
@@ -1,0 +1,14 @@
+<head>
+    <meta charset="utf-8"/>
+    <title>{{Name}}</title>
+    {{#Stylesheets}}
+        <link rel="stylesheet" type="text/css" href="{{.}}"/>
+    {{/Stylesheets}}
+    {{#Scripts}}
+        <script src="{{.}}"></script>
+    {{/Scripts}}
+    {{! Highlight.js dependency for syntax highlighting }}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/cpp.min.js"></script>
+</head>

--- a/clang-tools-extra/clang-doc/assets/namespace-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/namespace-template.mustache
@@ -7,20 +7,7 @@
 }}
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-    <meta charset="utf-8"/>
-    <title>{{NamespaceTitle}}</title>
-    {{#Stylesheets}}
-    <link rel="stylesheet" type="text/css" href="{{.}}"/>
-    {{/Stylesheets}}
-    {{#Scripts}}
-    <script src="{{.}}"></script>
-    {{/Scripts}}
-    {{! Highlight.js dependency for syntax highlighting }}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/cpp.min.js"></script>
-</head>
+{{>HeadPartial}}
 <body>
     <nav class="navbar">
         <div class="navbar__container">

--- a/clang-tools-extra/clang-doc/support/Utils.cpp
+++ b/clang-tools-extra/clang-doc/support/Utils.cpp
@@ -56,6 +56,8 @@ void getHtmlFiles(StringRef AssetsPath, clang::doc::ClangDocContext &CDCtx) {
       appendPathPosix(AssetsPath, "function-template.mustache");
   SmallString<128> CommentTemplate =
       appendPathPosix(AssetsPath, "comment-template.mustache");
+  SmallString<128> HeadTemplate =
+      appendPathPosix(AssetsPath, "head-template.mustache");
 
   CDCtx.MustacheTemplates.insert(
       {"namespace-template", NamespaceTemplate.c_str()});
@@ -64,4 +66,5 @@ void getHtmlFiles(StringRef AssetsPath, clang::doc::ClangDocContext &CDCtx) {
   CDCtx.MustacheTemplates.insert(
       {"function-template", FunctionTemplate.c_str()});
   CDCtx.MustacheTemplates.insert({"comment-template", CommentTemplate.c_str()});
+  CDCtx.MustacheTemplates.insert({"head-template", HeadTemplate.c_str()});
 }

--- a/clang-tools-extra/clang-doc/tool/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/tool/CMakeLists.txt
@@ -31,6 +31,7 @@ set(assets
   function-template.mustache
   namespace-template.mustache
   template.mustache
+  head-template.mustache
 )
 
 set(asset_dir "${CMAKE_CURRENT_SOURCE_DIR}/../assets")


### PR DESCRIPTION
The <head> sections of the existing partials are already identical, so
creating a partial will help reduce lines in the templates. Now
changes to <head> sections can easily propogate and can easily be added
to future HTML pages.