### PR TITLE
[bazel] Improve building on/for Windows

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -2,6 +2,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load(
@@ -577,23 +579,18 @@ exports_files(
     glob(["include/**/*.td"]),
 )
 
-genrule(
+write_file(
     name = "basic_version_gen",
-    outs = ["include/clang/Basic/Version.inc"],
-    cmd = (
-        "echo '#define CLANG_VERSION {vers}' >> $@\n" +
-        "echo '#define CLANG_VERSION_MAJOR {major}' >> $@\n" +
-        "echo '#define CLANG_VERSION_MAJOR_STRING \"{major}\"' >> $@\n" +
-        "echo '#define CLANG_VERSION_MINOR {minor}' >> $@\n" +
-        "echo '#define CLANG_VERSION_PATCHLEVEL {patch}' >> $@\n" +
-        "echo '#define MAX_CLANG_ABI_COMPAT_VERSION {major}' >> $@\n" +
-        "echo '#define CLANG_VERSION_STRING \"{vers}\"' >> $@\n"
-    ).format(
-        major = LLVM_VERSION_MAJOR,
-        minor = LLVM_VERSION_MINOR,
-        patch = LLVM_VERSION_PATCH,
-        vers = PACKAGE_VERSION,
-    ),
+    out = "include/clang/Basic/Version.inc",
+    content = [
+        "#define CLANG_VERSION {}".format(PACKAGE_VERSION),
+        "#define CLANG_VERSION_MAJOR {}".format(LLVM_VERSION_MAJOR),
+        "#define CLANG_VERSION_MAJOR_STRING \"{}\"".format(LLVM_VERSION_MAJOR),
+        "#define CLANG_VERSION_MINOR {}".format(LLVM_VERSION_MINOR),
+        "#define CLANG_VERSION_PATCHLEVEL {}".format(LLVM_VERSION_PATCH),
+        "#define MAX_CLANG_ABI_COMPAT_VERSION {}".format(LLVM_VERSION_MAJOR),
+        "#define CLANG_VERSION_STRING \"{}\"".format(PACKAGE_VERSION),
+    ],
 )
 
 cc_library(
@@ -611,13 +608,15 @@ cc_library(
 
 # TODO: This should get replaced with something that actually generates the
 # correct version number.
-genrule(
+write_file(
     name = "vcs_version_gen",
     # This should be under lib/Basic, but because of how the include paths
     # are passed through bazel, it's easier to drop generated files next to
     # the other includes.
-    outs = ["include/VCSVersion.inc"],
-    cmd = "echo '#undef CLANG_REVISION' > $@",
+    out = "include/VCSVersion.inc",
+    content = [
+        "#undef CLANG_REVISION",
+    ],
 )
 
 py_binary(
@@ -979,16 +978,21 @@ cc_library(
     ],
 )
 
-genrule(
+run_binary(
     name = "analysis_htmllogger_gen",
     srcs = [
-        "lib/Analysis/FlowSensitive/HTMLLogger.html",
         "lib/Analysis/FlowSensitive/HTMLLogger.css",
+        "lib/Analysis/FlowSensitive/HTMLLogger.html",
         "lib/Analysis/FlowSensitive/HTMLLogger.js",
     ],
     outs = ["lib/Analysis/FlowSensitive/HTMLLogger.inc"],
-    cmd = "$(location :bundle_resources) $@ $(SRCS)",
-    tools = [":bundle_resources"],
+    args = [
+        "$(execpath lib/Analysis/FlowSensitive/HTMLLogger.inc)",
+        "$(execpath lib/Analysis/FlowSensitive/HTMLLogger.html)",
+        "$(execpath lib/Analysis/FlowSensitive/HTMLLogger.css)",
+        "$(execpath lib/Analysis/FlowSensitive/HTMLLogger.js)",
+    ],
+    tool = ":bundle_resources",
 )
 
 cc_library(
@@ -1549,7 +1553,9 @@ cc_library(
         "lib/Driver",
     ],
     linkopts = select({
-        "@platforms//os:windows": ["version.lib"],
+        "//llvm:is_windows_clang_mingw": ["-lversion"],
+        "//llvm:is_windows_clang_cl": ["version.lib"],
+        "//llvm:is_windows_msvc": ["version.lib"],
         "//conditions:default": [],
     }),
     textual_hdrs = glob([

--- a/utils/bazel/llvm-project-overlay/lld/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lld/BUILD.bazel
@@ -2,6 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "//:vars.bzl",
@@ -19,17 +20,21 @@ package(
 licenses(["notice"])
 
 # TODO: Actually compute version info
-genrule(
+write_file(
     name = "config_version_gen",
-    outs = ["include/lld/Common/Version.inc"],
-    cmd = "echo '#define LLD_VERSION_STRING \"{}\"' > $@".format(LLVM_VERSION),
+    out = "include/lld/Common/Version.inc",
+    content = [
+        "#define LLD_VERSION_STRING \"{}\"".format(LLVM_VERSION),
+    ],
 )
 
-genrule(
+write_file(
     name = "vcs_version_gen",
-    outs = ["Common/VCSVersion.inc"],
-    cmd = "echo '#undef LLD_REVISION' >> $@\n" +
-          "echo '#undef LLD_REPOSITORY' >> $@\n",
+    out = "Common/VCSVersion.inc",
+    content = [
+        "#undef LLD_REVISION",
+        "#undef LLD_REPOSITORY",
+    ],
 )
 
 # See https://github.com/bazelbuild/bazel/issues/13803

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2,9 +2,12 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//mlir:tblgen.bzl", "gentbl_cc_library", "gentbl_filegroup", "td_library")
@@ -208,19 +211,92 @@ cc_library(
     deps = [":config"],
 )
 
-genrule(
+write_file(
     name = "generate_vcs_revision",
-    outs = ["include/llvm/Support/VCSRevision.h"],
-    cmd = "echo '#undef LLVM_REVISION' >> $@\n" +
-          "echo '#undef LLVM_REPOSITORY' >> $@\n",
+    out = "include/llvm/Support/VCSRevision.h",
+    content = [
+        "#undef LLVM_REVISION",
+        "#undef LLVM_REPOSITORY",
+    ],
 )
 
-genrule(
+write_file(
     name = "generate_static_extension_registry",
-    outs = ["include/llvm/Support/Extension.def"],
-    cmd = "echo -e '// extension handlers' >> $@\n" +
-          "echo -e '#undef HANDLE_EXTENSION' >> $@\n",
+    out = "include/llvm/Support/Extension.def",
+    content = [
+        "// extension handlers",
+        "#undef HANDLE_EXTENSION",
+    ],
 )
+
+config_setting(
+    name = "is_windows_clang_mingw",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "clang"},
+)
+
+config_setting(
+    name = "is_windows_clang_cl",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "clang-cl"},
+)
+
+config_setting(
+    name = "is_windows_msvc",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "msvc-cl"},
+)
+
+config_setting(
+    name = "is_x86_64_windows_clang_mingw",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+    flag_values = {"@rules_cc//cc/compiler:compiler": "clang"},
+)
+
+# TODO(zbarsky): Is there a better way to express this?
+config_setting(
+    name = "_stamp_binary_on_check",
+    values = {"stamp": "1"},
+)
+
+config_setting(
+    name = "_stamp_binary_off_check",
+    values = {"stamp": "0"},
+)
+
+selects.config_setting_group(
+    name = "_true",
+    match_any = [
+        ":_stamp_binary_on_check",
+        ":_stamp_binary_off_check",
+    ],
+)
+
+alias(
+    name = "non_windows",
+    actual = select({
+        "@platforms//os:windows": "@platforms//os:macos",
+        "//conditions:default": ":_true",
+    }),
+)
+
+selects.config_setting_group(
+    name = "is_x86_64_non_windows",
+    match_all = [
+        "@platforms//cpu:x86_64",
+        ":non_windows",
+    ],
+)
+
+BLAKE3_x86_64_ASM_SOURCE_PATTERNS = [
+    "lib/Support/BLAKE3/blake3_avx2_x86-64_%s.S",
+    "lib/Support/BLAKE3/blake3_avx512_x86-64_%s.S",
+    "lib/Support/BLAKE3/blake3_sse2_x86-64_%s.S",
+    "lib/Support/BLAKE3/blake3_sse41_x86-64_%s.S",
+]
 
 cc_library(
     name = "Support",
@@ -250,11 +326,13 @@ cc_library(
         "@platforms//cpu:aarch64": [
             "lib/Support/BLAKE3/blake3_neon.c",
         ],
-        "@platforms//cpu:x86_64": [
-            "lib/Support/BLAKE3/blake3_avx2_x86-64_unix.S",
-            "lib/Support/BLAKE3/blake3_avx512_x86-64_unix.S",
-            "lib/Support/BLAKE3/blake3_sse2_x86-64_unix.S",
-            "lib/Support/BLAKE3/blake3_sse41_x86-64_unix.S",
+        ":is_x86_64_windows_clang_mingw": [
+            pattern % "windows_gnu"
+            for pattern in BLAKE3_x86_64_ASM_SOURCE_PATTERNS
+        ],
+        ":is_x86_64_non_windows": [
+            pattern % "unix"
+            for pattern in BLAKE3_x86_64_ASM_SOURCE_PATTERNS
         ],
         "//conditions:default": [
         ],
@@ -297,7 +375,21 @@ cc_library(
     }),
     includes = ["include"],
     linkopts = select({
-        "@platforms//os:windows": [
+        ":is_windows_clang_mingw": [
+            "-lole32",
+            "-luuid",
+            "-lws2_32",
+            "-lntdll",
+        ],
+        ":is_windows_clang_cl": [
+            "ole32.lib",
+            "uuid.lib",
+            "ws2_32.lib",
+            "ntdll.lib",
+        ],
+        ":is_windows_msvc": [
+            "ole32.lib",
+            "uuid.lib",
             "ws2_32.lib",
             "ntdll.lib",
         ],


### PR DESCRIPTION
Few things going on here:
- I think we should be able to use the blake3 x86-64 asm on windows with some slight adjustments (sorry it's still named *_unix.S, renaming seemed like a bit bigger project)
- `genrule` is really evil because it bakes the path to the host bash into the command, which fails spectacularly when running on a non-windows remote executor. Swap to `write_file`/`run_binary` rules to mitigate it
- The existing windows linkopts do not work correctly for clang in mingw mode

With this set of changes (as well as another one that rewrites `bundle_resources.py` into C) I am able to hermetically cross-build clang/lld/etc from a windows host to a (mingw) windows target on a linux executor, and use the resulting compilers to compile C binaries/tests (see https://github.com/dzbarsky/toolchains_llvm_bootstrapped/actions/runs/20121686105/job/57743214313?pr=1 and https://github.com/dzbarsky/toolchains_llvm_bootstrapped/pull/1)