### PR TITLE
[clang-doc] Serialize the global namespace name in JSON

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -610,6 +610,8 @@ static void serializeInfo(const VarInfo &I, json::Object &Obj,
 static void serializeInfo(const NamespaceInfo &I, json::Object &Obj,
                           const std::optional<StringRef> RepositoryUrl) {
   serializeCommonAttributes(I, Obj, RepositoryUrl);
+  if (I.USR == GlobalNamespaceID)
+    Obj["Name"] = "Global Namespace";
 
   if (!I.Children.Namespaces.empty())
     serializeArray(I.Children.Namespaces, Obj, "Namespaces",

--- a/clang-tools-extra/clang-doc/assets/namespace-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/namespace-template.mustache
@@ -13,7 +13,7 @@
     <main>
         <div class="container">
             <div class="sidebar">
-                <h2>{{RecordType}} {{Name}}</h2>
+                <h2>{{#RecordType}}{{RecordType}} {{/RecordType}}{{Name}}</h2>
                 <ul>
                     {{#HasEnums}}
                     <li class="sidebar-section">

--- a/clang-tools-extra/test/clang-doc/json/concept.cpp
+++ b/clang-tools-extra/test/clang-doc/json/concept.cpp
@@ -31,6 +31,6 @@ concept Incrementable = requires(T x) {
 // CHECK-NEXT:        "USR": "{{[0-9A-F]*}}"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ],
-// CHECK:        "Name": "",
+// CHECK:        "Name": "Global Namespace",
 // CHECK:        "USR": "0000000000000000000000000000000000000000"
 // CHECK:      }

--- a/clang-tools-extra/test/clang-doc/json/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/json/namespace.cpp
@@ -75,7 +75,7 @@ typedef int MyTypedef;
 // CHECK-NEXT:   "HasEnums": true,
 // CHECK-NEXT:   "HasRecords": true,
 // CHECK-NEXT:   "InfoType": "namespace",
-// CHECK-NEXT:   "Name": "",
+// CHECK-NEXT:   "Name": "Global Namespace",
 // CHECK-NEXT:   "Namespaces": [
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "End": true,

--- a/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-separate-namespace.cpp
@@ -19,7 +19,7 @@ namespace MyNamespace {
 // CHECK-GLOBAL:             <main>
 // CHECK-GLOBAL-NEXT:            <div class="container">
 // CHECK-GLOBAL-NEXT:                <div class="sidebar">
-// CHECK-GLOBAL-NEXT:                    <h2> </h2>
+// CHECK-GLOBAL-NEXT:                    <h2>Global Namespace</h2>
 // CHECK-GLOBAL-NEXT:                    <ul>
 // CHECK-GLOBAL-NEXT:                    </ul>
 // CHECK-GLOBAL-NEXT:                </div>

--- a/clang-tools-extra/test/clang-doc/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/namespace.cpp
@@ -63,7 +63,7 @@ class AnonClass {};
 // MD-ANON-INDEX: ### anonFunction
 // MD-ANON-INDEX: *void anonFunction()*
 
-// HTML-ANON-INDEX: <h2> @nonymous_namespace</h2>
+// HTML-ANON-INDEX: <h2>@nonymous_namespace</h2>
 // HTML-ANON-INDEX:     <h2>Inner Classes</h2>
 // HTML-ANON-INDEX:         <ul class="class-container">
 // HTML-ANON-INDEX:             <li id="{{([0-9A-F]{40})}}" style="max-height: 40px;">
@@ -119,7 +119,7 @@ class ClassInNestedNamespace {};
 // MD-NESTED-INDEX: *void functionInNestedNamespace()*
 // MD-NESTED-INDEX: Function in NestedNamespace
 
-// HTML-NESTED-INDEX: <h2> NestedNamespace</h2>
+// HTML-NESTED-INDEX: <h2>NestedNamespace</h2>
 // HTML-NESTED-INDEX:     <h2>Inner Classes</h2>
 // HTML-NESTED-INDEX:     <ul class="class-container">
 // HTML-NESTED-INDEX:         <li id="{{([0-9A-F]{40})}}" style="max-height: 40px;">
@@ -145,7 +145,7 @@ class ClassInNestedNamespace {};
 // MD-PRIMARY-INDEX: *void functionInPrimaryNamespace()*
 // MD-PRIMARY-INDEX:  Function in PrimaryNamespace
 
-// HTML-PRIMARY-INDEX: <h2> PrimaryNamespace</h2>
+// HTML-PRIMARY-INDEX: <h2>PrimaryNamespace</h2>
 // HTML-PRIMARY-INDEX-NOT: <h2 id="Namespaces">Namespaces</h2>
 // HTML-PRIMARY-INDEX-NOT: <a href="NestedNamespace{{[\/]}}index.html">NestedNamespace</a>
 // HTML-PRIMARY-INDEX      <h2>Inner Classes</h2>
@@ -189,7 +189,7 @@ class ClassInAnotherNamespace {};
 // MD-ANOTHER-INDEX: *void functionInAnotherNamespace()*
 // MD-ANOTHER-INDEX: Function in AnotherNamespace
 
-// HTML-ANOTHER-INDEX: <h2> AnotherNamespace</h2>
+// HTML-ANOTHER-INDEX: <h2>AnotherNamespace</h2>
 // HTML-ANOTHER-INDEX:     <h2>Inner Classes</h2>
 // HTML-ANOTHER-INDEX:     <ul class="class-container">
 // HTML-ANOTHER-INDEX:         <li id="{{([0-9A-F]{40})}}" style="max-height: 40px;">

--- a/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
@@ -245,7 +245,7 @@ TEST_F(JSONGeneratorTest, emitNamespaceJSON) {
   "HasEnums": true,
   "HasRecords": true,
   "InfoType": "namespace",
-  "Name": "Namespace",
+  "Name": "Global Namespace",
   "Namespace": [
     "A"
   ],


### PR DESCRIPTION
Previously, the global namespace's "Name" field was left empty. It could
be identified this way, but it could also be identified by its USR.
Actually populating the "Name" field allows for nicer output in the
future.