### PR TITLE
[libc][darwin] avoid importing macros conflicting with function names in overlay mode

### DIFF
--- a/libc/hdr/stdio_overlay.h
+++ b/libc/hdr/stdio_overlay.h
@@ -66,4 +66,18 @@
 #undef LIBC_OLD_USE_EXTERN_INLINES
 #endif
 
+// undefine symbolic macros for Apple platforms in overlay mode
+#ifdef __APPLE__
+#undef getc_unlocked
+#undef putc_unlocked
+#undef getchar_unlocked
+#undef putchar_unlocked
+#undef fropen
+#undef fwopen
+#undef feof_unlocked
+#undef ferror_unlocked
+#undef clearerr_unlocked
+#undef fileno_unlocked
+#endif
+
 #endif // LLVM_LIBC_HDR_STDIO_OVERLAY_H


### PR DESCRIPTION
MacOS SDK defines certain functions as macros in its stdio header. This leads to problems in overlay mode.

This patch add undefs to macros that may conflict with function names in overlay header. We don't expect to import them via overlay macro headers anyway.

```bash
FAILED: [code=1] libc/src/__support/File/CMakeFiles/libc.src.__support.File.file.dir/file.cpp.o 
sccache /usr/bin/clang++ -DLIBC_NAMESPACE=__llvm_libc_22_0_0_git -D_DEBUG -I/Users/runner/work/llvm-project/llvm-project/libc -isystem /Users/runner/work/llvm-project/llvm-project/build/libc/include -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wno-pass-failed -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -g -std=gnu++17 -arch arm64 -I /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/usr/include -DLIBC_QSORT_IMPL=LIBC_QSORT_QUICK_SORT -DLIBC_COPT_STRING_LENGTH_IMPL=element -DLIBC_COPT_FIND_FIRST_CHARACTER_IMPL=element -DLIBC_ADD_NULL_CHECKS -DLIBC_ERRNO_MODE=LIBC_ERRNO_MODE_DEFAULT -DLIBC_THREAD_MODE=LIBC_THREAD_MODE_PLATFORM -DLIBC_COPT_RAW_MUTEX_DEFAULT_SPIN_COUNT=100 -fpie -ffixed-point -fno-builtin -fno-exceptions -fno-lax-vector-conversions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti -ftrivial-auto-var-init=pattern -fno-omit-frame-pointer -Wall -Wextra -Werror -Wconversion -Wno-sign-conversion -Wdeprecated -Wno-c99-extensions -Wno-gnu-imaginary-constant -Wno-pedantic -Wimplicit-fallthrough -Wwrite-strings -Wextra-semi -Wnewline-eof -Wnonportable-system-include-path -Wstrict-prototypes -Wthread-safety -Wglobal-constructors -MD -MT libc/src/__support/File/CMakeFiles/libc.src.__support.File.file.dir/file.cpp.o -MF libc/src/__support/File/CMakeFiles/libc.src.__support.File.file.dir/file.cpp.o.d -o libc/src/__support/File/CMakeFiles/libc.src.__support.File.file.dir/file.cpp.o -c /Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.cpp
In file included from /Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.cpp:9:
/Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.h:260:8: error: expected member name or ';' after declaration specifiers
  260 |   void clearerr_unlocked() { err = false; }
      |   ~~~~ ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:495:30: note: expanded from macro 'clearerr_unlocked'
  495 | #define clearerr_unlocked(p)    __sclearerr(p)
      |                                 ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:383:26: note: expanded from macro '__sclearerr'
  383 | #define __sclearerr(p)  ((void)((p)->_flags &= ~(__SERR|__SEOF)))
      |                           ^
In file included from /Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.cpp:9:
/Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.h:260:8: error: expected ')'
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:495:30: note: expanded from macro 'clearerr_unlocked'
  495 | #define clearerr_unlocked(p)    __sclearerr(p)
      |                                 ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:383:26: note: expanded from macro '__sclearerr'
  383 | #define __sclearerr(p)  ((void)((p)->_flags &= ~(__SERR|__SEOF)))
      |                           ^
/Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.h:260:8: note: to match this '('
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:495:30: note: expanded from macro 'clearerr_unlocked'
  495 | #define clearerr_unlocked(p)    __sclearerr(p)
      |                                 ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:383:25: note: expanded from macro '__sclearerr'
  383 | #define __sclearerr(p)  ((void)((p)->_flags &= ~(__SERR|__SEOF)))
      |                          ^
In file included from /Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.cpp:9:
/Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.h:260:8: error: unknown type name '_flags'
  260 |   void clearerr_unlocked() { err = false; }
      |        ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:495:30: note: expanded from macro 'clearerr_unlocked'
  495 | #define clearerr_unlocked(p)    __sclearerr(p)
      |                                 ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:383:37: note: expanded from macro '__sclearerr'
  383 | #define __sclearerr(p)  ((void)((p)->_flags &= ~(__SERR|__SEOF)))
      |                                      ^
In file included from /Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.cpp:9:
/Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.h:260:8: error: a type specifier is required for all declarations
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:495:30: note: expanded from macro 'clearerr_unlocked'
  495 | #define clearerr_unlocked(p)    __sclearerr(p)
      |                                 ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:383:34: note: expanded from macro '__sclearerr'
  383 | #define __sclearerr(p)  ((void)((p)->_flags &= ~(__SERR|__SEOF)))
      |                                   ^
In file included from /Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.cpp:9:
/Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.h:260:8: error: expected ')'
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:495:30: note: expanded from macro 'clearerr_unlocked'
  495 | #define clearerr_unlocked(p)    __sclearerr(p)
      |                                 ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:383:44: note: expanded from macro '__sclearerr'
  383 | #define __sclearerr(p)  ((void)((p)->_flags &= ~(__SERR|__SEOF)))
      |                                             ^
/Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.h:260:8: note: to match this '('
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:495:30: note: expanded from macro 'clearerr_unlocked'
  495 | #define clearerr_unlocked(p)    __sclearerr(p)
      |                                 ^
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:383:31: note: expanded from macro '__sclearerr'
  383 | #define __sclearerr(p)  ((void)((p)->_flags &= ~(__SERR|__SEOF)))
      |                                ^
/Users/runner/work/llvm-project/llvm-project/libc/src/__support/File/file.cpp:426:23: error: out-of-line definition of 'mode_flags' does not match any declaration in '__llvm_libc_22_0_0_git::File'
  426 | File::ModeFlags File::mode_flags(const char *mode) {
      |                       ^~~~~~~~~~
6 errors generated.
```