### PR TITLE
[CIR] Add newly implemented defer stmt class to nyi

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -289,6 +289,7 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
   case Stmt::OMPStripeDirectiveClass:
   case Stmt::ObjCAtCatchStmtClass:
   case Stmt::ObjCAtFinallyStmtClass:
+  case Stmt::DeferStmtClass:
     cgm.errorNYI(s->getSourceRange(),
                  std::string("emitStmt: ") + s->getStmtClassName());
     return mlir::failure();


### PR DESCRIPTION
The following warning turns into an error on the ci/cd

```
/Users/jjasmine/Developer/igalia/llvm-project/clang/lib/CIR/CodeGen/CIRGenStmt.cpp:117:11: warning: enumeration value 'DeferStmtClass' not handled in switch [-Wswitch]
  117 |   switch (s->getStmtClass()) {
      |           ^~~~~~~~~~~~~~~~~
1 warning generated.
```