### PR TITLE
[mlir][acc] Introduce acc loop tiling pass

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCUtils.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCUtils.h
@@ -10,7 +10,9 @@
 #define MLIR_DIALECT_OPENACC_OPENACCUTILS_H_
 
 #include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/IR/Remarks.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir {
 class DominanceInfo;
@@ -80,6 +82,17 @@ llvm::SmallVector<mlir::Value>
 getDominatingDataClauses(mlir::Operation *computeConstructOp,
                          mlir::DominanceInfo &domInfo,
                          mlir::PostDominanceInfo &postDomInfo);
+
+/// Emit an OpenACC remark for the given operation with the given message.
+///
+/// \param op The operation to emit the remark for.
+/// \param message The remark message.
+/// \param category Optional category for the remark. Defaults to "openacc".
+/// \return An in-flight remark object that can be used to append
+///         additional information to the remark.
+remark::detail::InFlightRemark emitRemark(mlir::Operation *op,
+                                          const llvm::Twine &message,
+                                          llvm::StringRef category = "openacc");
 
 } // namespace acc
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
@@ -152,4 +152,46 @@ def ACCLegalizeSerial : Pass<"acc-legalize-serial", "mlir::func::FuncOp"> {
       "mlir::arith::ArithDialect"];
 }
 
+
+def ACCLoopTiling : Pass<"acc-loop-tiling", "mlir::func::FuncOp"> {
+  let summary = "Tile OpenACC loops with tile clauses";
+  let description = [{
+    This pass implements loop tiling transformations for OpenACC loops that
+    have tile clauses. The pass transforms loops with `tile(size1, size2, ...)`
+    clauses into tiled loop nests.
+
+    For a 2-level nested loop with tile(T1, T2), the transformation produces:
+    - Outer tile loops that iterate over tiles
+    - Inner element loops that iterate within each tile
+
+    Example transformation:
+    ```
+    // Before:
+    #pragma acc loop tile(32, 32)
+    for (i = 0; i < N; i++)
+      for (j = 0; j < M; j++)
+        A[i][j] = ...
+
+    // After:
+    for (i = 0; i < N; i += 32)           // tile loop 1
+      for (j = 0; j < M; j += 32)         // tile loop 2
+        for (ii = i; ii < min(N, i+32); ii++)    // element loop 1
+          for (jj = j; jj < min(M, j+32); jj++)  // element loop 2
+            A[ii][jj] = ...
+    ```
+
+    The pass handles:
+    - Constant tile sizes
+    - Wildcard tile sizes ('*') which use a default tile size
+    - Collapsed loops with tile counts exceeding collapse count
+    - Proper handling of loop attributes (gang, worker, vector)
+  }];
+  let dependentDialects = ["mlir::acc::OpenACCDialect",
+      "mlir::arith::ArithDialect"];
+  let options = [
+    Option<"defaultTileSize", "default-tile-size", "int32_t", "32",
+           "Default tile size to use for wildcard ('*') tile sizes">
+  ];
+}
+
 #endif // MLIR_DIALECT_OPENACC_TRANSFORMS_PASSES

--- a/mlir/lib/Dialect/OpenACC/Analysis/OpenACCSupport.cpp
+++ b/mlir/lib/Dialect/OpenACC/Analysis/OpenACCSupport.cpp
@@ -41,6 +41,14 @@ InFlightDiagnostic OpenACCSupport::emitNYI(Location loc, const Twine &message) {
   return mlir::emitError(loc, "not yet implemented: " + message);
 }
 
+remark::detail::InFlightRemark
+OpenACCSupport::emitRemark(Operation *op, const Twine &message,
+                           llvm::StringRef category) {
+  if (impl)
+    return impl->emitRemark(op, message, category);
+  return acc::emitRemark(op, message, category);
+}
+
 bool OpenACCSupport::isValidSymbolUse(Operation *user, SymbolRefAttr symbol,
                                       Operation **definingOpPtr) {
   if (impl)

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCLoopTiling.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCLoopTiling.cpp
@@ -1,0 +1,220 @@
+//===- ACCLoopTiling.cpp - Tile ACC Loops ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass implements the OpenACC loop tiling transformation for acc.loop
+// operations that have the tile clause (OpenACC 3.4 spec, section 2.9.8).
+//
+// Overview:
+// ---------
+// The tile clause specifies that the iterations of the associated loops should
+// be divided into tiles (rectangular blocks). This pass transforms a single
+// or nested acc.loop with tile clauses into a structure of "tile loops"
+// (iterating over tiles) containing "element loops" (iterating within tiles).
+//
+// For example, tiling a 2-level nested loop with tile(T1, T2) produces:
+//
+//   // Before tiling:
+//   acc.loop tile(T1, T2) control(%i, %j) = (lb1, lb2) to (ub1, ub2) step (s1,
+//   s2)
+//
+//   // After tiling:
+//   acc.loop control(%i) = (lb1) to (ub1) step (s1*T1) {      // tile loop 1
+//     acc.loop control(%j) = (lb2) to (ub2) step (s2*T2) {    // tile loop 2
+//       acc.loop control(%ii) = (%i) to (min(ub1, %i+s1*T1)) step (s1) { //
+//       element 1
+//         acc.loop control(%jj) = (%j) to (min(ub2, %j+s2*T2)) step (s2) { //
+//         element 2
+//           // loop body using %ii, %jj
+//         }
+//       }
+//     }
+//   }
+//
+// Gang/worker/vector attributes are distributed as follows:
+// - gang: applied to tile loops
+// - vector: applied to element loops
+// - worker: removed from inner loops
+//
+// Unknown Tile Sizes:
+// -------------------
+// The OpenACC tile(*) syntax indicates an implementation-defined tile size.
+// In the IR, this is represented as -1. The pass resolves these to the
+// default tile size (configurable via pass option).
+//
+// Requirements:
+// -------------
+// 1. The pass uses the OpenACCSupport analysis for remark and NYI (not yet
+//    implemented) emission. Custom implementations can be registered via
+//    setImplementation() to provide pipeline-specific handling.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/OpenACC/Analysis/OpenACCSupport.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/Dialect/OpenACC/OpenACCUtilsTiling.h"
+#include "mlir/Dialect/OpenACC/Transforms/Passes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+
+namespace mlir {
+namespace acc {
+#define GEN_PASS_DEF_ACCLOOPTILING
+#include "mlir/Dialect/OpenACC/Transforms/Passes.h.inc"
+} // namespace acc
+} // namespace mlir
+
+#define DEBUG_TYPE "acc-loop-tile"
+
+namespace {
+using namespace mlir;
+
+struct ACCLoopTilingImpl : public OpRewritePattern<acc::LoopOp> {
+  ACCLoopTilingImpl(MLIRContext *context, int32_t defaultTileSize,
+                    acc::OpenACCSupport &accSupport)
+      : OpRewritePattern<acc::LoopOp>(context),
+        defaultTileSize(defaultTileSize), accSupport(accSupport) {}
+
+  // Check that tile size types are not narrower than IV types.
+  // We only check when both types are IntegerType. For IndexType, the width
+  // is target-dependent and the casting utility will handle it correctly.
+  LogicalResult checkTileSizeTypes(acc::LoopOp loop,
+                                   ArrayRef<Value> tileSizes) const {
+    auto ivTypes = loop.getBody().getArgumentTypes();
+    for (size_t i = 0; i < tileSizes.size() && i < ivTypes.size(); ++i) {
+      Type tileType = tileSizes[i].getType();
+      Type ivType = ivTypes[i];
+
+      // Skip unknown tile sizes (will be created with correct type)
+      auto constVal = getConstantIntValue(tileSizes[i]);
+      if (constVal && *constVal < 0)
+        continue;
+
+      // Only compare when both are integer types (not index)
+      auto tileIntType = dyn_cast<IntegerType>(tileType);
+      auto ivIntType = dyn_cast<IntegerType>(ivType);
+      if (tileIntType && ivIntType) {
+        if (tileIntType.getWidth() > ivIntType.getWidth()) {
+          accSupport.emitNYI(loop.getLoc(),
+                             "tile size type (i" +
+                                 std::to_string(tileIntType.getWidth()) +
+                                 ") is wider than loop IV type (i" +
+                                 std::to_string(ivIntType.getWidth()) + ")");
+          return failure();
+        }
+      }
+    }
+    return success();
+  }
+
+  void emitTilingRemarks(acc::LoopOp loop, ArrayRef<Value> tileSizes) const {
+    // Emit remarks for loop tiling
+    size_t tileLevel = tileSizes.size();
+    std::string msg =
+        "Tiling " + std::to_string(tileLevel) + "-level loop nest with tile(";
+    for (size_t i = 0; i < tileSizes.size(); ++i) {
+      std::optional<int64_t> val = getConstantIntValue(tileSizes[i]);
+      if (*val == -1)
+        msg += "*";
+      else
+        msg += std::to_string(*val);
+      if (i < tileSizes.size() - 1)
+        msg += ",";
+    }
+    msg += ")";
+    accSupport.emitRemark(loop, llvm::Twine(msg), DEBUG_TYPE);
+
+    // Emit remarks for unknown tile sizes that will be resolved to default
+    // TODO: Need to base the default tile size on some heuristics.
+    for (Value tileSize : tileSizes) {
+      std::optional<int64_t> val = getConstantIntValue(tileSize);
+      if (val && *val < 0) {
+        std::string unknownMsg = "Picking default tile size " +
+                                 std::to_string(defaultTileSize) +
+                                 " for unknown tile size '*'";
+        accSupport.emitRemark(loop, llvm::Twine(unknownMsg), DEBUG_TYPE);
+      }
+    }
+  }
+
+  LogicalResult matchAndRewrite(acc::LoopOp origLoop,
+                                PatternRewriter &rewriter) const override {
+
+    if (origLoop.getTileValues().empty())
+      return success();
+
+    SmallVector<Value> tileSizes(origLoop.getTileValues().begin(),
+                                 origLoop.getTileValues().end());
+    unsigned tileCount = tileSizes.size();
+    unsigned collapseCount = origLoop.getCollapseValue().value_or(1);
+
+    // Sanity check tile size types
+    if (failed(checkTileSizeTypes(origLoop, tileSizes)))
+      return failure();
+
+    // Emit remarks for loop tiling. This is emitted before the original loop
+    // is modified. However, it assumes that tiling will not fail.
+    emitTilingRemarks(origLoop, tileSizes);
+
+    LLVM_DEBUG(llvm::dbgs() << "\nBefore tiling:\n" << *origLoop << "\n");
+
+    // Clear tile operands from origLoop
+    rewriter.startOpModification(origLoop);
+    origLoop.getTileOperandsMutable().clear();
+    origLoop.removeTileOperandsSegmentsAttr();
+    origLoop.removeTileOperandsDeviceTypeAttr();
+    rewriter.finalizeOpModification(origLoop);
+
+    SmallVector<acc::LoopOp> loopsToTile;
+    if (collapseCount < tileCount) {
+      // Uncollapse tile loops before tiling if necessary
+      loopsToTile =
+          acc::uncollapseLoops(origLoop, tileCount, collapseCount, rewriter);
+      rewriter.replaceOp(origLoop, loopsToTile[0]);
+      LLVM_DEBUG(llvm::dbgs() << "\nAfter uncollapsing:\n"
+                              << *loopsToTile[0] << "\n");
+    } else {
+      loopsToTile.push_back(origLoop);
+    }
+
+    // loopsToTile is a vector of perfectly nested loops. The outermost loop
+    // may have multiple IVs but inner loops can only have one IV.
+    // The utility handles unknown tile sizes (*) by using `defaultTileSize`.
+    acc::tileACCLoops(loopsToTile, tileSizes, defaultTileSize, rewriter);
+
+    LLVM_DEBUG(llvm::dbgs() << "\nAfter tiling:\n " << *loopsToTile[0] << "\n");
+    return success();
+  }
+
+private:
+  int32_t defaultTileSize;
+  acc::OpenACCSupport &accSupport;
+};
+
+class ACCLoopTiling : public acc::impl::ACCLoopTilingBase<ACCLoopTiling> {
+public:
+  using ACCLoopTilingBase<ACCLoopTiling>::ACCLoopTilingBase;
+
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    MLIRContext *context = funcOp.getContext();
+    acc::OpenACCSupport &accSupport = getAnalysis<acc::OpenACCSupport>();
+
+    RewritePatternSet patterns(context);
+    patterns.insert<ACCLoopTilingImpl>(context, defaultTileSize, accSupport);
+    GreedyRewriteConfig grc;
+    grc.setUseTopDownTraversal(true);
+    grc.setMaxIterations(1);
+    (void)applyPatternsGreedily(funcOp, std::move(patterns), grc);
+  }
+};
+
+} // namespace

--- a/mlir/lib/Dialect/OpenACC/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACC/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(MLIROpenACCTransforms
   ACCImplicitData.cpp
+  ACCLoopTiling.cpp
   ACCImplicitDeclare.cpp
   ACCImplicitRoutine.cpp
   ACCLegalizeSerial.cpp

--- a/mlir/lib/Dialect/OpenACC/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/OpenACC/Utils/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_dialect_library(MLIROpenACCUtils
 
   LINK_LIBS PUBLIC
   MLIRArithDialect
+  MLIRArithUtils
   MLIROpenACCDialect
   MLIRIR
   MLIRSupport

--- a/mlir/test/Dialect/OpenACC/acc-loop-tiling-invalid.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-loop-tiling-invalid.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-opt %s -acc-loop-tiling -split-input-file -verify-diagnostics
+
+// Test that tile size type wider than IV type is rejected
+
+func.func @tile_wider_than_iv(%arg0: memref<100xf32>) {
+  %c0 = arith.constant 0 : i32
+  %c100 = arith.constant 100 : i32
+  %c1 = arith.constant 1 : i32
+  %c4_i64 = arith.constant 4 : i64  // i64 tile size with i32 IV
+  // expected-error @+1 {{not yet implemented: tile size type (i64) is wider than loop IV type (i32)}}
+  acc.loop tile({%c4_i64 : i64}) control(%i : i32) = (%c0 : i32) to (%c100 : i32) step (%c1 : i32) {
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  return
+}

--- a/mlir/test/Dialect/OpenACC/acc-loop-tiling-remarks.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-loop-tiling-remarks.mlir
@@ -1,0 +1,75 @@
+// RUN: mlir-opt %s -acc-loop-tiling --remarks-filter="(open)?acc.*" 2>&1 | FileCheck %s
+
+// Test that the pass emits remarks for loop tiling
+
+// CHECK: remark: [Passed] openacc | Category:acc-loop-tile | Function=single_loop_remark | Remark="Tiling 1-level loop nest with tile(4)"
+func.func @single_loop_remark(%arg0: memref<100xf32>) {
+  %c0 = arith.constant 0 : index
+  %c100 = arith.constant 100 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  acc.loop tile({%c4 : index}) control(%i : index) = (%c0 : index) to (%c100 : index) step (%c1 : index) {
+    %val = arith.index_castui %i : index to i32
+    %fval = arith.sitofp %val : i32 to f32
+    memref.store %fval, %arg0[%i] : memref<100xf32>
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  return
+}
+
+// CHECK: remark: [Passed] openacc | Category:acc-loop-tile | Function=nested_loop_remark | Remark="Tiling 2-level loop nest with tile(8,16)"
+func.func @nested_loop_remark(%arg0: memref<100x50xf32>) {
+  %c0 = arith.constant 0 : index
+  %c100 = arith.constant 100 : index
+  %c50 = arith.constant 50 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  acc.loop tile({%c8 : index, %c16 : index}) control(%i : index, %j : index) = (%c0, %c0 : index, index) to (%c100, %c50 : index, index) step (%c1, %c1 : index, index) {
+    %sum = arith.addi %i, %j : index
+    %val = arith.index_castui %sum : index to i32
+    %fval = arith.sitofp %val : i32 to f32
+    memref.store %fval, %arg0[%i, %j] : memref<100x50xf32>
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  return
+}
+
+// Test remark for unknown tile size (*) represented as -1
+// Should use default tile size
+
+// CHECK: remark: [Passed] openacc | Category:acc-loop-tile | Function=unknown_tile_remark | Remark="Tiling 1-level loop nest with tile(*)"
+// CHECK: remark: [Passed] openacc | Category:acc-loop-tile | Function=unknown_tile_remark | Remark="Picking default tile size {{[0-9]+}} for unknown tile size '*'"
+func.func @unknown_tile_remark(%arg0: memref<1000xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1000 = arith.constant 1000 : index
+  %c1 = arith.constant 1 : index
+  %cm1 = arith.constant -1 : i32  // tile(*) represented as -1
+  acc.loop tile({%cm1 : i32}) control(%i : index) = (%c0 : index) to (%c1000 : index) step (%c1 : index) {
+    %val = arith.index_castui %i : index to i32
+    %fval = arith.sitofp %val : i32 to f32
+    memref.store %fval, %arg0[%i] : memref<1000xf32>
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  return
+}
+
+// Test remark for multiple unknown tile sizes
+
+// CHECK: remark: [Passed] openacc | Category:acc-loop-tile | Function=multiple_unknown_tiles_remark | Remark="Tiling 2-level loop nest with tile(*,*)"
+// CHECK: remark: [Passed] openacc | Category:acc-loop-tile | Function=multiple_unknown_tiles_remark | Remark="Picking default tile size {{[0-9]+}} for unknown tile size '*'"
+// CHECK: remark: [Passed] openacc | Category:acc-loop-tile | Function=multiple_unknown_tiles_remark | Remark="Picking default tile size {{[0-9]+}} for unknown tile size '*'"
+func.func @multiple_unknown_tiles_remark(%arg0: memref<100x100xf32>) {
+  %c0 = arith.constant 0 : index
+  %c100 = arith.constant 100 : index
+  %c1 = arith.constant 1 : index
+  %cm1 = arith.constant -1 : i32  // tile(*) represented as -1
+  acc.loop tile({%cm1 : i32, %cm1 : i32}) control(%i : index, %j : index) = (%c0, %c0 : index, index) to (%c100, %c100 : index, index) step (%c1, %c1 : index, index) {
+    %sum = arith.addi %i, %j : index
+    %val = arith.index_castui %sum : index to i32
+    %fval = arith.sitofp %val : i32 to f32
+    memref.store %fval, %arg0[%i, %j] : memref<100x100xf32>
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  return
+}

--- a/mlir/test/Dialect/OpenACC/acc-loop-tiling.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-loop-tiling.mlir
@@ -1,0 +1,104 @@
+// RUN: mlir-opt %s -acc-loop-tiling | FileCheck %s
+
+// Test single-level loop tiling with tile(2)
+// Original loop: for i = 0 to 10 step 1
+// After tiling: tile loop (step=2) containing element loop (step=1)
+
+// CHECK-LABEL: func.func @single_loop_tile
+// CHECK:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[C10:.*]] = arith.constant 10 : index
+// CHECK:         %[[C1:.*]] = arith.constant 1 : index
+// CHECK:         %[[C2:.*]] = arith.constant 2 : index
+// CHECK:         acc.loop control(%[[IV:.*]] : index) = (%[[C0]] : index) to (%[[C10]] : index) step (%[[C2]] : index) {
+// CHECK:           %[[NEW_UB:.*]] = arith.addi %[[IV]], %[[C2]] : index
+// CHECK:           %[[MIN_UB:.*]] = arith.minsi %[[NEW_UB]], %[[C10]] : index
+// CHECK:           acc.loop control(%[[INNER_IV:.*]] : index) = (%[[IV]] : index) to (%[[MIN_UB]] : index) step (%[[C1]] : index) {
+// CHECK:             acc.yield
+// CHECK:           } attributes {independent = [#acc.device_type<none>]}
+// CHECK:           acc.yield
+// CHECK:         } attributes {independent = [#acc.device_type<none>]}
+func.func @single_loop_tile(%arg0: memref<10xf32>) {
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  acc.loop tile({%c2 : index}) control(%i : index) = (%c0 : index) to (%c10 : index) step (%c1 : index) {
+    %val = arith.index_castui %i : index to i32
+    %fval = arith.sitofp %val : i32 to f32
+    memref.store %fval, %arg0[%i] : memref<10xf32>
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  return
+}
+
+// Test 2-level nested loop tiling with tile(4, 8)
+// Creates: tile_loop_1 -> tile_loop_2 -> element_loop_1 -> element_loop_2
+
+// CHECK-LABEL: func.func @nested_loop_tile
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C100:.*]] = arith.constant 100 : index
+// CHECK-DAG:     %[[C50:.*]] = arith.constant 50 : index
+// CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C4:.*]] = arith.constant 4 : index
+// CHECK-DAG:     %[[C8:.*]] = arith.constant 8 : index
+// Outer tile loop with gang
+// CHECK:         acc.loop gang control(%[[I:.*]] : index) = (%[[C0]] : index) to (%[[C100]] : index) step (%[[C4]] : index) {
+// Inner tile loop
+// CHECK:           acc.loop control(%[[J:.*]] : index) = (%[[C0]] : index) to (%[[C50]] : index) step (%[[C8]] : index) {
+// Outer element loop with vector
+// CHECK:             acc.loop vector control({{.*}} : index) = (%[[I]] : index) to ({{.*}} : index) step (%[[C1]] : index) {
+// Inner element loop
+// CHECK:               acc.loop control({{.*}} : index) = (%[[J]] : index) to ({{.*}} : index) step (%[[C1]] : index) {
+// CHECK:                 acc.yield
+// CHECK:               }
+// CHECK:               acc.yield
+// CHECK:             }
+// CHECK:             acc.yield
+// CHECK:           }
+// CHECK:           acc.yield
+// CHECK:         }
+func.func @nested_loop_tile(%arg0: memref<100x50xf32>) {
+  %c0 = arith.constant 0 : index
+  %c100 = arith.constant 100 : index
+  %c50 = arith.constant 50 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c8 = arith.constant 8 : index
+  acc.loop gang vector tile({%c4 : index, %c8 : index}) control(%i : index, %j : index) = (%c0, %c0 : index, index) to (%c100, %c50 : index, index) step (%c1, %c1 : index, index) {
+    %sum = arith.addi %i, %j : index
+    %val = arith.index_castui %sum : index to i32
+    %fval = arith.sitofp %val : i32 to f32
+    memref.store %fval, %arg0[%i, %j] : memref<100x50xf32>
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  return
+}
+
+// Test unknown tile size (*) represented as -1
+// Should use default tile size (32)
+
+// CHECK-LABEL: func.func @unknown_tile_size
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1000:.*]] = arith.constant 1000 : index
+// CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C32:.*]] = arith.constant 32 : index
+// Tile loop with default tile size
+// CHECK:         acc.loop control(%[[IV:.*]] : index) = (%[[C0]] : index) to (%[[C1000]] : index) step (%[[C32]] : index) {
+// CHECK:           acc.loop control({{.*}} : index) = (%[[IV]] : index) to ({{.*}} : index) step (%[[C1]] : index) {
+// CHECK:             acc.yield
+// CHECK:           }
+// CHECK:           acc.yield
+// CHECK:         }
+func.func @unknown_tile_size(%arg0: memref<1000xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1000 = arith.constant 1000 : index
+  %c1 = arith.constant 1 : index
+  %cm1 = arith.constant -1 : i32  // tile(*) represented as -1
+  acc.loop tile({%cm1 : i32}) control(%i : index) = (%c0 : index) to (%c1000 : index) step (%c1 : index) {
+    %val = arith.index_castui %i : index to i32
+    %fval = arith.sitofp %val : i32 to f32
+    memref.store %fval, %arg0[%i] : memref<1000xf32>
+    acc.yield
+  } attributes {independent = [#acc.device_type<none>]}
+  return
+}


### PR DESCRIPTION
This pass implements the OpenACC loop tiling transformation for acc.loop operations that have the tile clause (OpenACC 3.4 spec, section 2.9.8).

The tile clause specifies that the iterations of the associated loops should be divided into tiles (rectangular blocks). The pass transforms a single or nested acc.loop with tile clauses into a structure of "tile loops" (iterating over tiles) containing "element loops" (iterating within tiles).

For example, tiling a 2-level nested loop with tile(T1, T2):
```
  // Before tiling:
  acc.loop tile(T1, T2) control(%i, %j) = ...

  // After tiling:
  acc.loop control(%i) step (s1*T1) {        // tile loop 1
    acc.loop control(%j) step (s2*T2) {      // tile loop 2
      acc.loop control(%ii) = (%i) to (min(ub1, %i+s1*T1)) {
        acc.loop control(%jj) = (%j) to (min(ub2, %j+s2*T2)) {
          // loop body using %ii, %jj
        }
      }
    }
  }
```

Key features:
- Handles constant tile sizes and wildcard tile sizes ('*') which use a configurable default tile size
- Properly handles collapsed loops with tile counts exceeding collapse count by uncollapsing loops before tiling
- Distributes gang/worker/vector attributes appropriately: gang -> tile loops, vector -> element loops
- Validates that tile size types are not wider than loop IV types
- Emits optimization remarks for tiling decisions

Three test files are added:
- acc-loop-tiling.mlir: Tests single and nested loop tiling with constant tile sizes, unknown tile sizes (*), and loops with collapse attributes
- acc-loop-tiling-invalid.mlir: Tests error diagnostic when tile size type is wider than the loop IV type
- acc-loop-tiling-remarks.mlir: Tests optimization remarks emitted for tiling decisions including default tile size selection