### PR TITLE
[runtimes] Modernize installation targets

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -1751,10 +1751,8 @@ if (LIBCXX_INSTALL_HEADERS)
 
   if (NOT CMAKE_CONFIGURATION_TYPES)
     add_custom_target(install-cxx-headers
-                      DEPENDS cxx-headers
-                      COMMAND "${CMAKE_COMMAND}"
-                              -DCMAKE_INSTALL_COMPONENT=cxx-headers
-                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+      DEPENDS cxx-headers
+      COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component cxx-headers)
     # Stripping is a no-op for headers
     add_custom_target(install-cxx-headers-stripped DEPENDS install-cxx-headers)
   endif()

--- a/libcxx/modules/CMakeLists.txt
+++ b/libcxx/modules/CMakeLists.txt
@@ -259,10 +259,8 @@ if (LIBCXX_INSTALL_MODULES)
 
   if (NOT CMAKE_CONFIGURATION_TYPES)
     add_custom_target(install-cxx-modules
-                      DEPENDS cxx-modules
-                      COMMAND "${CMAKE_COMMAND}"
-                              -DCMAKE_INSTALL_COMPONENT=cxx-modules
-                              -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+      DEPENDS cxx-modules
+      COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component cxx-modules)
     # Stripping is a no-op for modules
     add_custom_target(install-cxx-modules-stripped DEPENDS install-cxx-modules)
   endif()

--- a/libcxx/src/CMakeLists.txt
+++ b/libcxx/src/CMakeLists.txt
@@ -244,10 +244,6 @@ if (LIBCXX_ENABLE_ABI_LINKER_SCRIPT)
   )
 endif()
 
-if (LIBCXX_ENABLE_SHARED)
-  list(APPEND LIBCXX_BUILD_TARGETS "cxx_shared")
-endif()
-
 if(WIN32 AND NOT MINGW AND NOT "${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
   # Since we most likely do not have a mt.exe replacement, disable the
   # manifest bundling.  This allows a normal cmake invocation to pass which
@@ -295,16 +291,10 @@ if (LIBCXX_HERMETIC_STATIC_LIBRARY)
   target_compile_definitions(cxx_static PRIVATE _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS=)
 endif()
 
-if (LIBCXX_ENABLE_STATIC)
-  list(APPEND LIBCXX_BUILD_TARGETS "cxx_static")
-endif()
 # Attempt to merge the libc++.a archive and the ABI library archive into one.
 if (LIBCXX_STATICALLY_LINK_ABI_IN_STATIC_LIBRARY)
   target_link_libraries(cxx_static PRIVATE libcxx-abi-static-objects)
 endif()
-
-# Add a meta-target for both libraries.
-add_custom_target(cxx DEPENDS ${LIBCXX_BUILD_TARGETS})
 
 # Build the experimental static library
 set(LIBCXX_EXPERIMENTAL_SOURCES
@@ -355,6 +345,15 @@ set_target_properties(cxx_experimental
 cxx_add_common_build_flags(cxx_experimental)
 target_compile_options(cxx_experimental PUBLIC -D_LIBCPP_ENABLE_EXPERIMENTAL)
 
+# Add a meta-target for both libraries.
+add_custom_target(cxx)
+if (LIBCXX_ENABLE_SHARED)
+  add_dependencies(cxx cxx_shared)
+endif()
+if (LIBCXX_ENABLE_STATIC)
+  add_dependencies(cxx cxx_static)
+endif()
+
 if (LIBCXX_INSTALL_SHARED_LIBRARY)
   install(TARGETS cxx_shared
     ARCHIVE DESTINATION ${LIBCXX_INSTALL_LIBRARY_DIR} COMPONENT cxx
@@ -385,30 +384,26 @@ if (LIBCXX_ENABLE_SHARED AND LIBCXX_ENABLE_ABI_LINKER_SCRIPT)
 endif()
 
 if (NOT CMAKE_CONFIGURATION_TYPES)
-    if(LIBCXX_INSTALL_LIBRARY)
-      set(lib_install_target "cxx;cxx_experimental")
-    endif()
-    if(LIBCXX_INSTALL_HEADERS)
-      set(header_install_target install-cxx-headers)
-    endif()
-    if(LIBCXX_INSTALL_MODULES)
-      set(module_install_target install-cxx-modules)
-    endif()
-    add_custom_target(install-cxx
-                      DEPENDS ${lib_install_target}
-                              cxx_experimental
-                              ${header_install_target}
-                              ${module_install_target}
-                      COMMAND "${CMAKE_COMMAND}"
-                      -DCMAKE_INSTALL_COMPONENT=cxx
-                      -P "${LIBCXX_BINARY_DIR}/cmake_install.cmake")
-    add_custom_target(install-cxx-stripped
-                      DEPENDS ${lib_install_target}
-                              cxx_experimental
-                              ${header_install_target}
-                              ${module_install_target}
-                      COMMAND "${CMAKE_COMMAND}"
-                      -DCMAKE_INSTALL_COMPONENT=cxx
-                      -DCMAKE_INSTALL_DO_STRIP=1
-                      -P "${LIBCXX_BINARY_DIR}/cmake_install.cmake")
+  add_custom_target(install-cxx
+    COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component cxx)
+  add_custom_target(install-cxx-stripped
+    COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component cxx --strip)
+
+  add_dependencies(install-cxx cxx_experimental)
+  add_dependencies(install-cxx-stripped cxx_experimental)
+
+  if (LIBCXX_INSTALL_LIBRARY)
+    add_dependencies(install-cxx cxx)
+    add_dependencies(install-cxx-stripped cxx)
+  endif()
+
+  if(LIBCXX_INSTALL_HEADERS)
+    add_dependencies(install-cxx install-cxx-headers)
+    add_dependencies(install-cxx-stripped install-cxx-headers-stripped)
+  endif()
+
+  if(LIBCXX_INSTALL_MODULES)
+    add_dependencies(install-cxx install-cxx-modules)
+    add_dependencies(install-cxx-stripped install-cxx-modules-stripped)
+  endif()
 endif()

--- a/libcxxabi/include/CMakeLists.txt
+++ b/libcxxabi/include/CMakeLists.txt
@@ -30,10 +30,8 @@ if (LIBCXXABI_INSTALL_HEADERS)
   endforeach()
 
   add_custom_target(install-cxxabi-headers
-                    DEPENDS cxxabi-headers
-                    COMMAND "${CMAKE_COMMAND}"
-                            -DCMAKE_INSTALL_COMPONENT=cxxabi-headers
-                            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+    DEPENDS cxxabi-headers
+    COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component cxxabi-headers)
   # Stripping is a no-op for headers
   add_custom_target(install-cxxabi-headers-stripped DEPENDS install-cxxabi-headers)
 endif()

--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -219,13 +219,6 @@ target_link_libraries(cxxabi_shared
   PUBLIC cxxabi_shared_objects runtimes-libc-shared
   PRIVATE ${LIBCXXABI_LIBRARIES})
 
-if (LIBCXXABI_ENABLE_SHARED)
-list(APPEND LIBCXXABI_BUILD_TARGETS "cxxabi_shared")
-endif()
-if (LIBCXXABI_INSTALL_SHARED_LIBRARY)
-list(APPEND LIBCXXABI_INSTALL_TARGETS "cxxabi_shared")
-endif()
-
 # TODO: Move this to libc++'s HandleLibCXXABI.cmake since this is effectively trying to control
 #       what libc++ re-exports.
 add_library(cxxabi-reexports INTERFACE)
@@ -325,34 +318,42 @@ target_link_libraries(cxxabi_static
   PUBLIC cxxabi_static_objects
   PRIVATE ${LIBCXXABI_STATIC_LIBRARIES} ${LIBCXXABI_LIBRARIES})
 
-if (LIBCXXABI_ENABLE_STATIC)
-  list(APPEND LIBCXXABI_BUILD_TARGETS "cxxabi_static")
-endif()
-if (LIBCXXABI_INSTALL_STATIC_LIBRARY)
-  list(APPEND LIBCXXABI_INSTALL_TARGETS "cxxabi_static")
-endif()
-
 # Add a meta-target for both libraries.
-add_custom_target(cxxabi DEPENDS ${LIBCXXABI_BUILD_TARGETS})
-
-if (LIBCXXABI_INSTALL_LIBRARY)
-  install(TARGETS ${LIBCXXABI_INSTALL_TARGETS}
-    LIBRARY DESTINATION ${LIBCXXABI_INSTALL_LIBRARY_DIR} COMPONENT cxxabi
-    ARCHIVE DESTINATION ${LIBCXXABI_INSTALL_LIBRARY_DIR} COMPONENT cxxabi
-    RUNTIME DESTINATION ${LIBCXXABI_INSTALL_RUNTIME_DIR} COMPONENT cxxabi
-    )
+add_custom_target(cxxabi)
+if (LIBCXXABI_ENABLE_SHARED)
+  add_dependencies(cxxabi cxxabi_shared)
+endif()
+if (LIBCXXABI_ENABLE_STATIC)
+  add_dependencies(cxxabi cxxabi_static)
 endif()
 
-if (NOT CMAKE_CONFIGURATION_TYPES AND LIBCXXABI_INSTALL_LIBRARY)
+if (LIBCXXABI_INSTALL_SHARED_LIBRARY)
+  install(TARGETS cxxabi_shared
+    ARCHIVE DESTINATION ${LIBCXXABI_INSTALL_LIBRARY_DIR} COMPONENT cxxabi
+    LIBRARY DESTINATION ${LIBCXXABI_INSTALL_LIBRARY_DIR} COMPONENT cxxabi
+    RUNTIME DESTINATION ${LIBCXXABI_INSTALL_RUNTIME_DIR} COMPONENT cxxabi)
+endif()
+
+if (LIBCXXABI_INSTALL_STATIC_LIBRARY)
+  install(TARGETS cxxabi_static
+    ARCHIVE DESTINATION ${LIBCXXABI_INSTALL_LIBRARY_DIR} COMPONENT cxxabi
+    LIBRARY DESTINATION ${LIBCXXABI_INSTALL_LIBRARY_DIR} COMPONENT cxxabi
+    RUNTIME DESTINATION ${LIBCXXABI_INSTALL_RUNTIME_DIR} COMPONENT cxxabi)
+endif()
+
+if (NOT CMAKE_CONFIGURATION_TYPES)
   add_custom_target(install-cxxabi
-    DEPENDS cxxabi install-cxxabi-headers
-    COMMAND "${CMAKE_COMMAND}"
-            -DCMAKE_INSTALL_COMPONENT=cxxabi
-            -P "${LIBCXXABI_BINARY_DIR}/cmake_install.cmake")
+    COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component cxxabi)
   add_custom_target(install-cxxabi-stripped
-    DEPENDS cxxabi
-    COMMAND "${CMAKE_COMMAND}"
-            -DCMAKE_INSTALL_COMPONENT=cxxabi
-            -DCMAKE_INSTALL_DO_STRIP=1
-            -P "${LIBCXXABI_BINARY_DIR}/cmake_install.cmake")
+    COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component cxxabi --strip)
+
+  if (LIBCXXABI_INSTALL_LIBRARY)
+    add_dependencies(install-cxxabi cxxabi)
+    add_dependencies(install-cxxabi-stripped cxxabi)
+  endif()
+
+  if(LIBCXXABI_INSTALL_HEADERS)
+    add_dependencies(install-cxxabi install-cxxabi-headers)
+    add_dependencies(install-cxxabi-stripped install-cxxabi-headers-stripped)
+  endif()
 endif()

--- a/libunwind/include/CMakeLists.txt
+++ b/libunwind/include/CMakeLists.txt
@@ -21,12 +21,10 @@ if(LIBUNWIND_INSTALL_HEADERS)
     )
   endforeach()
 
-  if(NOT CMAKE_CONFIGURATION_TYPES)
+  if (NOT CMAKE_CONFIGURATION_TYPES)
     add_custom_target(install-unwind-headers
       DEPENDS unwind-headers
-      COMMAND "${CMAKE_COMMAND}"
-              -DCMAKE_INSTALL_COMPONENT=unwind-headers
-              -P "${LIBUNWIND_BINARY_DIR}/cmake_install.cmake")
+      COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component unwind-headers)
     add_custom_target(install-unwind-headers-stripped DEPENDS install-unwind-headers)
   endif()
 endif()

--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -159,13 +159,6 @@ set_target_properties(unwind_shared
     SOVERSION   "1"
 )
 
-if (LIBUNWIND_ENABLE_SHARED)
-  list(APPEND LIBUNWIND_BUILD_TARGETS "unwind_shared")
-endif()
-if (LIBUNWIND_INSTALL_SHARED_LIBRARY)
-  list(APPEND LIBUNWIND_INSTALL_TARGETS "unwind_shared")
-endif()
-
 # Build the static library.
 add_library(unwind_static_objects OBJECT EXCLUDE_FROM_ALL ${LIBUNWIND_SOURCES} ${LIBUNWIND_HEADERS})
 cxx_add_warning_flags(unwind_static_objects ${LIBUNWIND_ENABLE_WERROR} ${LIBUNWIND_ENABLE_PEDANTIC})
@@ -205,35 +198,40 @@ set_target_properties(unwind_static
     OUTPUT_NAME "${LIBUNWIND_STATIC_OUTPUT_NAME}"
 )
 
-if (LIBUNWIND_ENABLE_STATIC)
-  list(APPEND LIBUNWIND_BUILD_TARGETS "unwind_static")
-endif()
-if (LIBUNWIND_INSTALL_STATIC_LIBRARY)
-  list(APPEND LIBUNWIND_INSTALL_TARGETS "unwind_static")
-endif()
-
 # Add a meta-target for both libraries.
-add_custom_target(unwind DEPENDS ${LIBUNWIND_BUILD_TARGETS})
+add_custom_target(unwind)
+if (LIBUNWIND_ENABLE_SHARED)
+  add_dependencies(unwind unwind_shared)
+endif()
+if (LIBUNWIND_ENABLE_STATIC)
+  add_dependencies(unwind unwind_static)
+endif()
 
-if (LIBUNWIND_INSTALL_LIBRARY)
-  install(TARGETS ${LIBUNWIND_INSTALL_TARGETS}
-    LIBRARY DESTINATION ${LIBUNWIND_INSTALL_LIBRARY_DIR} COMPONENT unwind
+if (LIBUNWIND_INSTALL_SHARED_LIBRARY)
+  install(TARGETS unwind_shared
     ARCHIVE DESTINATION ${LIBUNWIND_INSTALL_LIBRARY_DIR} COMPONENT unwind
+    LIBRARY DESTINATION ${LIBUNWIND_INSTALL_LIBRARY_DIR} COMPONENT unwind
     RUNTIME DESTINATION ${LIBUNWIND_INSTALL_RUNTIME_DIR} COMPONENT unwind)
 endif()
 
-if (NOT CMAKE_CONFIGURATION_TYPES AND LIBUNWIND_INSTALL_LIBRARY)
+if (LIBUNWIND_INSTALL_STATIC_LIBRARY)
+  install(TARGETS unwind_static
+    ARCHIVE DESTINATION ${LIBUNWIND_INSTALL_LIBRARY_DIR} COMPONENT unwind
+    LIBRARY DESTINATION ${LIBUNWIND_INSTALL_LIBRARY_DIR} COMPONENT unwind
+    RUNTIME DESTINATION ${LIBUNWIND_INSTALL_RUNTIME_DIR} COMPONENT unwind)
+endif()
+
+if (NOT CMAKE_CONFIGURATION_TYPES)
   add_custom_target(install-unwind
-    DEPENDS unwind
-    COMMAND "${CMAKE_COMMAND}"
-            -DCMAKE_INSTALL_COMPONENT=unwind
-            -P "${LIBUNWIND_BINARY_DIR}/cmake_install.cmake")
+    COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component unwind)
   add_custom_target(install-unwind-stripped
-    DEPENDS unwind
-    COMMAND "${CMAKE_COMMAND}"
-            -DCMAKE_INSTALL_COMPONENT=unwind
-            -DCMAKE_INSTALL_DO_STRIP=1
-            -P "${LIBUNWIND_BINARY_DIR}/cmake_install.cmake")
+    COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --component unwind --strip)
+
+  if (LIBUNWIND_INSTALL_LIBRARY)
+    add_dependencies(install-unwind unwind)
+    add_dependencies(install-unwind-stripped unwind)
+  endif()
+
   if(LIBUNWIND_INSTALL_HEADERS)
     add_dependencies(install-unwind install-unwind-headers)
     add_dependencies(install-unwind-stripped install-unwind-headers-stripped)


### PR DESCRIPTION
This patch moves away from using cmake_install scripts to install the various targets when building runtimes, since those have been deprecated by CMake. Instead, we use `cmake --install` which is the prefered method.

This patch also localizes how we set dependencies on the various installation targets, allowing the removal of a few global variables that were used as lists.

Finally, it makes the way we set up installation targets for libc++, libc++abi and libunwind consistent again.