### PR TITLE
[CIR] Partially upstream coroutine co_return support

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -154,6 +154,7 @@ struct MissingFeatures {
   static bool coroOutsideFrameMD() { return false; }
   static bool coroCoReturn() { return false; }
   static bool coroCoYield() { return false; }
+  static bool unhandledException() { return false; };
 
   // Various handling of deferred processing in CIRGenModule.
   static bool cgmRelease() { return false; }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -154,7 +154,7 @@ struct MissingFeatures {
   static bool coroOutsideFrameMD() { return false; }
   static bool coroCoReturn() { return false; }
   static bool coroCoYield() { return false; }
-  static bool unhandledException() { return false; };
+  static bool coroutineExceptions() { return false; };
 
   // Various handling of deferred processing in CIRGenModule.
   static bool cgmRelease() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -495,7 +495,6 @@ mlir::LogicalResult CIRGenFunction::emitCoreturnStmt(CoreturnStmt const &s) {
     // Make sure to evaluate the non initlist expression of a co_return
     // with a void expression for side effects.
     RunCleanupsScope cleanupScope(*this);
-    assert(!cir::MissingFeatures::ehCleanupScope());
     emitIgnoredExpr(rv);
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1073,6 +1073,12 @@ public:
     // Holds the actual value for ScopeKind::Try
     cir::TryOp tryOp = nullptr;
 
+    // On a coroutine body, the OnFallthrough sub stmt holds the handler
+    // (CoreturnStmt) for control flow falling off the body. Keep track
+    // of emitted co_return in this scope and allow OnFallthrough to be
+    // skipeed.
+    bool hasCoreturnStmt = false;
+
     // Only Regular is used at the moment. Support for other kinds will be
     // added as the relevant statements/expressions are upstreamed.
     enum Kind {
@@ -1119,6 +1125,12 @@ public:
       cleanup();
       restore();
     }
+
+    // ---
+    // Coroutine tracking
+    // ---
+    bool hasCoreturn() const { return hasCoreturnStmt; }
+    void setCoreturn() { hasCoreturnStmt = true; }
 
     // ---
     // Kind
@@ -1474,6 +1486,8 @@ public:
   void emitDestructorBody(FunctionArgList &args);
 
   mlir::LogicalResult emitContinueStmt(const clang::ContinueStmt &s);
+
+  mlir::LogicalResult emitCoreturnStmt(const CoreturnStmt &s);
 
   void emitCXXConstructExpr(const clang::CXXConstructExpr *e,
                             AggValueSlot dest);

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -164,6 +164,8 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
     return emitCoroutineBody(cast<CoroutineBodyStmt>(*s));
   case Stmt::IndirectGotoStmtClass:
     return emitIndirectGotoStmt(cast<IndirectGotoStmt>(*s));
+  case Stmt::CoreturnStmtClass:
+    return emitCoreturnStmt(cast<CoreturnStmt>(*s));
   case Stmt::OpenACCComputeConstructClass:
     return emitOpenACCComputeConstruct(cast<OpenACCComputeConstruct>(*s));
   case Stmt::OpenACCLoopConstructClass:
@@ -384,7 +386,6 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
   case Stmt::CaseStmtClass:
   case Stmt::SEHLeaveStmtClass:
   case Stmt::SYCLKernelCallStmtClass:
-  case Stmt::CoreturnStmtClass:
   case Stmt::CapturedStmtClass:
   case Stmt::ObjCAtTryStmtClass:
   case Stmt::ObjCAtThrowStmtClass:


### PR DESCRIPTION
This PR partially upstreams support for the `co_return` keyword. It still needs to address the case where a `co_return` returns a value from a `co_await`. 
Additionally, this change focuses on `emitBodyAndFallthrough`, where depending on whether the function falls through or not it will emit the user written `co_await`. Another thing to note is the difference from classic CodeGen, previously it checked whether it could fall through by using `GetInsertBlock()` to verify that the block existed.  In our case, when a `co_return` is emitted, we mark `setCoreturn()` to indicate that the coroutine contains a `co_return`.
