### PR TITLE
[flang] Make lto-bc.f90 unsupported on Darwin

### DIFF
--- a/flang/test/Driver/lto-bc.f90
+++ b/flang/test/Driver/lto-bc.f90
@@ -1,6 +1,8 @@
 ! Test that the output is LLVM bitcode for LTO and not a native objectfile by
 ! disassembling it to LLVM IR. Also tests that module summaries are emitted for LTO
 
+! UNSUPPORTED: system-darwin
+
 ! RUN: %flang %s -c -o - | not llvm-dis -o %t
 ! RUN: %flang_fc1 %s -emit-llvm-bc -o - | llvm-dis -o - | FileCheck %s
 ! CHECK: define void @_QQmain()


### PR DESCRIPTION
It fails with the following error:

```
RUN: at line 23
/Users/leandro.lupori/home/git/flang/build/bin/flang -flto /Users/leandro.lupori/home/git/flang/llvm-project/flang/test/Driver/lto-bc.f90 -c -o - | llvm-dis -o - | /Users/leandro.lupori/home/git/flang/build/bin/FileCheck /Users/leandro.lupori/home/git/flang/llvm-project/flang/test/Driver/lto-bc.f90 --check-prefix=FULL
.---command stderr------------
| /Users/leandro.lupori/home/git/flang/llvm-project/flang/test/Driver/lto-bc.f90:27:9: error: FULL: expected string not found in input
| ! FULL: !{{.*}} = !{i32 1, !"ThinLTO", i32 0}
|         ^
| ...
| Input was:
| <<<<<<
| ...
|            24: !llvm.ident = !{!0}
| check:27'0     ~~~~~~~~~~~~~~~~~~~~
|            25: !llvm.module.flags = !{!1, !2}
| check:27'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|            26:
| check:27'0     ~
|            27: !0 = !{!"flang version 22.0.0 (git@github.com:llvm/llvm-project.git dde1990b01fa13087b0eab77579f528329555968)"}
| check:27'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|            28: !1 = !{i32 2, !"Debug Info Version", i32 3}
| check:27'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|            29: !2 = !{i32 8, !"PIC Level", i32 2}
| check:27'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| check:27'1     ?                                   possible intended match
| >>>>>>
`-----------------------------
```
