### PR TITLE
[lldb] fix failing tests due to CI diagnostics rendering

### DIFF
--- a/lldb/test/Shell/Commands/command-dwim-print.test
+++ b/lldb/test/Shell/Commands/command-dwim-print.test
@@ -1,16 +1,16 @@
 # RUN: echo quit | %lldb -o "dwim-print a" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK1
 #            (lldb) dwim-print a 
-# CHECK1:{{^                  \^}}
+# CHECK1:{{^                  (\^|˄)}}
 # CHECK1: {{^                  error: use of undeclared identifier 'a'}}
 # RUN: echo quit | %lldb -o "p a" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK2
 #            (lldb) p a 
-# CHECK2:{{^         \^}}
+# CHECK2:{{^         (\^|˄)}}
 # RUN: echo quit | %lldb -o "dwim-print -- a" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK3
 #            (lldb) dwim-print -- a 
-# CHECK3:{{^                     \^}}
+# CHECK3:{{^                     (\^|˄)}}
 # RUN: echo quit | %lldb -o "settings set show-inline-diagnostics false" \
 # RUN:   -o "dwim-print a" 2>&1 | FileCheck %s --check-prefix=CHECK4
 # CHECK4: error: <user expression 0>:1:1: use of undeclared identifier

--- a/lldb/test/Shell/Commands/command-expr-diagnostics.test
+++ b/lldb/test/Shell/Commands/command-expr-diagnostics.test
@@ -2,19 +2,19 @@
 # RUN: echo quit | %lldb -o "expression a+b" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK1
 #            (lldb) expression a+b
-# CHECK1:{{^                  \^ \^}}
-# CHECK1: {{^                  | error: use of undeclared identifier 'b'}}
+# CHECK1:{{^                  (\^|˄) (\^|˄)}}
+# CHECK1: {{^                  (\||│) error: use of undeclared identifier 'b'}}
 # CHECK1: {{^                  error: use of undeclared identifier 'a'}}
 
 # RUN: echo quit | %lldb -o "expr a" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK2
 #            (lldb) expr a 
-# CHECK2:{{^            \^}}
+# CHECK2:{{^            (\^|˄)}}
 
 # RUN: echo quit | %lldb -o "expr -i 0 -o 0 -- a" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK3
 #            (lldb) expr -i 0 -o 0 -- a
-# CHECK3:{{^                         \^}}
+# CHECK3:{{^                         (\^|˄)}}
 # CHECK3: {{^                         error: use of undeclared identifier 'a'}}
 
 # RUN: echo "int main(){return 0;}">%t.c
@@ -23,7 +23,7 @@
 # RUN: "expr --top-level -- template<typename T> T FOO(T x) { return x/2;}" -o \
 # RUN: "expression -- FOO(\"\")" 2>&1 | FileCheck %s --check-prefix=CHECK4
 #            (lldb) expression -- FOO("")
-# CHECK4:{{^                     \^}}
+# CHECK4:{{^                     (\^|˄)}}
 # CHECK4: {{^                     note: in instantiation of function template}}
 # CHECK4: error: <user expression
 

--- a/lldb/test/Shell/Commands/command-options.test
+++ b/lldb/test/Shell/Commands/command-options.test
@@ -1,16 +1,16 @@
 # RUN: echo quit | %lldb -O "log enable -x" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK1
 #            (lldb) log enable -x
-# CHECK1:{{^                  \^~}}
+# CHECK1:{{^                  (\^|˄)(~|˜)}}
 # CHECK1: {{^                  error: unknown or ambiguous option}}
 
 # RUN: echo quit | %lldb -O "    log enable -xxxxxxx" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK2
 #            (lldb)     log enable -xxxxxxx
-# CHECK2:{{^                      \^~~~~~~~}}
+# CHECK2:{{^                      [\^|]~~~~~~~}}
 # CHECK2: {{^                      error: unknown or ambiguous option}}
 # RUN: echo quit | %lldb -O "log enable dwarf all -f dwarf.log -x" \
 # RUN:   | FileCheck %s --strict-whitespace --check-prefix=CHECK3
 #            (lldb) log enable dwarf all -f dwarf.log -x
-# CHECK3:{{^                                         \^~}}
+# CHECK3:{{^                                         [\^|]~}}
 # CHECK3: {{^                                         error: unknown or ambiguous option}}


### PR DESCRIPTION
This patch fixes issues introduced by https://github.com/llvm/llvm-project/pull/171491 when running tests in CI.

The shell tests expect certain characters when matching diagnostics. With https://github.com/llvm/llvm-project/pull/171491, those characters can either be Unicode specific characters or their ASCII equivalent. The tests were always expecting the ASCII version. This patch fixes this by using a regex to match one or the other.