### PR TITLE
[flang] Make gcc-triple.f90 unsupported on Darwin

### DIFF
--- a/flang/test/Driver/gcc-triple.f90
+++ b/flang/test/Driver/gcc-triple.f90
@@ -1,4 +1,4 @@
-!! UNSUPPORTED: system-windows, system-aix
+!! UNSUPPORTED: system-windows, system-aix, system-darwin
 
 !! Test that --gcc-triple option is working as expected.
 

--- a/flang/test/Driver/gcc-triple.f90
+++ b/flang/test/Driver/gcc-triple.f90
@@ -1,4 +1,4 @@
-!! UNSUPPORTED: system-windows, system-aix, system-darwin
+!! UNSUPPORTED: system-windows, system-aix
 
 !! Test that --gcc-triple option is working as expected.
 
@@ -10,9 +10,9 @@
 ! DEFAULT_TRIPLE: {{^}}Selected GCC installation:
 ! DEFAULT_TRIPLE: fedora_39_tree/usr/lib/gcc/x86_64-linux-gnu/13
 
-! RUN: %flang -v --sysroot=%S/Inputs/fedora_39_tree --gcc-triple=x86_64-redhat-linux 2>&1 | FileCheck %s --check-prefix=TRIPLE_EXISTS
+! RUN: %flang --target=x86_64-redhat-linux-gnu -v --sysroot=%S/Inputs/fedora_39_tree --gcc-triple=x86_64-redhat-linux 2>&1 | FileCheck %s --check-prefix=TRIPLE_EXISTS
 ! TRIPLE_EXISTS: {{^}}Selected GCC installation:
 ! TRIPLE_EXISTS: fedora_39_tree/usr/lib/gcc/x86_64-redhat-linux/13
 
-! RUN: %flang -v --sysroot=%S/Inputs/fedora_39_tree --gcc-triple=x86_64-foo-linux 2>&1 | FileCheck %s --check-prefix=TRIPLE_DOES_NOT_EXISTS
+! RUN: %flang --target=x86_64-redhat-linux-gnu -v --sysroot=%S/Inputs/fedora_39_tree --gcc-triple=x86_64-foo-linux 2>&1 | FileCheck %s --check-prefix=TRIPLE_DOES_NOT_EXISTS
 ! TRIPLE_DOES_NOT_EXISTS-NOT: x86_64-foo-linux


### PR DESCRIPTION
It fails with the following error:

```
RUN: at line 13
/Users/leandro.lupori/home/git/flang/build/bin/flang -v --sysroot=/Users/leandro.lupori/home/git/flang/llvm-project/flang/test/Driver/Inputs/fedora_39_tree --gcc-triple=x86_64-redhat-linux 2>&1 | /Users/leandro.lupori/home/git/flang/build/bin/FileCheck /Users/leandro.lupori/home/git/flang/llvm-project/flang/test/Driver/gcc-triple.f90 --check-prefix=TRIPLE_EXISTS
.---command stderr------------
| /Users/leandro.lupori/home/git/flang/llvm-project/flang/test/Driver/gcc-triple.f90:14:18: error: TRIPLE_EXISTS: expected string not found in input
| ! TRIPLE_EXISTS: {{^}}Selected GCC installation:
|                  ^
| ...
| Input was:
| <<<<<<
|             1: flang version 22.0.0git (git@github.com:llvm/llvm-project.git dde1990b01fa13087b0eab77579f528329555968)
| check:14'0     X~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ error: no match found
|             2: Target: arm64-apple-darwin24.6.0
| check:14'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|             3: Thread model: posix
| check:14'0     ~~~~~~~~~~~~~~~~~~~~
|             4: InstalledDir: /Users/leandro.lupori/home/git/flang/build/bin
| check:14'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|             5: Build config: +assertions
| check:14'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
|             6: flang-22: warning: argument unused during compilation: '--gcc-triple=x86_64-redhat-linux' [-Wunused-command-line-argument]
| check:14'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| >>>>>>
`-----------------------------
```
