### PR TITLE
[clang-tidy] Add support for struct initialization in `bugprone-argument-comment`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
@@ -380,8 +380,8 @@ void ArgumentCommentCheck::checkCallArgs(ASTContext *Ctx,
 
     // If the argument comments are missing for literals add them.
     if (Comments.empty() && shouldAddComment(Args[I])) {
-      const std::string ArgComment =
-          (llvm::Twine("/*") + II->getName() + "=*/").str();
+      llvm::SmallString<32> ArgComment;
+      (llvm::Twine("/*") + II->getName() + "=*/").toStringRef(ArgComment);
       const DiagnosticBuilder Diag =
           diag(Args[I]->getBeginLoc(),
                "argument comment missing for literal argument %0")

--- a/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
@@ -148,14 +148,14 @@ static bool isLikelyTypo(const NamedDeclRange &Candidates, StringRef ArgName,
                          StringRef TargetName) {
   llvm::SmallString<64> ArgNameLower;
   ArgNameLower.reserve(ArgName.size());
-  for (char C : ArgName)
+  for (const char C : ArgName)
     ArgNameLower.push_back(llvm::toLower(C));
   const StringRef ArgNameLowerRef = StringRef(ArgNameLower);
   // The threshold is arbitrary.
   const unsigned UpperBound = ((ArgName.size() + 2) / 3) + 1;
   llvm::SmallString<64> TargetNameLower;
   TargetNameLower.reserve(TargetName.size());
-  for (char C : TargetName)
+  for (const char C : TargetName)
     TargetNameLower.push_back(llvm::toLower(C));
   const unsigned ThisED =
       ArgNameLowerRef.edit_distance(StringRef(TargetNameLower),
@@ -177,9 +177,9 @@ static bool isLikelyTypo(const NamedDeclRange &Candidates, StringRef ArgName,
     // from this candidate. This gives us greater confidence that this is a
     // typo of this candidate and not one with a similar name.
     llvm::SmallString<64> CandidateLower;
-    StringRef CandName = II->getName();
+    const StringRef CandName = II->getName();
     CandidateLower.reserve(CandName.size());
-    for (char C : CandName)
+    for (const char C : CandName)
       CandidateLower.push_back(llvm::toLower(C));
     const unsigned OtherED = ArgNameLowerRef.edit_distance(
         StringRef(CandidateLower),
@@ -363,7 +363,7 @@ void ArgumentCommentCheck::checkCallArgs(ASTContext *Ctx,
       }
     }
 
-    llvm::SmallVector<std::pair<SourceLocation, StringRef>, 4> Comments =
+    const llvm::SmallVector<std::pair<SourceLocation, StringRef>, 4> Comments =
         collectLeadingComments(Ctx, ArgBeginLoc, Args[I]);
     ArgBeginLoc = Args[I]->getEndLoc();
 
@@ -429,15 +429,15 @@ void ArgumentCommentCheck::checkRecordInitializer(ASTContext *Ctx,
       }
 
       const Expr *NextInit = InitList->getInit(InitIndex);
-      QualType InitType = NextInit->getType();
-      QualType BaseType = Base.getType();
+      const QualType InitType = NextInit->getType();
+      const QualType BaseType = Base.getType();
 
       // Check if this is an explicit initializer for the base.
       const Expr *Stripped = NextInit->IgnoreParenImpCasts();
       const auto *SubInitList = dyn_cast<InitListExpr>(Stripped);
-      bool IsExplicitSubInit =
+      const bool IsExplicitSubInit =
           SubInitList &&
-          Ctx->hasSameUnqualifiedType(SubInitList->getType(), BaseType);
+          ASTContext::hasSameUnqualifiedType(SubInitList->getType(), BaseType);
 
       if (IsExplicitSubInit) {
         unsigned SubIndex = 0;
@@ -445,7 +445,7 @@ void ArgumentCommentCheck::checkRecordInitializer(ASTContext *Ctx,
         checkRecordInitializer(Ctx, BaseRD, SubInitList, SubIndex, SubLoc);
         ArgBeginLoc = NextInit->getEndLoc();
         InitIndex++;
-      } else if (Ctx->hasSameUnqualifiedType(InitType, BaseType) ||
+      } else if (ASTContext::hasSameUnqualifiedType(InitType, BaseType) ||
                  (InitType->isRecordType() && BaseType->isRecordType() &&
                   cast<CXXRecordDecl>(InitType->getAsRecordDecl())
                       ->isDerivedFrom(cast<CXXRecordDecl>(BaseRD)))) {
@@ -476,7 +476,7 @@ void ArgumentCommentCheck::checkRecordInitializer(ASTContext *Ctx,
       continue;
     }
 
-    llvm::SmallVector<std::pair<SourceLocation, StringRef>, 4> Comments =
+    const llvm::SmallVector<std::pair<SourceLocation, StringRef>, 4> Comments =
         collectLeadingComments(Ctx, ArgBeginLoc, Arg);
     ArgBeginLoc = Arg->getEndLoc();
 

--- a/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
@@ -554,7 +554,6 @@ void ArgumentCommentCheck::check(const MatchFinder::MatchResult &Result) {
 
   if (const auto *InitList = dyn_cast<InitListExpr>(E)) {
     checkInitList(Result.Context, InitList);
-    return;
   }
 }
 

--- a/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.h
@@ -53,6 +53,8 @@ private:
                      SourceLocation ArgBeginLoc,
                      llvm::ArrayRef<const Expr *> Args);
 
+  void checkInitList(ASTContext *Ctx, const InitListExpr *InitList);
+
   bool shouldAddComment(const Expr *Arg) const;
 };
 

--- a/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.h
@@ -37,10 +37,6 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
 
-  bool shouldAddComment(const Expr *Arg) const;
-  bool isStrictMode() const { return StrictMode; }
-  llvm::Regex &getIdentRE() { return IdentRE; }
-
 private:
   const unsigned StrictMode : 1;
   const unsigned IgnoreSingleArgument : 1;
@@ -58,6 +54,11 @@ private:
                      llvm::ArrayRef<const Expr *> Args);
 
   void checkInitList(ASTContext *Ctx, const InitListExpr *InitList);
+  void checkRecordInitializer(ASTContext *Ctx, const RecordDecl *RD,
+                              const InitListExpr *InitList, unsigned &InitIndex,
+                              SourceLocation &ArgBeginLoc);
+
+  bool shouldAddComment(const Expr *Arg) const;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.h
@@ -37,6 +37,10 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
 
+  bool shouldAddComment(const Expr *Arg) const;
+  bool isStrictMode() const { return StrictMode; }
+  llvm::Regex &getIdentRE() { return IdentRE; }
+
 private:
   const unsigned StrictMode : 1;
   const unsigned IgnoreSingleArgument : 1;
@@ -54,8 +58,6 @@ private:
                      llvm::ArrayRef<const Expr *> Args);
 
   void checkInitList(ASTContext *Ctx, const InitListExpr *InitList);
-
-  bool shouldAddComment(const Expr *Arg) const;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -331,6 +331,11 @@ New check aliases
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved :doc:`bugprone-argument-comment
+  <clang-tidy/checks/bugprone/argument-comment>` check to support C++
+  aggregate initialization, including validation of comments against
+  struct field names and inheritance support.
+
 - Improved :doc:`bugprone-easily-swappable-parameters
   <clang-tidy/checks/bugprone/easily-swappable-parameters>` check by
   correcting a spelling mistake on its option

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/argument-comment.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/argument-comment.rst
@@ -19,6 +19,21 @@ that are placed right before the argument.
 
 The check tries to detect typos and suggest automated fixes for them.
 
+The check also supports C++ aggregate initialization, allowing comments to be
+validated against struct and class field names, including those inherited from
+base classes.
+
+.. code-block:: c++
+
+  struct Base { int b; };
+  struct Derived : Base { int d; };
+
+  void f() {
+    Derived d1 = {/*b=*/1, /*d=*/2}; // OK
+    Derived d2 = {/*x=*/1, /*d=*/2};
+    // warning: argument name 'x' in comment does not match parameter name 'b'
+  }
+
 Options
 -------
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/argument-comment-struct-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/argument-comment-struct-init.cpp
@@ -1,0 +1,56 @@
+// RUN: %check_clang_tidy %s bugprone-argument-comment %t
+
+struct A {
+  int x, y;
+};
+
+void testA() {
+  A a1 = {/*x=*/1, /*y=*/2};
+  A a2 = {/*y=*/1, /*x=*/2};
+  // CHECK-MESSAGES: [[@LINE-1]]:11: warning: argument name 'y' in comment does not match parameter name 'x' [bugprone-argument-comment]
+  // CHECK-MESSAGES: [[@LINE-2]]:20: warning: argument name 'x' in comment does not match parameter name 'y' [bugprone-argument-comment]
+
+  A a3 = {
+    /*x=*/1,
+    /*y=*/2
+  };
+
+  A a4 = {
+    /*y=*/1,
+    /*x=*/2
+  };
+  // CHECK-MESSAGES: [[@LINE-3]]:5: warning: argument name 'y' in comment does not match parameter name 'x' [bugprone-argument-comment]
+  // CHECK-MESSAGES: [[@LINE-3]]:5: warning: argument name 'x' in comment does not match parameter name 'y' [bugprone-argument-comment]
+}
+
+struct B {
+  int x, y, z;
+};
+
+void testB() {
+  B b1 = {/*x=*/1, /*y=*/2}; // Partial init
+  B b2 = {/*z=*/1, /*y=*/2}; // Typo x->z
+  // CHECK-MESSAGES: [[@LINE-1]]:11: warning: argument name 'z' in comment does not match parameter name 'x' [bugprone-argument-comment]
+}
+
+struct BitFields {
+  int a : 4;
+  int : 4;
+  int b : 4;
+};
+
+void testBitFields() {
+  BitFields b1 = {/*a=*/1, /*b=*/2};
+  BitFields b2 = {/*a=*/1, /*c=*/2};
+  // CHECK-MESSAGES: [[@LINE-1]]:28: warning: argument name 'c' in comment does not match parameter name 'b' [bugprone-argument-comment]
+}
+
+struct CorrectFix {
+  int long_field_name;
+  int other;
+};
+
+void testFix() {
+  CorrectFix c = {/*long_feild_name=*/1, 2};
+  // CHECK-MESSAGES: [[@LINE-1]]:19: warning: argument name 'long_feild_name' in comment does not match parameter name 'long_field_name' [bugprone-argument-comment]
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/argument-comment-struct-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/argument-comment-struct-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-argument-comment %t
+// RUN: %check_clang_tidy -std=c++17 %s bugprone-argument-comment %t
 
 struct A {
   int x, y;
@@ -53,4 +53,20 @@ struct CorrectFix {
 void testFix() {
   CorrectFix c = {/*long_feild_name=*/1, 2};
   // CHECK-MESSAGES: [[@LINE-1]]:19: warning: argument name 'long_feild_name' in comment does not match parameter name 'long_field_name' [bugprone-argument-comment]
+}
+
+struct Base {
+  int b;
+};
+
+struct Derived : Base {
+  int d;
+};
+
+void testInheritance() {
+  Derived d1 = {/*b=*/ 1, /*d=*/ 2};
+  Derived d2 = {/*x=*/ 1, /*d=*/ 2};
+  // CHECK-MESSAGES: [[@LINE-1]]:17: warning: argument name 'x' in comment does not match parameter name 'b' [bugprone-argument-comment]
+  Derived d3 = {/*b=*/ 1, /*x=*/ 2};
+  // CHECK-MESSAGES: [[@LINE-1]]:27: warning: argument name 'x' in comment does not match parameter name 'd' [bugprone-argument-comment]
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/argument-comment-struct-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/argument-comment-struct-init.cpp
@@ -29,7 +29,7 @@ struct B {
 
 void testB() {
   B b1 = {/*x=*/1, /*y=*/2}; // Partial init
-  B b2 = {/*z=*/1, /*y=*/2}; // Typo x->z
+  B b2 = {/*z=*/1, /*y=*/2};
   // CHECK-MESSAGES: [[@LINE-1]]:11: warning: argument name 'z' in comment does not match parameter name 'x' [bugprone-argument-comment]
 }
 
@@ -53,6 +53,7 @@ struct CorrectFix {
 void testFix() {
   CorrectFix c = {/*long_feild_name=*/1, 2};
   // CHECK-MESSAGES: [[@LINE-1]]:19: warning: argument name 'long_feild_name' in comment does not match parameter name 'long_field_name' [bugprone-argument-comment]
+  // CHECK-FIXES: CorrectFix c = {/*long_field_name=*/1, 2};
 }
 
 struct Base {
@@ -69,4 +70,63 @@ void testInheritance() {
   // CHECK-MESSAGES: [[@LINE-1]]:17: warning: argument name 'x' in comment does not match parameter name 'b' [bugprone-argument-comment]
   Derived d3 = {/*b=*/ 1, /*x=*/ 2};
   // CHECK-MESSAGES: [[@LINE-1]]:27: warning: argument name 'x' in comment does not match parameter name 'd' [bugprone-argument-comment]
+}
+
+
+struct DerivedExplicit : Base {
+  int d;
+};
+
+void testInheritanceExplicit() {
+  DerivedExplicit d1 = {{/*b=*/ 1}, /*d=*/ 2};
+  DerivedExplicit d2 = {{/*x=*/ 1}, /*d=*/ 2};
+  // CHECK-MESSAGES: [[@LINE-1]]:26: warning: argument name 'x' in comment does not match parameter name 'b' [bugprone-argument-comment]
+}
+
+struct DeepBase {
+  int db;
+};
+
+struct Middle : DeepBase {
+  int m;
+};
+
+struct DerivedDeep : Middle {
+  int d;
+};
+
+void testDeepInheritance() {
+  DerivedDeep d1 = {/*db=*/ 1, /*m=*/ 2, /*d=*/ 3};
+  DerivedDeep d2 = {/*x=*/ 1, /*m=*/ 2, /*d=*/ 3};
+  // CHECK-MESSAGES: [[@LINE-1]]:21: warning: argument name 'x' in comment does not match parameter name 'db' [bugprone-argument-comment]
+}
+
+struct Inner {
+  int i;
+};
+
+struct Outer {
+  Inner in;
+};
+
+void testNestedStruct() {
+  Outer o = {/*i=*/1};
+  // CHECK-MESSAGES: [[@LINE-1]]:14: warning: argument name 'i' in comment does not match parameter name 'in' [bugprone-argument-comment]
+}
+
+#define MACRO_VAL 1
+void testMacroVal() {
+  A a = {/*x=*/ MACRO_VAL, /*y=*/ 2};
+  A a2 = {/*y=*/ MACRO_VAL, /*x=*/ 2};
+  // CHECK-MESSAGES: [[@LINE-1]]:11: warning: argument name 'y' in comment does not match parameter name 'x' [bugprone-argument-comment]
+  // CHECK-MESSAGES: [[@LINE-2]]:29: warning: argument name 'x' in comment does not match parameter name 'y' [bugprone-argument-comment]
+}
+
+#define MACRO_INIT { /*x=*/ 1, /*y=*/ 2 }
+#define MACRO_INIT_BAD { /*y=*/ 1, /*x=*/ 2 }
+
+void testMacroInit() {
+  A a = MACRO_INIT;
+  A a2 = MACRO_INIT_BAD;
+  // Won't flag warnings.
 }


### PR DESCRIPTION
Closes #170921