### PR TITLE
[libc++][cmath] Adding `[[nodicard]]`

### DIFF
--- a/libcxx/include/__math/error_functions.h
+++ b/libcxx/include/__math/error_functions.h
@@ -23,33 +23,37 @@ namespace __math {
 
 // erf
 
-inline _LIBCPP_HIDE_FROM_ABI float erf(float __x) _NOEXCEPT { return __builtin_erff(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float erf(float __x) _NOEXCEPT { return __builtin_erff(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double erf(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double erf(double __x) _NOEXCEPT {
   return __builtin_erf(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double erf(long double __x) _NOEXCEPT { return __builtin_erfl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double erf(long double __x) _NOEXCEPT {
+  return __builtin_erfl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double erf(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double erf(_A1 __x) _NOEXCEPT {
   return __builtin_erf((double)__x);
 }
 
 // erfc
 
-inline _LIBCPP_HIDE_FROM_ABI float erfc(float __x) _NOEXCEPT { return __builtin_erfcf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float erfc(float __x) _NOEXCEPT { return __builtin_erfcf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double erfc(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double erfc(double __x) _NOEXCEPT {
   return __builtin_erfc(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double erfc(long double __x) _NOEXCEPT { return __builtin_erfcl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double erfc(long double __x) _NOEXCEPT {
+  return __builtin_erfcl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double erfc(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double erfc(_A1 __x) _NOEXCEPT {
   return __builtin_erfc((double)__x);
 }
 

--- a/libcxx/include/__math/exponential_functions.h
+++ b/libcxx/include/__math/exponential_functions.h
@@ -26,139 +26,155 @@ namespace __math {
 
 // exp
 
-inline _LIBCPP_HIDE_FROM_ABI float exp(float __x) _NOEXCEPT { return __builtin_expf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float exp(float __x) _NOEXCEPT { return __builtin_expf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double exp(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double exp(double __x) _NOEXCEPT {
   return __builtin_exp(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double exp(long double __x) _NOEXCEPT { return __builtin_expl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double exp(long double __x) _NOEXCEPT {
+  return __builtin_expl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double exp(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double exp(_A1 __x) _NOEXCEPT {
   return __builtin_exp((double)__x);
 }
 
 // frexp
 
-inline _LIBCPP_HIDE_FROM_ABI float frexp(float __x, int* __e) _NOEXCEPT { return __builtin_frexpf(__x, __e); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float frexp(float __x, int* __e) _NOEXCEPT {
+  return __builtin_frexpf(__x, __e);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double frexp(double __x, int* __e) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double frexp(double __x, int* __e) _NOEXCEPT {
   return __builtin_frexp(__x, __e);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double frexp(long double __x, int* __e) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double frexp(long double __x, int* __e) _NOEXCEPT {
   return __builtin_frexpl(__x, __e);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double frexp(_A1 __x, int* __e) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double frexp(_A1 __x, int* __e) _NOEXCEPT {
   return __builtin_frexp((double)__x, __e);
 }
 
 // ldexp
 
-inline _LIBCPP_HIDE_FROM_ABI float ldexp(float __x, int __e) _NOEXCEPT { return __builtin_ldexpf(__x, __e); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float ldexp(float __x, int __e) _NOEXCEPT {
+  return __builtin_ldexpf(__x, __e);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double ldexp(double __x, int __e) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double ldexp(double __x, int __e) _NOEXCEPT {
   return __builtin_ldexp(__x, __e);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double ldexp(long double __x, int __e) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double ldexp(long double __x, int __e) _NOEXCEPT {
   return __builtin_ldexpl(__x, __e);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double ldexp(_A1 __x, int __e) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double ldexp(_A1 __x, int __e) _NOEXCEPT {
   return __builtin_ldexp((double)__x, __e);
 }
 
 // exp2
 
-inline _LIBCPP_HIDE_FROM_ABI float exp2(float __x) _NOEXCEPT { return __builtin_exp2f(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float exp2(float __x) _NOEXCEPT { return __builtin_exp2f(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double exp2(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double exp2(double __x) _NOEXCEPT {
   return __builtin_exp2(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double exp2(long double __x) _NOEXCEPT { return __builtin_exp2l(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double exp2(long double __x) _NOEXCEPT {
+  return __builtin_exp2l(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double exp2(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double exp2(_A1 __x) _NOEXCEPT {
   return __builtin_exp2((double)__x);
 }
 
 // expm1
 
-inline _LIBCPP_HIDE_FROM_ABI float expm1(float __x) _NOEXCEPT { return __builtin_expm1f(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float expm1(float __x) _NOEXCEPT { return __builtin_expm1f(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double expm1(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double expm1(double __x) _NOEXCEPT {
   return __builtin_expm1(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double expm1(long double __x) _NOEXCEPT { return __builtin_expm1l(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double expm1(long double __x) _NOEXCEPT {
+  return __builtin_expm1l(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double expm1(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double expm1(_A1 __x) _NOEXCEPT {
   return __builtin_expm1((double)__x);
 }
 
 // scalbln
 
-inline _LIBCPP_HIDE_FROM_ABI float scalbln(float __x, long __y) _NOEXCEPT { return __builtin_scalblnf(__x, __y); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float scalbln(float __x, long __y) _NOEXCEPT {
+  return __builtin_scalblnf(__x, __y);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double scalbln(double __x, long __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double scalbln(double __x, long __y) _NOEXCEPT {
   return __builtin_scalbln(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double scalbln(long double __x, long __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double scalbln(long double __x, long __y) _NOEXCEPT {
   return __builtin_scalblnl(__x, __y);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double scalbln(_A1 __x, long __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double scalbln(_A1 __x, long __y) _NOEXCEPT {
   return __builtin_scalbln((double)__x, __y);
 }
 
 // scalbn
 
-inline _LIBCPP_HIDE_FROM_ABI float scalbn(float __x, int __y) _NOEXCEPT { return __builtin_scalbnf(__x, __y); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float scalbn(float __x, int __y) _NOEXCEPT {
+  return __builtin_scalbnf(__x, __y);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double scalbn(double __x, int __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double scalbn(double __x, int __y) _NOEXCEPT {
   return __builtin_scalbn(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double scalbn(long double __x, int __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double scalbn(long double __x, int __y) _NOEXCEPT {
   return __builtin_scalbnl(__x, __y);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double scalbn(_A1 __x, int __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double scalbn(_A1 __x, int __y) _NOEXCEPT {
   return __builtin_scalbn((double)__x, __y);
 }
 
 // pow
 
-inline _LIBCPP_HIDE_FROM_ABI float pow(float __x, float __y) _NOEXCEPT { return __builtin_powf(__x, __y); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float pow(float __x, float __y) _NOEXCEPT {
+  return __builtin_powf(__x, __y);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double pow(double __x, double __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double pow(double __x, double __y) _NOEXCEPT {
   return __builtin_pow(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double pow(long double __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double pow(long double __x, long double __y) _NOEXCEPT {
   return __builtin_powl(__x, __y);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> pow(_A1 __x, _A2 __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> pow(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2>;
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::pow((__result_type)__x, (__result_type)__y);

--- a/libcxx/include/__math/fdim.h
+++ b/libcxx/include/__math/fdim.h
@@ -23,19 +23,21 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace __math {
 
-inline _LIBCPP_HIDE_FROM_ABI float fdim(float __x, float __y) _NOEXCEPT { return __builtin_fdimf(__x, __y); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float fdim(float __x, float __y) _NOEXCEPT {
+  return __builtin_fdimf(__x, __y);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double fdim(double __x, double __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double fdim(double __x, double __y) _NOEXCEPT {
   return __builtin_fdim(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double fdim(long double __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double fdim(long double __x, long double __y) _NOEXCEPT {
   return __builtin_fdiml(__x, __y);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> fdim(_A1 __x, _A2 __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> fdim(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2>;
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::fdim((__result_type)__x, (__result_type)__y);

--- a/libcxx/include/__math/fma.h
+++ b/libcxx/include/__math/fma.h
@@ -23,16 +23,17 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace __math {
 
-inline _LIBCPP_HIDE_FROM_ABI float fma(float __x, float __y, float __z) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float fma(float __x, float __y, float __z) _NOEXCEPT {
   return __builtin_fmaf(__x, __y, __z);
 }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double fma(double __x, double __y, double __z) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double fma(double __x, double __y, double __z) _NOEXCEPT {
   return __builtin_fma(__x, __y, __z);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double fma(long double __x, long double __y, long double __z) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double
+fma(long double __x, long double __y, long double __z) _NOEXCEPT {
   return __builtin_fmal(__x, __y, __z);
 }
 
@@ -40,7 +41,7 @@ template <class _A1,
           class _A2,
           class _A3,
           __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value && is_arithmetic<_A3>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2, _A3> fma(_A1 __x, _A2 __y, _A3 __z) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2, _A3> fma(_A1 __x, _A2 __y, _A3 __z) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2, _A3>;
   static_assert(
       !(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value && _IsSame<_A3, __result_type>::value),

--- a/libcxx/include/__math/gamma.h
+++ b/libcxx/include/__math/gamma.h
@@ -23,17 +23,19 @@ namespace __math {
 
 // lgamma
 
-inline _LIBCPP_HIDE_FROM_ABI float lgamma(float __x) _NOEXCEPT { return __builtin_lgammaf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float lgamma(float __x) _NOEXCEPT { return __builtin_lgammaf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double lgamma(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double lgamma(double __x) _NOEXCEPT {
   return __builtin_lgamma(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double lgamma(long double __x) _NOEXCEPT { return __builtin_lgammal(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double lgamma(long double __x) _NOEXCEPT {
+  return __builtin_lgammal(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double lgamma(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double lgamma(_A1 __x) _NOEXCEPT {
   return __builtin_lgamma((double)__x);
 }
 
@@ -41,17 +43,19 @@ inline _LIBCPP_HIDE_FROM_ABI double lgamma(_A1 __x) _NOEXCEPT {
 
 // tgamma
 
-inline _LIBCPP_HIDE_FROM_ABI float tgamma(float __x) _NOEXCEPT { return __builtin_tgammaf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float tgamma(float __x) _NOEXCEPT { return __builtin_tgammaf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double tgamma(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double tgamma(double __x) _NOEXCEPT {
   return __builtin_tgamma(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double tgamma(long double __x) _NOEXCEPT { return __builtin_tgammal(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double tgamma(long double __x) _NOEXCEPT {
+  return __builtin_tgammal(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double tgamma(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double tgamma(_A1 __x) _NOEXCEPT {
   return __builtin_tgamma((double)__x);
 }
 

--- a/libcxx/include/__math/hyperbolic_functions.h
+++ b/libcxx/include/__math/hyperbolic_functions.h
@@ -23,49 +23,55 @@ namespace __math {
 
 // cosh
 
-inline _LIBCPP_HIDE_FROM_ABI float cosh(float __x) _NOEXCEPT { return __builtin_coshf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float cosh(float __x) _NOEXCEPT { return __builtin_coshf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double cosh(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double cosh(double __x) _NOEXCEPT {
   return __builtin_cosh(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double cosh(long double __x) _NOEXCEPT { return __builtin_coshl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double cosh(long double __x) _NOEXCEPT {
+  return __builtin_coshl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double cosh(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double cosh(_A1 __x) _NOEXCEPT {
   return __builtin_cosh((double)__x);
 }
 
 // sinh
 
-inline _LIBCPP_HIDE_FROM_ABI float sinh(float __x) _NOEXCEPT { return __builtin_sinhf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float sinh(float __x) _NOEXCEPT { return __builtin_sinhf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double sinh(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double sinh(double __x) _NOEXCEPT {
   return __builtin_sinh(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double sinh(long double __x) _NOEXCEPT { return __builtin_sinhl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double sinh(long double __x) _NOEXCEPT {
+  return __builtin_sinhl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double sinh(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double sinh(_A1 __x) _NOEXCEPT {
   return __builtin_sinh((double)__x);
 }
 
 // tanh
 
-inline _LIBCPP_HIDE_FROM_ABI float tanh(float __x) _NOEXCEPT { return __builtin_tanhf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float tanh(float __x) _NOEXCEPT { return __builtin_tanhf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double tanh(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double tanh(double __x) _NOEXCEPT {
   return __builtin_tanh(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double tanh(long double __x) _NOEXCEPT { return __builtin_tanhl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double tanh(long double __x) _NOEXCEPT {
+  return __builtin_tanhl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double tanh(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double tanh(_A1 __x) _NOEXCEPT {
   return __builtin_tanh((double)__x);
 }
 

--- a/libcxx/include/__math/hypot.h
+++ b/libcxx/include/__math/hypot.h
@@ -31,19 +31,21 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace __math {
 
-inline _LIBCPP_HIDE_FROM_ABI float hypot(float __x, float __y) _NOEXCEPT { return __builtin_hypotf(__x, __y); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float hypot(float __x, float __y) _NOEXCEPT {
+  return __builtin_hypotf(__x, __y);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double hypot(double __x, double __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double hypot(double __x, double __y) _NOEXCEPT {
   return __builtin_hypot(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double hypot(long double __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double hypot(long double __x, long double __y) _NOEXCEPT {
   return __builtin_hypotl(__x, __y);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> hypot(_A1 __x, _A2 __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> hypot(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2>;
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::hypot((__result_type)__x, (__result_type)__y);
@@ -79,11 +81,15 @@ _LIBCPP_HIDE_FROM_ABI _Real __hypot(_Real __x, _Real __y, _Real __z) {
   return __math::sqrt(__x * __x + __y * __y + __z * __z) / __scale;
 }
 
-inline _LIBCPP_HIDE_FROM_ABI float hypot(float __x, float __y, float __z) { return __math::__hypot(__x, __y, __z); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float hypot(float __x, float __y, float __z) {
+  return __math::__hypot(__x, __y, __z);
+}
 
-inline _LIBCPP_HIDE_FROM_ABI double hypot(double __x, double __y, double __z) { return __math::__hypot(__x, __y, __z); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double hypot(double __x, double __y, double __z) {
+  return __math::__hypot(__x, __y, __z);
+}
 
-inline _LIBCPP_HIDE_FROM_ABI long double hypot(long double __x, long double __y, long double __z) {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double hypot(long double __x, long double __y, long double __z) {
   return __math::__hypot(__x, __y, __z);
 }
 
@@ -91,7 +97,7 @@ template <class _A1,
           class _A2,
           class _A3,
           std::enable_if_t< is_arithmetic_v<_A1> && is_arithmetic_v<_A2> && is_arithmetic_v<_A3>, int> = 0 >
-_LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2, _A3> hypot(_A1 __x, _A2 __y, _A3 __z) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2, _A3> hypot(_A1 __x, _A2 __y, _A3 __z) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2, _A3>;
   static_assert(!(
       std::is_same_v<_A1, __result_type> && std::is_same_v<_A2, __result_type> && std::is_same_v<_A3, __result_type>));

--- a/libcxx/include/__math/inverse_hyperbolic_functions.h
+++ b/libcxx/include/__math/inverse_hyperbolic_functions.h
@@ -23,49 +23,55 @@ namespace __math {
 
 // acosh
 
-inline _LIBCPP_HIDE_FROM_ABI float acosh(float __x) _NOEXCEPT { return __builtin_acoshf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float acosh(float __x) _NOEXCEPT { return __builtin_acoshf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double acosh(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double acosh(double __x) _NOEXCEPT {
   return __builtin_acosh(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double acosh(long double __x) _NOEXCEPT { return __builtin_acoshl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double acosh(long double __x) _NOEXCEPT {
+  return __builtin_acoshl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double acosh(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double acosh(_A1 __x) _NOEXCEPT {
   return __builtin_acosh((double)__x);
 }
 
 // asinh
 
-inline _LIBCPP_HIDE_FROM_ABI float asinh(float __x) _NOEXCEPT { return __builtin_asinhf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float asinh(float __x) _NOEXCEPT { return __builtin_asinhf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double asinh(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double asinh(double __x) _NOEXCEPT {
   return __builtin_asinh(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double asinh(long double __x) _NOEXCEPT { return __builtin_asinhl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double asinh(long double __x) _NOEXCEPT {
+  return __builtin_asinhl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double asinh(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double asinh(_A1 __x) _NOEXCEPT {
   return __builtin_asinh((double)__x);
 }
 
 // atanh
 
-inline _LIBCPP_HIDE_FROM_ABI float atanh(float __x) _NOEXCEPT { return __builtin_atanhf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float atanh(float __x) _NOEXCEPT { return __builtin_atanhf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double atanh(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double atanh(double __x) _NOEXCEPT {
   return __builtin_atanh(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double atanh(long double __x) _NOEXCEPT { return __builtin_atanhl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double atanh(long double __x) _NOEXCEPT {
+  return __builtin_atanhl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double atanh(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double atanh(_A1 __x) _NOEXCEPT {
   return __builtin_atanh((double)__x);
 }
 

--- a/libcxx/include/__math/inverse_trigonometric_functions.h
+++ b/libcxx/include/__math/inverse_trigonometric_functions.h
@@ -26,67 +26,75 @@ namespace __math {
 
 // acos
 
-inline _LIBCPP_HIDE_FROM_ABI float acos(float __x) _NOEXCEPT { return __builtin_acosf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float acos(float __x) _NOEXCEPT { return __builtin_acosf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double acos(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double acos(double __x) _NOEXCEPT {
   return __builtin_acos(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double acos(long double __x) _NOEXCEPT { return __builtin_acosl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double acos(long double __x) _NOEXCEPT {
+  return __builtin_acosl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double acos(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double acos(_A1 __x) _NOEXCEPT {
   return __builtin_acos((double)__x);
 }
 
 // asin
 
-inline _LIBCPP_HIDE_FROM_ABI float asin(float __x) _NOEXCEPT { return __builtin_asinf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float asin(float __x) _NOEXCEPT { return __builtin_asinf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double asin(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double asin(double __x) _NOEXCEPT {
   return __builtin_asin(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double asin(long double __x) _NOEXCEPT { return __builtin_asinl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double asin(long double __x) _NOEXCEPT {
+  return __builtin_asinl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double asin(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double asin(_A1 __x) _NOEXCEPT {
   return __builtin_asin((double)__x);
 }
 
 // atan
 
-inline _LIBCPP_HIDE_FROM_ABI float atan(float __x) _NOEXCEPT { return __builtin_atanf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float atan(float __x) _NOEXCEPT { return __builtin_atanf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double atan(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double atan(double __x) _NOEXCEPT {
   return __builtin_atan(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double atan(long double __x) _NOEXCEPT { return __builtin_atanl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double atan(long double __x) _NOEXCEPT {
+  return __builtin_atanl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double atan(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double atan(_A1 __x) _NOEXCEPT {
   return __builtin_atan((double)__x);
 }
 
 // atan2
 
-inline _LIBCPP_HIDE_FROM_ABI float atan2(float __y, float __x) _NOEXCEPT { return __builtin_atan2f(__y, __x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float atan2(float __y, float __x) _NOEXCEPT {
+  return __builtin_atan2f(__y, __x);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double atan2(double __x, double __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double atan2(double __x, double __y) _NOEXCEPT {
   return __builtin_atan2(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double atan2(long double __y, long double __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double atan2(long double __y, long double __x) _NOEXCEPT {
   return __builtin_atan2l(__y, __x);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> atan2(_A1 __y, _A2 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> atan2(_A1 __y, _A2 __x) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2>;
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::atan2((__result_type)__y, (__result_type)__x);

--- a/libcxx/include/__math/logarithms.h
+++ b/libcxx/include/__math/logarithms.h
@@ -23,97 +23,107 @@ namespace __math {
 
 // log
 
-inline _LIBCPP_HIDE_FROM_ABI float log(float __x) _NOEXCEPT { return __builtin_logf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float log(float __x) _NOEXCEPT { return __builtin_logf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double log(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double log(double __x) _NOEXCEPT {
   return __builtin_log(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double log(long double __x) _NOEXCEPT { return __builtin_logl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double log(long double __x) _NOEXCEPT {
+  return __builtin_logl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double log(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double log(_A1 __x) _NOEXCEPT {
   return __builtin_log((double)__x);
 }
 
 // log10
 
-inline _LIBCPP_HIDE_FROM_ABI float log10(float __x) _NOEXCEPT { return __builtin_log10f(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float log10(float __x) _NOEXCEPT { return __builtin_log10f(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double log10(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double log10(double __x) _NOEXCEPT {
   return __builtin_log10(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double log10(long double __x) _NOEXCEPT { return __builtin_log10l(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double log10(long double __x) _NOEXCEPT {
+  return __builtin_log10l(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double log10(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double log10(_A1 __x) _NOEXCEPT {
   return __builtin_log10((double)__x);
 }
 
 // ilogb
 
-inline _LIBCPP_HIDE_FROM_ABI int ilogb(float __x) _NOEXCEPT { return __builtin_ilogbf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI int ilogb(float __x) _NOEXCEPT { return __builtin_ilogbf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI int ilogb(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI int ilogb(double __x) _NOEXCEPT {
   return __builtin_ilogb(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI int ilogb(long double __x) _NOEXCEPT { return __builtin_ilogbl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI int ilogb(long double __x) _NOEXCEPT { return __builtin_ilogbl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI int ilogb(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI int ilogb(_A1 __x) _NOEXCEPT {
   return __builtin_ilogb((double)__x);
 }
 
 // log1p
 
-inline _LIBCPP_HIDE_FROM_ABI float log1p(float __x) _NOEXCEPT { return __builtin_log1pf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float log1p(float __x) _NOEXCEPT { return __builtin_log1pf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double log1p(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double log1p(double __x) _NOEXCEPT {
   return __builtin_log1p(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double log1p(long double __x) _NOEXCEPT { return __builtin_log1pl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double log1p(long double __x) _NOEXCEPT {
+  return __builtin_log1pl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double log1p(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double log1p(_A1 __x) _NOEXCEPT {
   return __builtin_log1p((double)__x);
 }
 
 // log2
 
-inline _LIBCPP_HIDE_FROM_ABI float log2(float __x) _NOEXCEPT { return __builtin_log2f(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float log2(float __x) _NOEXCEPT { return __builtin_log2f(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double log2(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double log2(double __x) _NOEXCEPT {
   return __builtin_log2(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double log2(long double __x) _NOEXCEPT { return __builtin_log2l(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double log2(long double __x) _NOEXCEPT {
+  return __builtin_log2l(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double log2(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double log2(_A1 __x) _NOEXCEPT {
   return __builtin_log2((double)__x);
 }
 
 // logb
 
-inline _LIBCPP_HIDE_FROM_ABI float logb(float __x) _NOEXCEPT { return __builtin_logbf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float logb(float __x) _NOEXCEPT { return __builtin_logbf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double logb(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double logb(double __x) _NOEXCEPT {
   return __builtin_logb(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double logb(long double __x) _NOEXCEPT { return __builtin_logbl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double logb(long double __x) _NOEXCEPT {
+  return __builtin_logbl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double logb(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double logb(_A1 __x) _NOEXCEPT {
   return __builtin_logb((double)__x);
 }
 

--- a/libcxx/include/__math/modulo.h
+++ b/libcxx/include/__math/modulo.h
@@ -25,19 +25,21 @@ namespace __math {
 
 // fmod
 
-inline _LIBCPP_HIDE_FROM_ABI float fmod(float __x, float __y) _NOEXCEPT { return __builtin_fmodf(__x, __y); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float fmod(float __x, float __y) _NOEXCEPT {
+  return __builtin_fmodf(__x, __y);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double fmod(double __x, double __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double fmod(double __x, double __y) _NOEXCEPT {
   return __builtin_fmod(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double fmod(long double __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double fmod(long double __x, long double __y) _NOEXCEPT {
   return __builtin_fmodl(__x, __y);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> fmod(_A1 __x, _A2 __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> fmod(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2>;
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::fmod((__result_type)__x, (__result_type)__y);
@@ -45,14 +47,16 @@ inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> fmod(_A1 __x, _A2 __y) _NOEXC
 
 // modf
 
-inline _LIBCPP_HIDE_FROM_ABI float modf(float __x, float* __y) _NOEXCEPT { return __builtin_modff(__x, __y); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float modf(float __x, float* __y) _NOEXCEPT {
+  return __builtin_modff(__x, __y);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double modf(double __x, double* __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double modf(double __x, double* __y) _NOEXCEPT {
   return __builtin_modf(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double modf(long double __x, long double* __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double modf(long double __x, long double* __y) _NOEXCEPT {
   return __builtin_modfl(__x, __y);
 }
 

--- a/libcxx/include/__math/remainder.h
+++ b/libcxx/include/__math/remainder.h
@@ -25,19 +25,21 @@ namespace __math {
 
 // remainder
 
-inline _LIBCPP_HIDE_FROM_ABI float remainder(float __x, float __y) _NOEXCEPT { return __builtin_remainderf(__x, __y); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float remainder(float __x, float __y) _NOEXCEPT {
+  return __builtin_remainderf(__x, __y);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double remainder(double __x, double __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double remainder(double __x, double __y) _NOEXCEPT {
   return __builtin_remainder(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double remainder(long double __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double remainder(long double __x, long double __y) _NOEXCEPT {
   return __builtin_remainderl(__x, __y);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> remainder(_A1 __x, _A2 __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> remainder(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2>;
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::remainder((__result_type)__x, (__result_type)__y);
@@ -45,21 +47,22 @@ inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> remainder(_A1 __x, _A2 __y) _
 
 // remquo
 
-inline _LIBCPP_HIDE_FROM_ABI float remquo(float __x, float __y, int* __z) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float remquo(float __x, float __y, int* __z) _NOEXCEPT {
   return __builtin_remquof(__x, __y, __z);
 }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double remquo(double __x, double __y, int* __z) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double remquo(double __x, double __y, int* __z) _NOEXCEPT {
   return __builtin_remquo(__x, __y, __z);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double remquo(long double __x, long double __y, int* __z) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double
+remquo(long double __x, long double __y, int* __z) _NOEXCEPT {
   return __builtin_remquol(__x, __y, __z);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> remquo(_A1 __x, _A2 __y, int* __z) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> remquo(_A1 __x, _A2 __y, int* __z) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2>;
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::remquo((__result_type)__x, (__result_type)__y, __z);

--- a/libcxx/include/__math/roots.h
+++ b/libcxx/include/__math/roots.h
@@ -23,17 +23,19 @@ namespace __math {
 
 // sqrt
 
-inline _LIBCPP_HIDE_FROM_ABI float sqrt(float __x) _NOEXCEPT { return __builtin_sqrtf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float sqrt(float __x) _NOEXCEPT { return __builtin_sqrtf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double sqrt(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double sqrt(double __x) _NOEXCEPT {
   return __builtin_sqrt(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double sqrt(long double __x) _NOEXCEPT { return __builtin_sqrtl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double sqrt(long double __x) _NOEXCEPT {
+  return __builtin_sqrtl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double sqrt(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double sqrt(_A1 __x) _NOEXCEPT {
   return __builtin_sqrt((double)__x);
 }
 

--- a/libcxx/include/__math/rounding_functions.h
+++ b/libcxx/include/__math/rounding_functions.h
@@ -62,65 +62,71 @@ template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 
 // llrint
 
-inline _LIBCPP_HIDE_FROM_ABI long long llrint(float __x) _NOEXCEPT { return __builtin_llrintf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long long llrint(float __x) _NOEXCEPT { return __builtin_llrintf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI long long llrint(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI long long llrint(double __x) _NOEXCEPT {
   return __builtin_llrint(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long long llrint(long double __x) _NOEXCEPT { return __builtin_llrintl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long long llrint(long double __x) _NOEXCEPT {
+  return __builtin_llrintl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI long long llrint(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long long llrint(_A1 __x) _NOEXCEPT {
   return __builtin_llrint((double)__x);
 }
 
 // llround
 
-inline _LIBCPP_HIDE_FROM_ABI long long llround(float __x) _NOEXCEPT { return __builtin_llroundf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long long llround(float __x) _NOEXCEPT {
+  return __builtin_llroundf(__x);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI long long llround(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI long long llround(double __x) _NOEXCEPT {
   return __builtin_llround(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long long llround(long double __x) _NOEXCEPT { return __builtin_llroundl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long long llround(long double __x) _NOEXCEPT {
+  return __builtin_llroundl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI long long llround(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long long llround(_A1 __x) _NOEXCEPT {
   return __builtin_llround((double)__x);
 }
 
 // lrint
 
-inline _LIBCPP_HIDE_FROM_ABI long lrint(float __x) _NOEXCEPT { return __builtin_lrintf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long lrint(float __x) _NOEXCEPT { return __builtin_lrintf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI long lrint(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI long lrint(double __x) _NOEXCEPT {
   return __builtin_lrint(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long lrint(long double __x) _NOEXCEPT { return __builtin_lrintl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long lrint(long double __x) _NOEXCEPT { return __builtin_lrintl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI long lrint(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long lrint(_A1 __x) _NOEXCEPT {
   return __builtin_lrint((double)__x);
 }
 
 // lround
 
-inline _LIBCPP_HIDE_FROM_ABI long lround(float __x) _NOEXCEPT { return __builtin_lroundf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long lround(float __x) _NOEXCEPT { return __builtin_lroundf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI long lround(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI long lround(double __x) _NOEXCEPT {
   return __builtin_lround(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long lround(long double __x) _NOEXCEPT { return __builtin_lroundl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long lround(long double __x) _NOEXCEPT { return __builtin_lroundl(__x); }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI long lround(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long lround(_A1 __x) _NOEXCEPT {
   return __builtin_lround((double)__x);
 }
 
@@ -146,19 +152,21 @@ template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 
 // nextafter
 
-inline _LIBCPP_HIDE_FROM_ABI float nextafter(float __x, float __y) _NOEXCEPT { return __builtin_nextafterf(__x, __y); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float nextafter(float __x, float __y) _NOEXCEPT {
+  return __builtin_nextafterf(__x, __y);
+}
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double nextafter(double __x, double __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double nextafter(double __x, double __y) _NOEXCEPT {
   return __builtin_nextafter(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double nextafter(long double __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double nextafter(long double __x, long double __y) _NOEXCEPT {
   return __builtin_nextafterl(__x, __y);
 }
 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> nextafter(_A1 __x, _A2 __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> nextafter(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = __promote_t<_A1, _A2>;
   static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::nextafter((__result_type)__x, (__result_type)__y);
@@ -166,21 +174,21 @@ inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> nextafter(_A1 __x, _A2 __y) _
 
 // nexttoward
 
-inline _LIBCPP_HIDE_FROM_ABI float nexttoward(float __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float nexttoward(float __x, long double __y) _NOEXCEPT {
   return __builtin_nexttowardf(__x, __y);
 }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double nexttoward(double __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double nexttoward(double __x, long double __y) _NOEXCEPT {
   return __builtin_nexttoward(__x, __y);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double nexttoward(long double __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double nexttoward(long double __x, long double __y) _NOEXCEPT {
   return __builtin_nexttowardl(__x, __y);
 }
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double nexttoward(_A1 __x, long double __y) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double nexttoward(_A1 __x, long double __y) _NOEXCEPT {
   return __builtin_nexttoward((double)__x, __y);
 }
 

--- a/libcxx/include/__math/special_functions.h
+++ b/libcxx/include/__math/special_functions.h
@@ -59,21 +59,29 @@ _LIBCPP_HIDE_FROM_ABI _Real __hermite(unsigned __n, _Real __x) {
   // NOLINTEND(readability-identifier-naming)
 }
 
-inline _LIBCPP_HIDE_FROM_ABI double hermite(unsigned __n, double __x) { return std::__hermite(__n, __x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double hermite(unsigned __n, double __x) {
+  return std::__hermite(__n, __x);
+}
 
-inline _LIBCPP_HIDE_FROM_ABI float hermite(unsigned __n, float __x) {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float hermite(unsigned __n, float __x) {
   // use double internally -- float is too prone to overflow!
   return static_cast<float>(std::hermite(__n, static_cast<double>(__x)));
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double hermite(unsigned __n, long double __x) { return std::__hermite(__n, __x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double hermite(unsigned __n, long double __x) {
+  return std::__hermite(__n, __x);
+}
 
-inline _LIBCPP_HIDE_FROM_ABI float hermitef(unsigned __n, float __x) { return std::hermite(__n, __x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float hermitef(unsigned __n, float __x) {
+  return std::hermite(__n, __x);
+}
 
-inline _LIBCPP_HIDE_FROM_ABI long double hermitel(unsigned __n, long double __x) { return std::hermite(__n, __x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double hermitel(unsigned __n, long double __x) {
+  return std::hermite(__n, __x);
+}
 
 template <class _Integer, std::enable_if_t<std::is_integral_v<_Integer>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI double hermite(unsigned __n, _Integer __x) {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double hermite(unsigned __n, _Integer __x) {
   return std::hermite(__n, static_cast<double>(__x));
 }
 

--- a/libcxx/include/__math/trigonometric_functions.h
+++ b/libcxx/include/__math/trigonometric_functions.h
@@ -23,49 +23,55 @@ namespace __math {
 
 // cos
 
-inline _LIBCPP_HIDE_FROM_ABI float cos(float __x) _NOEXCEPT { return __builtin_cosf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float cos(float __x) _NOEXCEPT { return __builtin_cosf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double cos(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double cos(double __x) _NOEXCEPT {
   return __builtin_cos(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double cos(long double __x) _NOEXCEPT { return __builtin_cosl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double cos(long double __x) _NOEXCEPT {
+  return __builtin_cosl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double cos(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double cos(_A1 __x) _NOEXCEPT {
   return __builtin_cos((double)__x);
 }
 
 // sin
 
-inline _LIBCPP_HIDE_FROM_ABI float sin(float __x) _NOEXCEPT { return __builtin_sinf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float sin(float __x) _NOEXCEPT { return __builtin_sinf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double sin(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double sin(double __x) _NOEXCEPT {
   return __builtin_sin(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double sin(long double __x) _NOEXCEPT { return __builtin_sinl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double sin(long double __x) _NOEXCEPT {
+  return __builtin_sinl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double sin(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double sin(_A1 __x) _NOEXCEPT {
   return __builtin_sin((double)__x);
 }
 
 // tan
 
-inline _LIBCPP_HIDE_FROM_ABI float tan(float __x) _NOEXCEPT { return __builtin_tanf(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float tan(float __x) _NOEXCEPT { return __builtin_tanf(__x); }
 
 template <class = int>
-_LIBCPP_HIDE_FROM_ABI double tan(double __x) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI double tan(double __x) _NOEXCEPT {
   return __builtin_tan(__x);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double tan(long double __x) _NOEXCEPT { return __builtin_tanl(__x); }
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long double tan(long double __x) _NOEXCEPT {
+  return __builtin_tanl(__x);
+}
 
 template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI double tan(_A1 __x) _NOEXCEPT {
+[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI double tan(_A1 __x) _NOEXCEPT {
   return __builtin_tan((double)__x);
 }
 

--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -586,21 +586,23 @@ _LIBCPP_HIDE_FROM_ABI constexpr _Fp __lerp(_Fp __a, _Fp __b, _Fp __t) noexcept {
     return __x < __b ? __x : __b;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr float lerp(float __a, float __b, float __t) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI inline constexpr float lerp(float __a, float __b, float __t) _NOEXCEPT {
   return __lerp(__a, __b, __t);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr double lerp(double __a, double __b, double __t) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI inline constexpr double lerp(double __a, double __b, double __t) _NOEXCEPT {
   return __lerp(__a, __b, __t);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr long double lerp(long double __a, long double __b, long double __t) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI inline constexpr long double
+lerp(long double __a, long double __b, long double __t) _NOEXCEPT {
   return __lerp(__a, __b, __t);
 }
 
 template <class _A1, class _A2, class _A3>
   requires(is_arithmetic_v<_A1> && is_arithmetic_v<_A2> && is_arithmetic_v<_A3>)
-_LIBCPP_HIDE_FROM_ABI inline constexpr __promote_t<_A1, _A2, _A3> lerp(_A1 __a, _A2 __b, _A3 __t) noexcept {
+[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI inline constexpr __promote_t<_A1, _A2, _A3>
+lerp(_A1 __a, _A2 __b, _A3 __t) noexcept {
   using __result_type = __promote_t<_A1, _A2, _A3>;
   static_assert(!(
       _IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value && _IsSame<_A3, __result_type>::value));

--- a/libcxx/test/libcxx/diagnostics/cmath.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/cmath.nodiscard.verify.cpp
@@ -6,162 +6,483 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // We don't control the implementation of the math.h functions on windows
 // UNSUPPORTED: windows
 
+// Check that functions are marked `[[nodiscard]]`.
 // Check that functions from `<cmath>` that Clang marks with the `[[gnu::const]]` attribute are declared
 // `[[nodiscard]]`.
 
-// clang-format off
-
 #include <cmath>
+
 #include "test_macros.h"
 
 void test() {
-  // These tests rely on Clang's behaviour of adding `[[gnu::const]]` to the double overload of most of the functions
-  // below.
-  // Without that attribute being added implicitly, this test can't be checked consistently because its result depends
-  // on whether we're getting libc++'s own `std::foo(double)` or the underlying C library's `foo(double)`.
-#ifdef TEST_COMPILER_CLANG
-  std::ceil(0.);                 // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::fabs(0.);                 // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::floor(0.);                // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::cbrt(0.);                 // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::copysign(0., 0.);         // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::fmax(0., 0.);             // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::fmin(0., 0.);             // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::nearbyint(0.);            // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::rint(0.);                 // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::round(0.);                // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
-  std::trunc(0.);                // expected-warning-re {{ignoring return value of function declared with {{.*}} attribute}}
+  // Some tests rely on Clang's behaviour of adding `[[gnu::const]]` to the double overload of most of the functions
+  // below. Without that attribute being added implicitly, this test can't be checked consistently because its result
+  // depends on whether we're getting libc++'s own `std::foo(double)` or the underlying C library's `foo(double)`, e.g.
+  // std::fabs(double).
+
+  // Functions
+
+  std::fabs(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fabs(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::fabs(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fabs(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Floating point manipulation functions
+
+  std::copysign(0.F, 0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::copysign(0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::copysign(0U, 0U);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Error functions
+
+  std::erf(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::erf(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::erf(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::erf(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::erfc(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::erfc(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::erfc(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::erfc(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Exponential functions
+
+  std::exp(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::exp(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::exp(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::exp(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Floating point manipulation functions
+
+  int* iPtr = nullptr;
+
+  std::frexp(0.F, iPtr); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::frexp(0., iPtr); /// expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::frexp(0.L, iPtr); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::frexp(0U, iPtr);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::ldexp(0.F, 2); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::ldexp(0., 2);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::ldexp(0.L, 2); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::ldexp(0U, 2);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Exponential functions
+
+  std::exp2(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::exp2(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::exp2(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::exp2(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::expm1(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::expm1(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::expm1(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::expm1(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Floating point manipulation functions
+
+  std::scalbln(0.F, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::scalbln(0., 0.L); // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::scalbln(0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::scalbln(0U, 0.L);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::scalbn(0.F, 0); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::scalbn(0., 0);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::scalbn(0.L, 0); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::scalbn(0U, 0);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Power functions
+
+  std::pow(0.F, 0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::pow(0., 0.);   // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::pow(0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::pow(0U, 0U);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Basic operations
+
+  std::fdim(0.F, 0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fdim(0., 0.);   // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::fdim(0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fdim(0U, 0U);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::fma(0.F, 0.F, 0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fma(0., 0., 0.); // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::fma(0.L, 0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fma(0U, 0U, 0U);    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Error functions
+
+  std::lgamma(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::lgamma(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::lgamma(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::lgamma(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::tgamma(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::tgamma(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::tgamma(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::tgamma(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Hyperbolic functions
+
+  std::cosh(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::cosh(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::cosh(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::cosh(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::sinh(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::sinh(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::sinh(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::sinh(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::tanh(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::tanh(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::tanh(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::tanh(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Power functions
+
+  std::hypot(0.F, 0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hypot(0., 0.);   // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::hypot(0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hypot(0U, 0U);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+#if TEST_STD_VER >= 17
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hypot(0.F, 0.F, 0.F);
+  // // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::hypot(0., 0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hypot(0.L, 0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hypot(0U, 0U, 0U);
+#endif // _LIBCPP_STD_VER >= 17
+
+  // Hyperbolic functions
+
+  std::acosh(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::acosh(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::acosh(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::acosh(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::asinh(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::asinh(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::asinh(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::asinh(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::atanh(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::atanh(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::atanh(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::atanh(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Trigonometric functions
+
+  std::acos(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::acos(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::acos(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::acos(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::asin(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::asin(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::asin(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::asin(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::atan(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::atan(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::atan(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::atan(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::atan2(0.F, 0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::atan2(0., 0.);   // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::atan2(0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::atan2(0U, 0U);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Exponential functions
+
+  std::log(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::log(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::log(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::log(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::log10(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::log10(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::log10(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::log10(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::ilogb(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::ilogb(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::ilogb(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::ilogb(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::log1p(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::log1p(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::log1p(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::log1p(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::log2(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::log2(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::log2(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::log2(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::logb(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::logb(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::logb(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::logb(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Basic operations
+
+  std::fmax(0.F, 0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fmax(0., 0.);   // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::fmax(0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fmax(0U, 0U);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::fmin(0.F, 0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fmin(0., 0.);   // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::fmin(0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fmin(0U, 0U);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::fmod(0.F, 0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fmod(0., 0.);   // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::fmod(0.L, 0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fmod(0U, 0U);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  float* fPtr       = nullptr;
+  double* dPtr      = nullptr;
+  long double* lPtr = nullptr;
+
+  std::modf(0.F, fPtr); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::modf(0., dPtr);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::modf(0.L, lPtr); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::remainder(0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::remainder(0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::remainder(0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::remainder(0U, 0U);
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::remquo(0.F, 0.F, iPtr);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::remquo(0., 0., iPtr);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::remquo(0.L, 0.L, iPtr);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::remquo(0U, 0U, iPtr);
+
+  // Power functions
+
+  std::sqrt(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::sqrt(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::sqrt(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::sqrt(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::cbrt(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::cbrt(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::cbrt(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::cbrt(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // Nearest integer floating point operations
+
+  std::ceil(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::ceil(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::ceil(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::ceil(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::floor(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::floor(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::floor(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::floor(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::llrint(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::llrint(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::llrint(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::llrint(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::llround(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::llround(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::llround(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::llround(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::lrint(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::lrint(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::lrint(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::lrint(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::lround(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::lround(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::lround(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::lround(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::nearbyint(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::nearbyint(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::nearbyint(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::nearbyint(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::nextafter(0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::nextafter(0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::nextafter(0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::nextafter(0U, 0U);
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::nexttoward(0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::nexttoward(0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::nexttoward(0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::nexttoward(0U, 0U);
+
+  std::rint(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::rint(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::rint(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::rint(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::round(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::round(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::round(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::round(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::trunc(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::trunc(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::trunc(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::trunc(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+#if TEST_STD_VER >= 17
+  // Mathematical special functions
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hermite(0U, 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hermite(0U, 0.F);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hermite(0U, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hermitef(0U, 0.F);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hermitel(0U, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::hermite(0U, 0U);
+#endif // TEST_STD_VER >= 17
+
+  std::signbit(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::signbit(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::signbit(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::signbit(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::isfinite(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isfinite(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::isfinite(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isfinite(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::isinf(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isinf(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::isinf(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isinf(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::isnan(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isnan(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::isnan(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isnan(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::isnormal(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isnormal(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::isnormal(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isnormal(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isgreater(0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::isgreater(0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isgreater(0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isgreater(0U, 0U);
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isgreaterequal(0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::isgreaterequal(0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isgreaterequal(0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isgreaterequal(0U, 0U);
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isless(0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::isless(0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isless(0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isless(0U, 0U);
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::islessequal(0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::islessequal(0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::islessequal(0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::islessequal(0U, 0U);
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::islessgreater(0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::islessgreater(0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::islessgreater(0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::islessgreater(0U, 0U);
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isunordered(0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::isunordered(0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isunordered(0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::isunordered(0U, 0U);
+
+  // Trigonometric functions
+
+  std::cos(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::cos(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::cos(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::cos(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::sin(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::sin(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::sin(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::sin(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  std::tan(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::tan(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::tan(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::tan(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+  // [c.math.lerp], linear interpolation
+
+#if TEST_STD_VER >= 20
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::lerp(0.F, 0.F, 0.F);
+  // expected-warning-re@+1 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::lerp(0., 0., 0.);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::lerp(0.L, 0.L, 0.L);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::lerp(0U, 0U, 0U);
 #endif
 
-  std::signbit(0.f);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::signbit(0.);              // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::signbit(0.l);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::signbit(0);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::signbit(0U);              // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::fpclassify(0.f);          // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fpclassify(0.);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fpclassify(0.l);          // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fpclassify(0);            // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fpclassify(0U);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::isfinite(0.f);            // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isfinite(0.);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isfinite(0.l);            // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isfinite(0);              // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isfinite(0U);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::isinf(0.f);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isinf(0.);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isinf(0.l);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isinf(0);                 // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isinf(0U);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::isnan(0.f);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isnan(0.);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isnan(0.l);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isnan(0);                 // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isnan(0U);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::isnormal(0.f);            // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isnormal(0.);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isnormal(0.l);            // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isnormal(0);              // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isnormal(0U);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::isgreater(0.f, 0.f);      // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isgreater(0., 0.);        // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isgreater(0.l, 0.l);      // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isgreater(0, 0);          // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isgreater(0U, 0U);        // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::isgreaterequal(0.f, 0.f); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isgreaterequal(0., 0.);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isgreaterequal(0.l, 0.l); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isgreaterequal(0, 0);     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isgreaterequal(0U, 0U);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::isless(0.f, 0.f);         // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isless(0., 0.);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isless(0.l, 0.l);         // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isless(0, 0);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isless(0U, 0U);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::islessequal(0.f, 0.f);    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::islessequal(0., 0.);      // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::islessequal(0.l, 0.l);    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::islessequal(0, 0);        // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::islessequal(0U, 0U);      // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::islessgreater(0.f, 0.f);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::islessgreater(0., 0.);    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::islessgreater(0.l, 0.l);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::islessgreater(0, 0);      // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::islessgreater(0U, 0U);    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::isunordered(0.f, 0.f);    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isunordered(0., 0.);      // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isunordered(0.l, 0.l);    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isunordered(0, 0);        // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::isunordered(0U, 0U);      // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::ceil(0.f);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::ceil(0.l);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::ceil(0);                  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::ceil(0U);                 // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::fabs(0.f);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fabs(0.l);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fabs(0);                  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fabs(0U);                 // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::floor(0.f);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::floor(0.l);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::floor(0);                 // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::floor(0U);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::cbrt(0.f);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::cbrt(0.l);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::cbrt(0);                  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::cbrt(0U);                 // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::copysign(0.f, 0.f);       // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::copysign(0.l, 0.l);       // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::copysign(0, 0);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::copysign(0U, 0U);         // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::fmax(0.f, 0.f);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fmax(0.l, 0.l);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fmax(0, 0);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fmax(0U, 0U);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::fmin(0.f, 0.f);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fmin(0.l, 0.l);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fmin(0, 0);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::fmin(0U, 0U);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::nearbyint(0.f);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::nearbyint(0.l);           // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::nearbyint(0);             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::nearbyint(0U);            // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::rint(0.f);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::rint(0.l);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::rint(0);                  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::rint(0U);                 // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::round(0.f);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::round(0.l);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::round(0);                 // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::round(0U);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-
-  std::trunc(0.f);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::trunc(0.l);               // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::trunc(0);                 // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::trunc(0U);                // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fpclassify(0.F); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fpclassify(0.);  // expected-warning-re 0-1 {{ignoring return value of function declared with {{.*}} attribute}}
+  std::fpclassify(0.L); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::fpclassify(0U);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
 }

--- a/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
@@ -859,7 +859,7 @@ struct test_two_args {
     (void)::remainder(T(), U());
     int ip;
     ASSERT_SAME_TYPE(decltype(::remquo(T(), U(), &ip)), PromoteResult);
-    ::remquo(T(), U(), &ip);
+    (void)::remquo(T(), U(), &ip);
   }
 };
 


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

- https://libcxx.llvm.org/CodingGuidelines.htm
- https://wg21.link/c.math