### PR TITLE
[Offload] Debug message update part 2

### DIFF
--- a/offload/include/OffloadPolicy.h
+++ b/offload/include/OffloadPolicy.h
@@ -16,6 +16,8 @@
 
 #include "PluginManager.h"
 
+using namespace llvm::omp::target::debug;
+
 enum kmp_target_offload_kind_t {
   tgt_disabled = 0,
   tgt_default = 1,
@@ -35,12 +37,12 @@ class OffloadPolicy {
       return;
     default:
       if (PM.getNumDevices()) {
-        DP("Default TARGET OFFLOAD policy is now mandatory "
-           "(devices were found)\n");
+        ODBG(ODT_Init) << "Default TARGET OFFLOAD policy is now mandatory "
+                       << "(devices were found)";
         Kind = MANDATORY;
       } else {
-        DP("Default TARGET OFFLOAD policy is now disabled "
-           "(no devices were found)\n");
+        ODBG(ODT_Init) << "Default TARGET OFFLOAD policy is now disabled "
+                       << "(no devices were found)";
         Kind = DISABLED;
       }
       return;

--- a/offload/include/OpenMP/OMPT/Connector.h
+++ b/offload/include/OpenMP/OMPT/Connector.h
@@ -27,6 +27,8 @@
 
 #include "Shared/Debug.h"
 
+using namespace llvm::omp::target::debug;
+
 #pragma push_macro("DEBUG_PREFIX")
 #undef DEBUG_PREFIX
 #define DEBUG_PREFIX "OMPT"
@@ -76,7 +78,7 @@ private:
     std::string LibName = LibIdent;
     LibName += ".so";
 
-    DP("OMPT: Trying to load library %s\n", LibName.c_str());
+    ODBG(ODT_Tool) << "OMPT: Trying to load library " << LibName;
     auto DynLibHandle = std::make_unique<llvm::sys::DynamicLibrary>(
         llvm::sys::DynamicLibrary::getPermanentLibrary(LibName.c_str(),
                                                        &ErrMsg));
@@ -85,12 +87,13 @@ private:
       LibConnHandle = nullptr;
     } else {
       auto LibConnRtn = "ompt_" + LibIdent + "_connect";
-      DP("OMPT: Trying to get address of connection routine %s\n",
-         LibConnRtn.c_str());
+      ODBG(ODT_Tool) << "OMPT: Trying to get address of connection routine "
+                     << LibConnRtn;
       LibConnHandle = reinterpret_cast<OmptConnectRtnTy>(
           DynLibHandle->getAddressOfSymbol(LibConnRtn.c_str()));
     }
-    DP("OMPT: Library connection handle = %p\n", LibConnHandle);
+    ODBG(ODT_Tool) << "OMPT: Library connection handle = "
+                   << reinterpret_cast<void *>(LibConnHandle);
     IsInitialized = true;
   }
 

--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -529,6 +529,7 @@ constexpr const char *ODT_EmptyMapping = "EmptyMapping";
 constexpr const char *ODT_Device = "Device";
 constexpr const char *ODT_Interface = "Interface";
 constexpr const char *ODT_Alloc = "Alloc";
+constexpr const char *ODT_Tool = "Tool";
 
 static inline odbg_ostream reportErrorStream() {
 #ifdef OMPTARGET_DEBUG

--- a/offload/include/Shared/EnvironmentVar.h
+++ b/offload/include/Shared/EnvironmentVar.h
@@ -19,6 +19,8 @@
 #include <sstream>
 #include <string>
 
+using namespace llvm::omp::target::debug;
+
 /// Utility class for parsing strings to other types.
 struct StringParser {
   /// Parse a string to another type.
@@ -61,7 +63,8 @@ public:
       IsPresent = StringParser::parse<Ty>(EnvStr, Data);
 
       if (!IsPresent) {
-        DP("Ignoring invalid value %s for envar %s\n", EnvStr, Name.data());
+        ODBG(ODT_Init) << "Ignoring invalid value " << EnvStr << " for envar "
+                       << Name;
         Data = Default;
       }
     }
@@ -180,12 +183,13 @@ inline llvm::Error Envar<Ty>::init(llvm::StringRef Name, GetterFunctor Getter,
         // not present and reset to the getter value (default).
         IsPresent = false;
         Data = Default;
-        DP("Setter of envar %s failed, resetting to %s\n", Name.data(),
-           std::to_string(Data).data());
+        ODBG(ODT_Init) << "Setter of envar " << Name << " failed, resetting to "
+                       << std::to_string(Data);
         consumeError(std::move(Err));
       }
     } else {
-      DP("Ignoring invalid value %s for envar %s\n", EnvStr, Name.data());
+      ODBG(ODT_Init) << "Ignoring invalid value " << EnvStr << " for envar "
+                     << Name;
       Data = Default;
     }
   } else {

--- a/offload/libomptarget/OpenMP/Mapping.cpp
+++ b/offload/libomptarget/OpenMP/Mapping.cpp
@@ -138,7 +138,7 @@ LookupResult MappingInfoTy::lookupMapping(HDTTMapAccessorTy &HDTTMap,
   uintptr_t HP = (uintptr_t)HstPtrBegin;
   LookupResult LR;
 
-  ODBG(ODT_Mapping) << "Looking up mapping(HstPtrBegin=" << HP
+  ODBG(ODT_Mapping) << "Looking up mapping(HstPtrBegin=" << HstPtrBegin
                     << ", Size=" << Size << ")...";
 
   if (HDTTMap->empty())
@@ -346,12 +346,12 @@ TargetPointerResultTy MappingInfoTy::getTargetPointer(
         OFFLOAD_FAIL) {
       ODBG(ODT_Mapping) << "Multiple new mappings of " << Size
                         << " bytes detected (hst:" << HstPtrBegin
-                        << ") -> (tgt:" << LR.TPR.TargetPointer;
+                        << ") -> (tgt:" << LR.TPR.TargetPointer << ")";
       return std::move(LR.TPR);
     }
 
     ODBG(ODT_Mapping) << "Moving " << Size << " bytes (hst:" << HstPtrBegin
-                      << ") -> (tgt:" << LR.TPR.TargetPointer;
+                      << ") -> (tgt:" << LR.TPR.TargetPointer << ")";
 
     int Ret = Device.submitData(LR.TPR.TargetPointer, HstPtrBegin, Size,
                                 AsyncInfo, LR.TPR.getEntry());

--- a/offload/libomptarget/OpenMP/Mapping.cpp
+++ b/offload/libomptarget/OpenMP/Mapping.cpp
@@ -376,7 +376,7 @@ TargetPointerResultTy MappingInfoTy::getTargetPointer(
         if (Ret != OFFLOAD_SUCCESS) {
           // If it fails to wait for the event, we need to return nullptr in
           // case of any data race.
-          REPORT() << "Failed to wait for event " << Event;
+          REPORT() << "Failed to wait for event " << Event << ".";
           return TargetPointerResultTy{};
         }
       }

--- a/offload/libomptarget/OpenMP/Mapping.cpp
+++ b/offload/libomptarget/OpenMP/Mapping.cpp
@@ -15,6 +15,8 @@
 #include "Shared/Requirements.h"
 #include "device.h"
 
+using namespace llvm::omp::target::debug;
+
 /// Dump a table of all the host-target pointer pairs on failure
 void dumpTargetPointerMappings(const ident_t *Loc, DeviceTy &Device,
                                bool toStdOut) {
@@ -59,12 +61,13 @@ int MappingInfoTy::associatePtr(void *HstPtrBegin, void *TgtPtrBegin,
     bool IsValid = HDTT.HstPtrEnd == (uintptr_t)HstPtrBegin + Size &&
                    HDTT.TgtPtrBegin == (uintptr_t)TgtPtrBegin;
     if (IsValid) {
-      DP("Attempt to re-associate the same device ptr+offset with the same "
-         "host ptr, nothing to do\n");
+      ODBG(ODT_MappingExists) << "Attempt to re-associate the same device "
+                              << "ptr+offset with the same "
+                              << "host ptr, nothing to do";
       return OFFLOAD_SUCCESS;
     }
-    REPORT("Not allowed to re-associate a different device ptr+offset with "
-           "the same host ptr\n");
+    REPORT() << "Not allowed to re-associate a different device ptr+offset "
+             << "with the same host ptr";
     return OFFLOAD_FAIL;
   }
 
@@ -80,12 +83,12 @@ int MappingInfoTy::associatePtr(void *HstPtrBegin, void *TgtPtrBegin,
                /*UseHoldRefCount=*/false, /*Name=*/nullptr,
                /*IsRefCountINF=*/true))
            .first->HDTT;
-  DP("Creating new map entry: HstBase=" DPxMOD ", HstBegin=" DPxMOD
-     ", HstEnd=" DPxMOD ", TgtBegin=" DPxMOD ", DynRefCount=%s, "
-     "HoldRefCount=%s\n",
-     DPxPTR(NewEntry.HstPtrBase), DPxPTR(NewEntry.HstPtrBegin),
-     DPxPTR(NewEntry.HstPtrEnd), DPxPTR(NewEntry.TgtPtrBegin),
-     NewEntry.dynRefCountToStr().c_str(), NewEntry.holdRefCountToStr().c_str());
+  ODBG(ODT_Mapping) << "Creating new map entry: HstBase=" << NewEntry.HstPtrBase
+                    << ", HstBegin=" << NewEntry.HstPtrBegin
+                    << ", HstEnd=" << NewEntry.HstPtrEnd
+                    << ", TgtBegin=" << NewEntry.TgtPtrBegin
+                    << ", DynRefCount=" << NewEntry.dynRefCountToStr()
+                    << ", HoldRefCount=" << NewEntry.holdRefCountToStr();
   (void)NewEntry;
 
   // Notify the plugin about the new mapping.
@@ -97,7 +100,7 @@ int MappingInfoTy::disassociatePtr(void *HstPtrBegin) {
 
   auto It = HDTTMap->find(HstPtrBegin);
   if (It == HDTTMap->end()) {
-    REPORT("Association not found\n");
+    REPORT() << "Association not found";
     return OFFLOAD_FAIL;
   }
   // Mapping exists
@@ -108,13 +111,13 @@ int MappingInfoTy::disassociatePtr(void *HstPtrBegin) {
     // This is based on OpenACC 3.1, sec 3.2.33 "acc_unmap_data", L3656-3657:
     // "It is an error to call acc_unmap_data if the structured reference
     // count for the pointer is not zero."
-    REPORT("Trying to disassociate a pointer with a non-zero hold reference "
-           "count\n");
+    REPORT() << "Trying to disassociate a pointer with a non-zero "
+             << "hold reference count";
     return OFFLOAD_FAIL;
   }
 
   if (HDTT.isDynRefCountInf()) {
-    DP("Association found, removing it\n");
+    ODBG(ODT_Mapping) << "Association found, removing it";
     void *Event = HDTT.getEvent();
     delete &HDTT;
     if (Event)
@@ -123,8 +126,8 @@ int MappingInfoTy::disassociatePtr(void *HstPtrBegin) {
     return Device.notifyDataUnmapped(HstPtrBegin);
   }
 
-  REPORT("Trying to disassociate a pointer which was not mapped via "
-         "omp_target_associate_ptr\n");
+  REPORT() << "Trying to disassociate a pointer which was not mapped via "
+           << "omp_target_associate_ptr";
   return OFFLOAD_FAIL;
 }
 
@@ -135,8 +138,8 @@ LookupResult MappingInfoTy::lookupMapping(HDTTMapAccessorTy &HDTTMap,
   uintptr_t HP = (uintptr_t)HstPtrBegin;
   LookupResult LR;
 
-  DP("Looking up mapping(HstPtrBegin=" DPxMOD ", Size=%" PRId64 ")...\n",
-     DPxPTR(HP), Size);
+  ODBG(ODT_Mapping) << "Looking up mapping(HstPtrBegin=" << HP
+                    << ", Size=" << Size << ")...";
 
   if (HDTTMap->empty())
     return LR;
@@ -185,12 +188,12 @@ LookupResult MappingInfoTy::lookupMapping(HDTTMapAccessorTy &HDTTMap,
     }
 
     if (LR.Flags.ExtendsBefore) {
-      DP("WARNING: Pointer is not mapped but section extends into already "
-         "mapped data\n");
+      ODBG(ODT_Mapping) << "WARNING: Pointer is not mapped but section extends "
+                        << "into already mapped data";
     }
     if (LR.Flags.ExtendsAfter) {
-      DP("WARNING: Pointer is already mapped but section extends beyond mapped "
-         "region\n");
+      ODBG(ODT_Mapping) << "WARNING: Pointer is already mapped but section "
+                        << "extends beyond mapped region";
     }
   }
 
@@ -269,17 +272,16 @@ TargetPointerResultTy MappingInfoTy::getTargetPointer(
            "Return HstPtrBegin " DPxMOD " Size=%" PRId64 " for unified shared "
            "memory\n",
            DPxPTR((uintptr_t)HstPtrBegin), Size);
-      DP("Return HstPtrBegin " DPxMOD " Size=%" PRId64 " for unified shared "
-         "memory\n",
-         DPxPTR((uintptr_t)HstPtrBegin), Size);
+      ODBG(ODT_Mapping) << "Return HstPtrBegin " << HstPtrBegin
+                        << " Size=" << Size << " for unified shared memory";
       LR.TPR.Flags.IsPresent = false;
       LR.TPR.Flags.IsHostPointer = true;
       LR.TPR.TargetPointer = HstPtrBegin;
     }
   } else if (HasPresentModifier) {
-    DP("Mapping required by 'present' map type modifier does not exist for "
-       "HstPtrBegin=" DPxMOD ", Size=%" PRId64 "\n",
-       DPxPTR(HstPtrBegin), Size);
+    ODBG(ODT_Mapping) << "Mapping required by 'present' map type modifier does "
+                      << "not exist for HstPtrBegin=" << HstPtrBegin
+                      << ", Size=" << Size;
     MESSAGE("device mapping required by 'present' map type modifier does not "
             "exist for host address " DPxMOD " (%" PRId64 " bytes)",
             DPxPTR(HstPtrBegin), Size);
@@ -342,19 +344,19 @@ TargetPointerResultTy MappingInfoTy::getTargetPointer(
     };
     if (LR.TPR.getEntry()->foreachShadowPointerInfo(FailOnPtrFound) ==
         OFFLOAD_FAIL) {
-      DP("Multiple new mappings of %" PRId64 " bytes detected (hst:" DPxMOD
-         ") -> (tgt:" DPxMOD ")\n",
-         Size, DPxPTR(HstPtrBegin), DPxPTR(LR.TPR.TargetPointer));
+      ODBG(ODT_Mapping) << "Multiple new mappings of " << Size
+                        << " bytes detected (hst:" << HstPtrBegin
+                        << ") -> (tgt:" << LR.TPR.TargetPointer;
       return std::move(LR.TPR);
     }
 
-    DP("Moving %" PRId64 " bytes (hst:" DPxMOD ") -> (tgt:" DPxMOD ")\n", Size,
-       DPxPTR(HstPtrBegin), DPxPTR(LR.TPR.TargetPointer));
+    ODBG(ODT_Mapping) << "Moving " << Size << " bytes (hst:" << HstPtrBegin
+                      << ") -> (tgt:" << LR.TPR.TargetPointer;
 
     int Ret = Device.submitData(LR.TPR.TargetPointer, HstPtrBegin, Size,
                                 AsyncInfo, LR.TPR.getEntry());
     if (Ret != OFFLOAD_SUCCESS) {
-      REPORT("Copying data to device failed.\n");
+      REPORT() << "Copying data to device failed.";
       // We will also return nullptr if the data movement fails because that
       // pointer points to a corrupted memory region so it doesn't make any
       // sense to continue to use it.
@@ -374,7 +376,7 @@ TargetPointerResultTy MappingInfoTy::getTargetPointer(
         if (Ret != OFFLOAD_SUCCESS) {
           // If it fails to wait for the event, we need to return nullptr in
           // case of any data race.
-          REPORT("Failed to wait for event " DPxMOD ".\n", DPxPTR(Event));
+          REPORT() << "Failed to wait for event " << Event;
           return TargetPointerResultTy{};
         }
       }
@@ -444,9 +446,8 @@ TargetPointerResultTy MappingInfoTy::getTgtPtrBegin(
     // If the value isn't found in the mapping and unified shared memory
     // is on then it means we have stumbled upon a value which we need to
     // use directly from the host.
-    DP("Get HstPtrBegin " DPxMOD " Size=%" PRId64 " for unified shared "
-       "memory\n",
-       DPxPTR((uintptr_t)HstPtrBegin), Size);
+    ODBG(ODT_Mapping) << "Get HstPtrBegin " << HstPtrBegin << " Size=" << Size
+                      << " for unified shared memory";
     LR.TPR.Flags.IsPresent = false;
     LR.TPR.Flags.IsHostPointer = true;
     LR.TPR.TargetPointer = HstPtrBegin;
@@ -490,7 +491,7 @@ int MappingInfoTy::eraseMapEntry(HDTTMapAccessorTy &HDTTMap,
                            : "unknown");
 
   if (HDTTMap->erase(Entry) == 0) {
-    REPORT("Trying to remove a non-existent map entry\n");
+    REPORT() << "Trying to remove a non-existent map entry";
     return OFFLOAD_FAIL;
   }
 
@@ -501,13 +502,13 @@ int MappingInfoTy::deallocTgtPtrAndEntry(HostDataToTargetTy *Entry,
                                          int64_t Size) {
   assert(Entry && "Trying to deallocate a null entry.");
 
-  DP("Deleting tgt data " DPxMOD " of size %" PRId64 " by freeing allocation "
-     "starting at " DPxMOD "\n",
-     DPxPTR(Entry->TgtPtrBegin), Size, DPxPTR(Entry->TgtAllocBegin));
+  ODBG(ODT_Mapping) << "Deleting tgt data " << Entry->TgtPtrBegin << " of size "
+                    << Size << " by freeing allocation "
+                    << "starting at " << Entry->TgtAllocBegin;
 
   void *Event = Entry->getEvent();
   if (Event && Device.destroyEvent(Event) != OFFLOAD_SUCCESS) {
-    REPORT("Failed to destroy event " DPxMOD "\n", DPxPTR(Event));
+    REPORT() << "Failed to destroy event " << Event;
     return OFFLOAD_FAIL;
   }
 

--- a/offload/libomptarget/OpenMP/OMPT/Callback.cpp
+++ b/offload/libomptarget/OpenMP/OMPT/Callback.cpp
@@ -35,6 +35,7 @@ FOREACH_OMPT_EMI_EVENT(defineOmptCallback)
 #undef defineOmptCallback
 
 using namespace llvm::omp::target::ompt;
+using namespace llvm::omp::target::debug;
 
 /// Forward declaration
 class LibomptargetRtlFinalizer;
@@ -410,11 +411,13 @@ void Interface::endTarget(int64_t DeviceId, void *Code) {
 }
 
 void Interface::beginTargetDataOperation() {
-  DP("in ompt_target_region_begin (TargetRegionId = %lu)\n", TargetData.value);
+  ODBG(ODT_Tool) << "in ompt_target_region_begin (TargetRegionId = "
+                 << TargetData.value << ")";
 }
 
 void Interface::endTargetDataOperation() {
-  DP("in ompt_target_region_end (TargetRegionId = %lu)\n", TargetData.value);
+  ODBG(ODT_Tool) << "in ompt_target_region_end (TargetRegionId = "
+                 << TargetData.value << ")";
 }
 
 void Interface::beginTargetRegion() {
@@ -462,12 +465,12 @@ private:
 int llvm::omp::target::ompt::initializeLibrary(ompt_function_lookup_t lookup,
                                                int initial_device_num,
                                                ompt_data_t *tool_data) {
-  DP("Executing initializeLibrary\n");
+  ODBG(ODT_Tool) << "Executing initializeLibrary";
 #define bindOmptFunctionName(OmptFunction, DestinationFunction)                \
   if (lookup)                                                                  \
     DestinationFunction = (OmptFunction##_t)lookup(#OmptFunction);             \
-  DP("initializeLibrary bound %s=%p\n", #DestinationFunction,                  \
-     ((void *)(uint64_t)DestinationFunction));
+  ODBG(ODT_Tool) << "initializeLibrary bound " << #DestinationFunction << "="  \
+                 << ((void *)(uint64_t)DestinationFunction);
 
   bindOmptFunctionName(ompt_get_callback, lookupCallbackByCode);
   bindOmptFunctionName(ompt_get_task_data, ompt_get_task_data_fn);
@@ -493,7 +496,7 @@ int llvm::omp::target::ompt::initializeLibrary(ompt_function_lookup_t lookup,
 }
 
 void llvm::omp::target::ompt::finalizeLibrary(ompt_data_t *data) {
-  DP("Executing finalizeLibrary\n");
+  ODBG(ODT_Tool) << "Executing finalizeLibrary";
   // Before disabling OMPT, call the (plugin) finalizations that were registered
   // with this library
   LibraryFinalizer->finalize();
@@ -502,7 +505,7 @@ void llvm::omp::target::ompt::finalizeLibrary(ompt_data_t *data) {
 }
 
 void llvm::omp::target::ompt::connectLibrary() {
-  DP("Entering connectLibrary\n");
+  ODBG(ODT_Tool) << "Entering connectLibrary";
   // Connect with libomp
   static OmptLibraryConnectorTy LibompConnector("libomp");
   static ompt_start_tool_result_t OmptResult;
@@ -525,7 +528,7 @@ void llvm::omp::target::ompt::connectLibrary() {
   FOREACH_OMPT_EMI_EVENT(bindOmptCallback)
 #undef bindOmptCallback
 
-  DP("Exiting connectLibrary\n");
+  ODBG(ODT_Tool) << "Exiting connectLibrary";
 }
 
 #endif // OMPT_SUPPORT

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -22,6 +22,7 @@
 
 using namespace llvm;
 using namespace llvm::sys;
+using namespace llvm::omp::target::debug;
 
 PluginManager *PM = nullptr;
 
@@ -32,11 +33,11 @@ PluginManager *PM = nullptr;
 void PluginManager::init() {
   TIMESCOPE();
   if (OffloadPolicy::isOffloadDisabled()) {
-    DP("Offload is disabled. Skipping plugin initialization\n");
+    ODBG(ODT_Init) << "Offload is disabled. Skipping plugin initialization";
     return;
   }
 
-  ODBG("Init") << "Loading RTLs";
+  ODBG(ODT_Init) << "Loading RTLs";
 
   // Attempt to create an instance of each supported plugin.
 #define PLUGIN_TARGET(Name)                                                    \
@@ -46,12 +47,12 @@ void PluginManager::init() {
   } while (false);
 #include "Shared/Targets.def"
 
-  DP("RTLs loaded!\n");
+  ODBG(ODT_Init) << "RTLs loaded!";
 }
 
 void PluginManager::deinit() {
   TIMESCOPE();
-  DP("Unloading RTLs...\n");
+  ODBG(ODT_Deinit) << "Unloading RTLs...";
 
   for (auto &Plugin : Plugins) {
     if (!Plugin->is_initialized())
@@ -59,12 +60,12 @@ void PluginManager::deinit() {
 
     if (auto Err = Plugin->deinit()) {
       [[maybe_unused]] std::string InfoMsg = toString(std::move(Err));
-      DP("Failed to deinit plugin: %s\n", InfoMsg.c_str());
+      ODBG(ODT_Deinit) << "Failed to deinit plugin: " << InfoMsg;
     }
     Plugin.release();
   }
 
-  DP("RTLs unloaded!\n");
+  ODBG(ODT_Deinit) << "RTLs unloaded!";
 }
 
 bool PluginManager::initializePlugin(GenericPluginTy &Plugin) {
@@ -73,12 +74,13 @@ bool PluginManager::initializePlugin(GenericPluginTy &Plugin) {
 
   if (auto Err = Plugin.init()) {
     [[maybe_unused]] std::string InfoMsg = toString(std::move(Err));
-    DP("Failed to init plugin: %s\n", InfoMsg.c_str());
+    ODBG(ODT_Init) << "Failed to init plugin: " << InfoMsg;
     return false;
   }
 
-  DP("Registered plugin %s with %d visible device(s)\n", Plugin.getName(),
-     Plugin.number_of_devices());
+  ODBG(ODT_Init) << "Registered plugin " << Plugin.getName() << " with "
+                 << Plugin.number_of_devices() << " visible device(s)";
+
   return true;
 }
 
@@ -105,7 +107,7 @@ bool PluginManager::initializeDevice(GenericPluginTy &Plugin,
   auto Device = std::make_unique<DeviceTy>(&Plugin, UserId, DeviceId);
   if (auto Err = Device->init()) {
     [[maybe_unused]] std::string InfoMsg = toString(std::move(Err));
-    DP("Failed to init device %d: %s\n", DeviceId, InfoMsg.c_str());
+    ODBG(ODT_Init) << "Failed to init device " << DeviceId << ": " << InfoMsg;
     return false;
   }
 
@@ -229,7 +231,8 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
         continue;
 
       if (!R.number_of_devices()) {
-        DP("Skipping plugin %s with no visible devices\n", R.getName());
+        ODBG(ODT_Init) << "Skipping plugin " << R.getName()
+                       << " with no visible devices";
         continue;
       }
 
@@ -239,17 +242,18 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
         // registered for the same device in the case that they are mutually
         // compatible, such as sm_80 and sm_89.
         if (UsedDevices[&R].contains(DeviceId)) {
-          DP("Image " DPxMOD
-             " is a duplicate, not loaded on RTL %s device %d!\n",
-             DPxPTR(Img->ImageStart), R.getName(), DeviceId);
+          ODBG(ODT_Init) << "Image " << Img->ImageStart
+                         << " is a duplicate, not loaded on RTL " << R.getName()
+                         << " device " << DeviceId;
           continue;
         }
 
         if (!R.isDeviceCompatible(DeviceId, Buffer))
           continue;
 
-        DP("Image " DPxMOD " is compatible with RTL %s device %d!\n",
-           DPxPTR(Img->ImageStart), R.getName(), DeviceId);
+        ODBG(ODT_Init) << "Image " << Img->ImageStart
+                       << " is compatible with RTL " << R.getName()
+                       << " device " << DeviceId;
 
         if (!initializeDevice(R, DeviceId))
           continue;
@@ -269,8 +273,8 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
         TranslationTable &TT =
             (PM->HostEntriesBeginToTransTable)[Desc->HostEntriesBegin];
 
-        DP("Registering image " DPxMOD " with RTL %s!\n",
-           DPxPTR(Img->ImageStart), R.getName());
+        ODBG(ODT_Init) << "Registering image " << Img->ImageStart
+                       << " with RTL " << R.getName();
 
         auto UserId = PM->DeviceIds[std::make_pair(&R, DeviceId)];
         if (TT.TargetsTable.size() < static_cast<size_t>(UserId + 1)) {
@@ -292,7 +296,7 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
       }
     }
     if (!FoundRTL)
-      DP("No RTL found for image " DPxMOD "!\n", DPxPTR(Img->ImageStart));
+      ODBG(ODT_Init) << "No RTL found for image " << Img->ImageStart;
   }
   PM->RTLsMtx.unlock();
 
@@ -309,7 +313,7 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
   if (UseAutoZeroCopy)
     addRequirements(OMPX_REQ_AUTO_ZERO_COPY);
 
-  DP("Done registering entries!\n");
+  ODBG(ODT_Init) << "Done registering entries!";
 }
 
 // Temporary forward declaration, old style CTor/DTor handling is going away.
@@ -317,7 +321,7 @@ int target(ident_t *Loc, DeviceTy &Device, void *HostPtr,
            KernelArgsTy &KernelArgs, AsyncInfoTy &AsyncInfo);
 
 void PluginManager::unregisterLib(__tgt_bin_desc *Desc) {
-  DP("Unloading target library!\n");
+  ODBG(ODT_Deinit) << "Unloading target library!";
 
   Desc = upgradeLegacyEntries(Desc);
 
@@ -341,19 +345,20 @@ void PluginManager::unregisterLib(__tgt_bin_desc *Desc) {
 
       FoundRTL = &R;
 
-      DP("Unregistered image " DPxMOD " from RTL\n", DPxPTR(Img->ImageStart));
+      ODBG(ODT_Deinit) << "Unregistered image " << Img->ImageStart
+                       << " from RTL";
 
       break;
     }
 
     // if no RTL was found proceed to unregister the next image
     if (!FoundRTL) {
-      DP("No RTLs in use support the image " DPxMOD "!\n",
-         DPxPTR(Img->ImageStart));
+      ODBG(ODT_Deinit) << "No RTLs in use support the image "
+                       << Img->ImageStart;
     }
   }
   PM->RTLsMtx.unlock();
-  DP("Done unregistering images!\n");
+  ODBG(ODT_Deinit) << "Done unregistering images!";
 
   // Remove entries from PM->HostPtrToTableMap
   PM->TblMapMtx.lock();
@@ -367,18 +372,18 @@ void PluginManager::unregisterLib(__tgt_bin_desc *Desc) {
   auto TransTable =
       PM->HostEntriesBeginToTransTable.find(Desc->HostEntriesBegin);
   if (TransTable != PM->HostEntriesBeginToTransTable.end()) {
-    DP("Removing translation table for descriptor " DPxMOD "\n",
-       DPxPTR(Desc->HostEntriesBegin));
+    ODBG(ODT_Deinit) << "Removing translation table for descriptor "
+                     << Desc->HostEntriesBegin;
     PM->HostEntriesBeginToTransTable.erase(TransTable);
   } else {
-    DP("Translation table for descriptor " DPxMOD " cannot be found, probably "
-       "it has been already removed.\n",
-       DPxPTR(Desc->HostEntriesBegin));
+    ODBG(ODT_Deinit) << "Translation table for descriptor "
+                     << Desc->HostEntriesBegin << " cannot be found, probably "
+                     << "it has been already removed.";
   }
 
   PM->TblMapMtx.unlock();
 
-  DP("Done unregistering library!\n");
+  ODBG(ODT_Deinit) << "Done unregistering library!";
 }
 
 /// Map global data and execute pending ctors
@@ -393,8 +398,8 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
     for (auto *HostEntriesBegin : PM->HostEntriesBeginRegistrationOrder) {
       TranslationTable *TransTable =
           &PM->HostEntriesBeginToTransTable[HostEntriesBegin];
-      DP("Trans table %p : %p\n", TransTable->HostTable.EntriesBegin,
-         TransTable->HostTable.EntriesEnd);
+      ODBG(ODT_Init) << "Trans table " << TransTable->HostTable.EntriesBegin
+                     << " : " << TransTable->HostTable.EntriesEnd;
       if (TransTable->HostTable.EntriesBegin ==
           TransTable->HostTable.EntriesEnd) {
         // No host entry so no need to proceed
@@ -411,7 +416,7 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
              "Not expecting a device ID outside the table's bounds!");
       __tgt_device_image *Img = TransTable->TargetsImages[DeviceId];
       if (!Img) {
-        REPORT("No image loaded for device id %d.\n", DeviceId);
+        REPORT() << "No image loaded for device id " << DeviceId;
         Rc = OFFLOAD_FAIL;
         break;
       }
@@ -419,8 +424,7 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
       // 2) Load the image onto the given device.
       auto BinaryOrErr = Device.loadBinary(Img);
       if (llvm::Error Err = BinaryOrErr.takeError()) {
-        REPORT("Failed to load image %s\n",
-               llvm::toString(std::move(Err)).c_str());
+        REPORT() << "Failed to load image " << llvm::toString(std::move(Err));
         Rc = OFFLOAD_FAIL;
         break;
       }
@@ -440,7 +444,7 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
           if (!(Entry.Flags & OMP_DECLARE_TARGET_INDIRECT_VTABLE))
             if (Device.RTL->get_global(Binary, Entry.Size, Entry.SymbolName,
                                        &DeviceEntry.Address) != OFFLOAD_SUCCESS)
-              REPORT("Failed to load symbol %s\n", Entry.SymbolName);
+              REPORT() << "Failed to load symbol " << Entry.SymbolName;
 
           // If unified memory is active, the corresponding global is a device
           // reference to the host global. We need to initialize the pointer on
@@ -452,15 +456,16 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
             if (Device.RTL->data_submit(DeviceId, DeviceEntry.Address,
                                         Entry.Address,
                                         Entry.Size) != OFFLOAD_SUCCESS)
-              REPORT("Failed to write symbol for USM %s\n", Entry.SymbolName);
+              REPORT() << "Failed to write symbol for USM " << Entry.SymbolName;
         } else if (Entry.Address) {
           if (Device.RTL->get_function(Binary, Entry.SymbolName,
                                        &DeviceEntry.Address) != OFFLOAD_SUCCESS)
-            REPORT("Failed to load kernel %s\n", Entry.SymbolName);
+            REPORT() << "Failed to load kernel " << Entry.SymbolName;
         }
-        DP("Entry point " DPxMOD " maps to%s %s (" DPxMOD ")\n",
-           DPxPTR(Entry.Address), (Entry.Size) ? " global" : "",
-           Entry.SymbolName, DPxPTR(DeviceEntry.Address));
+        ODBG(ODT_Mapping) << "Entry point " << Entry.Address << " maps to"
+                          << (Entry.Size ? " global" : "") << " "
+                          << Entry.SymbolName << " (" << DeviceEntry.Address
+                          << ")";
 
         DeviceEntries.emplace_back(DeviceEntry);
       }
@@ -511,10 +516,10 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
           CurrDeviceEntryAddr = DevPtr;
         }
 
-        DP("Add mapping from host " DPxMOD " to device " DPxMOD " with size %zu"
-           ", name \"%s\"\n",
-           DPxPTR(CurrHostEntry->Address), DPxPTR(CurrDeviceEntry->Address),
-           CurrDeviceEntry->Size, CurrDeviceEntry->SymbolName);
+        ODBG(ODT_Mapping) << "Add mapping from host " << CurrHostEntry->Address
+                          << " to device " << CurrDeviceEntry->Address
+                          << " with size " << CurrDeviceEntry->Size
+                          << ", name \"" << CurrDeviceEntry->SymbolName << "\"";
         HDTTMap->emplace(new HostDataToTargetTy(
             (uintptr_t)CurrHostEntry->Address /*HstPtrBase*/,
             (uintptr_t)CurrHostEntry->Address /*HstPtrBegin*/,

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -296,7 +296,7 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
       }
     }
     if (!FoundRTL)
-      ODBG(ODT_Init) << "No RTL found for image " << Img->ImageStart;
+      ODBG(ODT_Init) << "No RTL found for image " << Img->ImageStart << "!";
   }
   PM->RTLsMtx.unlock();
 
@@ -416,7 +416,7 @@ static int loadImagesOntoDevice(DeviceTy &Device) {
              "Not expecting a device ID outside the table's bounds!");
       __tgt_device_image *Img = TransTable->TargetsImages[DeviceId];
       if (!Img) {
-        REPORT() << "No image loaded for device id " << DeviceId;
+        REPORT() << "No image loaded for device id " << DeviceId << ".";
         Rc = OFFLOAD_FAIL;
         break;
       }


### PR DESCRIPTION
Update debug messages based on the new method from #170425. Added a new debug type `Tool` and updated the following files.
- include/OffloadPolicy.h
- include/OpenMP/OMPT/Connector.h
- include/Shared/Debug.h
- include/Shared/EnvironmentVar.h
- libomptarget/OpenMP/Mapping.cpp
- libomptarget/OpenMP/OMPT/Callback.cpp
- libomptarget/PluginManager.cpp