### PR TITLE
[flang-rt][device] Enable MapException on the device with error message

### DIFF
--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -57,6 +57,7 @@ set(supported_sources
   edit-input.cpp
   edit-output.cpp
   environment.cpp
+  exceptions.cpp
   external-unit.cpp
   extrema.cpp
   file.cpp

--- a/flang/include/flang/Runtime/exceptions.h
+++ b/flang/include/flang/Runtime/exceptions.h
@@ -24,12 +24,12 @@ extern "C" {
 
 // Map a set of IEEE_FLAG_TYPE exception values to a libm fenv.h excepts value.
 // This mapping is done at runtime to support cross compilation.
-std::uint32_t RTNAME(MapException)(std::uint32_t excepts);
+std::uint32_t RTDECL(MapException)(std::uint32_t excepts);
 
 // Exception processing functions that call the corresponding libm functions,
 // and also include support for denormal exceptions where available.
 void RTNAME(feclearexcept)(std::uint32_t excepts);
-void RTNAME(feraiseexcept)(std::uint32_t excepts);
+void RTDECL(feraiseexcept)(std::uint32_t excepts);
 std::uint32_t RTNAME(fetestexcept)(std::uint32_t excepts);
 void RTNAME(fedisableexcept)(std::uint32_t excepts);
 void RTNAME(feenableexcept)(std::uint32_t excepts);


### PR DESCRIPTION
As it is done in `flang-rt/lib/runtime/edit-input.cpp`, emit a runtime error message when trying to raise IEEE exception on the device. `MapException` and `feraiseexcept` are used in the lowering of the nearest intrinsic even on the device. 