### PR TITLE
[CIR] Upstream support for C++ method pointers

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -552,6 +552,34 @@ def CIR_FuncType : CIR_Type<"Func", "func"> {
 }
 
 //===----------------------------------------------------------------------===//
+// MethodType
+//===----------------------------------------------------------------------===//
+
+def CIR_MethodType : CIR_Type<"Method", "method",
+    [DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]> {
+  let summary = "CIR type that represents C++ pointer-to-member-function type";
+  let description = [{
+    `cir.method` models the pointer-to-member-function type in C++. The layout
+    of this type is ABI-dependent.
+  }];
+
+  let parameters = (ins "cir::FuncType":$member_func_ty,
+                        "cir::RecordType":$class_ty);
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins
+      "cir::FuncType":$member_func_ty, "cir::RecordType":$class_ty
+    ), [{
+      return $_get(member_func_ty.getContext(), member_func_ty, class_ty);
+    }]>,
+  ];
+
+  let assemblyFormat = [{
+    `<` qualified($member_func_ty) `in` $class_ty `>`
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Void type
 //===----------------------------------------------------------------------===//
 
@@ -732,7 +760,7 @@ def CIRRecordType : Type<
 def CIR_AnyType : AnyTypeOf<[
   CIR_VoidType, CIR_BoolType, CIR_ArrayType, CIR_VectorType, CIR_IntType,
   CIR_AnyFloatType, CIR_PointerType, CIR_FuncType, CIR_RecordType,
-  CIR_ComplexType, CIR_VPtrType, CIR_DataMemberType
+  CIR_ComplexType, CIR_VPtrType, CIR_DataMemberType, CIR_MethodType
 ]>;
 
 #endif // CLANG_CIR_DIALECT_IR_CIRTYPES_TD

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -545,8 +545,8 @@ mlir::Type CIRGenTypes::convertType(QualType type) {
     if (mpt->isMemberDataPointer()) {
       resultType = cir::DataMemberType::get(memberTy, clsTy);
     } else {
-      assert(!cir::MissingFeatures::methodType());
-      cgm.errorNYI(SourceLocation(), "MethodType");
+      auto memberFuncTy = mlir::cast<cir::FuncType>(memberTy);
+      resultType = cir::MethodType::get(memberFuncTy, clsTy);
     }
     break;
   }

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -268,6 +268,11 @@ static void prepareCXXABITypeConverter(mlir::TypeConverter &converter,
         lowerModule.getCXXABI().lowerDataMemberType(type, converter);
     return converter.convertType(abiType);
   });
+  converter.addConversion([&](cir::MethodType type) -> mlir::Type {
+    mlir::Type abiType =
+        lowerModule.getCXXABI().lowerMethodType(type, converter);
+    return converter.convertType(abiType);
+  });
   // This is necessary in order to convert CIR function types that have argument
   // or return types that use CIR types that we are lowering in this pass.
   converter.addConversion([&](cir::FuncType type) -> mlir::Type {

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -40,6 +40,12 @@ public:
   lowerDataMemberType(cir::DataMemberType type,
                       const mlir::TypeConverter &typeConverter) const = 0;
 
+  /// Lower the given member function pointer type to its ABI type. The returned
+  /// type is also a CIR type.
+  virtual mlir::Type
+  lowerMethodType(cir::MethodType type,
+                  const mlir::TypeConverter &typeConverter) const = 0;
+
   /// Lower the given data member pointer constant to a constant of the ABI
   /// type. The returned constant is represented as an attribute as well.
   virtual mlir::TypedAttr

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2888,6 +2888,12 @@ static void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
     assert(!cir::MissingFeatures::addressSpace());
     return mlir::LLVM::LLVMPointerType::get(type.getContext());
   });
+  converter.addConversion([&, lowerModule](cir::MethodType type) -> mlir::Type {
+    assert(lowerModule && "CXXABI is not available");
+    mlir::Type abiType =
+        lowerModule->getCXXABI().lowerMethodType(type, converter);
+    return converter.convertType(abiType);
+  });
   converter.addConversion([&](cir::ArrayType type) -> mlir::Type {
     mlir::Type ty =
         convertTypeForMemory(converter, dataLayout, type.getElementType());

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2888,12 +2888,6 @@ static void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
     assert(!cir::MissingFeatures::addressSpace());
     return mlir::LLVM::LLVMPointerType::get(type.getContext());
   });
-  converter.addConversion([&, lowerModule](cir::MethodType type) -> mlir::Type {
-    assert(lowerModule && "CXXABI is not available");
-    mlir::Type abiType =
-        lowerModule->getCXXABI().lowerMethodType(type, converter);
-    return converter.convertType(abiType);
-  });
   converter.addConversion([&](cir::ArrayType type) -> mlir::Type {
     mlir::Type ty =
         convertTypeForMemory(converter, dataLayout, type.getElementType());

--- a/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll --check-prefix=LLVM %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct Foo {
+  void m1(int);
+  virtual void m2(int);
+  virtual void m3(int);
+};
+
+void unused_pointer_to_member_func(void (Foo::*func)(int)) {
+}
+
+// CIR: cir.func {{.*}} @_Z29unused_pointer_to_member_funcM3FooFviE(%[[ARG:.*]]: !cir.method<!cir.func<(!s32i)> in !rec_Foo> {{.*}})
+// CIR:   %[[FUNC:.*]] = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["func", init]
+
+// NOTE: The difference between LLVM and OGCG are due to the lack of calling convention handling in CIR.
+
+// LLVM: define {{.*}} void @_Z29unused_pointer_to_member_funcM3FooFviE({ i64, i64 } %[[ARG:.*]])
+// LLVM:   %[[FUNC:.*]] = alloca { i64, i64 }
+// LLVM:   store { i64, i64 } %[[ARG]], ptr %[[FUNC]]
+
+// OGCG: define {{.*}} void @_Z29unused_pointer_to_member_funcM3FooFviE(i64 %[[FUNC_COERCE0:.*]], i64 %[[FUNC_COERCE1:.*]])
+// OGCG:   %[[FUNC:.*]] = alloca { i64, i64 }
+// OGCG:   %[[FUNC_ADDR:.*]] = alloca { i64, i64 }
+// OGCG:   %[[FUNC_0:.*]] = getelementptr inbounds nuw { i64, i64 }, ptr %[[FUNC]], i32 0, i32 0
+// OGCG:   store i64 %[[FUNC_COERCE0]], ptr %[[FUNC_0]]
+// OGCG:   %[[FUNC_1:.*]] = getelementptr inbounds nuw { i64, i64 }, ptr %[[FUNC]], i32 0, i32 1
+// OGCG:   store i64 %[[FUNC_COERCE1]], ptr %[[FUNC_1]]
+// OGCG:   %[[FUNC1:.*]] = load { i64, i64 }, ptr %[[FUNC]]
+// OGCG:   store { i64, i64 } %[[FUNC1]], ptr %[[FUNC_ADDR]]


### PR DESCRIPTION
This adds CIR support for C++ pointer-to-member types. This only adds support for the type. Using the type in a non-trivial way requires a new CIR constant attribute which will be added in a follow-up PR.