### PR TITLE
[clang-doc] Add JSON bools for parents, vparents and test

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -551,6 +551,7 @@ static void serializeInfo(const RecordInfo &I, json::Object &Obj,
       auto &MemberObj = *MemberVal.getAsObject();
       MemberObj["Name"] = Member.Name;
       MemberObj["Type"] = Member.Type.Name;
+      MemberObj["IsStatic"] = Member.IsStatic;
 
       if (Member.Access == AccessSpecifier::AS_public)
         PubMembersArrayRef.push_back(MemberVal);

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -572,12 +572,16 @@ static void serializeInfo(const RecordInfo &I, json::Object &Obj,
           serializeInfo(Base, BaseObj, RepositoryUrl);
         });
 
-  if (!I.Parents.empty())
+  if (!I.Parents.empty()) {
     serializeArray(I.Parents, Obj, "Parents", SerializeReferenceLambda);
+    Obj["HasParents"] = true;
+  }
 
-  if (!I.VirtualParents.empty())
+  if (!I.VirtualParents.empty()) {
     serializeArray(I.VirtualParents, Obj, "VirtualParents",
                    SerializeReferenceLambda);
+    Obj["HasVirtualParents"] = true;
+  }
 
   if (I.Template)
     serializeInfo(I.Template.value(), Obj);

--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -154,7 +154,7 @@
                     <div>
                         {{#PublicMembers}}
                         <div id="{{Name}}" class="delimiter-container">
-                            <pre><code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code></pre>
+                            <pre><code class="language-cpp code-clang-doc" >{{#IsStatic}}static {{/IsStatic}}{{Type}} {{Name}}</code></pre>
                             {{#MemberComments}}
                             <div>
                                 {{>Comments}}
@@ -171,7 +171,7 @@
                     <div>
                         {{#Obj}}
                         <div id="{{Name}}" class="delimiter-container">
-                            <pre><code class="language-cpp code-clang-doc" >{{Type}} {{Name}}</code></pre>
+                            <pre><code class="language-cpp code-clang-doc" >{{#IsStatic}}static {{/IsStatic}}{{Type}} {{Name}}</code></pre>
                             {{#MemberComments}}
                             <div>
                                 {{>Comments}}

--- a/clang-tools-extra/test/clang-doc/basic-project.mustache.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.mustache.test
@@ -204,7 +204,7 @@ HTML-CALC:                     <div id="public_val" class="delimiter-container">
 HTML-CALC:                         <pre><code class="language-cpp code-clang-doc" >int public_val</code></pre>
 HTML-CALC:                     </div>
 HTML-CALC:                     <div id="static_val" class="delimiter-container">
-HTML-CALC:                         <pre><code class="language-cpp code-clang-doc" >const int static_val</code></pre>
+HTML-CALC:                         <pre><code class="language-cpp code-clang-doc" >static const int static_val</code></pre>
 HTML-CALC:                     </div>
 HTML-CALC:                 </div>
 HTML-CALC:             </section>

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -158,6 +158,7 @@ protected:
 // CHECK-NEXT:    ],
 // CHECK-NEXT:    "ProtectedMembers": [
 // CHECK-NEXT:      {
+// CHECK-NEXT:        "IsStatic": false,
 // CHECK-NEXT:        "Name": "ProtectedField",
 // CHECK-NEXT:        "Type": "int"
 // CHECK-NEXT:      }
@@ -198,6 +199,7 @@ protected:
 // CHECK-NEXT:        },
 // CHECK:         "PublicMembers": [
 // CHECK-NEXT:      {
+// CHECK-NEXT:        "IsStatic": false,
 // CHECK-NEXT:        "Name": "PublicField",
 // CHECK-NEXT:        "Type": "int"
 // CHECK-NEXT:      }

--- a/clang-tools-extra/test/clang-doc/json/inheritance.cpp
+++ b/clang-tools-extra/test/clang-doc/json/inheritance.cpp
@@ -1,0 +1,111 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClass.json
+
+class Virtual {};
+class Foo : virtual Virtual {};
+class Bar : Foo {};
+class Fizz : virtual Virtual {};
+class Buzz : Fizz {};
+
+class MyClass : Bar, Buzz {};
+
+// CHECK:       "Bases": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:     "Access": "private",
+// CHECK-NEXT:      "InfoType": "record",
+// CHECK-NEXT:      "IsParent": true,
+// CHECK-NEXT:      "IsTypedef": false,
+// CHECK-NEXT:      "IsVirtual": false,
+// CHECK-NEXT:      "MangledName": "",
+// CHECK-NEXT:      "Name": "Bar",
+// CHECK-NEXT:      "Path": "GlobalNamespace",
+// CHECK-NEXT:      "TagType": "struct",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "Access": "private",
+// CHECK-NEXT:      "InfoType": "record",
+// CHECK-NEXT:      "IsParent": false,
+// CHECK-NEXT:      "IsTypedef": false,
+// CHECK-NEXT:      "IsVirtual": false,
+// CHECK-NEXT:      "MangledName": "",
+// CHECK-NEXT:      "Name": "Foo",
+// CHECK-NEXT:      "Path": "GlobalNamespace",
+// CHECK-NEXT:      "TagType": "struct",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "Access": "private",
+// CHECK-NEXT:      "InfoType": "record",
+// CHECK-NEXT:      "IsParent": false,
+// CHECK-NEXT:      "IsTypedef": false,
+// CHECK-NEXT:      "IsVirtual": true,
+// CHECK-NEXT:      "MangledName": "",
+// CHECK-NEXT:      "Name": "Virtual",
+// CHECK-NEXT:      "Path": "GlobalNamespace",
+// CHECK-NEXT:      "TagType": "struct",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "Access": "private",
+// CHECK-NEXT:      "InfoType": "record",
+// CHECK-NEXT:      "IsParent": true,
+// CHECK-NEXT:      "IsTypedef": false,
+// CHECK-NEXT:      "IsVirtual": false,
+// CHECK-NEXT:      "MangledName": "",
+// CHECK-NEXT:      "Name": "Buzz",
+// CHECK-NEXT:      "Path": "GlobalNamespace",
+// CHECK-NEXT:      "TagType": "struct",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "Access": "private",
+// CHECK-NEXT:      "InfoType": "record",
+// CHECK-NEXT:      "IsParent": false,
+// CHECK-NEXT:      "IsTypedef": false,
+// CHECK-NEXT:      "IsVirtual": false,
+// CHECK-NEXT:      "MangledName": "",
+// CHECK-NEXT:      "Name": "Fizz",
+// CHECK-NEXT:      "Path": "GlobalNamespace",
+// CHECK-NEXT:      "TagType": "struct",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "Access": "private",
+// CHECK-NEXT:      "End": true,
+// CHECK-NEXT:      "InfoType": "record",
+// CHECK-NEXT:      "IsParent": false,
+// CHECK-NEXT:      "IsTypedef": false,
+// CHECK-NEXT:      "IsVirtual": true,
+// CHECK-NEXT:      "MangledName": "",
+// CHECK-NEXT:      "Name": "Virtual",
+// CHECK-NEXT:      "Path": "GlobalNamespace",
+// CHECK-NEXT:      "TagType": "struct",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:    }
+// CHECK-NEXT:  ],
+// CHECK:       "Parents": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "Name": "Bar",
+// CHECK-NEXT:      "Path": "GlobalNamespace",
+// CHECK-NEXT:      "QualName": "Bar",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "End": true,
+// CHECK-NEXT:      "Name": "Buzz",
+// CHECK-NEXT:      "Path": "GlobalNamespace",
+// CHECK-NEXT:      "QualName": "Buzz",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:    }
+// CHECK-NEXT:  ],
+// CHECK:       "VirtualParents": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "End": true,
+// CHECK-NEXT:      "Name": "Virtual",
+// CHECK-NEXT:      "Path": "GlobalNamespace",
+// CHECK-NEXT:      "QualName": "Virtual",
+// CHECK-NEXT:      "USR": "{{[0-9A-F]*}}"
+// CHECK-NEXT:    }
+// CHECK-NEXT:  ]

--- a/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
@@ -90,6 +90,7 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
       ],
       "PublicMembers": [
         {
+          "IsStatic": false,
           "Name": "N",
           "Type": "int"
         }
@@ -140,6 +141,7 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
   "Path": "GlobalNamespace",
   "ProtectedMembers": [
     {
+      "IsStatic": false,
       "Name": "X",
       "Type": "int"
     }

--- a/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
@@ -116,8 +116,10 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
     }
   ],
   "HasEnums": true,
+  "HasParents": true,
   "HasPublicFunctions": true,
   "HasRecords": true,
+  "HasVirtualParents": true,
   "InfoType": "record",
   "IsTypedef": false,
   "Location": {


### PR DESCRIPTION
Parents and virtual parents didn't have "Has" bools in JSON output. That
made it difficult to only create output conditionally.

Also add an explicit test for inheritance and parents, vparents, and
bases which actually weren't tested in JSON