### PR TITLE
[clang][Driver][SPIRV] Add better error when SPIR-V tools is not found

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -93,6 +93,12 @@ def err_drv_hipspv_no_hip_path : Error<
   "'--hip-path' must be specified when offloading to SPIR-V unless '-nogpuinc' "
   "is given">;
 
+def err_drv_no_spv_tools : Error<"cannot find SPIR-V Tools binary '%0', which "
+                                 "is required for SPIR-V compilation. "
+                                 "It can be obtained from your system package "
+                                 "manager or from KhronosGroup/SPIRV-Tools "
+                                 "on GitHub">;
+
 def err_drv_undetermined_gpu_arch : Error<
   "cannot determine %0 architecture: %1; consider passing it via '%2'; "
   "environment variable CLANG_TOOLCHAIN_PROGRAM_TIMEOUT specifies the tool "

--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -65,6 +65,11 @@ void SPIRV::constructAssembleCommand(Compilation &C, const Tool &T,
   if (!llvm::sys::fs::can_execute(ExeCand))
     ExeCand = T.getToolChain().GetProgramPath("spirv-as");
 
+  if (!llvm::sys::fs::can_execute(ExeCand) &&
+      !C.getArgs().hasArg(clang::options::OPT__HASH_HASH_HASH)) {
+    C.getDriver().Diag(clang::diag::err_drv_no_spv_tools) << "spirv-as";
+    return;
+  }
   const char *Exec = C.getArgs().MakeArgString(ExeCand);
   C.addCommand(std::make_unique<Command>(JA, T, ResponseFileSupport::None(),
                                          Exec, CmdArgs, Input, Output));
@@ -133,6 +138,11 @@ void SPIRV::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   // the default linker (spirv-link).
   if (Args.hasArg(options::OPT_sycl_link))
     Linker = ToolChain.GetProgramPath("clang-sycl-linker");
+  else if (!llvm::sys::fs::can_execute(Linker) &&
+           !C.getArgs().hasArg(clang::options::OPT__HASH_HASH_HASH)) {
+    C.getDriver().Diag(clang::diag::err_drv_no_spv_tools) << getShortName();
+    return;
+  }
   C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
                                          Args.MakeArgString(Linker), CmdArgs,
                                          Inputs, Output));

--- a/clang/test/Driver/spirv-tools-err.c
+++ b/clang/test/Driver/spirv-tools-err.c
@@ -1,0 +1,7 @@
+// UNSUPPORTED: spirv-tools
+// REQUIRES: spirv-registered-target
+
+// RUN: env PATH='' not %clang -o /dev/null --target=spirv64 --save-temps -v %s 2>&1 | FileCheck %s
+
+// CHECK: error: cannot find SPIR-V Tools binary 'spirv-as'
+// CHECK: error: cannot find SPIR-V Tools binary 'spirv-link'


### PR DESCRIPTION
Today if SPIR-V Tools is not found, you get the below error:

```
clang: error: unable to execute command: posix_spawn failed: No such file or directory
clang: error: spirv-as command failed with exit code 1 (use -v to see invocation)
```
which is not exactly user friendly. 

Explain what software package is missing and give suggestions on getting it.