### PR TITLE
[clang][driver][darwin] Base the system prefix on the SDK, not the target

### DIFF
--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -144,17 +144,27 @@ public:
   DarwinSDKInfo(
       VersionTuple Version, VersionTuple MaximumDeploymentTarget,
       llvm::Triple::OSType OS,
+      llvm::SmallDenseMap<llvm::Triple, std::string> SystemPrefixes =
+          llvm::SmallDenseMap<llvm::Triple, std::string>(),
       llvm::DenseMap<OSEnvPair::StorageType,
                      std::optional<RelatedTargetVersionMapping>>
           VersionMappings =
               llvm::DenseMap<OSEnvPair::StorageType,
                              std::optional<RelatedTargetVersionMapping>>())
       : Version(Version), MaximumDeploymentTarget(MaximumDeploymentTarget),
-        OS(OS), VersionMappings(std::move(VersionMappings)) {}
+        OS(OS), SystemPrefixes(SystemPrefixes),
+        VersionMappings(std::move(VersionMappings)) {}
 
   const llvm::VersionTuple &getVersion() const { return Version; }
 
   const llvm::Triple::OSType &getOS() const { return OS; }
+
+  const StringRef getSystemPrefix(llvm::Triple Triple) const {
+    auto SystemPrefix = SystemPrefixes.find(Triple);
+    if (SystemPrefix == SystemPrefixes.end())
+      return StringRef();
+    return SystemPrefix->getSecond();
+  }
 
   // Returns the optional, target-specific version mapping that maps from one
   // target to another target.
@@ -181,6 +191,7 @@ private:
   VersionTuple Version;
   VersionTuple MaximumDeploymentTarget;
   llvm::Triple::OSType OS;
+  llvm::SmallDenseMap<llvm::Triple, std::string> SystemPrefixes;
   // Need to wrap the value in an optional here as the value has to be default
   // constructible, and std::unique_ptr doesn't like DarwinSDKInfo being
   // Optional as Optional is trying to copy it in emplace.

--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -16,6 +16,7 @@
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
+#include <unordered_map>
 
 namespace llvm {
 namespace json {
@@ -144,8 +145,8 @@ public:
   DarwinSDKInfo(
       VersionTuple Version, VersionTuple MaximumDeploymentTarget,
       llvm::Triple::OSType OS,
-      llvm::SmallDenseMap<llvm::Triple, std::string> SystemPrefixes =
-          llvm::SmallDenseMap<llvm::Triple, std::string>(),
+      std::unordered_map<llvm::Triple, std::string> SystemPrefixes =
+          std::unordered_map<llvm::Triple, std::string>(),
       llvm::DenseMap<OSEnvPair::StorageType,
                      std::optional<RelatedTargetVersionMapping>>
           VersionMappings =
@@ -163,7 +164,7 @@ public:
     auto SystemPrefix = SystemPrefixes.find(Triple);
     if (SystemPrefix == SystemPrefixes.end())
       return StringRef();
-    return SystemPrefix->getSecond();
+    return SystemPrefix->second;
   }
 
   // Returns the optional, target-specific version mapping that maps from one
@@ -191,7 +192,7 @@ private:
   VersionTuple Version;
   VersionTuple MaximumDeploymentTarget;
   llvm::Triple::OSType OS;
-  llvm::SmallDenseMap<llvm::Triple, std::string> SystemPrefixes;
+  std::unordered_map<llvm::Triple, std::string> SystemPrefixes;
   // Need to wrap the value in an optional here as the value has to be default
   // constructible, and std::unique_ptr doesn't like DarwinSDKInfo being
   // Optional as Optional is trying to copy it in emplace.

--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -85,10 +85,10 @@ static llvm::Triple::OSType parseOS(const llvm::json::Object &Obj) {
       .Default(llvm::Triple::UnknownOS);
 }
 
-static llvm::SmallDenseMap<llvm::Triple, std::string>
+static std::unordered_map<llvm::Triple, std::string>
 parseSystemPrefixes(const llvm::json::Object &Obj, llvm::Triple::OSType SDKOS,
                     VersionTuple Version) {
-  llvm::SmallDenseMap<llvm::Triple, std::string> SystemPrefixes;
+  std::unordered_map<llvm::Triple, std::string> SystemPrefixes;
   auto SupportedTargets = Obj.getObject("SupportedTargets");
   if (!SupportedTargets)
     return SystemPrefixes;
@@ -152,7 +152,7 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(const llvm::json::Object *Obj) {
   if (!MaximumDeploymentVersion)
     return std::nullopt;
   llvm::Triple::OSType OS = parseOS(*Obj);
-  llvm::SmallDenseMap<llvm::Triple, std::string> SystemPrefixes =
+  std::unordered_map<llvm::Triple, std::string> SystemPrefixes =
       parseSystemPrefixes(*Obj, OS, *Version);
   llvm::DenseMap<OSEnvPair::StorageType,
                  std::optional<RelatedTargetVersionMapping>>

--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -85,6 +85,52 @@ static llvm::Triple::OSType parseOS(const llvm::json::Object &Obj) {
       .Default(llvm::Triple::UnknownOS);
 }
 
+static llvm::SmallDenseMap<llvm::Triple, std::string>
+parseSystemPrefixes(const llvm::json::Object &Obj, llvm::Triple::OSType SDKOS,
+                    VersionTuple Version) {
+  llvm::SmallDenseMap<llvm::Triple, std::string> SystemPrefixes;
+  auto SupportedTargets = Obj.getObject("SupportedTargets");
+  if (!SupportedTargets)
+    return SystemPrefixes;
+  for (auto SupportedTargetPair : *SupportedTargets) {
+    StringRef PlatformOrVariant = SupportedTargetPair.getFirst();
+    if ((PlatformOrVariant == "iosmac") && (Version < VersionTuple(99)))
+      // iosmac has an invalid SystemPrefix, skip it.
+      continue;
+
+    llvm::json::Object *SupportedTarget =
+        SupportedTargetPair.getSecond().getAsObject();
+    auto Archs = SupportedTarget->getArray("Archs");
+    auto Vendor = SupportedTarget->getString("LLVMTargetTripleVendor");
+    auto OS = SupportedTarget->getString("LLVMTargetTripleSys");
+    auto SystemPrefix = SupportedTarget->getString("SystemPrefix");
+    if (!SystemPrefix) {
+      // Older SDKs don't have SystemPrefix in SupportedTargets, manually add
+      // their prefixes.
+      if ((SDKOS == llvm::Triple::DriverKit) && (Version < VersionTuple(22, 1)))
+        SystemPrefix = "/System/DriverKit";
+    }
+    if (!Archs || !Vendor || !OS || !SystemPrefix)
+      continue;
+
+    auto Environment =
+        SupportedTarget->getString("LLVMTargetTripleEnvironment");
+
+    for (auto Arch : *Archs) {
+      auto ArchString = Arch.getAsString();
+      if (!ArchString)
+        continue;
+      llvm::Triple Triple;
+      if (Environment)
+        Triple = llvm::Triple(*ArchString, *Vendor, *OS, *Environment);
+      else
+        Triple = llvm::Triple(*ArchString, *Vendor, *OS);
+      SystemPrefixes[Triple] = *SystemPrefix;
+    }
+  }
+  return SystemPrefixes;
+}
+
 static std::optional<VersionTuple> getVersionKey(const llvm::json::Object &Obj,
                                                  StringRef Key) {
   auto Value = Obj.getString(Key);
@@ -106,6 +152,8 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(const llvm::json::Object *Obj) {
   if (!MaximumDeploymentVersion)
     return std::nullopt;
   llvm::Triple::OSType OS = parseOS(*Obj);
+  llvm::SmallDenseMap<llvm::Triple, std::string> SystemPrefixes =
+      parseSystemPrefixes(*Obj, OS, *Version);
   llvm::DenseMap<OSEnvPair::StorageType,
                  std::optional<RelatedTargetVersionMapping>>
       VersionMappings;
@@ -149,7 +197,7 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(const llvm::json::Object *Obj) {
 
   return DarwinSDKInfo(std::move(*Version),
                        std::move(*MaximumDeploymentVersion), OS,
-                       std::move(VersionMappings));
+                       std::move(SystemPrefixes), std::move(VersionMappings));
 }
 
 Expected<std::optional<DarwinSDKInfo>>

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -197,6 +197,9 @@ public:
                                       llvm::opt::ArgStringList &CmdArgs) const {
   }
 
+  virtual void AppendPlatformPrefix(SmallString<128> &Path,
+                                    const llvm::Triple &T) const {}
+
   /// On some iOS platforms, kernel and kernel modules were built statically. Is
   /// this such a target?
   virtual bool isKernelStatic() const { return false; }
@@ -669,6 +672,9 @@ public:
 
   void AddLinkARCArgs(const llvm::opt::ArgList &Args,
                       llvm::opt::ArgStringList &CmdArgs) const override;
+
+  void AppendPlatformPrefix(SmallString<128> &Path,
+                            const llvm::Triple &T) const override;
 
   unsigned GetDefaultDwarfVersion() const override;
   // Until dtrace (via CTF) and LLDB can deal with distributed debug info,

--- a/clang/test/Driver/Inputs/DriverKit21.0.1.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/DriverKit21.0.1.sdk/SDKSettings.json
@@ -1,0 +1,4 @@
+{"Version": "21.0.1", "CanonicalName": "driverkit21.0.1", "MaximumDeploymentTarget": "21.0.1.99",
+ "SupportedTargets": {
+   "driverkit": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "driverkit", "LLVMTargetTripleEnvironment": ""}
+}}

--- a/clang/test/Driver/Inputs/DriverKit23.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/DriverKit23.0.sdk/SDKSettings.json
@@ -1,1 +1,4 @@
-{"Version":"23.0", "CanonicalName": "driverkit23.0", "MaximumDeploymentTarget": "23.0.99"}
+{"Version":"23.0", "CanonicalName": "driverkit23.0", "MaximumDeploymentTarget": "23.0.99",
+ "SupportedTargets": {
+   "driverkit": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "driverkit", "LLVMTargetTripleEnvironment": "", "SystemPrefix": "\/System\/DriverKit"}
+}}

--- a/clang/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
@@ -2,6 +2,20 @@
   "Version":"10.15",
   "CanonicalName": "macosx10.15",
   "MaximumDeploymentTarget": "10.15.99",
+  "SupportedTargets": {
+      "macosx": {
+          "Archs": ["x86_64"],
+          "LLVMTargetTripleVendor": "apple",
+          "LLVMTargetTripleSys": "macosx",
+          "LLVMTargetTripleEnvironment": ""
+      },
+      "iosmac": {
+          "Archs": ["x86_64"],
+          "LLVMTargetTripleVendor": "apple",
+          "LLVMTargetTripleSys": "ios",
+          "LLVMTargetTripleEnvironment": "macabi"
+      }
+  },
   "VersionMap" : {
       "macOS_iOSMac" : {
           "10.15" : "13.1",

--- a/clang/test/Driver/Inputs/MacOSX15.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX15.0.sdk/SDKSettings.json
@@ -1,1 +1,5 @@
-{"Version":"15.0", "CanonicalName": "macosx15.0", "MaximumDeploymentTarget": "15.0.99"}
+{"Version":"15.0", "CanonicalName": "macosx15.0", "MaximumDeploymentTarget": "15.0.99",
+ "SupportedTargets": {
+   "macosx": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "macos", "LLVMTargetTripleEnvironment": "", "SystemPrefix": ""},
+   "iosmac": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "macabi", "SystemPrefix": "\/System\/iOSSupport"}
+}}

--- a/clang/test/Driver/Inputs/MacOSX15.1.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX15.1.sdk/SDKSettings.json
@@ -1,1 +1,5 @@
-{"Version":"15.1", "CanonicalName": "macosx15.1", "MaximumDeploymentTarget": "15.1.99"}
+{"Version":"15.1", "CanonicalName": "macosx15.1", "MaximumDeploymentTarget": "15.1.99",
+ "SupportedTargets": {
+   "macosx": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "macos", "LLVMTargetTripleEnvironment": "", "SystemPrefix": ""},
+   "iosmac": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "macabi", "SystemPrefix": "\/System\/iOSSupport"}
+}}

--- a/clang/test/Driver/Inputs/WatchOS6.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/WatchOS6.0.sdk/SDKSettings.json
@@ -1,1 +1,4 @@
-{"Version":"6.0", "CanonicalName": "watchos6.0", "MaximumDeploymentTarget": "6.0.99"}
+{"Version":"6.0", "CanonicalName": "watchos6.0", "MaximumDeploymentTarget": "6.0.99",
+ "SupportedTargets": {
+   "watchos": {"Archs": ["armv7k", "arm64_32"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "watchos", "LLVMTargetTripleEnvironment": ""}
+}}

--- a/clang/test/Driver/Inputs/iPhoneOS13.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/iPhoneOS13.0.sdk/SDKSettings.json
@@ -1,1 +1,4 @@
-{"Version":"13.0", "CanonicalName": "iphoneos13.0", "MaximumDeploymentTarget": "13.0.99"}
+{"Version":"13.0", "CanonicalName": "iphoneos13.0", "MaximumDeploymentTarget": "13.0.99",
+ "SupportedTargets": {
+   "iphoneos": {"Archs": ["armv7", "armv7s", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": ""}
+}}

--- a/clang/test/Driver/driverkit-path.c
+++ b/clang/test/Driver/driverkit-path.c
@@ -26,6 +26,10 @@ int main() { return 0; }
 
 // RUN: %clang %s -target x86_64-apple-driverkit19.0 -isysroot %S/Inputs/DriverKit19.0.sdk -x c++ -### 2>&1 \
 // RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit19.0.sdk --check-prefix=INC
+// RUN: %clang %s -target x86_64-apple-driverkit21.0.1 -isysroot %S/Inputs/DriverKit21.0.1.sdk -x c++ -### 2>&1 \
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit21.0.1.sdk --check-prefix=INC
+// RUN: %clang %s -target x86_64-apple-driverkit23.0 -isysroot %S/Inputs/DriverKit23.0.sdk -x c++ -### 2>&1 \
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit23.0.sdk --check-prefix=INC
 //
 // INC: "-isysroot" "[[SDKROOT]]"
 // INC: "-internal-isystem" "[[SDKROOT]]/System/DriverKit/usr/local/include"

--- a/clang/test/InstallAPI/Inputs/MacOSX13.0.sdk/SDKSettings.json
+++ b/clang/test/InstallAPI/Inputs/MacOSX13.0.sdk/SDKSettings.json
@@ -3,7 +3,24 @@
   "Version": "13.0",
   "CanonicalName": "macosx13.0",
   "MaximumDeploymentTarget": "13.0.99",
-  "PropertyConditionFallbackNames": [], "VersionMap": {
+  "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "macosx": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "macos",
+      "LLVMTargetTripleEnvironment": "",
+      "SystemPrefix": ""
+    },
+    "iosmac": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "ios",
+      "LLVMTargetTripleEnvironment": "macabi",
+      "SystemPrefix": "\/System\/iOSSupport"
+    }
+  },
+  "VersionMap": {
     "iOSMac_macOS": {
       "16.1": "13.0",
       "15.0": "12.0",

--- a/clang/test/Sema/Inputs/AppleTVOS15.0.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/AppleTVOS15.0.sdk/SDKSettings.json
@@ -4,6 +4,14 @@
   "CanonicalName": "appletvos15.0",
   "MaximumDeploymentTarget": "15.0.99",
   "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "appletvos": {
+      "Archs": ["arm64e", "arm64"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "tvos",
+      "LLVMTargetTripleEnvironment": ""
+    }
+  },
   "VersionMap": {
     "iOS_tvOS": {
       "10.0": "10.0",

--- a/clang/test/Sema/Inputs/MacOSX11.0.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/MacOSX11.0.sdk/SDKSettings.json
@@ -3,7 +3,22 @@
   "Version": "11.0",
   "CanonicalName": "macosx11.0",
   "MaximumDeploymentTarget": "11.0.99",
-  "PropertyConditionFallbackNames": [], "VersionMap": {
+  "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "macosx": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "macosx",
+      "LLVMTargetTripleEnvironment": ""
+    },
+    "iosmac": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "ios",
+      "LLVMTargetTripleEnvironment": "macabi"
+    }
+  },
+  "VersionMap": {
     "iOSMac_macOS": {
       "13.2": "10.15.1",
       "13.4": "10.15.4",

--- a/clang/test/Sema/Inputs/WatchOS7.0.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/WatchOS7.0.sdk/SDKSettings.json
@@ -4,6 +4,14 @@
   "CanonicalName": "watchos7.0",
   "MaximumDeploymentTarget": "7.0.99",
   "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "watchos": {
+      "Archs": ["arm64_32", "armv7k"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "watchos",
+      "LLVMTargetTripleEnvironment": ""
+    }
+  },
   "VersionMap": {
     "iOS_watchOS": {
       "10.0": "3.0",

--- a/clang/test/Sema/Inputs/XROS.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/XROS.sdk/SDKSettings.json
@@ -3,6 +3,9 @@
   "Version": "26.0",
   "CanonicalName": "xros26.0",
   "MaximumDeploymentTarget": "26.0.99",
+  "SupportedTargets": {
+    "xros": {"Archs": ["arm64e", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "xros", "LLVMTargetTripleEnvironment": "", "SystemPrefix": ""}
+  },
   "VersionMap": {
     "iOS_xrOS":{"15.0":"1.0", "16.0":"2.0", "19.0":"26.0", "26.0":"26.0"}
   }

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_TARGETPARSER_TRIPLE_H
 #define LLVM_TARGETPARSER_TRIPLE_H
 
-#include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/VersionTuple.h"
+#include <functional>
 
 // Some system headers or GCC predefined macros conflict with identifiers in
 // this file.  Undefine them here.
@@ -203,8 +203,7 @@ public:
     OpenEmbedded,
     Intel,
     Meta,
-    LastVendorType = Meta,
-    TombstoneVendor = LastVendorType + 1
+    LastVendorType = Meta
   };
   enum OSType {
     UnknownOS,
@@ -1366,28 +1365,16 @@ public:
   LLVM_ABI std::string computeDataLayout(StringRef ABIName = "") const;
 };
 
-inline hash_code hash_value(const Triple &Val) {
-  return hash_combine(Val.getArch(), Val.getSubArch(), Val.getVendor(),
-                      Val.getOS(), Val.getEnvironment(), Val.getObjectFormat());
-}
-
-template <> struct DenseMapInfo<Triple> {
-  static inline Triple getEmptyKey() { return Triple(); }
-
-  static inline Triple getTombstoneKey() {
-    Triple TombstoneKey;
-    TombstoneKey.setVendor(Triple::TombstoneVendor);
-    return TombstoneKey;
-  }
-
-  static unsigned getHashValue(const Triple &Val) { return hash_value(Val); }
-
-  static bool isEqual(const Triple &LHS, const Triple &RHS) {
-    return LHS == RHS;
-  }
-};
-
 } // End llvm namespace
 
+namespace std {
+template <> struct hash<llvm::Triple> {
+  size_t operator()(const llvm::Triple &Val) const {
+    return hash_combine(Val.getArch(), Val.getSubArch(), Val.getVendor(),
+                        Val.getOS(), Val.getEnvironment(),
+                        Val.getObjectFormat());
+  }
+};
+} // namespace std
 
 #endif

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -281,6 +281,8 @@ StringRef Triple::getVendorTypeName(VendorType Kind) {
   case SUSE: return "suse";
   case Meta:
     return "meta";
+  case TombstoneVendor:
+    return "tombstone";
   }
 
   llvm_unreachable("Invalid VendorType!");

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -281,8 +281,6 @@ StringRef Triple::getVendorTypeName(VendorType Kind) {
   case SUSE: return "suse";
   case Meta:
     return "meta";
-  case TombstoneVendor:
-    return "tombstone";
   }
 
   llvm_unreachable("Invalid VendorType!");

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -3325,6 +3325,19 @@ TEST(TripleTest, isCompatibleWith) {
   }
 }
 
+TEST(TripleTest, equalsAndHash) {
+  EXPECT_EQ(Triple("arm64-apple-ios26.0"), Triple("arm64-apple-ios26.0"));
+  EXPECT_EQ(Triple("arm64-apple-ios26.0"), Triple("arm64-apple-ios26.1"));
+  EXPECT_NE(Triple("arm64-apple-ios26.0"), Triple("arm64-apple-macos26.0"));
+  EXPECT_NE(Triple("arm64-apple-ios26.0"),
+            Triple("arm64-apple-ios26.0-macabi"));
+
+  EXPECT_EQ(hash_value(Triple("arm64-apple-ios26.0")),
+            hash_value(Triple("arm64-apple-ios26.0")));
+  EXPECT_EQ(hash_value(Triple("arm64-apple-ios26.0")),
+            hash_value(Triple("arm64-apple-ios26.1")));
+}
+
 TEST(DataLayoutTest, UEFI) {
   Triple TT = Triple("x86_64-unknown-uefi");
 

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -3332,10 +3332,11 @@ TEST(TripleTest, equalsAndHash) {
   EXPECT_NE(Triple("arm64-apple-ios26.0"),
             Triple("arm64-apple-ios26.0-macabi"));
 
-  EXPECT_EQ(hash_value(Triple("arm64-apple-ios26.0")),
-            hash_value(Triple("arm64-apple-ios26.0")));
-  EXPECT_EQ(hash_value(Triple("arm64-apple-ios26.0")),
-            hash_value(Triple("arm64-apple-ios26.1")));
+  std::hash<Triple> Hasher;
+  EXPECT_EQ(Hasher(Triple("arm64-apple-ios26.0")),
+            Hasher(Triple("arm64-apple-ios26.0")));
+  EXPECT_EQ(Hasher(Triple("arm64-apple-ios26.0")),
+            Hasher(Triple("arm64-apple-ios26.1")));
 }
 
 TEST(DataLayoutTest, UEFI) {


### PR DESCRIPTION
The search path prefix is really a property of the SDK, and not the target triple. The target is just being used as a proxy for the SDK. That's problemmatic when the SDK being used doesn't match the target assumption, and the prefix should be taken from the SDK rather than hard coded.

The prefix is actually per target triple within an SDK, so make a map from target to prefix in DarwinSDKInfo. That requires making Triple support being used as a DenseMap key. From there, have the DarwinClang tool chain get the prefix from its SDKInfo.