### PR TITLE
[libc++][NFC] Wrap line endings for clang-tidy tests

### DIFF
--- a/libcxx/test/libcxx/clang_tidy.gen.py
+++ b/libcxx/test/libcxx/clang_tidy.gen.py
@@ -27,10 +27,10 @@ for header in public_headers:
 {lit_header_undeprecations.get(header, '')}
 
 // TODO: run clang-tidy with modules enabled once they are supported
-// RUN: %{{clang-tidy}} %s --warnings-as-errors=*                                           \
-// RUN:                    -header-filter=.*                                                \
-// RUN:                    --config-file=%{{libcxx-dir}}/.clang-tidy                        \
-// RUN:                    --load=%{{test-tools-dir}}/clang_tidy_checks/libcxx-tidy.plugin  \
+// RUN: %{{clang-tidy}} %s --warnings-as-errors=*                                           \\
+// RUN:                    -header-filter=.*                                                \\
+// RUN:                    --config-file=%{{libcxx-dir}}/.clang-tidy                        \\
+// RUN:                    --load=%{{test-tools-dir}}/clang_tidy_checks/libcxx-tidy.plugin  \\
 // RUN:                    -- -Wweak-vtables %{{compile_flags}} -fno-modules
 
 #include <{header}>

--- a/libcxx/test/libcxx/clang_tidy.gen.py
+++ b/libcxx/test/libcxx/clang_tidy.gen.py
@@ -27,7 +27,11 @@ for header in public_headers:
 {lit_header_undeprecations.get(header, '')}
 
 // TODO: run clang-tidy with modules enabled once they are supported
-// RUN: %{{clang-tidy}} %s --warnings-as-errors=* -header-filter=.* --config-file=%{{libcxx-dir}}/.clang-tidy --load=%{{test-tools-dir}}/clang_tidy_checks/libcxx-tidy.plugin -- -Wweak-vtables %{{compile_flags}} -fno-modules
+// RUN: %{{clang-tidy}} %s --warnings-as-errors=*                                           \
+// RUN:                    -header-filter=.*                                                \
+// RUN:                    --config-file=%{{libcxx-dir}}/.clang-tidy                        \
+// RUN:                    --load=%{{test-tools-dir}}/clang_tidy_checks/libcxx-tidy.plugin  \
+// RUN:                    -- -Wweak-vtables %{{compile_flags}} -fno-modules
 
 #include <{header}>
 """)

--- a/libcxx/test/libcxx/clang_tidy.sh.py
+++ b/libcxx/test/libcxx/clang_tidy.sh.py
@@ -8,4 +8,8 @@
 
 # REQUIRES: has-clang-tidy
 
-# RUN: %{python} %{libcxx-dir}/../clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -clang-tidy-binary %{clang-tidy} -warnings-as-errors "*" -source-filter=".*libcxx/src.*" -quiet -p %{bin-dir}/..
+# RUN: %{python} %{libcxx-dir}/../clang-tools-extra/clang-tidy/tool/run-clang-tidy.py   \
+# RUN:      -clang-tidy-binary %{clang-tidy}                                            \
+# RUN:      -warnings-as-errors "*"                                                     \
+# RUN:      -source-filter=".*libcxx/src.*"                                             \
+# RUN:      -quiet -p %{bin-dir}/..


### PR DESCRIPTION
Otherwise, the lines are extremely long and basically impossible to read.