### PR TITLE
[clang][ssaf] Speculative fix of unittest build

### DIFF
--- a/clang/unittests/Analysis/Scalable/CMakeLists.txt
+++ b/clang/unittests/Analysis/Scalable/CMakeLists.txt
@@ -11,6 +11,12 @@ add_distinct_clang_unittest(ClangScalableAnalysisFrameworkTests
   clangFrontend
   clangSerialization
   clangTooling
+  LINK_LIBS
+  clangTesting
+  LLVMTestingSupport
+  LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
   )
 
 add_custom_target(ClangScalableAnalysisTests


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/169131

Should fix:
ASTEntityMappingTest.cpp.o: undefined reference to symbol '_ZN4llvm3omp27isAllowedClauseForDirectiveENS0_9DirectiveENS0_6ClauseEj'

https://lab.llvm.org/buildbot/#/builders/10/builds/18851