### PR TITLE
[alpha.webkit.UncountedLocalVarsChecker] Ignore a VarDecl in "if" with trivial "then"

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -573,6 +573,15 @@ public:
     });
   }
 
+  bool IsStatementTrivial(const Stmt* S) {
+    auto CacheIt = Cache.find(S);
+    if (CacheIt != Cache.end())
+      return CacheIt->second;
+    bool Result = Visit(S);
+    Cache[S] = Result;
+    return Result;
+  }
+
   bool VisitStmt(const Stmt *S) {
     // All statements are non-trivial unless overriden later.
     // Don't even recurse into children by default.
@@ -876,9 +885,7 @@ bool TrivialFunctionAnalysis::isTrivialImpl(
 bool TrivialFunctionAnalysis::isTrivialImpl(
     const Stmt *S, TrivialFunctionAnalysis::CacheTy &Cache) {
   TrivialFunctionAnalysisVisitor V(Cache);
-  bool Result = V.Visit(S);
-  assert(Cache.contains(S) && "Top-level statement not properly cached!");
-  return Result;
+  return V.IsStatementTrivial(S);
 }
 
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -573,7 +573,7 @@ public:
     });
   }
 
-  bool IsStatementTrivial(const Stmt* S) {
+  bool IsStatementTrivial(const Stmt *S) {
     auto CacheIt = Cache.find(S);
     if (CacheIt != Cache.end())
       return CacheIt->second;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -235,6 +235,10 @@ public:
 
       bool TraverseIfStmt(IfStmt *IS) override {
         if (IS->getConditionVariable()) {
+          // This code currently does not explicitly check the "else" statement
+          // since getConditionVariable returns nullptr when there is a
+          // condition defined after ";" as in "if (auto foo = ~; !foo)". If
+          // this semantics change, we should add an explicit check for "else".
           if (auto *Then = IS->getThen(); !Then || TFA.isTrivial(Then))
             return true;
         }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -234,6 +234,10 @@ public:
       }
 
       bool TraverseIfStmt(IfStmt *IS) override {
+        if (IS->getConditionVariable()) {
+          if (auto *Then = IS->getThen(); !Then || TFA.isTrivial(Then))
+            return true;
+        }
         if (!TFA.isTrivial(IS))
           return DynamicRecursiveASTVisitor::TraverseIfStmt(IS);
         return true;

--- a/clang/test/Analysis/Checkers/WebKit/local-vars-checked-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/local-vars-checked-const-member.cpp
@@ -21,10 +21,8 @@ public:
   CheckedObj& ensureObj4() {
     if (!m_obj4)
       const_cast<CheckedPtr<CheckedObj>&>(m_obj4) = new CheckedObj;
-    if (auto* next = m_obj4->next()) {
-      // expected-warning@-1{{Local variable 'next' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    if (auto* next = m_obj4->next())
       return *next;
-    }
     return *m_obj4;
   }
 

--- a/clang/test/Analysis/Checkers/WebKit/local-vars-counted-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/local-vars-counted-const-member.cpp
@@ -21,10 +21,8 @@ public:
   RefCountable& ensureObj4() {
     if (!m_obj4)
       const_cast<RefPtr<RefCountable>&>(m_obj4) = RefCountable::create();
-    if (auto* next = m_obj4->next()) {
-      // expected-warning@-1{{Local variable 'next' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    if (auto* next = m_obj4->next())
       return *next;
-    }
     return *m_obj4;
   }
 

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -534,7 +534,7 @@ namespace vardecl_in_if_condition {
     if (auto* obj = provide(); !obj) // expected-warning@{{Local variable 'obj' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
       return nullptr;
     else
-      return obj;
+      return obj->next();
   }
 
 }

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -493,3 +493,41 @@ namespace virtual_function {
     // expected-warning@-1{{Local variable 'baz' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
   }
 }
+
+namespace vardecl_in_if_condition {
+  RefCountable* provide();
+
+  RefCountable* get() {
+    if (auto* obj = provide())
+      return obj; // no warning
+    return nullptr;
+  }
+
+  RefCountable* get_non_trivial_then() {
+    if (auto* obj = provide()) // expected-warning{{Local variable 'obj' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+      return obj->next();
+    return nullptr;
+  }
+
+  RefCountable* get_non_trivial_else() {
+    if (auto* obj = provide())
+      return obj;
+    else
+      return provide()->next();
+    return nullptr;
+  }
+
+  RefCountable& get_ref() {
+    if (auto* obj = provide())
+      return *obj; // no warning
+    static Ref<RefCountable> empty = RefCountable::create();
+    return empty.get();
+  }
+
+  RefCountable* get_non_trivial_condition() {
+    if (auto* obj = provide(); obj && obj->next())
+      return obj; // expected-warning@-1{{Local variable 'obj' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    return nullptr;
+  }
+
+}

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -530,4 +530,11 @@ namespace vardecl_in_if_condition {
     return nullptr;
   }
 
+  RefCountable* get_non_trivial_else() {
+    if (auto* obj = provide(); !obj) // expected-warning@{{Local variable 'obj' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+      return nullptr;
+    else
+      return obj;
+  }
+
 }

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -530,8 +530,8 @@ namespace vardecl_in_if_condition {
     return nullptr;
   }
 
-  RefCountable* get_non_trivial_else() {
-    if (auto* obj = provide(); !obj) // expected-warning@{{Local variable 'obj' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  RefCountable* get_non_trivial_else2() {
+    if (auto* obj = provide(); !obj) // expected-warning{{Local variable 'obj' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
       return nullptr;
     else
       return obj->next();


### PR DESCRIPTION
Don't emit a warning when a variable declaration appears within the "if" condition and if its "then" statement is trivial.