### PR TITLE
[flang] Fix homonymous interface and procedure warning

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4535,24 +4535,10 @@ void InterfaceVisitor::CheckGenericProcedures(Symbol &generic) {
   ResolveSpecificsInGeneric(generic, true);
   auto &details{generic.get<GenericDetails>()};
   if (auto *proc{details.CheckSpecific()}) {
-    // Use the source location that is not in a module file for the warning,
-    // with the generic interface location being the default if both the
-    // interface and the procedure are in module files.
-    // If both the generic interface and procedure are not in module files,
-    // compare their locations and use the one that appears later in the
-    // source file.
-    SourceName at;
-    bool procInMod{context().IsInModuleFile(proc->name())};
-    bool genInMod{context().IsInModuleFile(generic.name())};
-    if ((!genInMod && procInMod) || (genInMod && procInMod)) {
-      at = generic.name();
-    } else if (!procInMod && genInMod) {
-      at = proc->name();
-    } else {
-      at = proc->name().begin() > generic.name().begin() ? proc->name()
-                                                         : generic.name();
-    }
-    context().Warn(common::UsageWarning::HomonymousSpecific, at,
+    context().Warn(common::UsageWarning::HomonymousSpecific,
+        context().allCookedSources().Precedes(generic.name(), proc->name())
+            ? proc->name()
+            : generic.name(),
         "'%s' should not be the name of both a generic interface and a procedure unless it is a specific procedure of the generic"_warn_en_US,
         generic.name());
   }

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4535,9 +4535,24 @@ void InterfaceVisitor::CheckGenericProcedures(Symbol &generic) {
   ResolveSpecificsInGeneric(generic, true);
   auto &details{generic.get<GenericDetails>()};
   if (auto *proc{details.CheckSpecific()}) {
-    context().Warn(common::UsageWarning::HomonymousSpecific,
-        proc->name().begin() > generic.name().begin() ? proc->name()
-                                                      : generic.name(),
+    // Use the source location that is not in a module file for the warning,
+    // with the generic interface location being the default if both the
+    // interface and the procedure are in module files.
+    // If both the generic interface and procedure are not in module files,
+    // compare their locations and use the one that appears later in the
+    // source file.
+    SourceName at;
+    bool procInMod{context().IsInModuleFile(proc->name())};
+    bool genInMod{context().IsInModuleFile(generic.name())};
+    if ((!genInMod && procInMod) || (genInMod && procInMod)) {
+      at = generic.name();
+    } else if (!procInMod && genInMod) {
+      at = proc->name();
+    } else {
+      at = proc->name().begin() > generic.name().begin() ? proc->name()
+                                                         : generic.name();
+    }
+    context().Warn(common::UsageWarning::HomonymousSpecific, at,
         "'%s' should not be the name of both a generic interface and a procedure unless it is a specific procedure of the generic"_warn_en_US,
         generic.name());
   }

--- a/flang/test/Semantics/bug159554.f90
+++ b/flang/test/Semantics/bug159554.f90
@@ -1,3 +1,4 @@
+!UNSUPPORTED: system-darwin
 !RUN: %python %S/test_errors.py %s %flang_fc1
 use, intrinsic :: iso_c_binding
 interface c_funloc

--- a/flang/test/Semantics/bug159554.f90
+++ b/flang/test/Semantics/bug159554.f90
@@ -1,6 +1,5 @@
 !RUN: %python %S/test_errors.py %s %flang_fc1
 use, intrinsic :: iso_c_binding
-!WARNING: 'c_funloc' should not be the name of both a generic interface and a procedure unless it is a specific procedure of the generic [-Whomonymous-specific]
 interface c_funloc
 !ERROR: 'c_funloc' is already declared in this scoping unit
   function c_funloc()

--- a/flang/test/Semantics/bug159554.f90
+++ b/flang/test/Semantics/bug159554.f90
@@ -1,4 +1,3 @@
-!UNSUPPORTED: system-darwin
 !RUN: %python %S/test_errors.py %s %flang_fc1
 use, intrinsic :: iso_c_binding
 interface c_funloc

--- a/flang/test/Semantics/bug159554.f90
+++ b/flang/test/Semantics/bug159554.f90
@@ -1,5 +1,6 @@
 !RUN: %python %S/test_errors.py %s %flang_fc1
 use, intrinsic :: iso_c_binding
+!WARNING: 'c_funloc' should not be the name of both a generic interface and a procedure unless it is a specific procedure of the generic [-Whomonymous-specific]
 interface c_funloc
 !ERROR: 'c_funloc' is already declared in this scoping unit
   function c_funloc()


### PR DESCRIPTION
When emitting an homonymous generic interface and procedure warning,
the source locations of the interface and the procedure were being
compared to find the one that occurred later in the source file.

The problem is that they could be in different source/module files,
which makes the comparison invalid.

Fix it by using parser::AllCookedSources::Precedes() instead, that
correctly handle names in different source files.