### PR TITLE
[RISC-V][MC] Fix tied operand register class mismatch in P-extension

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -437,7 +437,7 @@ class RVPTernary_rrr<bits<4> f, bits<2> w, bits<3> funct3, string opcodestr>
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPWideningTernary_rrr<bits<4> f, bits<2> w, string opcodestr>
     : RVPWideningBase<w, 0b1, (outs GPRPairRV32:$rd_wb),
-                     (ins GPR:$rd, GPR:$rs1, GPR:$rs2), opcodestr> {
+                     (ins GPRPairRV32:$rd, GPR:$rs1, GPR:$rs2), opcodestr> {
   let Inst{30-27} = f;
 
   let Constraints = "$rd = $rd_wb";


### PR DESCRIPTION
I have a change to validate the operand classes emitted in the AsmParser
and that caused llvm/test/MC/RISCV/rv32p-valid.s to fail due to the rd_wb
register using a different register class from rd:
`PWADDA_H operand 1 register X6 is not a member of register class GPRPair`
This happens because tablegen's AsmMatcherEmitter emits code to literally
copy over the tied registers and does not feed them through the equivalent
of RISCVAsmParser::validateTargetOperandClass() which would allow adjusting
these operand classes.

Ideally we would handle this in tablegen (or at least add an error), but
the tied operand handling logic is rather complex and I don't understand
it yet. For now just update the rd register class to match rd_wb.
