### PR TITLE
[mlir][amdgpu] Add type conversion to populate method (NFC)

### DIFF
--- a/mlir/include/mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h
+++ b/mlir/include/mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h
@@ -24,7 +24,7 @@ class Pass;
 
 /// Note: This function will also add conversions for the AMDGPU-specific
 /// address spaces, but those can be added separately using
-/// populateAMDGPUMemorySpaceAttributeConversions().
+/// populateAMDGPUTypeAndAttributeConversions().
 void populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
                                              RewritePatternSet &patterns,
                                              amdgpu::Chipset chipset);
@@ -33,8 +33,7 @@ void populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
 /// by mapping amdgpu::AddressSpace::fat_raw_buffer to ptr addrspace(7),
 /// amdgpu::AddressSpace::buffer_rsrc to ptr addrspace(8), and
 /// amdgpu::AddressSpace::fat_strided_buffer to ptr addrspace(9).
-void populateAMDGPUMemorySpaceAttributeConversions(
-    TypeConverter &typeConverter);
+void populateAMDGPUTypeAndAttributeConversions(TypeConverter &typeConverter);
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h
+++ b/mlir/include/mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h
@@ -23,7 +23,7 @@ class Pass;
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Note: This function will also add conversions for the AMDGPU-specific
-/// address spaces, but those can be added separately using
+/// address spaces and types, but those can be added separately using
 /// populateAMDGPUTypeAndAttributeConversions().
 void populateAMDGPUToROCDLConversionPatterns(LLVMTypeConverter &converter,
                                              RewritePatternSet &patterns,


### PR DESCRIPTION
* Renames populateAMDGPUMemorySpaceAttributeConversions to populateAMDGPUTypeAndAttributeConversions.
* Adds TDMBaseType conversion to populateAMDGPUTypeAndAttributeConversions.