### PR TITLE
[RISCV] Use SP-relative Accesses with frame pointers

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
@@ -753,8 +753,17 @@ int64_t RISCVRegisterInfo::getFrameIndexInstrOffset(const MachineInstr *MI,
 }
 
 Register RISCVRegisterInfo::getFrameRegister(const MachineFunction &MF) const {
-  const TargetFrameLowering *TFI = getFrameLowering(MF);
-  return TFI->hasFP(MF) ? RISCV::X8 : RISCV::X2;
+  // This approximates most of the checks in `RISCVFrameLowering::hasFPImpl`,
+  // except that if you have forced frame pointers with a flag, but otherwise
+  // could have eliminated them, then we will use the stack pointer as we are
+  // better at compressing sp-relative accesses.
+  //
+  // We have to use a frame pointer for:
+  // - Stack Realignment
+  // - Variable Sized Objects
+  const MachineFrameInfo &MFI = MF.getFrameInfo();
+  return (hasStackRealignment(MF) || MFI.hasVarSizedObjects()) ? RISCV::X8
+                                                               : RISCV::X2;
 }
 
 StringRef RISCVRegisterInfo::getRegAsmName(MCRegister Reg) const {

--- a/llvm/test/CodeGen/RISCV/GlobalISel/vararg.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/vararg.ll
@@ -96,18 +96,18 @@ define i32 @va1(ptr %fmt, ...) {
 ; RV32-WITHFP-NEXT:    .cfi_offset s0, -40
 ; RV32-WITHFP-NEXT:    addi s0, sp, 16
 ; RV32-WITHFP-NEXT:    .cfi_def_cfa s0, 32
-; RV32-WITHFP-NEXT:    sw a1, 4(s0)
-; RV32-WITHFP-NEXT:    sw a2, 8(s0)
-; RV32-WITHFP-NEXT:    sw a3, 12(s0)
-; RV32-WITHFP-NEXT:    sw a4, 16(s0)
-; RV32-WITHFP-NEXT:    addi a0, s0, 4
-; RV32-WITHFP-NEXT:    sw a0, -12(s0)
-; RV32-WITHFP-NEXT:    lw a0, -12(s0)
-; RV32-WITHFP-NEXT:    sw a5, 20(s0)
-; RV32-WITHFP-NEXT:    sw a6, 24(s0)
-; RV32-WITHFP-NEXT:    sw a7, 28(s0)
+; RV32-WITHFP-NEXT:    sw a1, 20(sp)
+; RV32-WITHFP-NEXT:    sw a2, 24(sp)
+; RV32-WITHFP-NEXT:    sw a3, 28(sp)
+; RV32-WITHFP-NEXT:    sw a4, 32(sp)
+; RV32-WITHFP-NEXT:    addi a0, sp, 20
+; RV32-WITHFP-NEXT:    sw a0, 4(sp)
+; RV32-WITHFP-NEXT:    lw a0, 4(sp)
+; RV32-WITHFP-NEXT:    sw a5, 36(sp)
+; RV32-WITHFP-NEXT:    sw a6, 40(sp)
+; RV32-WITHFP-NEXT:    sw a7, 44(sp)
 ; RV32-WITHFP-NEXT:    addi a1, a0, 4
-; RV32-WITHFP-NEXT:    sw a1, -12(s0)
+; RV32-WITHFP-NEXT:    sw a1, 4(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV32-WITHFP-NEXT:    .cfi_def_cfa sp, 48
 ; RV32-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -128,24 +128,24 @@ define i32 @va1(ptr %fmt, ...) {
 ; RV64-WITHFP-NEXT:    .cfi_offset s0, -80
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
 ; RV64-WITHFP-NEXT:    .cfi_def_cfa s0, 64
-; RV64-WITHFP-NEXT:    sd a1, 8(s0)
-; RV64-WITHFP-NEXT:    sd a2, 16(s0)
-; RV64-WITHFP-NEXT:    sd a3, 24(s0)
-; RV64-WITHFP-NEXT:    sd a4, 32(s0)
-; RV64-WITHFP-NEXT:    addi a0, s0, -24
-; RV64-WITHFP-NEXT:    addi a1, s0, 8
-; RV64-WITHFP-NEXT:    sd a1, -24(s0)
+; RV64-WITHFP-NEXT:    sd a1, 40(sp)
+; RV64-WITHFP-NEXT:    sd a2, 48(sp)
+; RV64-WITHFP-NEXT:    sd a3, 56(sp)
+; RV64-WITHFP-NEXT:    sd a4, 64(sp)
+; RV64-WITHFP-NEXT:    addi a0, sp, 8
+; RV64-WITHFP-NEXT:    addi a1, sp, 40
+; RV64-WITHFP-NEXT:    sd a1, 8(sp)
 ; RV64-WITHFP-NEXT:    lw a0, 4(a0)
-; RV64-WITHFP-NEXT:    lwu a1, -24(s0)
-; RV64-WITHFP-NEXT:    sd a5, 40(s0)
-; RV64-WITHFP-NEXT:    sd a6, 48(s0)
-; RV64-WITHFP-NEXT:    sd a7, 56(s0)
+; RV64-WITHFP-NEXT:    lwu a1, 8(sp)
+; RV64-WITHFP-NEXT:    sd a5, 72(sp)
+; RV64-WITHFP-NEXT:    sd a6, 80(sp)
+; RV64-WITHFP-NEXT:    sd a7, 88(sp)
 ; RV64-WITHFP-NEXT:    slli a0, a0, 32
 ; RV64-WITHFP-NEXT:    or a0, a0, a1
 ; RV64-WITHFP-NEXT:    addi a1, a0, 4
 ; RV64-WITHFP-NEXT:    srli a2, a1, 32
-; RV64-WITHFP-NEXT:    sw a1, -24(s0)
-; RV64-WITHFP-NEXT:    sw a2, -20(s0)
+; RV64-WITHFP-NEXT:    sw a1, 8(sp)
+; RV64-WITHFP-NEXT:    sw a2, 12(sp)
 ; RV64-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV64-WITHFP-NEXT:    .cfi_def_cfa sp, 96
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
@@ -214,20 +214,20 @@ define iXLen @va1_va_arg(ptr %fmt, ...) nounwind {
 ; RV32-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    addi s0, sp, 16
-; RV32-WITHFP-NEXT:    sw a1, 4(s0)
-; RV32-WITHFP-NEXT:    sw a2, 8(s0)
-; RV32-WITHFP-NEXT:    sw a3, 12(s0)
-; RV32-WITHFP-NEXT:    sw a4, 16(s0)
-; RV32-WITHFP-NEXT:    sw a5, 20(s0)
-; RV32-WITHFP-NEXT:    sw a6, 24(s0)
-; RV32-WITHFP-NEXT:    sw a7, 28(s0)
-; RV32-WITHFP-NEXT:    addi a0, s0, 4
-; RV32-WITHFP-NEXT:    sw a0, -12(s0)
-; RV32-WITHFP-NEXT:    lw a0, -12(s0)
+; RV32-WITHFP-NEXT:    sw a1, 20(sp)
+; RV32-WITHFP-NEXT:    sw a2, 24(sp)
+; RV32-WITHFP-NEXT:    sw a3, 28(sp)
+; RV32-WITHFP-NEXT:    sw a4, 32(sp)
+; RV32-WITHFP-NEXT:    sw a5, 36(sp)
+; RV32-WITHFP-NEXT:    sw a6, 40(sp)
+; RV32-WITHFP-NEXT:    sw a7, 44(sp)
+; RV32-WITHFP-NEXT:    addi a0, sp, 20
+; RV32-WITHFP-NEXT:    sw a0, 4(sp)
+; RV32-WITHFP-NEXT:    lw a0, 4(sp)
 ; RV32-WITHFP-NEXT:    addi a0, a0, 3
 ; RV32-WITHFP-NEXT:    andi a0, a0, -4
 ; RV32-WITHFP-NEXT:    addi a1, a0, 4
-; RV32-WITHFP-NEXT:    sw a1, -12(s0)
+; RV32-WITHFP-NEXT:    sw a1, 4(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV32-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32-WITHFP-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
@@ -240,20 +240,20 @@ define iXLen @va1_va_arg(ptr %fmt, ...) nounwind {
 ; RV64-WITHFP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
-; RV64-WITHFP-NEXT:    sd a1, 8(s0)
-; RV64-WITHFP-NEXT:    sd a2, 16(s0)
-; RV64-WITHFP-NEXT:    sd a3, 24(s0)
-; RV64-WITHFP-NEXT:    sd a4, 32(s0)
-; RV64-WITHFP-NEXT:    sd a5, 40(s0)
-; RV64-WITHFP-NEXT:    sd a6, 48(s0)
-; RV64-WITHFP-NEXT:    sd a7, 56(s0)
-; RV64-WITHFP-NEXT:    addi a0, s0, 8
-; RV64-WITHFP-NEXT:    sd a0, -24(s0)
-; RV64-WITHFP-NEXT:    ld a0, -24(s0)
+; RV64-WITHFP-NEXT:    sd a1, 40(sp)
+; RV64-WITHFP-NEXT:    sd a2, 48(sp)
+; RV64-WITHFP-NEXT:    sd a3, 56(sp)
+; RV64-WITHFP-NEXT:    sd a4, 64(sp)
+; RV64-WITHFP-NEXT:    sd a5, 72(sp)
+; RV64-WITHFP-NEXT:    sd a6, 80(sp)
+; RV64-WITHFP-NEXT:    sd a7, 88(sp)
+; RV64-WITHFP-NEXT:    addi a0, sp, 40
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
 ; RV64-WITHFP-NEXT:    addi a0, a0, 7
 ; RV64-WITHFP-NEXT:    andi a0, a0, -8
 ; RV64-WITHFP-NEXT:    addi a1, a0, 8
-; RV64-WITHFP-NEXT:    sd a1, -24(s0)
+; RV64-WITHFP-NEXT:    sd a1, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(a0)
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; RV64-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
@@ -628,20 +628,20 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; RV32-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    addi s0, sp, 16
-; RV32-WITHFP-NEXT:    sw a1, 4(s0)
-; RV32-WITHFP-NEXT:    sw a2, 8(s0)
-; RV32-WITHFP-NEXT:    sw a3, 12(s0)
-; RV32-WITHFP-NEXT:    sw a4, 16(s0)
-; RV32-WITHFP-NEXT:    addi a0, s0, 4
-; RV32-WITHFP-NEXT:    sw a0, -12(s0)
-; RV32-WITHFP-NEXT:    lw a0, -12(s0)
-; RV32-WITHFP-NEXT:    sw a5, 20(s0)
-; RV32-WITHFP-NEXT:    sw a6, 24(s0)
-; RV32-WITHFP-NEXT:    sw a7, 28(s0)
+; RV32-WITHFP-NEXT:    sw a1, 20(sp)
+; RV32-WITHFP-NEXT:    sw a2, 24(sp)
+; RV32-WITHFP-NEXT:    sw a3, 28(sp)
+; RV32-WITHFP-NEXT:    sw a4, 32(sp)
+; RV32-WITHFP-NEXT:    addi a0, sp, 20
+; RV32-WITHFP-NEXT:    sw a0, 4(sp)
+; RV32-WITHFP-NEXT:    lw a0, 4(sp)
+; RV32-WITHFP-NEXT:    sw a5, 36(sp)
+; RV32-WITHFP-NEXT:    sw a6, 40(sp)
+; RV32-WITHFP-NEXT:    sw a7, 44(sp)
 ; RV32-WITHFP-NEXT:    addi a1, a0, 7
 ; RV32-WITHFP-NEXT:    addi a0, a0, 15
 ; RV32-WITHFP-NEXT:    andi a1, a1, -8
-; RV32-WITHFP-NEXT:    sw a0, -12(s0)
+; RV32-WITHFP-NEXT:    sw a0, 4(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a1)
 ; RV32-WITHFP-NEXT:    lw a1, 4(a1)
 ; RV32-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -655,20 +655,20 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; RV64-WITHFP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
-; RV64-WITHFP-NEXT:    sd a1, 8(s0)
-; RV64-WITHFP-NEXT:    sd a2, 16(s0)
-; RV64-WITHFP-NEXT:    sd a3, 24(s0)
-; RV64-WITHFP-NEXT:    sd a4, 32(s0)
-; RV64-WITHFP-NEXT:    addi a0, s0, 8
-; RV64-WITHFP-NEXT:    sd a0, -24(s0)
-; RV64-WITHFP-NEXT:    ld a0, -24(s0)
-; RV64-WITHFP-NEXT:    sd a5, 40(s0)
-; RV64-WITHFP-NEXT:    sd a6, 48(s0)
-; RV64-WITHFP-NEXT:    sd a7, 56(s0)
+; RV64-WITHFP-NEXT:    sd a1, 40(sp)
+; RV64-WITHFP-NEXT:    sd a2, 48(sp)
+; RV64-WITHFP-NEXT:    sd a3, 56(sp)
+; RV64-WITHFP-NEXT:    sd a4, 64(sp)
+; RV64-WITHFP-NEXT:    addi a0, sp, 40
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
+; RV64-WITHFP-NEXT:    sd a5, 72(sp)
+; RV64-WITHFP-NEXT:    sd a6, 80(sp)
+; RV64-WITHFP-NEXT:    sd a7, 88(sp)
 ; RV64-WITHFP-NEXT:    addi a1, a0, 7
 ; RV64-WITHFP-NEXT:    addi a0, a0, 15
 ; RV64-WITHFP-NEXT:    andi a1, a1, -8
-; RV64-WITHFP-NEXT:    sd a0, -24(s0)
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(a1)
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; RV64-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
@@ -742,20 +742,20 @@ define iXLen @va2_va_arg(ptr %fmt, ...) nounwind {
 ; RV32-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    addi s0, sp, 16
-; RV32-WITHFP-NEXT:    sw a1, 4(s0)
-; RV32-WITHFP-NEXT:    sw a2, 8(s0)
-; RV32-WITHFP-NEXT:    sw a3, 12(s0)
-; RV32-WITHFP-NEXT:    sw a4, 16(s0)
-; RV32-WITHFP-NEXT:    sw a5, 20(s0)
-; RV32-WITHFP-NEXT:    sw a6, 24(s0)
-; RV32-WITHFP-NEXT:    sw a7, 28(s0)
-; RV32-WITHFP-NEXT:    addi a0, s0, 4
-; RV32-WITHFP-NEXT:    sw a0, -12(s0)
-; RV32-WITHFP-NEXT:    lw a0, -12(s0)
+; RV32-WITHFP-NEXT:    sw a1, 20(sp)
+; RV32-WITHFP-NEXT:    sw a2, 24(sp)
+; RV32-WITHFP-NEXT:    sw a3, 28(sp)
+; RV32-WITHFP-NEXT:    sw a4, 32(sp)
+; RV32-WITHFP-NEXT:    sw a5, 36(sp)
+; RV32-WITHFP-NEXT:    sw a6, 40(sp)
+; RV32-WITHFP-NEXT:    sw a7, 44(sp)
+; RV32-WITHFP-NEXT:    addi a0, sp, 20
+; RV32-WITHFP-NEXT:    sw a0, 4(sp)
+; RV32-WITHFP-NEXT:    lw a0, 4(sp)
 ; RV32-WITHFP-NEXT:    addi a0, a0, 3
 ; RV32-WITHFP-NEXT:    andi a0, a0, -4
 ; RV32-WITHFP-NEXT:    addi a1, a0, 4
-; RV32-WITHFP-NEXT:    sw a1, -12(s0)
+; RV32-WITHFP-NEXT:    sw a1, 4(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV32-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32-WITHFP-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
@@ -768,20 +768,20 @@ define iXLen @va2_va_arg(ptr %fmt, ...) nounwind {
 ; RV64-WITHFP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
-; RV64-WITHFP-NEXT:    sd a1, 8(s0)
-; RV64-WITHFP-NEXT:    sd a2, 16(s0)
-; RV64-WITHFP-NEXT:    sd a3, 24(s0)
-; RV64-WITHFP-NEXT:    sd a4, 32(s0)
-; RV64-WITHFP-NEXT:    sd a5, 40(s0)
-; RV64-WITHFP-NEXT:    sd a6, 48(s0)
-; RV64-WITHFP-NEXT:    sd a7, 56(s0)
-; RV64-WITHFP-NEXT:    addi a0, s0, 8
-; RV64-WITHFP-NEXT:    sd a0, -24(s0)
-; RV64-WITHFP-NEXT:    ld a0, -24(s0)
+; RV64-WITHFP-NEXT:    sd a1, 40(sp)
+; RV64-WITHFP-NEXT:    sd a2, 48(sp)
+; RV64-WITHFP-NEXT:    sd a3, 56(sp)
+; RV64-WITHFP-NEXT:    sd a4, 64(sp)
+; RV64-WITHFP-NEXT:    sd a5, 72(sp)
+; RV64-WITHFP-NEXT:    sd a6, 80(sp)
+; RV64-WITHFP-NEXT:    sd a7, 88(sp)
+; RV64-WITHFP-NEXT:    addi a0, sp, 40
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
 ; RV64-WITHFP-NEXT:    addi a0, a0, 7
 ; RV64-WITHFP-NEXT:    andi a0, a0, -8
 ; RV64-WITHFP-NEXT:    addi a1, a0, 8
-; RV64-WITHFP-NEXT:    sd a1, -24(s0)
+; RV64-WITHFP-NEXT:    sd a1, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(a0)
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; RV64-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
@@ -977,18 +977,18 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; RV32-WITHFP-NEXT:    sw ra, 20(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    addi s0, sp, 24
-; RV32-WITHFP-NEXT:    addi a0, s0, 4
-; RV32-WITHFP-NEXT:    sw a0, -12(s0)
-; RV32-WITHFP-NEXT:    lw a0, -12(s0)
-; RV32-WITHFP-NEXT:    sw a3, 4(s0)
-; RV32-WITHFP-NEXT:    sw a4, 8(s0)
-; RV32-WITHFP-NEXT:    sw a5, 12(s0)
-; RV32-WITHFP-NEXT:    sw a6, 16(s0)
-; RV32-WITHFP-NEXT:    sw a7, 20(s0)
+; RV32-WITHFP-NEXT:    addi a0, sp, 28
+; RV32-WITHFP-NEXT:    sw a0, 12(sp)
+; RV32-WITHFP-NEXT:    lw a0, 12(sp)
+; RV32-WITHFP-NEXT:    sw a3, 28(sp)
+; RV32-WITHFP-NEXT:    sw a4, 32(sp)
+; RV32-WITHFP-NEXT:    sw a5, 36(sp)
+; RV32-WITHFP-NEXT:    sw a6, 40(sp)
+; RV32-WITHFP-NEXT:    sw a7, 44(sp)
 ; RV32-WITHFP-NEXT:    addi a3, a0, 7
 ; RV32-WITHFP-NEXT:    addi a0, a0, 15
 ; RV32-WITHFP-NEXT:    andi a3, a3, -8
-; RV32-WITHFP-NEXT:    sw a0, -12(s0)
+; RV32-WITHFP-NEXT:    sw a0, 12(sp)
 ; RV32-WITHFP-NEXT:    lw a4, 0(a3)
 ; RV32-WITHFP-NEXT:    lw a3, 4(a3)
 ; RV32-WITHFP-NEXT:    add a0, a1, a4
@@ -1006,19 +1006,19 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; RV64-WITHFP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
-; RV64-WITHFP-NEXT:    mv a0, s0
-; RV64-WITHFP-NEXT:    sd a0, -24(s0)
-; RV64-WITHFP-NEXT:    ld a0, -24(s0)
-; RV64-WITHFP-NEXT:    sd a2, 0(s0)
-; RV64-WITHFP-NEXT:    sd a3, 8(s0)
-; RV64-WITHFP-NEXT:    sd a4, 16(s0)
-; RV64-WITHFP-NEXT:    sd a5, 24(s0)
-; RV64-WITHFP-NEXT:    sd a6, 32(s0)
-; RV64-WITHFP-NEXT:    sd a7, 40(s0)
+; RV64-WITHFP-NEXT:    addi a0, sp, 32
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
+; RV64-WITHFP-NEXT:    sd a2, 32(sp)
+; RV64-WITHFP-NEXT:    sd a3, 40(sp)
+; RV64-WITHFP-NEXT:    sd a4, 48(sp)
+; RV64-WITHFP-NEXT:    sd a5, 56(sp)
+; RV64-WITHFP-NEXT:    sd a6, 64(sp)
+; RV64-WITHFP-NEXT:    sd a7, 72(sp)
 ; RV64-WITHFP-NEXT:    addi a2, a0, 7
 ; RV64-WITHFP-NEXT:    addi a0, a0, 15
 ; RV64-WITHFP-NEXT:    andi a2, a2, -8
-; RV64-WITHFP-NEXT:    sd a0, -24(s0)
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(a2)
 ; RV64-WITHFP-NEXT:    add a0, a1, a0
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
@@ -1094,19 +1094,19 @@ define iXLen @va3_va_arg(iXLen %a, iXLen %b, ...) nounwind {
 ; RV32-WITHFP-NEXT:    sw ra, 20(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    addi s0, sp, 24
-; RV32-WITHFP-NEXT:    sw a2, 0(s0)
-; RV32-WITHFP-NEXT:    sw a3, 4(s0)
-; RV32-WITHFP-NEXT:    sw a4, 8(s0)
-; RV32-WITHFP-NEXT:    sw a5, 12(s0)
-; RV32-WITHFP-NEXT:    sw a6, 16(s0)
-; RV32-WITHFP-NEXT:    sw a7, 20(s0)
-; RV32-WITHFP-NEXT:    mv a0, s0
-; RV32-WITHFP-NEXT:    sw a0, -12(s0)
-; RV32-WITHFP-NEXT:    lw a0, -12(s0)
+; RV32-WITHFP-NEXT:    sw a2, 24(sp)
+; RV32-WITHFP-NEXT:    sw a3, 28(sp)
+; RV32-WITHFP-NEXT:    sw a4, 32(sp)
+; RV32-WITHFP-NEXT:    sw a5, 36(sp)
+; RV32-WITHFP-NEXT:    sw a6, 40(sp)
+; RV32-WITHFP-NEXT:    sw a7, 44(sp)
+; RV32-WITHFP-NEXT:    addi a0, sp, 24
+; RV32-WITHFP-NEXT:    sw a0, 12(sp)
+; RV32-WITHFP-NEXT:    lw a0, 12(sp)
 ; RV32-WITHFP-NEXT:    addi a0, a0, 3
 ; RV32-WITHFP-NEXT:    andi a0, a0, -4
 ; RV32-WITHFP-NEXT:    addi a2, a0, 4
-; RV32-WITHFP-NEXT:    sw a2, -12(s0)
+; RV32-WITHFP-NEXT:    sw a2, 12(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV32-WITHFP-NEXT:    add a0, a1, a0
 ; RV32-WITHFP-NEXT:    lw ra, 20(sp) # 4-byte Folded Reload
@@ -1120,19 +1120,19 @@ define iXLen @va3_va_arg(iXLen %a, iXLen %b, ...) nounwind {
 ; RV64-WITHFP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
-; RV64-WITHFP-NEXT:    sd a2, 0(s0)
-; RV64-WITHFP-NEXT:    sd a3, 8(s0)
-; RV64-WITHFP-NEXT:    sd a4, 16(s0)
-; RV64-WITHFP-NEXT:    sd a5, 24(s0)
-; RV64-WITHFP-NEXT:    sd a6, 32(s0)
-; RV64-WITHFP-NEXT:    sd a7, 40(s0)
-; RV64-WITHFP-NEXT:    mv a0, s0
-; RV64-WITHFP-NEXT:    sd a0, -24(s0)
-; RV64-WITHFP-NEXT:    ld a0, -24(s0)
+; RV64-WITHFP-NEXT:    sd a2, 32(sp)
+; RV64-WITHFP-NEXT:    sd a3, 40(sp)
+; RV64-WITHFP-NEXT:    sd a4, 48(sp)
+; RV64-WITHFP-NEXT:    sd a5, 56(sp)
+; RV64-WITHFP-NEXT:    sd a6, 64(sp)
+; RV64-WITHFP-NEXT:    sd a7, 72(sp)
+; RV64-WITHFP-NEXT:    addi a0, sp, 32
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
 ; RV64-WITHFP-NEXT:    addi a0, a0, 7
 ; RV64-WITHFP-NEXT:    andi a0, a0, -8
 ; RV64-WITHFP-NEXT:    addi a2, a0, 8
-; RV64-WITHFP-NEXT:    sd a2, -24(s0)
+; RV64-WITHFP-NEXT:    sd a2, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(a0)
 ; RV64-WITHFP-NEXT:    add a0, a1, a0
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
@@ -1329,43 +1329,43 @@ define iXLen @va4_va_copy(i32 %argno, ...) nounwind {
 ; RV32-WITHFP-NEXT:    sw s1, 20(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    sw s2, 16(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    addi s0, sp, 32
-; RV32-WITHFP-NEXT:    sw a1, 4(s0)
-; RV32-WITHFP-NEXT:    sw a2, 8(s0)
-; RV32-WITHFP-NEXT:    sw a3, 12(s0)
-; RV32-WITHFP-NEXT:    sw a4, 16(s0)
-; RV32-WITHFP-NEXT:    sw a5, 20(s0)
-; RV32-WITHFP-NEXT:    sw a6, 24(s0)
-; RV32-WITHFP-NEXT:    sw a7, 28(s0)
-; RV32-WITHFP-NEXT:    addi a0, s0, 4
-; RV32-WITHFP-NEXT:    sw a0, -20(s0)
-; RV32-WITHFP-NEXT:    lw a0, -20(s0)
+; RV32-WITHFP-NEXT:    sw a1, 36(sp)
+; RV32-WITHFP-NEXT:    sw a2, 40(sp)
+; RV32-WITHFP-NEXT:    sw a3, 44(sp)
+; RV32-WITHFP-NEXT:    sw a4, 48(sp)
+; RV32-WITHFP-NEXT:    sw a5, 52(sp)
+; RV32-WITHFP-NEXT:    sw a6, 56(sp)
+; RV32-WITHFP-NEXT:    sw a7, 60(sp)
+; RV32-WITHFP-NEXT:    addi a0, sp, 36
+; RV32-WITHFP-NEXT:    sw a0, 12(sp)
+; RV32-WITHFP-NEXT:    lw a0, 12(sp)
 ; RV32-WITHFP-NEXT:    addi a0, a0, 3
 ; RV32-WITHFP-NEXT:    li s1, -4
 ; RV32-WITHFP-NEXT:    and a0, a0, s1
 ; RV32-WITHFP-NEXT:    addi a1, a0, 4
-; RV32-WITHFP-NEXT:    sw a1, -20(s0)
-; RV32-WITHFP-NEXT:    lw a1, -20(s0)
+; RV32-WITHFP-NEXT:    sw a1, 12(sp)
+; RV32-WITHFP-NEXT:    lw a1, 12(sp)
 ; RV32-WITHFP-NEXT:    lw s2, 0(a0)
-; RV32-WITHFP-NEXT:    sw a1, -24(s0)
-; RV32-WITHFP-NEXT:    lw a0, -24(s0)
+; RV32-WITHFP-NEXT:    sw a1, 8(sp)
+; RV32-WITHFP-NEXT:    lw a0, 8(sp)
 ; RV32-WITHFP-NEXT:    call notdead
-; RV32-WITHFP-NEXT:    lw a0, -20(s0)
+; RV32-WITHFP-NEXT:    lw a0, 12(sp)
 ; RV32-WITHFP-NEXT:    addi a0, a0, 3
 ; RV32-WITHFP-NEXT:    and a0, a0, s1
 ; RV32-WITHFP-NEXT:    addi a1, a0, 4
-; RV32-WITHFP-NEXT:    sw a1, -20(s0)
-; RV32-WITHFP-NEXT:    lw a1, -20(s0)
+; RV32-WITHFP-NEXT:    sw a1, 12(sp)
+; RV32-WITHFP-NEXT:    lw a1, 12(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV32-WITHFP-NEXT:    addi a1, a1, 3
 ; RV32-WITHFP-NEXT:    and a1, a1, s1
 ; RV32-WITHFP-NEXT:    addi a2, a1, 4
-; RV32-WITHFP-NEXT:    sw a2, -20(s0)
-; RV32-WITHFP-NEXT:    lw a2, -20(s0)
+; RV32-WITHFP-NEXT:    sw a2, 12(sp)
+; RV32-WITHFP-NEXT:    lw a2, 12(sp)
 ; RV32-WITHFP-NEXT:    lw a1, 0(a1)
 ; RV32-WITHFP-NEXT:    addi a2, a2, 3
 ; RV32-WITHFP-NEXT:    andi a2, a2, -4
 ; RV32-WITHFP-NEXT:    addi a3, a2, 4
-; RV32-WITHFP-NEXT:    sw a3, -20(s0)
+; RV32-WITHFP-NEXT:    sw a3, 12(sp)
 ; RV32-WITHFP-NEXT:    lw a2, 0(a2)
 ; RV32-WITHFP-NEXT:    add a0, a0, s2
 ; RV32-WITHFP-NEXT:    add a1, a1, a2
@@ -1385,46 +1385,46 @@ define iXLen @va4_va_copy(i32 %argno, ...) nounwind {
 ; RV64-WITHFP-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    sd s2, 16(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    addi s0, sp, 48
-; RV64-WITHFP-NEXT:    sd a1, 8(s0)
-; RV64-WITHFP-NEXT:    sd a2, 16(s0)
-; RV64-WITHFP-NEXT:    sd a3, 24(s0)
-; RV64-WITHFP-NEXT:    sd a4, 32(s0)
-; RV64-WITHFP-NEXT:    sd a5, 40(s0)
-; RV64-WITHFP-NEXT:    sd a6, 48(s0)
-; RV64-WITHFP-NEXT:    sd a7, 56(s0)
-; RV64-WITHFP-NEXT:    addi a0, s0, 8
-; RV64-WITHFP-NEXT:    sd a0, -40(s0)
-; RV64-WITHFP-NEXT:    ld a0, -40(s0)
+; RV64-WITHFP-NEXT:    sd a1, 56(sp)
+; RV64-WITHFP-NEXT:    sd a2, 64(sp)
+; RV64-WITHFP-NEXT:    sd a3, 72(sp)
+; RV64-WITHFP-NEXT:    sd a4, 80(sp)
+; RV64-WITHFP-NEXT:    sd a5, 88(sp)
+; RV64-WITHFP-NEXT:    sd a6, 96(sp)
+; RV64-WITHFP-NEXT:    sd a7, 104(sp)
+; RV64-WITHFP-NEXT:    addi a0, sp, 56
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
 ; RV64-WITHFP-NEXT:    addi a0, a0, 7
 ; RV64-WITHFP-NEXT:    li s1, -8
 ; RV64-WITHFP-NEXT:    and a0, a0, s1
 ; RV64-WITHFP-NEXT:    addi a1, a0, 8
-; RV64-WITHFP-NEXT:    sd a1, -40(s0)
-; RV64-WITHFP-NEXT:    ld a1, -40(s0)
+; RV64-WITHFP-NEXT:    sd a1, 8(sp)
+; RV64-WITHFP-NEXT:    ld a1, 8(sp)
 ; RV64-WITHFP-NEXT:    ld s2, 0(a0)
-; RV64-WITHFP-NEXT:    sd a1, -48(s0)
-; RV64-WITHFP-NEXT:    lw a0, -44(s0)
-; RV64-WITHFP-NEXT:    lwu a1, -48(s0)
+; RV64-WITHFP-NEXT:    sd a1, 0(sp)
+; RV64-WITHFP-NEXT:    lw a0, 4(sp)
+; RV64-WITHFP-NEXT:    lwu a1, 0(sp)
 ; RV64-WITHFP-NEXT:    slli a0, a0, 32
 ; RV64-WITHFP-NEXT:    or a0, a0, a1
 ; RV64-WITHFP-NEXT:    call notdead
-; RV64-WITHFP-NEXT:    ld a0, -40(s0)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
 ; RV64-WITHFP-NEXT:    addi a0, a0, 7
 ; RV64-WITHFP-NEXT:    and a0, a0, s1
 ; RV64-WITHFP-NEXT:    addi a1, a0, 8
-; RV64-WITHFP-NEXT:    sd a1, -40(s0)
-; RV64-WITHFP-NEXT:    ld a1, -40(s0)
+; RV64-WITHFP-NEXT:    sd a1, 8(sp)
+; RV64-WITHFP-NEXT:    ld a1, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(a0)
 ; RV64-WITHFP-NEXT:    addi a1, a1, 7
 ; RV64-WITHFP-NEXT:    and a1, a1, s1
 ; RV64-WITHFP-NEXT:    addi a2, a1, 8
-; RV64-WITHFP-NEXT:    sd a2, -40(s0)
-; RV64-WITHFP-NEXT:    ld a2, -40(s0)
+; RV64-WITHFP-NEXT:    sd a2, 8(sp)
+; RV64-WITHFP-NEXT:    ld a2, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a1, 0(a1)
 ; RV64-WITHFP-NEXT:    addi a2, a2, 7
 ; RV64-WITHFP-NEXT:    andi a2, a2, -8
 ; RV64-WITHFP-NEXT:    addi a3, a2, 8
-; RV64-WITHFP-NEXT:    sd a3, -40(s0)
+; RV64-WITHFP-NEXT:    sd a3, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a2, 0(a2)
 ; RV64-WITHFP-NEXT:    add a0, a0, s2
 ; RV64-WITHFP-NEXT:    add a1, a1, a2
@@ -1512,21 +1512,21 @@ define iXLen @va6_no_fixed_args(...) nounwind {
 ; RV32-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    addi s0, sp, 16
-; RV32-WITHFP-NEXT:    sw a0, 0(s0)
-; RV32-WITHFP-NEXT:    sw a1, 4(s0)
-; RV32-WITHFP-NEXT:    sw a2, 8(s0)
-; RV32-WITHFP-NEXT:    sw a3, 12(s0)
-; RV32-WITHFP-NEXT:    sw a4, 16(s0)
-; RV32-WITHFP-NEXT:    sw a5, 20(s0)
-; RV32-WITHFP-NEXT:    sw a6, 24(s0)
-; RV32-WITHFP-NEXT:    sw a7, 28(s0)
-; RV32-WITHFP-NEXT:    mv a0, s0
-; RV32-WITHFP-NEXT:    sw a0, -12(s0)
-; RV32-WITHFP-NEXT:    lw a0, -12(s0)
+; RV32-WITHFP-NEXT:    sw a0, 16(sp)
+; RV32-WITHFP-NEXT:    sw a1, 20(sp)
+; RV32-WITHFP-NEXT:    sw a2, 24(sp)
+; RV32-WITHFP-NEXT:    sw a3, 28(sp)
+; RV32-WITHFP-NEXT:    sw a4, 32(sp)
+; RV32-WITHFP-NEXT:    sw a5, 36(sp)
+; RV32-WITHFP-NEXT:    sw a6, 40(sp)
+; RV32-WITHFP-NEXT:    sw a7, 44(sp)
+; RV32-WITHFP-NEXT:    addi a0, sp, 16
+; RV32-WITHFP-NEXT:    sw a0, 4(sp)
+; RV32-WITHFP-NEXT:    lw a0, 4(sp)
 ; RV32-WITHFP-NEXT:    addi a0, a0, 3
 ; RV32-WITHFP-NEXT:    andi a0, a0, -4
 ; RV32-WITHFP-NEXT:    addi a1, a0, 4
-; RV32-WITHFP-NEXT:    sw a1, -12(s0)
+; RV32-WITHFP-NEXT:    sw a1, 4(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV32-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32-WITHFP-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
@@ -1539,21 +1539,21 @@ define iXLen @va6_no_fixed_args(...) nounwind {
 ; RV64-WITHFP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
-; RV64-WITHFP-NEXT:    sd a0, 0(s0)
-; RV64-WITHFP-NEXT:    sd a1, 8(s0)
-; RV64-WITHFP-NEXT:    sd a2, 16(s0)
-; RV64-WITHFP-NEXT:    sd a3, 24(s0)
-; RV64-WITHFP-NEXT:    sd a4, 32(s0)
-; RV64-WITHFP-NEXT:    sd a5, 40(s0)
-; RV64-WITHFP-NEXT:    sd a6, 48(s0)
-; RV64-WITHFP-NEXT:    sd a7, 56(s0)
-; RV64-WITHFP-NEXT:    mv a0, s0
-; RV64-WITHFP-NEXT:    sd a0, -24(s0)
-; RV64-WITHFP-NEXT:    ld a0, -24(s0)
+; RV64-WITHFP-NEXT:    sd a0, 32(sp)
+; RV64-WITHFP-NEXT:    sd a1, 40(sp)
+; RV64-WITHFP-NEXT:    sd a2, 48(sp)
+; RV64-WITHFP-NEXT:    sd a3, 56(sp)
+; RV64-WITHFP-NEXT:    sd a4, 64(sp)
+; RV64-WITHFP-NEXT:    sd a5, 72(sp)
+; RV64-WITHFP-NEXT:    sd a6, 80(sp)
+; RV64-WITHFP-NEXT:    sd a7, 88(sp)
+; RV64-WITHFP-NEXT:    addi a0, sp, 32
+; RV64-WITHFP-NEXT:    sd a0, 8(sp)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
 ; RV64-WITHFP-NEXT:    addi a0, a0, 7
 ; RV64-WITHFP-NEXT:    andi a0, a0, -8
 ; RV64-WITHFP-NEXT:    addi a1, a0, 8
-; RV64-WITHFP-NEXT:    sd a1, -24(s0)
+; RV64-WITHFP-NEXT:    sd a1, 8(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(a0)
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; RV64-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
@@ -1670,19 +1670,33 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; RV32-WITHFP-NEXT:    lui a0, 24414
 ; RV32-WITHFP-NEXT:    addi a0, a0, -1728
 ; RV32-WITHFP-NEXT:    sub sp, sp, a0
-; RV32-WITHFP-NEXT:    lui a0, 24414
-; RV32-WITHFP-NEXT:    addi a0, a0, 272
-; RV32-WITHFP-NEXT:    sub a0, s0, a0
-; RV32-WITHFP-NEXT:    sw a1, 4(s0)
-; RV32-WITHFP-NEXT:    sw a2, 8(s0)
-; RV32-WITHFP-NEXT:    sw a3, 12(s0)
-; RV32-WITHFP-NEXT:    sw a4, 16(s0)
-; RV32-WITHFP-NEXT:    addi a1, s0, 4
+; RV32-WITHFP-NEXT:    mv a0, sp
+; RV32-WITHFP-NEXT:    lui t0, 24414
+; RV32-WITHFP-NEXT:    add t0, sp, t0
+; RV32-WITHFP-NEXT:    sw a1, 276(t0)
+; RV32-WITHFP-NEXT:    lui a1, 24414
+; RV32-WITHFP-NEXT:    add a1, sp, a1
+; RV32-WITHFP-NEXT:    sw a2, 280(a1)
+; RV32-WITHFP-NEXT:    lui a1, 24414
+; RV32-WITHFP-NEXT:    add a1, sp, a1
+; RV32-WITHFP-NEXT:    sw a3, 284(a1)
+; RV32-WITHFP-NEXT:    lui a1, 24414
+; RV32-WITHFP-NEXT:    add a1, sp, a1
+; RV32-WITHFP-NEXT:    sw a4, 288(a1)
+; RV32-WITHFP-NEXT:    lui a1, 24414
+; RV32-WITHFP-NEXT:    addi a1, a1, 276
+; RV32-WITHFP-NEXT:    add a1, sp, a1
 ; RV32-WITHFP-NEXT:    sw a1, 0(a0)
 ; RV32-WITHFP-NEXT:    lw a1, 0(a0)
-; RV32-WITHFP-NEXT:    sw a5, 20(s0)
-; RV32-WITHFP-NEXT:    sw a6, 24(s0)
-; RV32-WITHFP-NEXT:    sw a7, 28(s0)
+; RV32-WITHFP-NEXT:    lui a2, 24414
+; RV32-WITHFP-NEXT:    add a2, sp, a2
+; RV32-WITHFP-NEXT:    sw a5, 292(a2)
+; RV32-WITHFP-NEXT:    lui a2, 24414
+; RV32-WITHFP-NEXT:    add a2, sp, a2
+; RV32-WITHFP-NEXT:    sw a6, 296(a2)
+; RV32-WITHFP-NEXT:    lui a2, 24414
+; RV32-WITHFP-NEXT:    add a2, sp, a2
+; RV32-WITHFP-NEXT:    sw a7, 300(a2)
 ; RV32-WITHFP-NEXT:    addi a2, a1, 4
 ; RV32-WITHFP-NEXT:    sw a2, 0(a0)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a1)
@@ -1711,20 +1725,34 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; RV64-WITHFP-NEXT:    lui a0, 24414
 ; RV64-WITHFP-NEXT:    addi a0, a0, -1680
 ; RV64-WITHFP-NEXT:    sub sp, sp, a0
-; RV64-WITHFP-NEXT:    lui a0, 24414
-; RV64-WITHFP-NEXT:    addi a0, a0, 288
-; RV64-WITHFP-NEXT:    sub a0, s0, a0
-; RV64-WITHFP-NEXT:    sd a1, 8(s0)
-; RV64-WITHFP-NEXT:    sd a2, 16(s0)
-; RV64-WITHFP-NEXT:    sd a3, 24(s0)
-; RV64-WITHFP-NEXT:    sd a4, 32(s0)
-; RV64-WITHFP-NEXT:    addi a1, s0, 8
+; RV64-WITHFP-NEXT:    mv a0, sp
+; RV64-WITHFP-NEXT:    lui t0, 24414
+; RV64-WITHFP-NEXT:    add t0, sp, t0
+; RV64-WITHFP-NEXT:    sd a1, 296(t0)
+; RV64-WITHFP-NEXT:    lui a1, 24414
+; RV64-WITHFP-NEXT:    add a1, sp, a1
+; RV64-WITHFP-NEXT:    sd a2, 304(a1)
+; RV64-WITHFP-NEXT:    lui a1, 24414
+; RV64-WITHFP-NEXT:    add a1, sp, a1
+; RV64-WITHFP-NEXT:    sd a3, 312(a1)
+; RV64-WITHFP-NEXT:    lui a1, 24414
+; RV64-WITHFP-NEXT:    add a1, sp, a1
+; RV64-WITHFP-NEXT:    sd a4, 320(a1)
+; RV64-WITHFP-NEXT:    lui a1, 24414
+; RV64-WITHFP-NEXT:    addi a1, a1, 296
+; RV64-WITHFP-NEXT:    add a1, sp, a1
 ; RV64-WITHFP-NEXT:    sd a1, 0(a0)
 ; RV64-WITHFP-NEXT:    lwu a1, 0(a0)
 ; RV64-WITHFP-NEXT:    lw a2, 4(a0)
-; RV64-WITHFP-NEXT:    sd a5, 40(s0)
-; RV64-WITHFP-NEXT:    sd a6, 48(s0)
-; RV64-WITHFP-NEXT:    sd a7, 56(s0)
+; RV64-WITHFP-NEXT:    lui a3, 24414
+; RV64-WITHFP-NEXT:    add a3, sp, a3
+; RV64-WITHFP-NEXT:    sd a5, 328(a3)
+; RV64-WITHFP-NEXT:    lui a3, 24414
+; RV64-WITHFP-NEXT:    add a3, sp, a3
+; RV64-WITHFP-NEXT:    sd a6, 336(a3)
+; RV64-WITHFP-NEXT:    lui a3, 24414
+; RV64-WITHFP-NEXT:    add a3, sp, a3
+; RV64-WITHFP-NEXT:    sd a7, 344(a3)
 ; RV64-WITHFP-NEXT:    slli a2, a2, 32
 ; RV64-WITHFP-NEXT:    or a1, a2, a1
 ; RV64-WITHFP-NEXT:    addi a2, a1, 4
@@ -1799,14 +1827,14 @@ define iXLen @va_vprintf(ptr %fmt, ptr %arg_start) {
 ; RV32-WITHFP-NEXT:    .cfi_offset s0, -8
 ; RV32-WITHFP-NEXT:    addi s0, sp, 16
 ; RV32-WITHFP-NEXT:    .cfi_def_cfa s0, 0
-; RV32-WITHFP-NEXT:    sw a1, -12(s0)
-; RV32-WITHFP-NEXT:    lw a0, -12(s0)
-; RV32-WITHFP-NEXT:    sw a0, -16(s0)
-; RV32-WITHFP-NEXT:    lw a0, -16(s0)
+; RV32-WITHFP-NEXT:    sw a1, 4(sp)
+; RV32-WITHFP-NEXT:    lw a0, 4(sp)
+; RV32-WITHFP-NEXT:    sw a0, 0(sp)
+; RV32-WITHFP-NEXT:    lw a0, 0(sp)
 ; RV32-WITHFP-NEXT:    addi a0, a0, 3
 ; RV32-WITHFP-NEXT:    andi a0, a0, -4
 ; RV32-WITHFP-NEXT:    addi a1, a0, 4
-; RV32-WITHFP-NEXT:    sw a1, -16(s0)
+; RV32-WITHFP-NEXT:    sw a1, 0(sp)
 ; RV32-WITHFP-NEXT:    lw a0, 0(a0)
 ; RV32-WITHFP-NEXT:    .cfi_def_cfa sp, 16
 ; RV32-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -1827,14 +1855,14 @@ define iXLen @va_vprintf(ptr %fmt, ptr %arg_start) {
 ; RV64-WITHFP-NEXT:    .cfi_offset s0, -16
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
 ; RV64-WITHFP-NEXT:    .cfi_def_cfa s0, 0
-; RV64-WITHFP-NEXT:    sd a1, -24(s0)
-; RV64-WITHFP-NEXT:    ld a0, -24(s0)
-; RV64-WITHFP-NEXT:    sd a0, -32(s0)
-; RV64-WITHFP-NEXT:    ld a0, -32(s0)
+; RV64-WITHFP-NEXT:    sd a1, 8(sp)
+; RV64-WITHFP-NEXT:    ld a0, 8(sp)
+; RV64-WITHFP-NEXT:    sd a0, 0(sp)
+; RV64-WITHFP-NEXT:    ld a0, 0(sp)
 ; RV64-WITHFP-NEXT:    addi a0, a0, 7
 ; RV64-WITHFP-NEXT:    andi a0, a0, -8
 ; RV64-WITHFP-NEXT:    addi a1, a0, 8
-; RV64-WITHFP-NEXT:    sd a1, -32(s0)
+; RV64-WITHFP-NEXT:    sd a1, 0(sp)
 ; RV64-WITHFP-NEXT:    ld a0, 0(a0)
 ; RV64-WITHFP-NEXT:    .cfi_def_cfa sp, 32
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
@@ -1910,16 +1938,16 @@ define i32 @va_printf(ptr %fmt, ...) {
 ; RV32-WITHFP-NEXT:    .cfi_offset s0, -40
 ; RV32-WITHFP-NEXT:    addi s0, sp, 16
 ; RV32-WITHFP-NEXT:    .cfi_def_cfa s0, 32
-; RV32-WITHFP-NEXT:    sw a1, 4(s0)
-; RV32-WITHFP-NEXT:    sw a2, 8(s0)
-; RV32-WITHFP-NEXT:    sw a3, 12(s0)
-; RV32-WITHFP-NEXT:    sw a4, 16(s0)
-; RV32-WITHFP-NEXT:    addi a1, s0, 4
-; RV32-WITHFP-NEXT:    sw a1, -12(s0)
-; RV32-WITHFP-NEXT:    lw a1, -12(s0)
-; RV32-WITHFP-NEXT:    sw a5, 20(s0)
-; RV32-WITHFP-NEXT:    sw a6, 24(s0)
-; RV32-WITHFP-NEXT:    sw a7, 28(s0)
+; RV32-WITHFP-NEXT:    sw a1, 20(sp)
+; RV32-WITHFP-NEXT:    sw a2, 24(sp)
+; RV32-WITHFP-NEXT:    sw a3, 28(sp)
+; RV32-WITHFP-NEXT:    sw a4, 32(sp)
+; RV32-WITHFP-NEXT:    addi a1, sp, 20
+; RV32-WITHFP-NEXT:    sw a1, 4(sp)
+; RV32-WITHFP-NEXT:    lw a1, 4(sp)
+; RV32-WITHFP-NEXT:    sw a5, 36(sp)
+; RV32-WITHFP-NEXT:    sw a6, 40(sp)
+; RV32-WITHFP-NEXT:    sw a7, 44(sp)
 ; RV32-WITHFP-NEXT:    call va_vprintf
 ; RV32-WITHFP-NEXT:    .cfi_def_cfa sp, 48
 ; RV32-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -1940,16 +1968,16 @@ define i32 @va_printf(ptr %fmt, ...) {
 ; RV64-WITHFP-NEXT:    .cfi_offset s0, -80
 ; RV64-WITHFP-NEXT:    addi s0, sp, 32
 ; RV64-WITHFP-NEXT:    .cfi_def_cfa s0, 64
-; RV64-WITHFP-NEXT:    sd a1, 8(s0)
-; RV64-WITHFP-NEXT:    sd a2, 16(s0)
-; RV64-WITHFP-NEXT:    sd a3, 24(s0)
-; RV64-WITHFP-NEXT:    sd a4, 32(s0)
-; RV64-WITHFP-NEXT:    addi a1, s0, 8
-; RV64-WITHFP-NEXT:    sd a1, -24(s0)
-; RV64-WITHFP-NEXT:    ld a1, -24(s0)
-; RV64-WITHFP-NEXT:    sd a5, 40(s0)
-; RV64-WITHFP-NEXT:    sd a6, 48(s0)
-; RV64-WITHFP-NEXT:    sd a7, 56(s0)
+; RV64-WITHFP-NEXT:    sd a1, 40(sp)
+; RV64-WITHFP-NEXT:    sd a2, 48(sp)
+; RV64-WITHFP-NEXT:    sd a3, 56(sp)
+; RV64-WITHFP-NEXT:    sd a4, 64(sp)
+; RV64-WITHFP-NEXT:    addi a1, sp, 40
+; RV64-WITHFP-NEXT:    sd a1, 8(sp)
+; RV64-WITHFP-NEXT:    ld a1, 8(sp)
+; RV64-WITHFP-NEXT:    sd a5, 72(sp)
+; RV64-WITHFP-NEXT:    sd a6, 80(sp)
+; RV64-WITHFP-NEXT:    sd a7, 88(sp)
 ; RV64-WITHFP-NEXT:    call va_vprintf
 ; RV64-WITHFP-NEXT:    .cfi_def_cfa sp, 96
 ; RV64-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/callee-saved-gprs.ll
+++ b/llvm/test/CodeGen/RISCV/callee-saved-gprs.ll
@@ -305,17 +305,17 @@ define void @callee() {
 ; RV32I-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV32I-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV32I-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, -56(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, -60(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, -64(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, -68(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, -72(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a1, 20(a0)
-; RV32I-WITH-FP-NEXT:    sw a1, -76(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a7, 24(a0)
 ; RV32I-WITH-FP-NEXT:    lw t0, 28(a0)
 ; RV32I-WITH-FP-NEXT:    lw t1, 32(a0)
@@ -368,17 +368,17 @@ define void @callee() {
 ; RV32I-WITH-FP-NEXT:    sw t1, 32(a0)
 ; RV32I-WITH-FP-NEXT:    sw t0, 28(a0)
 ; RV32I-WITH-FP-NEXT:    sw a7, 24(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, -76(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, -72(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, -68(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, -64(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, -60(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a1, 4(a0)
-; RV32I-WITH-FP-NEXT:    lw a1, -56(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV32I-WITH-FP-NEXT:    .cfi_def_cfa sp, 80
 ; RV32I-WITH-FP-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
@@ -541,17 +541,17 @@ define void @callee() {
 ; RV32IZCMP-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV32IZCMP-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV32IZCMP-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, -56(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, -60(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, -64(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, -68(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, -72(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a1, 20(a0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, -76(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 4(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw t4, 24(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    lw t5, 28(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    lw t6, 32(a0)
@@ -604,17 +604,17 @@ define void @callee() {
 ; RV32IZCMP-WITH-FP-NEXT:    sw t6, 32(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    sw t5, 28(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    sw t4, 24(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, -76(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 4(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, -72(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, -68(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, -64(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, -60(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a1, 4(a0)
-; RV32IZCMP-WITH-FP-NEXT:    lw a1, -56(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV32IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 80
 ; RV32IZCMP-WITH-FP-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
@@ -914,17 +914,17 @@ define void @callee() {
 ; RV64I-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV64I-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV64I-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, -112(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a1, 48(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, -120(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, -128(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, -136(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, -144(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a1, 20(a0)
-; RV64I-WITH-FP-NEXT:    sd a1, -152(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a7, 24(a0)
 ; RV64I-WITH-FP-NEXT:    lw t0, 28(a0)
 ; RV64I-WITH-FP-NEXT:    lw t1, 32(a0)
@@ -977,17 +977,17 @@ define void @callee() {
 ; RV64I-WITH-FP-NEXT:    sw t1, 32(a0)
 ; RV64I-WITH-FP-NEXT:    sw t0, 28(a0)
 ; RV64I-WITH-FP-NEXT:    sw a7, 24(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, -152(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, -144(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, -136(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, -128(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, -120(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a1, 4(a0)
-; RV64I-WITH-FP-NEXT:    ld a1, -112(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a1, 48(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV64I-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV64I-WITH-FP-NEXT:    ld ra, 152(sp) # 8-byte Folded Reload
@@ -1150,17 +1150,17 @@ define void @callee() {
 ; RV64IZCMP-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV64IZCMP-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV64IZCMP-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, -112(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 48(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, -120(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, -128(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, -136(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, -144(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a1, 20(a0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, -152(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw t4, 24(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    lw t5, 28(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    lw t6, 32(a0)
@@ -1213,17 +1213,17 @@ define void @callee() {
 ; RV64IZCMP-WITH-FP-NEXT:    sw t6, 32(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    sw t5, 28(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    sw t4, 24(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, -152(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, -144(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, -136(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, -128(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, -120(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a1, 4(a0)
-; RV64IZCMP-WITH-FP-NEXT:    ld a1, -112(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a1, 48(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV64IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV64IZCMP-WITH-FP-NEXT:    ld ra, 152(sp) # 8-byte Folded Reload
@@ -1617,49 +1617,49 @@ define void @caller() {
 ; RV32I-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV32I-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV32I-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -56(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -60(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -64(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -68(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -72(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -76(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -80(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -84(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -88(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -92(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -96(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -100(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -104(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -108(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -112(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -116(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -120(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -124(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -128(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -132(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -136(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw a0, 84(s1)
-; RV32I-WITH-FP-NEXT:    sw a0, -140(s0) # 4-byte Folded Spill
+; RV32I-WITH-FP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
 ; RV32I-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV32I-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV32I-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -1681,49 +1681,49 @@ define void @caller() {
 ; RV32I-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV32I-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV32I-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -140(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -136(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -132(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -128(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -124(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -120(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -116(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -112(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -108(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -104(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -100(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -96(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -92(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -88(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -84(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -80(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -76(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -72(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -68(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -64(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -60(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 4(s1)
-; RV32I-WITH-FP-NEXT:    lw a0, -56(s0) # 4-byte Folded Reload
+; RV32I-WITH-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
 ; RV32I-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV32I-WITH-FP-NEXT:    .cfi_def_cfa sp, 144
 ; RV32I-WITH-FP-NEXT:    lw ra, 140(sp) # 4-byte Folded Reload
@@ -1923,49 +1923,49 @@ define void @caller() {
 ; RV32IZCMP-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV32IZCMP-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -56(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -60(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -64(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -68(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -72(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -76(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -80(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -84(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -88(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -92(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -96(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -100(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -104(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -108(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -112(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -116(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -120(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -124(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -128(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -132(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -136(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw a0, 84(s1)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, -140(s0) # 4-byte Folded Spill
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
 ; RV32IZCMP-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -1987,49 +1987,49 @@ define void @caller() {
 ; RV32IZCMP-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -140(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -136(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -132(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -128(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -124(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -120(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -116(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -112(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -108(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -104(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -100(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -96(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -92(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -88(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -84(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -80(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -76(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -72(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -68(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -64(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -60(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 4(s1)
-; RV32IZCMP-WITH-FP-NEXT:    lw a0, -56(s0) # 4-byte Folded Reload
+; RV32IZCMP-WITH-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
 ; RV32IZCMP-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV32IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 144
 ; RV32IZCMP-WITH-FP-NEXT:    lw ra, 140(sp) # 4-byte Folded Reload
@@ -2415,49 +2415,49 @@ define void @caller() {
 ; RV64I-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV64I-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV64I-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -112(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -120(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -128(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -136(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -144(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -152(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -160(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -168(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -176(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -184(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -192(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -200(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -208(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -216(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -224(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -232(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -240(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -248(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -256(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -264(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -272(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw a0, 84(s1)
-; RV64I-WITH-FP-NEXT:    sd a0, -280(s0) # 8-byte Folded Spill
+; RV64I-WITH-FP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
 ; RV64I-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV64I-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV64I-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -2479,49 +2479,49 @@ define void @caller() {
 ; RV64I-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV64I-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV64I-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -280(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -272(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -264(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -256(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -248(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -240(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -232(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -224(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -216(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -208(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -200(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -192(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -184(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -176(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -168(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -160(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -152(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -144(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -136(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -128(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -120(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 4(s1)
-; RV64I-WITH-FP-NEXT:    ld a0, -112(s0) # 8-byte Folded Reload
+; RV64I-WITH-FP-NEXT:    ld a0, 176(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV64I-WITH-FP-NEXT:    .cfi_def_cfa sp, 288
 ; RV64I-WITH-FP-NEXT:    ld ra, 280(sp) # 8-byte Folded Reload
@@ -2721,49 +2721,49 @@ define void @caller() {
 ; RV64IZCMP-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV64IZCMP-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -112(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -120(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -128(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -136(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -144(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -152(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -160(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -168(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -176(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -184(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -192(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -200(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -208(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -216(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -224(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -232(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -240(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -248(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -256(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -264(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -272(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw a0, 84(s1)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, -280(s0) # 8-byte Folded Spill
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
 ; RV64IZCMP-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -2785,49 +2785,49 @@ define void @caller() {
 ; RV64IZCMP-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -280(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -272(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -264(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -256(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -248(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -240(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -232(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -224(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -216(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -208(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -200(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -192(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -184(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -176(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -168(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -160(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -152(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -144(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -136(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -128(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -120(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 4(s1)
-; RV64IZCMP-WITH-FP-NEXT:    ld a0, -112(s0) # 8-byte Folded Reload
+; RV64IZCMP-WITH-FP-NEXT:    ld a0, 176(sp) # 8-byte Folded Reload
 ; RV64IZCMP-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV64IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 288
 ; RV64IZCMP-WITH-FP-NEXT:    ld ra, 280(sp) # 8-byte Folded Reload
@@ -3265,14 +3265,14 @@ define void @varargs(...) {
 ; RV32I-WITH-FP-NEXT:    .cfi_offset s0, -40
 ; RV32I-WITH-FP-NEXT:    addi s0, sp, 16
 ; RV32I-WITH-FP-NEXT:    .cfi_def_cfa s0, 32
-; RV32I-WITH-FP-NEXT:    sw a4, 16(s0)
-; RV32I-WITH-FP-NEXT:    sw a5, 20(s0)
-; RV32I-WITH-FP-NEXT:    sw a6, 24(s0)
-; RV32I-WITH-FP-NEXT:    sw a7, 28(s0)
-; RV32I-WITH-FP-NEXT:    sw a0, 0(s0)
-; RV32I-WITH-FP-NEXT:    sw a1, 4(s0)
-; RV32I-WITH-FP-NEXT:    sw a2, 8(s0)
-; RV32I-WITH-FP-NEXT:    sw a3, 12(s0)
+; RV32I-WITH-FP-NEXT:    sw a4, 32(sp)
+; RV32I-WITH-FP-NEXT:    sw a5, 36(sp)
+; RV32I-WITH-FP-NEXT:    sw a6, 40(sp)
+; RV32I-WITH-FP-NEXT:    sw a7, 44(sp)
+; RV32I-WITH-FP-NEXT:    sw a0, 16(sp)
+; RV32I-WITH-FP-NEXT:    sw a1, 20(sp)
+; RV32I-WITH-FP-NEXT:    sw a2, 24(sp)
+; RV32I-WITH-FP-NEXT:    sw a3, 28(sp)
 ; RV32I-WITH-FP-NEXT:    call callee
 ; RV32I-WITH-FP-NEXT:    .cfi_def_cfa sp, 48
 ; RV32I-WITH-FP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -3314,14 +3314,14 @@ define void @varargs(...) {
 ; RV32IZCMP-WITH-FP-NEXT:    .cfi_offset s0, -40
 ; RV32IZCMP-WITH-FP-NEXT:    addi s0, sp, 16
 ; RV32IZCMP-WITH-FP-NEXT:    .cfi_def_cfa s0, 32
-; RV32IZCMP-WITH-FP-NEXT:    sw a4, 16(s0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a5, 20(s0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a6, 24(s0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a7, 28(s0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a0, 0(s0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a1, 4(s0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a2, 8(s0)
-; RV32IZCMP-WITH-FP-NEXT:    sw a3, 12(s0)
+; RV32IZCMP-WITH-FP-NEXT:    sw a4, 32(sp)
+; RV32IZCMP-WITH-FP-NEXT:    sw a5, 36(sp)
+; RV32IZCMP-WITH-FP-NEXT:    sw a6, 40(sp)
+; RV32IZCMP-WITH-FP-NEXT:    sw a7, 44(sp)
+; RV32IZCMP-WITH-FP-NEXT:    sw a0, 16(sp)
+; RV32IZCMP-WITH-FP-NEXT:    sw a1, 20(sp)
+; RV32IZCMP-WITH-FP-NEXT:    sw a2, 24(sp)
+; RV32IZCMP-WITH-FP-NEXT:    sw a3, 28(sp)
 ; RV32IZCMP-WITH-FP-NEXT:    call callee
 ; RV32IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 48
 ; RV32IZCMP-WITH-FP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -3382,14 +3382,14 @@ define void @varargs(...) {
 ; RV64I-WITH-FP-NEXT:    .cfi_offset s0, -80
 ; RV64I-WITH-FP-NEXT:    addi s0, sp, 16
 ; RV64I-WITH-FP-NEXT:    .cfi_def_cfa s0, 64
-; RV64I-WITH-FP-NEXT:    sd a4, 32(s0)
-; RV64I-WITH-FP-NEXT:    sd a5, 40(s0)
-; RV64I-WITH-FP-NEXT:    sd a6, 48(s0)
-; RV64I-WITH-FP-NEXT:    sd a7, 56(s0)
-; RV64I-WITH-FP-NEXT:    sd a0, 0(s0)
-; RV64I-WITH-FP-NEXT:    sd a1, 8(s0)
-; RV64I-WITH-FP-NEXT:    sd a2, 16(s0)
-; RV64I-WITH-FP-NEXT:    sd a3, 24(s0)
+; RV64I-WITH-FP-NEXT:    sd a4, 48(sp)
+; RV64I-WITH-FP-NEXT:    sd a5, 56(sp)
+; RV64I-WITH-FP-NEXT:    sd a6, 64(sp)
+; RV64I-WITH-FP-NEXT:    sd a7, 72(sp)
+; RV64I-WITH-FP-NEXT:    sd a0, 16(sp)
+; RV64I-WITH-FP-NEXT:    sd a1, 24(sp)
+; RV64I-WITH-FP-NEXT:    sd a2, 32(sp)
+; RV64I-WITH-FP-NEXT:    sd a3, 40(sp)
 ; RV64I-WITH-FP-NEXT:    call callee
 ; RV64I-WITH-FP-NEXT:    .cfi_def_cfa sp, 80
 ; RV64I-WITH-FP-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
@@ -3431,14 +3431,14 @@ define void @varargs(...) {
 ; RV64IZCMP-WITH-FP-NEXT:    .cfi_offset s0, -80
 ; RV64IZCMP-WITH-FP-NEXT:    addi s0, sp, 16
 ; RV64IZCMP-WITH-FP-NEXT:    .cfi_def_cfa s0, 64
-; RV64IZCMP-WITH-FP-NEXT:    sd a4, 32(s0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a5, 40(s0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a6, 48(s0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a7, 56(s0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a0, 0(s0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a1, 8(s0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a2, 16(s0)
-; RV64IZCMP-WITH-FP-NEXT:    sd a3, 24(s0)
+; RV64IZCMP-WITH-FP-NEXT:    sd a4, 48(sp)
+; RV64IZCMP-WITH-FP-NEXT:    sd a5, 56(sp)
+; RV64IZCMP-WITH-FP-NEXT:    sd a6, 64(sp)
+; RV64IZCMP-WITH-FP-NEXT:    sd a7, 72(sp)
+; RV64IZCMP-WITH-FP-NEXT:    sd a0, 16(sp)
+; RV64IZCMP-WITH-FP-NEXT:    sd a1, 24(sp)
+; RV64IZCMP-WITH-FP-NEXT:    sd a2, 32(sp)
+; RV64IZCMP-WITH-FP-NEXT:    sd a3, 40(sp)
 ; RV64IZCMP-WITH-FP-NEXT:    call callee
 ; RV64IZCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 80
 ; RV64IZCMP-WITH-FP-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/calling-conv-ilp32-ilp32f-common.ll
+++ b/llvm/test/CodeGen/RISCV/calling-conv-ilp32-ilp32f-common.ll
@@ -112,10 +112,10 @@ define i32 @callee_aligned_stack(i32 %a, i32 %b, fp128 %c, i32 %d, i32 %e, i64 %
 ; RV32I-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 16
 ; RV32I-WITHFP-NEXT:    lw a0, 0(a2)
-; RV32I-WITHFP-NEXT:    lw a1, 8(s0)
-; RV32I-WITHFP-NEXT:    lw a2, 0(s0)
-; RV32I-WITHFP-NEXT:    lw a3, 20(s0)
-; RV32I-WITHFP-NEXT:    lw a4, 16(s0)
+; RV32I-WITHFP-NEXT:    lw a1, 24(sp)
+; RV32I-WITHFP-NEXT:    lw a2, 16(sp)
+; RV32I-WITHFP-NEXT:    lw a3, 36(sp)
+; RV32I-WITHFP-NEXT:    lw a4, 32(sp)
 ; RV32I-WITHFP-NEXT:    add a0, a0, a7
 ; RV32I-WITHFP-NEXT:    add a1, a2, a1
 ; RV32I-WITHFP-NEXT:    add a0, a0, a1
@@ -207,7 +207,7 @@ define void @caller_aligned_stack() nounwind {
 ; RV32I-WITHFP-NEXT:    lui s1, 688509
 ; RV32I-WITHFP-NEXT:    li a0, 1
 ; RV32I-WITHFP-NEXT:    li a1, 11
-; RV32I-WITHFP-NEXT:    addi a2, s0, -32
+; RV32I-WITHFP-NEXT:    addi a2, sp, 32
 ; RV32I-WITHFP-NEXT:    li a3, 12
 ; RV32I-WITHFP-NEXT:    li a4, 13
 ; RV32I-WITHFP-NEXT:    sw a6, 20(sp)
@@ -225,10 +225,10 @@ define void @caller_aligned_stack() nounwind {
 ; RV32I-WITHFP-NEXT:    addi t2, t5, -328
 ; RV32I-WITHFP-NEXT:    addi t3, t6, 1311
 ; RV32I-WITHFP-NEXT:    addi a5, s1, -2048
-; RV32I-WITHFP-NEXT:    sw t3, -32(s0)
-; RV32I-WITHFP-NEXT:    sw t2, -28(s0)
-; RV32I-WITHFP-NEXT:    sw t1, -24(s0)
-; RV32I-WITHFP-NEXT:    sw t0, -20(s0)
+; RV32I-WITHFP-NEXT:    sw t3, 32(sp)
+; RV32I-WITHFP-NEXT:    sw t2, 36(sp)
+; RV32I-WITHFP-NEXT:    sw t1, 40(sp)
+; RV32I-WITHFP-NEXT:    sw t0, 44(sp)
 ; RV32I-WITHFP-NEXT:    call callee_aligned_stack
 ; RV32I-WITHFP-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/calling-conv-ilp32-ilp32f-ilp32d-common.ll
+++ b/llvm/test/CodeGen/RISCV/calling-conv-ilp32-ilp32f-ilp32d-common.ll
@@ -105,8 +105,8 @@ define i32 @callee_many_scalars(i8 %a, i16 %b, i32 %c, i64 %d, i32 %e, i32 %f, i
 ; RV32I-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 16
-; RV32I-WITHFP-NEXT:    lw t0, 4(s0)
-; RV32I-WITHFP-NEXT:    lw t1, 0(s0)
+; RV32I-WITHFP-NEXT:    lw t0, 20(sp)
+; RV32I-WITHFP-NEXT:    lw t1, 16(sp)
 ; RV32I-WITHFP-NEXT:    zext.b a0, a0
 ; RV32I-WITHFP-NEXT:    slli a1, a1, 16
 ; RV32I-WITHFP-NEXT:    xor a3, a3, a7
@@ -270,16 +270,16 @@ define i32 @caller_large_scalars() nounwind {
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 48
 ; RV32I-WITHFP-NEXT:    lui a1, 524272
 ; RV32I-WITHFP-NEXT:    li a2, 1
-; RV32I-WITHFP-NEXT:    addi a0, s0, -24
-; RV32I-WITHFP-NEXT:    sw zero, -48(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -44(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -40(s0)
-; RV32I-WITHFP-NEXT:    sw a1, -36(s0)
-; RV32I-WITHFP-NEXT:    addi a1, s0, -48
-; RV32I-WITHFP-NEXT:    sw a2, -24(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -20(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -16(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -12(s0)
+; RV32I-WITHFP-NEXT:    addi a0, sp, 24
+; RV32I-WITHFP-NEXT:    sw zero, 0(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 4(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 8(sp)
+; RV32I-WITHFP-NEXT:    sw a1, 12(sp)
+; RV32I-WITHFP-NEXT:    mv a1, sp
+; RV32I-WITHFP-NEXT:    sw a2, 24(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 28(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 32(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 36(sp)
 ; RV32I-WITHFP-NEXT:    call callee_large_scalars
 ; RV32I-WITHFP-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
@@ -321,7 +321,7 @@ define i32 @callee_large_scalars_exhausted_regs(i32 %a, i32 %b, i32 %c, i32 %d, 
 ; RV32I-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 16
-; RV32I-WITHFP-NEXT:    lw a0, 4(s0)
+; RV32I-WITHFP-NEXT:    lw a0, 20(sp)
 ; RV32I-WITHFP-NEXT:    lw a1, 0(a7)
 ; RV32I-WITHFP-NEXT:    lw a2, 4(a7)
 ; RV32I-WITHFP-NEXT:    lw a3, 8(a7)
@@ -386,7 +386,7 @@ define i32 @caller_large_scalars_exhausted_regs() nounwind {
 ; RV32I-WITHFP-NEXT:    sw ra, 60(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    sw s0, 56(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 64
-; RV32I-WITHFP-NEXT:    addi a6, s0, -48
+; RV32I-WITHFP-NEXT:    addi a6, sp, 16
 ; RV32I-WITHFP-NEXT:    li a7, 9
 ; RV32I-WITHFP-NEXT:    lui t0, 524272
 ; RV32I-WITHFP-NEXT:    li t1, 8
@@ -399,15 +399,15 @@ define i32 @caller_large_scalars_exhausted_regs() nounwind {
 ; RV32I-WITHFP-NEXT:    sw a7, 0(sp)
 ; RV32I-WITHFP-NEXT:    sw a6, 4(sp)
 ; RV32I-WITHFP-NEXT:    li a6, 7
-; RV32I-WITHFP-NEXT:    sw zero, -48(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -44(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -40(s0)
-; RV32I-WITHFP-NEXT:    sw t0, -36(s0)
-; RV32I-WITHFP-NEXT:    addi a7, s0, -24
-; RV32I-WITHFP-NEXT:    sw t1, -24(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -20(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -16(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -12(s0)
+; RV32I-WITHFP-NEXT:    sw zero, 16(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 20(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 24(sp)
+; RV32I-WITHFP-NEXT:    sw t0, 28(sp)
+; RV32I-WITHFP-NEXT:    addi a7, sp, 40
+; RV32I-WITHFP-NEXT:    sw t1, 40(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 44(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 48(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 52(sp)
 ; RV32I-WITHFP-NEXT:    call callee_large_scalars_exhausted_regs
 ; RV32I-WITHFP-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
@@ -443,9 +443,9 @@ define i32 @caller_mixed_scalar_libcalls(i64 %a) nounwind {
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 32
 ; RV32I-WITHFP-NEXT:    mv a2, a1
 ; RV32I-WITHFP-NEXT:    mv a1, a0
-; RV32I-WITHFP-NEXT:    addi a0, s0, -24
+; RV32I-WITHFP-NEXT:    addi a0, sp, 8
 ; RV32I-WITHFP-NEXT:    call __floatditf
-; RV32I-WITHFP-NEXT:    lw a0, -24(s0)
+; RV32I-WITHFP-NEXT:    lw a0, 8(sp)
 ; RV32I-WITHFP-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    addi sp, sp, 32
@@ -580,15 +580,15 @@ define i32 @caller_large_struct() nounwind {
 ; RV32I-WITHFP-NEXT:    li a1, 2
 ; RV32I-WITHFP-NEXT:    li a2, 3
 ; RV32I-WITHFP-NEXT:    li a3, 4
-; RV32I-WITHFP-NEXT:    sw a0, -24(s0)
-; RV32I-WITHFP-NEXT:    sw a1, -20(s0)
-; RV32I-WITHFP-NEXT:    sw a2, -16(s0)
-; RV32I-WITHFP-NEXT:    sw a3, -12(s0)
-; RV32I-WITHFP-NEXT:    sw a0, -40(s0)
-; RV32I-WITHFP-NEXT:    sw a1, -36(s0)
-; RV32I-WITHFP-NEXT:    sw a2, -32(s0)
-; RV32I-WITHFP-NEXT:    sw a3, -28(s0)
-; RV32I-WITHFP-NEXT:    addi a0, s0, -40
+; RV32I-WITHFP-NEXT:    sw a0, 24(sp)
+; RV32I-WITHFP-NEXT:    sw a1, 28(sp)
+; RV32I-WITHFP-NEXT:    sw a2, 32(sp)
+; RV32I-WITHFP-NEXT:    sw a3, 36(sp)
+; RV32I-WITHFP-NEXT:    sw a0, 8(sp)
+; RV32I-WITHFP-NEXT:    sw a1, 12(sp)
+; RV32I-WITHFP-NEXT:    sw a2, 16(sp)
+; RV32I-WITHFP-NEXT:    sw a3, 20(sp)
+; RV32I-WITHFP-NEXT:    addi a0, sp, 8
 ; RV32I-WITHFP-NEXT:    call callee_large_struct
 ; RV32I-WITHFP-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload
@@ -632,10 +632,10 @@ define i32 @callee_aligned_stack(i32 %a, i32 %b, fp128 %c, i32 %d, i32 %e, i64 %
 ; RV32I-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 16
 ; RV32I-WITHFP-NEXT:    lw a0, 0(a2)
-; RV32I-WITHFP-NEXT:    lw a1, 8(s0)
-; RV32I-WITHFP-NEXT:    lw a2, 0(s0)
-; RV32I-WITHFP-NEXT:    lw a3, 20(s0)
-; RV32I-WITHFP-NEXT:    lw a4, 16(s0)
+; RV32I-WITHFP-NEXT:    lw a1, 24(sp)
+; RV32I-WITHFP-NEXT:    lw a2, 16(sp)
+; RV32I-WITHFP-NEXT:    lw a3, 36(sp)
+; RV32I-WITHFP-NEXT:    lw a4, 32(sp)
 ; RV32I-WITHFP-NEXT:    add a0, a0, a7
 ; RV32I-WITHFP-NEXT:    add a1, a2, a1
 ; RV32I-WITHFP-NEXT:    add a0, a0, a1
@@ -719,7 +719,7 @@ define void @caller_aligned_stack() nounwind {
 ; RV32I-WITHFP-NEXT:    lui t6, 688509
 ; RV32I-WITHFP-NEXT:    li a0, 1
 ; RV32I-WITHFP-NEXT:    li a1, 11
-; RV32I-WITHFP-NEXT:    addi a2, s0, -32
+; RV32I-WITHFP-NEXT:    addi a2, sp, 32
 ; RV32I-WITHFP-NEXT:    li a3, 12
 ; RV32I-WITHFP-NEXT:    li a4, 13
 ; RV32I-WITHFP-NEXT:    sw a6, 20(sp)
@@ -735,10 +735,10 @@ define void @caller_aligned_stack() nounwind {
 ; RV32I-WITHFP-NEXT:    addi t2, t4, -328
 ; RV32I-WITHFP-NEXT:    addi t3, t5, 1311
 ; RV32I-WITHFP-NEXT:    addi a5, t6, -2048
-; RV32I-WITHFP-NEXT:    sw t3, -32(s0)
-; RV32I-WITHFP-NEXT:    sw t2, -28(s0)
-; RV32I-WITHFP-NEXT:    sw t1, -24(s0)
-; RV32I-WITHFP-NEXT:    sw t0, -20(s0)
+; RV32I-WITHFP-NEXT:    sw t3, 32(sp)
+; RV32I-WITHFP-NEXT:    sw t2, 36(sp)
+; RV32I-WITHFP-NEXT:    sw t1, 40(sp)
+; RV32I-WITHFP-NEXT:    sw t0, 44(sp)
 ; RV32I-WITHFP-NEXT:    call callee_aligned_stack
 ; RV32I-WITHFP-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
@@ -922,7 +922,7 @@ define void @caller_large_scalar_ret() nounwind {
 ; RV32I-WITHFP-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 32
-; RV32I-WITHFP-NEXT:    addi a0, s0, -32
+; RV32I-WITHFP-NEXT:    mv a0, sp
 ; RV32I-WITHFP-NEXT:    call callee_large_scalar_ret
 ; RV32I-WITHFP-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload
@@ -995,10 +995,10 @@ define i32 @caller_large_struct_ret() nounwind {
 ; RV32I-WITHFP-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 32
-; RV32I-WITHFP-NEXT:    addi a0, s0, -24
+; RV32I-WITHFP-NEXT:    addi a0, sp, 8
 ; RV32I-WITHFP-NEXT:    call callee_large_struct_ret
-; RV32I-WITHFP-NEXT:    lw a0, -24(s0)
-; RV32I-WITHFP-NEXT:    lw a1, -12(s0)
+; RV32I-WITHFP-NEXT:    lw a0, 8(sp)
+; RV32I-WITHFP-NEXT:    lw a1, 20(sp)
 ; RV32I-WITHFP-NEXT:    add a0, a0, a1
 ; RV32I-WITHFP-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 24(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/calling-conv-ilp32.ll
+++ b/llvm/test/CodeGen/RISCV/calling-conv-ilp32.ll
@@ -90,7 +90,7 @@ define i32 @callee_float_on_stack(i64 %a, i64 %b, i64 %c, i64 %d, float %e) noun
 ; RV32I-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 16
-; RV32I-WITHFP-NEXT:    lw a0, 0(s0)
+; RV32I-WITHFP-NEXT:    lw a0, 16(sp)
 ; RV32I-WITHFP-NEXT:    add a0, a6, a0
 ; RV32I-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32I-WITHFP-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/calling-conv-ilp32e.ll
+++ b/llvm/test/CodeGen/RISCV/calling-conv-ilp32e.ll
@@ -175,8 +175,8 @@ define i32 @callee_float_on_stack(i64 %a, i64 %b, i64 %c, i64 %d, float %e) {
 ; ILP32E-WITHFP-NEXT:    .cfi_offset s0, -8
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 8
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa s0, 0
-; ILP32E-WITHFP-NEXT:    lw a0, 8(s0)
-; ILP32E-WITHFP-NEXT:    lw a1, 0(s0)
+; ILP32E-WITHFP-NEXT:    lw a0, 16(sp)
+; ILP32E-WITHFP-NEXT:    lw a1, 8(sp)
 ; ILP32E-WITHFP-NEXT:    add a0, a1, a0
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa sp, 8
 ; ILP32E-WITHFP-NEXT:    lw ra, 4(sp) # 4-byte Folded Reload
@@ -202,8 +202,8 @@ define i32 @callee_float_on_stack(i64 %a, i64 %b, i64 %c, i64 %d, float %e) {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 8(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 0(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 16(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 8(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a1, a0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa sp, 8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    tail __riscv_restore_1
@@ -612,11 +612,11 @@ define i32 @callee_aligned_stack(i32 %a, i32 %b, fp128 %c, i32 %d, i32 %e, i64 %
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 8
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-NEXT:    lw a0, 0(a2)
-; ILP32E-WITHFP-NEXT:    lw a1, 12(s0)
-; ILP32E-WITHFP-NEXT:    lw a2, 4(s0)
-; ILP32E-WITHFP-NEXT:    lw a3, 8(s0)
-; ILP32E-WITHFP-NEXT:    lw a4, 24(s0)
-; ILP32E-WITHFP-NEXT:    lw a5, 20(s0)
+; ILP32E-WITHFP-NEXT:    lw a1, 20(sp)
+; ILP32E-WITHFP-NEXT:    lw a2, 12(sp)
+; ILP32E-WITHFP-NEXT:    lw a3, 16(sp)
+; ILP32E-WITHFP-NEXT:    lw a4, 32(sp)
+; ILP32E-WITHFP-NEXT:    lw a5, 28(sp)
 ; ILP32E-WITHFP-NEXT:    add a0, a0, a2
 ; ILP32E-WITHFP-NEXT:    add a1, a3, a1
 ; ILP32E-WITHFP-NEXT:    add a0, a0, a1
@@ -655,11 +655,11 @@ define i32 @callee_aligned_stack(i32 %a, i32 %b, fp128 %c, i32 %d, i32 %e, i64 %
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 0(a2)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 12(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a2, 4(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a3, 8(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a4, 24(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a5, 20(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 20(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a2, 12(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a3, 16(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a4, 32(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a5, 28(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a0, a2
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a1, a3, a1
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    add a0, a0, a1
@@ -1177,10 +1177,10 @@ define i32 @callee_many_scalars(i8 %a, i16 %b, i32 %c, i64 %d, i32 %e, i32 %f, i
 ; ILP32E-WITHFP-NEXT:    .cfi_offset s0, -8
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 8
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa s0, 0
-; ILP32E-WITHFP-NEXT:    lw a6, 12(s0)
-; ILP32E-WITHFP-NEXT:    lw a7, 0(s0)
-; ILP32E-WITHFP-NEXT:    lw t0, 4(s0)
-; ILP32E-WITHFP-NEXT:    lw t1, 8(s0)
+; ILP32E-WITHFP-NEXT:    lw a6, 20(sp)
+; ILP32E-WITHFP-NEXT:    lw a7, 8(sp)
+; ILP32E-WITHFP-NEXT:    lw t0, 12(sp)
+; ILP32E-WITHFP-NEXT:    lw t1, 16(sp)
 ; ILP32E-WITHFP-NEXT:    zext.b a0, a0
 ; ILP32E-WITHFP-NEXT:    slli a1, a1, 16
 ; ILP32E-WITHFP-NEXT:    srli a1, a1, 16
@@ -1232,10 +1232,10 @@ define i32 @callee_many_scalars(i8 %a, i16 %b, i32 %c, i64 %d, i32 %e, i32 %f, i
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a6, 12(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a7, 0(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw t0, 4(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw t1, 8(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a6, 20(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a7, 8(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw t0, 12(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw t1, 16(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    zext.b a0, a0
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    slli a1, a1, 16
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    srli a1, a1, 16
@@ -1660,8 +1660,8 @@ define i32 @callee_large_scalars_exhausted_regs(i32 %a, i32 %b, i32 %c, i32 %d, 
 ; ILP32E-WITHFP-NEXT:    .cfi_offset s0, -8
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 8
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa s0, 0
-; ILP32E-WITHFP-NEXT:    lw a0, 12(s0)
-; ILP32E-WITHFP-NEXT:    lw a1, 4(s0)
+; ILP32E-WITHFP-NEXT:    lw a0, 20(sp)
+; ILP32E-WITHFP-NEXT:    lw a1, 12(sp)
 ; ILP32E-WITHFP-NEXT:    lw a2, 0(a0)
 ; ILP32E-WITHFP-NEXT:    lw a3, 4(a0)
 ; ILP32E-WITHFP-NEXT:    lw a4, 8(a0)
@@ -1717,8 +1717,8 @@ define i32 @callee_large_scalars_exhausted_regs(i32 %a, i32 %b, i32 %c, i32 %d, 
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_offset s0, -8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi s0, sp, 8
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa s0, 0
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 12(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 4(s0)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a0, 20(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a1, 12(sp)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a2, 0(a0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a3, 4(a0)
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    lw a4, 8(a0)
@@ -2255,15 +2255,15 @@ define i32 @caller_large_struct() {
 ; ILP32E-WITHFP-NEXT:    li a1, 2
 ; ILP32E-WITHFP-NEXT:    li a2, 3
 ; ILP32E-WITHFP-NEXT:    li a3, 4
-; ILP32E-WITHFP-NEXT:    sw a0, -24(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, -20(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, -16(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, -12(s0)
-; ILP32E-WITHFP-NEXT:    sw a0, -40(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, -36(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, -32(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, -28(s0)
-; ILP32E-WITHFP-NEXT:    addi a0, s0, -40
+; ILP32E-WITHFP-NEXT:    sw a0, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 24(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 28(sp)
+; ILP32E-WITHFP-NEXT:    sw a0, 0(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 4(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 8(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 12(sp)
+; ILP32E-WITHFP-NEXT:    mv a0, sp
 ; ILP32E-WITHFP-NEXT:    call callee_large_struct
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa sp, 40
 ; ILP32E-WITHFP-NEXT:    lw ra, 36(sp) # 4-byte Folded Reload
@@ -2313,15 +2313,15 @@ define i32 @caller_large_struct() {
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a1, 2
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a2, 3
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    li a3, 4
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, -24(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, -20(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, -16(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, -12(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, -40(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, -36(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, -32(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, -28(s0)
-; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi a0, s0, -40
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 16(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, 20(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, 24(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, 28(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a0, 0(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a1, 4(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a2, 8(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    sw a3, 12(sp)
+; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    mv a0, sp
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    call callee_large_struct
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    .cfi_def_cfa sp, 40
 ; ILP32E-WITHFP-SAVE-RESTORE-NEXT:    addi sp, sp, 32

--- a/llvm/test/CodeGen/RISCV/calling-conv-lp64.ll
+++ b/llvm/test/CodeGen/RISCV/calling-conv-lp64.ll
@@ -91,7 +91,7 @@ define i64 @callee_float_on_stack(i128 %a, i128 %b, i128 %c, i128 %d, float %e) 
 ; RV64I-WITHFP-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
 ; RV64I-WITHFP-NEXT:    sd s0, 0(sp) # 8-byte Folded Spill
 ; RV64I-WITHFP-NEXT:    addi s0, sp, 16
-; RV64I-WITHFP-NEXT:    lw a0, 0(s0)
+; RV64I-WITHFP-NEXT:    lw a0, 16(sp)
 ; RV64I-WITHFP-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
 ; RV64I-WITHFP-NEXT:    ld s0, 0(sp) # 8-byte Folded Reload
 ; RV64I-WITHFP-NEXT:    addi sp, sp, 16

--- a/llvm/test/CodeGen/RISCV/emit-x8-as-fp.ll
+++ b/llvm/test/CodeGen/RISCV/emit-x8-as-fp.ll
@@ -19,10 +19,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV32I-DEFAULT-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-DEFAULT-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-DEFAULT-NEXT:    addi s0, sp, 16
-; RV32I-DEFAULT-NEXT:    sw a0, -12(s0)
-; RV32I-DEFAULT-NEXT:    sw a1, -16(s0)
-; RV32I-DEFAULT-NEXT:    lw a0, -12(s0)
-; RV32I-DEFAULT-NEXT:    lw a1, -16(s0)
+; RV32I-DEFAULT-NEXT:    sw a0, 4(sp)
+; RV32I-DEFAULT-NEXT:    sw a1, 0(sp)
+; RV32I-DEFAULT-NEXT:    lw a0, 4(sp)
+; RV32I-DEFAULT-NEXT:    lw a1, 0(sp)
 ; RV32I-DEFAULT-NEXT:    add a0, a0, a1
 ; RV32I-DEFAULT-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32I-DEFAULT-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
@@ -35,10 +35,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV64I-DEFAULT-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64I-DEFAULT-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64I-DEFAULT-NEXT:    addi s0, sp, 32
-; RV64I-DEFAULT-NEXT:    sw a0, -20(s0)
-; RV64I-DEFAULT-NEXT:    sw a1, -24(s0)
-; RV64I-DEFAULT-NEXT:    lw a0, -20(s0)
-; RV64I-DEFAULT-NEXT:    lw a1, -24(s0)
+; RV64I-DEFAULT-NEXT:    sw a0, 12(sp)
+; RV64I-DEFAULT-NEXT:    sw a1, 8(sp)
+; RV64I-DEFAULT-NEXT:    lw a0, 12(sp)
+; RV64I-DEFAULT-NEXT:    lw a1, 8(sp)
 ; RV64I-DEFAULT-NEXT:    addw a0, a0, a1
 ; RV64I-DEFAULT-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; RV64I-DEFAULT-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
@@ -51,10 +51,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV32I-EMIT-FP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-EMIT-FP-NEXT:    sw fp, 8(sp) # 4-byte Folded Spill
 ; RV32I-EMIT-FP-NEXT:    addi fp, sp, 16
-; RV32I-EMIT-FP-NEXT:    sw a0, -12(fp)
-; RV32I-EMIT-FP-NEXT:    sw a1, -16(fp)
-; RV32I-EMIT-FP-NEXT:    lw a0, -12(fp)
-; RV32I-EMIT-FP-NEXT:    lw a1, -16(fp)
+; RV32I-EMIT-FP-NEXT:    sw a0, 4(sp)
+; RV32I-EMIT-FP-NEXT:    sw a1, 0(sp)
+; RV32I-EMIT-FP-NEXT:    lw a0, 4(sp)
+; RV32I-EMIT-FP-NEXT:    lw a1, 0(sp)
 ; RV32I-EMIT-FP-NEXT:    add a0, a0, a1
 ; RV32I-EMIT-FP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32I-EMIT-FP-NEXT:    lw fp, 8(sp) # 4-byte Folded Reload
@@ -67,10 +67,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV64I-EMIT-FP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; RV64I-EMIT-FP-NEXT:    sd fp, 16(sp) # 8-byte Folded Spill
 ; RV64I-EMIT-FP-NEXT:    addi fp, sp, 32
-; RV64I-EMIT-FP-NEXT:    sw a0, -20(fp)
-; RV64I-EMIT-FP-NEXT:    sw a1, -24(fp)
-; RV64I-EMIT-FP-NEXT:    lw a0, -20(fp)
-; RV64I-EMIT-FP-NEXT:    lw a1, -24(fp)
+; RV64I-EMIT-FP-NEXT:    sw a0, 12(sp)
+; RV64I-EMIT-FP-NEXT:    sw a1, 8(sp)
+; RV64I-EMIT-FP-NEXT:    lw a0, 12(sp)
+; RV64I-EMIT-FP-NEXT:    lw a1, 8(sp)
 ; RV64I-EMIT-FP-NEXT:    addw a0, a0, a1
 ; RV64I-EMIT-FP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; RV64I-EMIT-FP-NEXT:    ld fp, 16(sp) # 8-byte Folded Reload
@@ -83,10 +83,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV32I-NUMERIC-NEXT:    sw x1, 12(x2) # 4-byte Folded Spill
 ; RV32I-NUMERIC-NEXT:    sw x8, 8(x2) # 4-byte Folded Spill
 ; RV32I-NUMERIC-NEXT:    addi x8, x2, 16
-; RV32I-NUMERIC-NEXT:    sw x10, -12(x8)
-; RV32I-NUMERIC-NEXT:    sw x11, -16(x8)
-; RV32I-NUMERIC-NEXT:    lw x10, -12(x8)
-; RV32I-NUMERIC-NEXT:    lw x11, -16(x8)
+; RV32I-NUMERIC-NEXT:    sw x10, 4(x2)
+; RV32I-NUMERIC-NEXT:    sw x11, 0(x2)
+; RV32I-NUMERIC-NEXT:    lw x10, 4(x2)
+; RV32I-NUMERIC-NEXT:    lw x11, 0(x2)
 ; RV32I-NUMERIC-NEXT:    add x10, x10, x11
 ; RV32I-NUMERIC-NEXT:    lw x1, 12(x2) # 4-byte Folded Reload
 ; RV32I-NUMERIC-NEXT:    lw x8, 8(x2) # 4-byte Folded Reload
@@ -99,10 +99,10 @@ define signext i32 @add(i32 %0, i32 %1) #0 {
 ; RV64I-NUMERIC-NEXT:    sd x1, 24(x2) # 8-byte Folded Spill
 ; RV64I-NUMERIC-NEXT:    sd x8, 16(x2) # 8-byte Folded Spill
 ; RV64I-NUMERIC-NEXT:    addi x8, x2, 32
-; RV64I-NUMERIC-NEXT:    sw x10, -20(x8)
-; RV64I-NUMERIC-NEXT:    sw x11, -24(x8)
-; RV64I-NUMERIC-NEXT:    lw x10, -20(x8)
-; RV64I-NUMERIC-NEXT:    lw x11, -24(x8)
+; RV64I-NUMERIC-NEXT:    sw x10, 12(x2)
+; RV64I-NUMERIC-NEXT:    sw x11, 8(x2)
+; RV64I-NUMERIC-NEXT:    lw x10, 12(x2)
+; RV64I-NUMERIC-NEXT:    lw x11, 8(x2)
 ; RV64I-NUMERIC-NEXT:    addw x10, x10, x11
 ; RV64I-NUMERIC-NEXT:    ld x1, 24(x2) # 8-byte Folded Reload
 ; RV64I-NUMERIC-NEXT:    ld x8, 16(x2) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/frame.ll
+++ b/llvm/test/CodeGen/RISCV/frame.ll
@@ -29,12 +29,12 @@ define i32 @test() nounwind {
 ; RV32I-WITHFP-NEXT:    sw ra, 28(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    sw s0, 24(sp) # 4-byte Folded Spill
 ; RV32I-WITHFP-NEXT:    addi s0, sp, 32
-; RV32I-WITHFP-NEXT:    sw zero, -16(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -32(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -28(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -24(s0)
-; RV32I-WITHFP-NEXT:    sw zero, -20(s0)
-; RV32I-WITHFP-NEXT:    addi a0, s0, -28
+; RV32I-WITHFP-NEXT:    sw zero, 16(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 0(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 4(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 8(sp)
+; RV32I-WITHFP-NEXT:    sw zero, 12(sp)
+; RV32I-WITHFP-NEXT:    addi a0, sp, 4
 ; RV32I-WITHFP-NEXT:    call test1
 ; RV32I-WITHFP-NEXT:    li a0, 0
 ; RV32I-WITHFP-NEXT:    lw ra, 28(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/frameaddr-returnaddr.ll
+++ b/llvm/test/CodeGen/RISCV/frameaddr-returnaddr.ll
@@ -13,7 +13,7 @@ define ptr @test_frameaddress_0() nounwind {
 ; RV32I-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi s0, sp, 16
-; RV32I-NEXT:    mv a0, s0
+; RV32I-NEXT:    mv a0, sp
 ; RV32I-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    addi sp, sp, 16
@@ -25,7 +25,7 @@ define ptr @test_frameaddress_0() nounwind {
 ; RV64I-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    sd s0, 0(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    addi s0, sp, 16
-; RV64I-NEXT:    mv a0, s0
+; RV64I-NEXT:    mv a0, sp
 ; RV64I-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    ld s0, 0(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    addi sp, sp, 16
@@ -41,7 +41,7 @@ define ptr @test_frameaddress_2() nounwind {
 ; RV32I-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi s0, sp, 16
-; RV32I-NEXT:    lw a0, -8(s0)
+; RV32I-NEXT:    lw a0, -8(sp)
 ; RV32I-NEXT:    lw a0, -8(a0)
 ; RV32I-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32I-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
@@ -54,7 +54,7 @@ define ptr @test_frameaddress_2() nounwind {
 ; RV64I-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    sd s0, 0(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    addi s0, sp, 16
-; RV64I-NEXT:    ld a0, -16(s0)
+; RV64I-NEXT:    ld a0, -16(sp)
 ; RV64I-NEXT:    ld a0, -16(a0)
 ; RV64I-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload
 ; RV64I-NEXT:    ld s0, 0(sp) # 8-byte Folded Reload
@@ -71,9 +71,9 @@ define ptr @test_frameaddress_3_alloca() nounwind {
 ; RV32I-NEXT:    sw ra, 108(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s0, 104(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi s0, sp, 112
-; RV32I-NEXT:    addi a0, s0, -108
+; RV32I-NEXT:    addi a0, sp, 4
 ; RV32I-NEXT:    call notdead
-; RV32I-NEXT:    lw a0, -8(s0)
+; RV32I-NEXT:    lw a0, -8(sp)
 ; RV32I-NEXT:    lw a0, -8(a0)
 ; RV32I-NEXT:    lw a0, -8(a0)
 ; RV32I-NEXT:    lw ra, 108(sp) # 4-byte Folded Reload
@@ -87,9 +87,9 @@ define ptr @test_frameaddress_3_alloca() nounwind {
 ; RV64I-NEXT:    sd ra, 120(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    sd s0, 112(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    addi s0, sp, 128
-; RV64I-NEXT:    addi a0, s0, -116
+; RV64I-NEXT:    addi a0, sp, 12
 ; RV64I-NEXT:    call notdead
-; RV64I-NEXT:    ld a0, -16(s0)
+; RV64I-NEXT:    ld a0, -16(sp)
 ; RV64I-NEXT:    ld a0, -16(a0)
 ; RV64I-NEXT:    ld a0, -16(a0)
 ; RV64I-NEXT:    ld ra, 120(sp) # 8-byte Folded Reload
@@ -123,7 +123,7 @@ define ptr @test_returnaddress_2() nounwind {
 ; RV32I-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32I-NEXT:    addi s0, sp, 16
-; RV32I-NEXT:    lw a0, -8(s0)
+; RV32I-NEXT:    lw a0, -8(sp)
 ; RV32I-NEXT:    lw a0, -8(a0)
 ; RV32I-NEXT:    lw a0, -4(a0)
 ; RV32I-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -137,7 +137,7 @@ define ptr @test_returnaddress_2() nounwind {
 ; RV64I-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    sd s0, 0(sp) # 8-byte Folded Spill
 ; RV64I-NEXT:    addi s0, sp, 16
-; RV64I-NEXT:    ld a0, -16(s0)
+; RV64I-NEXT:    ld a0, -16(sp)
 ; RV64I-NEXT:    ld a0, -16(a0)
 ; RV64I-NEXT:    ld a0, -8(a0)
 ; RV64I-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/interrupt-attr.ll
+++ b/llvm/test/CodeGen/RISCV/interrupt-attr.ll
@@ -2959,50 +2959,44 @@ define void @foo_fp_with_call() #2 {
 ; CHECK-RV32-V-NEXT:    sub sp, sp, a0
 ; CHECK-RV32-V-NEXT:    csrr a0, vlenb
 ; CHECK-RV32-V-NEXT:    slli a0, a0, 3
-; CHECK-RV32-V-NEXT:    sub a0, s0, a0
-; CHECK-RV32-V-NEXT:    addi a0, a0, -80
-; CHECK-RV32-V-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV32-V-NEXT:    csrr a0, vlenb
-; CHECK-RV32-V-NEXT:    slli a0, a0, 4
-; CHECK-RV32-V-NEXT:    sub a0, s0, a0
-; CHECK-RV32-V-NEXT:    addi a0, a0, -80
-; CHECK-RV32-V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV32-V-NEXT:    csrr a0, vlenb
-; CHECK-RV32-V-NEXT:    slli a0, a0, 3
 ; CHECK-RV32-V-NEXT:    mv a1, a0
 ; CHECK-RV32-V-NEXT:    slli a0, a0, 1
 ; CHECK-RV32-V-NEXT:    add a0, a0, a1
-; CHECK-RV32-V-NEXT:    sub a0, s0, a0
-; CHECK-RV32-V-NEXT:    addi a0, a0, -80
-; CHECK-RV32-V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV32-V-NEXT:    add a0, sp, a0
+; CHECK-RV32-V-NEXT:    addi a0, a0, 12
+; CHECK-RV32-V-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV32-V-NEXT:    csrr a0, vlenb
-; CHECK-RV32-V-NEXT:    slli a0, a0, 5
-; CHECK-RV32-V-NEXT:    sub a0, s0, a0
-; CHECK-RV32-V-NEXT:    addi a0, a0, -80
+; CHECK-RV32-V-NEXT:    slli a0, a0, 4
+; CHECK-RV32-V-NEXT:    add a0, sp, a0
+; CHECK-RV32-V-NEXT:    addi a0, a0, 12
+; CHECK-RV32-V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV32-V-NEXT:    csrr a0, vlenb
+; CHECK-RV32-V-NEXT:    slli a0, a0, 3
+; CHECK-RV32-V-NEXT:    add a0, sp, a0
+; CHECK-RV32-V-NEXT:    addi a0, a0, 12
+; CHECK-RV32-V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV32-V-NEXT:    addi a0, sp, 12
 ; CHECK-RV32-V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV32-V-NEXT:    call otherfoo
 ; CHECK-RV32-V-NEXT:    csrr a0, vlenb
 ; CHECK-RV32-V-NEXT:    slli a0, a0, 3
-; CHECK-RV32-V-NEXT:    sub a0, s0, a0
-; CHECK-RV32-V-NEXT:    addi a0, a0, -80
-; CHECK-RV32-V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV32-V-NEXT:    csrr a0, vlenb
-; CHECK-RV32-V-NEXT:    slli a0, a0, 4
-; CHECK-RV32-V-NEXT:    sub a0, s0, a0
-; CHECK-RV32-V-NEXT:    addi a0, a0, -80
-; CHECK-RV32-V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV32-V-NEXT:    csrr a0, vlenb
-; CHECK-RV32-V-NEXT:    slli a0, a0, 3
 ; CHECK-RV32-V-NEXT:    mv a1, a0
 ; CHECK-RV32-V-NEXT:    slli a0, a0, 1
 ; CHECK-RV32-V-NEXT:    add a0, a0, a1
-; CHECK-RV32-V-NEXT:    sub a0, s0, a0
-; CHECK-RV32-V-NEXT:    addi a0, a0, -80
-; CHECK-RV32-V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV32-V-NEXT:    add a0, sp, a0
+; CHECK-RV32-V-NEXT:    addi a0, a0, 12
+; CHECK-RV32-V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV32-V-NEXT:    csrr a0, vlenb
-; CHECK-RV32-V-NEXT:    slli a0, a0, 5
-; CHECK-RV32-V-NEXT:    sub a0, s0, a0
-; CHECK-RV32-V-NEXT:    addi a0, a0, -80
+; CHECK-RV32-V-NEXT:    slli a0, a0, 4
+; CHECK-RV32-V-NEXT:    add a0, sp, a0
+; CHECK-RV32-V-NEXT:    addi a0, a0, 12
+; CHECK-RV32-V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV32-V-NEXT:    csrr a0, vlenb
+; CHECK-RV32-V-NEXT:    slli a0, a0, 3
+; CHECK-RV32-V-NEXT:    add a0, sp, a0
+; CHECK-RV32-V-NEXT:    addi a0, a0, 12
+; CHECK-RV32-V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV32-V-NEXT:    addi a0, sp, 12
 ; CHECK-RV32-V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV32-V-NEXT:    addi sp, s0, -80
 ; CHECK-RV32-V-NEXT:    lw ra, 76(sp) # 4-byte Folded Reload
@@ -3071,50 +3065,44 @@ define void @foo_fp_with_call() #2 {
 ; CHECK-RV32-FV-NEXT:    sub sp, sp, a0
 ; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
 ; CHECK-RV32-FV-NEXT:    slli a0, a0, 3
-; CHECK-RV32-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FV-NEXT:    addi a0, a0, -160
-; CHECK-RV32-FV-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FV-NEXT:    slli a0, a0, 4
-; CHECK-RV32-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FV-NEXT:    addi a0, a0, -160
-; CHECK-RV32-FV-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FV-NEXT:    slli a0, a0, 3
 ; CHECK-RV32-FV-NEXT:    mv a1, a0
 ; CHECK-RV32-FV-NEXT:    slli a0, a0, 1
 ; CHECK-RV32-FV-NEXT:    add a0, a0, a1
-; CHECK-RV32-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FV-NEXT:    addi a0, a0, -160
-; CHECK-RV32-FV-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV32-FV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FV-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FV-NEXT:    slli a0, a0, 5
-; CHECK-RV32-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FV-NEXT:    addi a0, a0, -160
+; CHECK-RV32-FV-NEXT:    slli a0, a0, 4
+; CHECK-RV32-FV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FV-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
+; CHECK-RV32-FV-NEXT:    slli a0, a0, 3
+; CHECK-RV32-FV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FV-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV32-FV-NEXT:    addi a0, sp, 12
 ; CHECK-RV32-FV-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV32-FV-NEXT:    call otherfoo
 ; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
 ; CHECK-RV32-FV-NEXT:    slli a0, a0, 3
-; CHECK-RV32-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FV-NEXT:    addi a0, a0, -160
-; CHECK-RV32-FV-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FV-NEXT:    slli a0, a0, 4
-; CHECK-RV32-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FV-NEXT:    addi a0, a0, -160
-; CHECK-RV32-FV-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FV-NEXT:    slli a0, a0, 3
 ; CHECK-RV32-FV-NEXT:    mv a1, a0
 ; CHECK-RV32-FV-NEXT:    slli a0, a0, 1
 ; CHECK-RV32-FV-NEXT:    add a0, a0, a1
-; CHECK-RV32-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FV-NEXT:    addi a0, a0, -160
-; CHECK-RV32-FV-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV32-FV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FV-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FV-NEXT:    slli a0, a0, 5
-; CHECK-RV32-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FV-NEXT:    addi a0, a0, -160
+; CHECK-RV32-FV-NEXT:    slli a0, a0, 4
+; CHECK-RV32-FV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FV-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV32-FV-NEXT:    csrr a0, vlenb
+; CHECK-RV32-FV-NEXT:    slli a0, a0, 3
+; CHECK-RV32-FV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FV-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV32-FV-NEXT:    addi a0, sp, 12
 ; CHECK-RV32-FV-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV32-FV-NEXT:    addi sp, s0, -160
 ; CHECK-RV32-FV-NEXT:    lw ra, 156(sp) # 4-byte Folded Reload
@@ -3203,50 +3191,44 @@ define void @foo_fp_with_call() #2 {
 ; CHECK-RV32-FDV-NEXT:    sub sp, sp, a0
 ; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
 ; CHECK-RV32-FDV-NEXT:    slli a0, a0, 3
-; CHECK-RV32-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FDV-NEXT:    addi a0, a0, -240
-; CHECK-RV32-FDV-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FDV-NEXT:    slli a0, a0, 4
-; CHECK-RV32-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FDV-NEXT:    addi a0, a0, -240
-; CHECK-RV32-FDV-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FDV-NEXT:    slli a0, a0, 3
 ; CHECK-RV32-FDV-NEXT:    mv a1, a0
 ; CHECK-RV32-FDV-NEXT:    slli a0, a0, 1
 ; CHECK-RV32-FDV-NEXT:    add a0, a0, a1
-; CHECK-RV32-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FDV-NEXT:    addi a0, a0, -240
-; CHECK-RV32-FDV-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV32-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FDV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FDV-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FDV-NEXT:    slli a0, a0, 5
-; CHECK-RV32-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FDV-NEXT:    addi a0, a0, -240
+; CHECK-RV32-FDV-NEXT:    slli a0, a0, 4
+; CHECK-RV32-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FDV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FDV-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
+; CHECK-RV32-FDV-NEXT:    slli a0, a0, 3
+; CHECK-RV32-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FDV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FDV-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV32-FDV-NEXT:    addi a0, sp, 12
 ; CHECK-RV32-FDV-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV32-FDV-NEXT:    call otherfoo
 ; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
 ; CHECK-RV32-FDV-NEXT:    slli a0, a0, 3
-; CHECK-RV32-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FDV-NEXT:    addi a0, a0, -240
-; CHECK-RV32-FDV-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FDV-NEXT:    slli a0, a0, 4
-; CHECK-RV32-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FDV-NEXT:    addi a0, a0, -240
-; CHECK-RV32-FDV-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FDV-NEXT:    slli a0, a0, 3
 ; CHECK-RV32-FDV-NEXT:    mv a1, a0
 ; CHECK-RV32-FDV-NEXT:    slli a0, a0, 1
 ; CHECK-RV32-FDV-NEXT:    add a0, a0, a1
-; CHECK-RV32-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FDV-NEXT:    addi a0, a0, -240
-; CHECK-RV32-FDV-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV32-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FDV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FDV-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV32-FDV-NEXT:    slli a0, a0, 5
-; CHECK-RV32-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV32-FDV-NEXT:    addi a0, a0, -240
+; CHECK-RV32-FDV-NEXT:    slli a0, a0, 4
+; CHECK-RV32-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FDV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FDV-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV32-FDV-NEXT:    csrr a0, vlenb
+; CHECK-RV32-FDV-NEXT:    slli a0, a0, 3
+; CHECK-RV32-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV32-FDV-NEXT:    addi a0, a0, 12
+; CHECK-RV32-FDV-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV32-FDV-NEXT:    addi a0, sp, 12
 ; CHECK-RV32-FDV-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV32-FDV-NEXT:    addi sp, s0, -240
 ; CHECK-RV32-FDV-NEXT:    lw ra, 236(sp) # 4-byte Folded Reload
@@ -4119,50 +4101,44 @@ define void @foo_fp_with_call() #2 {
 ; CHECK-RV64-V-NEXT:    sub sp, sp, a0
 ; CHECK-RV64-V-NEXT:    csrr a0, vlenb
 ; CHECK-RV64-V-NEXT:    slli a0, a0, 3
-; CHECK-RV64-V-NEXT:    sub a0, s0, a0
-; CHECK-RV64-V-NEXT:    addi a0, a0, -160
-; CHECK-RV64-V-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64-V-NEXT:    csrr a0, vlenb
-; CHECK-RV64-V-NEXT:    slli a0, a0, 4
-; CHECK-RV64-V-NEXT:    sub a0, s0, a0
-; CHECK-RV64-V-NEXT:    addi a0, a0, -160
-; CHECK-RV64-V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64-V-NEXT:    csrr a0, vlenb
-; CHECK-RV64-V-NEXT:    slli a0, a0, 3
 ; CHECK-RV64-V-NEXT:    mv a1, a0
 ; CHECK-RV64-V-NEXT:    slli a0, a0, 1
 ; CHECK-RV64-V-NEXT:    add a0, a0, a1
-; CHECK-RV64-V-NEXT:    sub a0, s0, a0
-; CHECK-RV64-V-NEXT:    addi a0, a0, -160
-; CHECK-RV64-V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV64-V-NEXT:    add a0, sp, a0
+; CHECK-RV64-V-NEXT:    addi a0, a0, 24
+; CHECK-RV64-V-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV64-V-NEXT:    csrr a0, vlenb
-; CHECK-RV64-V-NEXT:    slli a0, a0, 5
-; CHECK-RV64-V-NEXT:    sub a0, s0, a0
-; CHECK-RV64-V-NEXT:    addi a0, a0, -160
+; CHECK-RV64-V-NEXT:    slli a0, a0, 4
+; CHECK-RV64-V-NEXT:    add a0, sp, a0
+; CHECK-RV64-V-NEXT:    addi a0, a0, 24
+; CHECK-RV64-V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV64-V-NEXT:    csrr a0, vlenb
+; CHECK-RV64-V-NEXT:    slli a0, a0, 3
+; CHECK-RV64-V-NEXT:    add a0, sp, a0
+; CHECK-RV64-V-NEXT:    addi a0, a0, 24
+; CHECK-RV64-V-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV64-V-NEXT:    addi a0, sp, 24
 ; CHECK-RV64-V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV64-V-NEXT:    call otherfoo
 ; CHECK-RV64-V-NEXT:    csrr a0, vlenb
 ; CHECK-RV64-V-NEXT:    slli a0, a0, 3
-; CHECK-RV64-V-NEXT:    sub a0, s0, a0
-; CHECK-RV64-V-NEXT:    addi a0, a0, -160
-; CHECK-RV64-V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64-V-NEXT:    csrr a0, vlenb
-; CHECK-RV64-V-NEXT:    slli a0, a0, 4
-; CHECK-RV64-V-NEXT:    sub a0, s0, a0
-; CHECK-RV64-V-NEXT:    addi a0, a0, -160
-; CHECK-RV64-V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64-V-NEXT:    csrr a0, vlenb
-; CHECK-RV64-V-NEXT:    slli a0, a0, 3
 ; CHECK-RV64-V-NEXT:    mv a1, a0
 ; CHECK-RV64-V-NEXT:    slli a0, a0, 1
 ; CHECK-RV64-V-NEXT:    add a0, a0, a1
-; CHECK-RV64-V-NEXT:    sub a0, s0, a0
-; CHECK-RV64-V-NEXT:    addi a0, a0, -160
-; CHECK-RV64-V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV64-V-NEXT:    add a0, sp, a0
+; CHECK-RV64-V-NEXT:    addi a0, a0, 24
+; CHECK-RV64-V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV64-V-NEXT:    csrr a0, vlenb
-; CHECK-RV64-V-NEXT:    slli a0, a0, 5
-; CHECK-RV64-V-NEXT:    sub a0, s0, a0
-; CHECK-RV64-V-NEXT:    addi a0, a0, -160
+; CHECK-RV64-V-NEXT:    slli a0, a0, 4
+; CHECK-RV64-V-NEXT:    add a0, sp, a0
+; CHECK-RV64-V-NEXT:    addi a0, a0, 24
+; CHECK-RV64-V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV64-V-NEXT:    csrr a0, vlenb
+; CHECK-RV64-V-NEXT:    slli a0, a0, 3
+; CHECK-RV64-V-NEXT:    add a0, sp, a0
+; CHECK-RV64-V-NEXT:    addi a0, a0, 24
+; CHECK-RV64-V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV64-V-NEXT:    addi a0, sp, 24
 ; CHECK-RV64-V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV64-V-NEXT:    addi sp, s0, -160
 ; CHECK-RV64-V-NEXT:    ld ra, 152(sp) # 8-byte Folded Reload
@@ -4231,50 +4207,44 @@ define void @foo_fp_with_call() #2 {
 ; CHECK-RV64-FV-NEXT:    sub sp, sp, a0
 ; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
 ; CHECK-RV64-FV-NEXT:    slli a0, a0, 3
-; CHECK-RV64-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FV-NEXT:    addi a0, a0, -240
-; CHECK-RV64-FV-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FV-NEXT:    slli a0, a0, 4
-; CHECK-RV64-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FV-NEXT:    addi a0, a0, -240
-; CHECK-RV64-FV-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FV-NEXT:    slli a0, a0, 3
 ; CHECK-RV64-FV-NEXT:    mv a1, a0
 ; CHECK-RV64-FV-NEXT:    slli a0, a0, 1
 ; CHECK-RV64-FV-NEXT:    add a0, a0, a1
-; CHECK-RV64-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FV-NEXT:    addi a0, a0, -240
-; CHECK-RV64-FV-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV64-FV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FV-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FV-NEXT:    slli a0, a0, 5
-; CHECK-RV64-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FV-NEXT:    addi a0, a0, -240
+; CHECK-RV64-FV-NEXT:    slli a0, a0, 4
+; CHECK-RV64-FV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FV-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
+; CHECK-RV64-FV-NEXT:    slli a0, a0, 3
+; CHECK-RV64-FV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FV-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV64-FV-NEXT:    addi a0, sp, 24
 ; CHECK-RV64-FV-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV64-FV-NEXT:    call otherfoo
 ; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
 ; CHECK-RV64-FV-NEXT:    slli a0, a0, 3
-; CHECK-RV64-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FV-NEXT:    addi a0, a0, -240
-; CHECK-RV64-FV-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FV-NEXT:    slli a0, a0, 4
-; CHECK-RV64-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FV-NEXT:    addi a0, a0, -240
-; CHECK-RV64-FV-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FV-NEXT:    slli a0, a0, 3
 ; CHECK-RV64-FV-NEXT:    mv a1, a0
 ; CHECK-RV64-FV-NEXT:    slli a0, a0, 1
 ; CHECK-RV64-FV-NEXT:    add a0, a0, a1
-; CHECK-RV64-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FV-NEXT:    addi a0, a0, -240
-; CHECK-RV64-FV-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV64-FV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FV-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FV-NEXT:    slli a0, a0, 5
-; CHECK-RV64-FV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FV-NEXT:    addi a0, a0, -240
+; CHECK-RV64-FV-NEXT:    slli a0, a0, 4
+; CHECK-RV64-FV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FV-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV64-FV-NEXT:    csrr a0, vlenb
+; CHECK-RV64-FV-NEXT:    slli a0, a0, 3
+; CHECK-RV64-FV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FV-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV64-FV-NEXT:    addi a0, sp, 24
 ; CHECK-RV64-FV-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV64-FV-NEXT:    addi sp, s0, -240
 ; CHECK-RV64-FV-NEXT:    ld ra, 232(sp) # 8-byte Folded Reload
@@ -4363,50 +4333,44 @@ define void @foo_fp_with_call() #2 {
 ; CHECK-RV64-FDV-NEXT:    sub sp, sp, a0
 ; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
 ; CHECK-RV64-FDV-NEXT:    slli a0, a0, 3
-; CHECK-RV64-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FDV-NEXT:    addi a0, a0, -320
-; CHECK-RV64-FDV-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FDV-NEXT:    slli a0, a0, 4
-; CHECK-RV64-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FDV-NEXT:    addi a0, a0, -320
-; CHECK-RV64-FDV-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FDV-NEXT:    slli a0, a0, 3
 ; CHECK-RV64-FDV-NEXT:    mv a1, a0
 ; CHECK-RV64-FDV-NEXT:    slli a0, a0, 1
 ; CHECK-RV64-FDV-NEXT:    add a0, a0, a1
-; CHECK-RV64-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FDV-NEXT:    addi a0, a0, -320
-; CHECK-RV64-FDV-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV64-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FDV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FDV-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FDV-NEXT:    slli a0, a0, 5
-; CHECK-RV64-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FDV-NEXT:    addi a0, a0, -320
+; CHECK-RV64-FDV-NEXT:    slli a0, a0, 4
+; CHECK-RV64-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FDV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FDV-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
+; CHECK-RV64-FDV-NEXT:    slli a0, a0, 3
+; CHECK-RV64-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FDV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FDV-NEXT:    vs8r.v v16, (a0) # vscale x 64-byte Folded Spill
+; CHECK-RV64-FDV-NEXT:    addi a0, sp, 24
 ; CHECK-RV64-FDV-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
 ; CHECK-RV64-FDV-NEXT:    call otherfoo
 ; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
 ; CHECK-RV64-FDV-NEXT:    slli a0, a0, 3
-; CHECK-RV64-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FDV-NEXT:    addi a0, a0, -320
-; CHECK-RV64-FDV-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FDV-NEXT:    slli a0, a0, 4
-; CHECK-RV64-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FDV-NEXT:    addi a0, a0, -320
-; CHECK-RV64-FDV-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FDV-NEXT:    slli a0, a0, 3
 ; CHECK-RV64-FDV-NEXT:    mv a1, a0
 ; CHECK-RV64-FDV-NEXT:    slli a0, a0, 1
 ; CHECK-RV64-FDV-NEXT:    add a0, a0, a1
-; CHECK-RV64-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FDV-NEXT:    addi a0, a0, -320
-; CHECK-RV64-FDV-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV64-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FDV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FDV-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
-; CHECK-RV64-FDV-NEXT:    slli a0, a0, 5
-; CHECK-RV64-FDV-NEXT:    sub a0, s0, a0
-; CHECK-RV64-FDV-NEXT:    addi a0, a0, -320
+; CHECK-RV64-FDV-NEXT:    slli a0, a0, 4
+; CHECK-RV64-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FDV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FDV-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV64-FDV-NEXT:    csrr a0, vlenb
+; CHECK-RV64-FDV-NEXT:    slli a0, a0, 3
+; CHECK-RV64-FDV-NEXT:    add a0, sp, a0
+; CHECK-RV64-FDV-NEXT:    addi a0, a0, 24
+; CHECK-RV64-FDV-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; CHECK-RV64-FDV-NEXT:    addi a0, sp, 24
 ; CHECK-RV64-FDV-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; CHECK-RV64-FDV-NEXT:    addi sp, s0, -320
 ; CHECK-RV64-FDV-NEXT:    ld ra, 312(sp) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/ipra.ll
+++ b/llvm/test/CodeGen/RISCV/ipra.ll
@@ -95,8 +95,8 @@ define internal void @foobar(ptr %live_throughout.0.val) norecurse nounwind {
 ; RV64-WITHFP-NEXT:    sd s0, 48(sp) # 8-byte Folded Spill
 ; RV64-WITHFP-NEXT:    addi s0, sp, 64
 ; RV64-WITHFP-NEXT:    mv a1, a0
-; RV64-WITHFP-NEXT:    addi a0, s0, -48
-; RV64-WITHFP-NEXT:    addi a2, s0, -52
+; RV64-WITHFP-NEXT:    addi a0, sp, 16
+; RV64-WITHFP-NEXT:    addi a2, sp, 12
 ; RV64-WITHFP-NEXT:    call bmp_iter_set_init
 ; RV64-WITHFP-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
 ; RV64-WITHFP-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
@@ -110,8 +110,8 @@ define internal void @foobar(ptr %live_throughout.0.val) norecurse nounwind {
 ; RV32-WITHFP-NEXT:    sw s0, 40(sp) # 4-byte Folded Spill
 ; RV32-WITHFP-NEXT:    addi s0, sp, 48
 ; RV32-WITHFP-NEXT:    mv a1, a0
-; RV32-WITHFP-NEXT:    addi a0, s0, -32
-; RV32-WITHFP-NEXT:    addi a2, s0, -36
+; RV32-WITHFP-NEXT:    addi a0, sp, 16
+; RV32-WITHFP-NEXT:    addi a2, sp, 12
 ; RV32-WITHFP-NEXT:    call bmp_iter_set_init
 ; RV32-WITHFP-NEXT:    lw ra, 44(sp) # 4-byte Folded Reload
 ; RV32-WITHFP-NEXT:    lw s0, 40(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/large-stack.ll
+++ b/llvm/test/CodeGen/RISCV/large-stack.ll
@@ -103,9 +103,7 @@ define void @test_emergency_spill_slot(i32 %a) {
 ; RV32I-WITHFP-NEXT:    addi a1, a1, 688
 ; RV32I-WITHFP-NEXT:    sub sp, sp, a1
 ; RV32I-WITHFP-NEXT:    lui a1, 78
-; RV32I-WITHFP-NEXT:    lui a2, 98
-; RV32I-WITHFP-NEXT:    addi a2, a2, -1388
-; RV32I-WITHFP-NEXT:    sub a2, s0, a2
+; RV32I-WITHFP-NEXT:    addi a2, sp, 12
 ; RV32I-WITHFP-NEXT:    add a1, a2, a1
 ; RV32I-WITHFP-NEXT:    #APP
 ; RV32I-WITHFP-NEXT:    nop

--- a/llvm/test/CodeGen/RISCV/local-stack-slot-allocation.ll
+++ b/llvm/test/CodeGen/RISCV/local-stack-slot-allocation.ll
@@ -130,8 +130,8 @@ define void @frame_pointer() "frame-pointer"="all" {
 ; RV32I-NEXT:    addi s0, sp, 2032
 ; RV32I-NEXT:    .cfi_def_cfa s0, 0
 ; RV32I-NEXT:    addi sp, sp, -480
-; RV32I-NEXT:    lbu a0, -1960(s0)
-; RV32I-NEXT:    sb a0, -1960(s0)
+; RV32I-NEXT:    lbu a0, 552(sp)
+; RV32I-NEXT:    sb a0, 552(sp)
 ; RV32I-NEXT:    addi sp, sp, 480
 ; RV32I-NEXT:    .cfi_def_cfa sp, 2032
 ; RV32I-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload
@@ -153,7 +153,7 @@ define void @frame_pointer() "frame-pointer"="all" {
 ; RV64I-NEXT:    addi s0, sp, 2032
 ; RV64I-NEXT:    .cfi_def_cfa s0, 0
 ; RV64I-NEXT:    addi sp, sp, -496
-; RV64I-NEXT:    addi a0, s0, -1972
+; RV64I-NEXT:    addi a0, sp, 556
 ; RV64I-NEXT:    lbu a1, 0(a0)
 ; RV64I-NEXT:    sb a1, 0(a0)
 ; RV64I-NEXT:    addi sp, sp, 496

--- a/llvm/test/CodeGen/RISCV/push-pop-popret.ll
+++ b/llvm/test/CodeGen/RISCV/push-pop-popret.ll
@@ -4011,8 +4011,8 @@ define i32 @use_fp(i32 %x) {
 ; RV32IZCMP-NEXT:    addi s0, sp, 32
 ; RV32IZCMP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IZCMP-NEXT:    mv s1, a0
-; RV32IZCMP-NEXT:    addi a1, s0, -20
-; RV32IZCMP-NEXT:    mv a0, s0
+; RV32IZCMP-NEXT:    mv a0, sp
+; RV32IZCMP-NEXT:    addi a1, sp, 12
 ; RV32IZCMP-NEXT:    call bar
 ; RV32IZCMP-NEXT:    mv a0, s1
 ; RV32IZCMP-NEXT:    .cfi_def_cfa sp, 32
@@ -4028,8 +4028,8 @@ define i32 @use_fp(i32 %x) {
 ; RV64IZCMP-NEXT:    addi s0, sp, 48
 ; RV64IZCMP-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IZCMP-NEXT:    mv s1, a0
-; RV64IZCMP-NEXT:    addi a1, s0, -36
-; RV64IZCMP-NEXT:    mv a0, s0
+; RV64IZCMP-NEXT:    mv a0, sp
+; RV64IZCMP-NEXT:    addi a1, sp, 12
 ; RV64IZCMP-NEXT:    call bar
 ; RV64IZCMP-NEXT:    mv a0, s1
 ; RV64IZCMP-NEXT:    .cfi_def_cfa sp, 48
@@ -4045,8 +4045,8 @@ define i32 @use_fp(i32 %x) {
 ; RV32IZCMP-SR-NEXT:    addi s0, sp, 32
 ; RV32IZCMP-SR-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IZCMP-SR-NEXT:    mv s1, a0
-; RV32IZCMP-SR-NEXT:    addi a1, s0, -20
-; RV32IZCMP-SR-NEXT:    mv a0, s0
+; RV32IZCMP-SR-NEXT:    mv a0, sp
+; RV32IZCMP-SR-NEXT:    addi a1, sp, 12
 ; RV32IZCMP-SR-NEXT:    call bar
 ; RV32IZCMP-SR-NEXT:    mv a0, s1
 ; RV32IZCMP-SR-NEXT:    .cfi_def_cfa sp, 32
@@ -4062,8 +4062,8 @@ define i32 @use_fp(i32 %x) {
 ; RV64IZCMP-SR-NEXT:    addi s0, sp, 48
 ; RV64IZCMP-SR-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IZCMP-SR-NEXT:    mv s1, a0
-; RV64IZCMP-SR-NEXT:    addi a1, s0, -36
-; RV64IZCMP-SR-NEXT:    mv a0, s0
+; RV64IZCMP-SR-NEXT:    mv a0, sp
+; RV64IZCMP-SR-NEXT:    addi a1, sp, 12
 ; RV64IZCMP-SR-NEXT:    call bar
 ; RV64IZCMP-SR-NEXT:    mv a0, s1
 ; RV64IZCMP-SR-NEXT:    .cfi_def_cfa sp, 48
@@ -4082,8 +4082,8 @@ define i32 @use_fp(i32 %x) {
 ; RV32I-NEXT:    addi s0, sp, 16
 ; RV32I-NEXT:    .cfi_def_cfa s0, 0
 ; RV32I-NEXT:    mv s1, a0
-; RV32I-NEXT:    addi a1, s0, -16
-; RV32I-NEXT:    mv a0, s0
+; RV32I-NEXT:    mv a0, sp
+; RV32I-NEXT:    mv a1, sp
 ; RV32I-NEXT:    call bar
 ; RV32I-NEXT:    mv a0, s1
 ; RV32I-NEXT:    .cfi_def_cfa sp, 16
@@ -4110,8 +4110,8 @@ define i32 @use_fp(i32 %x) {
 ; RV64I-NEXT:    addi s0, sp, 32
 ; RV64I-NEXT:    .cfi_def_cfa s0, 0
 ; RV64I-NEXT:    mv s1, a0
-; RV64I-NEXT:    addi a1, s0, -28
-; RV64I-NEXT:    mv a0, s0
+; RV64I-NEXT:    mv a0, sp
+; RV64I-NEXT:    addi a1, sp, 4
 ; RV64I-NEXT:    call bar
 ; RV64I-NEXT:    mv a0, s1
 ; RV64I-NEXT:    .cfi_def_cfa sp, 32

--- a/llvm/test/CodeGen/RISCV/qci-interrupt-attr.ll
+++ b/llvm/test/CodeGen/RISCV/qci-interrupt-attr.ll
@@ -1184,17 +1184,17 @@ define void @test_spill_nest() "interrupt"="qci-nest" {
 ; QCI-FP-NEXT:    lui a0, %hi(var)
 ; QCI-FP-NEXT:    addi a0, a0, %lo(var)
 ; QCI-FP-NEXT:    lw a1, 0(a0)
-; QCI-FP-NEXT:    sw a1, -144(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 4(a0)
-; QCI-FP-NEXT:    sw a1, -148(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 8(a0)
-; QCI-FP-NEXT:    sw a1, -152(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 12(a0)
-; QCI-FP-NEXT:    sw a1, -156(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 16(a0)
-; QCI-FP-NEXT:    sw a1, -160(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 20(a0)
-; QCI-FP-NEXT:    sw a1, -164(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw t4, 24(a0)
 ; QCI-FP-NEXT:    lw t5, 28(a0)
 ; QCI-FP-NEXT:    lw t6, 32(a0)
@@ -1247,17 +1247,17 @@ define void @test_spill_nest() "interrupt"="qci-nest" {
 ; QCI-FP-NEXT:    sw t6, 32(a0)
 ; QCI-FP-NEXT:    sw t5, 28(a0)
 ; QCI-FP-NEXT:    sw t4, 24(a0)
-; QCI-FP-NEXT:    lw a1, -164(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 20(a0)
-; QCI-FP-NEXT:    lw a1, -160(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 16(a0)
-; QCI-FP-NEXT:    lw a1, -156(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 12(a0)
-; QCI-FP-NEXT:    lw a1, -152(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 8(a0)
-; QCI-FP-NEXT:    lw a1, -148(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 4(a0)
-; QCI-FP-NEXT:    lw a1, -144(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 32(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 0(a0)
 ; QCI-FP-NEXT:    .cfi_def_cfa sp, 176
 ; QCI-FP-NEXT:    lw s1, 76(sp) # 4-byte Folded Reload
@@ -1574,17 +1574,17 @@ define void @test_spill_nest() "interrupt"="qci-nest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lui a0, %hi(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi a0, a0, %lo(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 0(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -164(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 4(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -168(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -172(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -176(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -180(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -184(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t4, 24(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t5, 28(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t6, 32(a0)
@@ -1637,17 +1637,17 @@ define void @test_spill_nest() "interrupt"="qci-nest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t6, 32(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t5, 28(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t4, 24(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -184(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -180(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -176(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -172(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -168(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 4(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -164(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 0(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    .cfi_def_cfa sp, 192
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    qc.cm.pop {ra, s0-s11}, 96
@@ -1866,17 +1866,17 @@ define void @test_spill_nonest() "interrupt"="qci-nonest" {
 ; QCI-FP-NEXT:    lui a0, %hi(var)
 ; QCI-FP-NEXT:    addi a0, a0, %lo(var)
 ; QCI-FP-NEXT:    lw a1, 0(a0)
-; QCI-FP-NEXT:    sw a1, -144(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 4(a0)
-; QCI-FP-NEXT:    sw a1, -148(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 8(a0)
-; QCI-FP-NEXT:    sw a1, -152(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 12(a0)
-; QCI-FP-NEXT:    sw a1, -156(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 16(a0)
-; QCI-FP-NEXT:    sw a1, -160(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a1, 20(a0)
-; QCI-FP-NEXT:    sw a1, -164(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw t4, 24(a0)
 ; QCI-FP-NEXT:    lw t5, 28(a0)
 ; QCI-FP-NEXT:    lw t6, 32(a0)
@@ -1929,17 +1929,17 @@ define void @test_spill_nonest() "interrupt"="qci-nonest" {
 ; QCI-FP-NEXT:    sw t6, 32(a0)
 ; QCI-FP-NEXT:    sw t5, 28(a0)
 ; QCI-FP-NEXT:    sw t4, 24(a0)
-; QCI-FP-NEXT:    lw a1, -164(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 20(a0)
-; QCI-FP-NEXT:    lw a1, -160(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 16(a0)
-; QCI-FP-NEXT:    lw a1, -156(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 12(a0)
-; QCI-FP-NEXT:    lw a1, -152(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 8(a0)
-; QCI-FP-NEXT:    lw a1, -148(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 4(a0)
-; QCI-FP-NEXT:    lw a1, -144(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a1, 32(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a1, 0(a0)
 ; QCI-FP-NEXT:    .cfi_def_cfa sp, 176
 ; QCI-FP-NEXT:    lw s1, 76(sp) # 4-byte Folded Reload
@@ -2256,17 +2256,17 @@ define void @test_spill_nonest() "interrupt"="qci-nonest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lui a0, %hi(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi a0, a0, %lo(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 0(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -164(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 4(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -168(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -172(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -176(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -180(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, -184(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t4, 24(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t5, 28(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw t6, 32(a0)
@@ -2319,17 +2319,17 @@ define void @test_spill_nonest() "interrupt"="qci-nonest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t6, 32(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t5, 28(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw t4, 24(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -184(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 20(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -180(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 16(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -176(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 12(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -172(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 8(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -168(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 4(a0)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, -164(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a1, 0(a0)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    .cfi_def_cfa sp, 192
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    qc.cm.pop {ra, s0-s11}, 96
@@ -2592,49 +2592,49 @@ define void @test_spill_call_nest() "interrupt"="qci-nest" {
 ; QCI-FP-NEXT:    lui s1, %hi(var)
 ; QCI-FP-NEXT:    addi s1, s1, %lo(var)
 ; QCI-FP-NEXT:    lw a0, 0(s1)
-; QCI-FP-NEXT:    sw a0, -144(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 4(s1)
-; QCI-FP-NEXT:    sw a0, -148(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 8(s1)
-; QCI-FP-NEXT:    sw a0, -152(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 12(s1)
-; QCI-FP-NEXT:    sw a0, -156(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 16(s1)
-; QCI-FP-NEXT:    sw a0, -160(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 20(s1)
-; QCI-FP-NEXT:    sw a0, -164(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 24(s1)
-; QCI-FP-NEXT:    sw a0, -168(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 28(s1)
-; QCI-FP-NEXT:    sw a0, -172(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 32(s1)
-; QCI-FP-NEXT:    sw a0, -176(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 36(s1)
-; QCI-FP-NEXT:    sw a0, -180(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 40(s1)
-; QCI-FP-NEXT:    sw a0, -184(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 44(s1)
-; QCI-FP-NEXT:    sw a0, -188(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 48(s1)
-; QCI-FP-NEXT:    sw a0, -192(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 52(s1)
-; QCI-FP-NEXT:    sw a0, -196(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 56(s1)
-; QCI-FP-NEXT:    sw a0, -200(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 60(s1)
-; QCI-FP-NEXT:    sw a0, -204(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 64(s1)
-; QCI-FP-NEXT:    sw a0, -208(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 68(s1)
-; QCI-FP-NEXT:    sw a0, -212(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 72(s1)
-; QCI-FP-NEXT:    sw a0, -216(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 76(s1)
-; QCI-FP-NEXT:    sw a0, -220(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 80(s1)
-; QCI-FP-NEXT:    sw a0, -224(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 84(s1)
-; QCI-FP-NEXT:    sw a0, -228(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw s4, 88(s1)
 ; QCI-FP-NEXT:    lw s5, 92(s1)
 ; QCI-FP-NEXT:    lw s6, 96(s1)
@@ -2667,49 +2667,49 @@ define void @test_spill_call_nest() "interrupt"="qci-nest" {
 ; QCI-FP-NEXT:    sw s6, 96(s1)
 ; QCI-FP-NEXT:    sw s5, 92(s1)
 ; QCI-FP-NEXT:    sw s4, 88(s1)
-; QCI-FP-NEXT:    lw a0, -228(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 84(s1)
-; QCI-FP-NEXT:    lw a0, -224(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 80(s1)
-; QCI-FP-NEXT:    lw a0, -220(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 76(s1)
-; QCI-FP-NEXT:    lw a0, -216(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 72(s1)
-; QCI-FP-NEXT:    lw a0, -212(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 68(s1)
-; QCI-FP-NEXT:    lw a0, -208(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 64(s1)
-; QCI-FP-NEXT:    lw a0, -204(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 60(s1)
-; QCI-FP-NEXT:    lw a0, -200(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 56(s1)
-; QCI-FP-NEXT:    lw a0, -196(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 52(s1)
-; QCI-FP-NEXT:    lw a0, -192(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 48(s1)
-; QCI-FP-NEXT:    lw a0, -188(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 44(s1)
-; QCI-FP-NEXT:    lw a0, -184(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 40(s1)
-; QCI-FP-NEXT:    lw a0, -180(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 36(s1)
-; QCI-FP-NEXT:    lw a0, -176(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 32(s1)
-; QCI-FP-NEXT:    lw a0, -172(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 28(s1)
-; QCI-FP-NEXT:    lw a0, -168(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 24(s1)
-; QCI-FP-NEXT:    lw a0, -164(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 20(s1)
-; QCI-FP-NEXT:    lw a0, -160(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 16(s1)
-; QCI-FP-NEXT:    lw a0, -156(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 12(s1)
-; QCI-FP-NEXT:    lw a0, -152(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 8(s1)
-; QCI-FP-NEXT:    lw a0, -148(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 4(s1)
-; QCI-FP-NEXT:    lw a0, -144(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 0(s1)
 ; QCI-FP-NEXT:    .cfi_def_cfa sp, 240
 ; QCI-FP-NEXT:    lw s1, 140(sp) # 4-byte Folded Reload
@@ -3124,49 +3124,49 @@ define void @test_spill_call_nest() "interrupt"="qci-nest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lui s1, %hi(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi s1, s1, %lo(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 0(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -164(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 4(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -168(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -172(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -176(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -180(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -184(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -188(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -192(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -196(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -200(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -204(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -208(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -212(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -216(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -220(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -224(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -228(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -232(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -236(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -240(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -244(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -248(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s4, 88(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s5, 92(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s6, 96(s1)
@@ -3199,49 +3199,49 @@ define void @test_spill_call_nest() "interrupt"="qci-nest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s6, 96(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s5, 92(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s4, 88(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -248(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -244(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -240(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -236(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -232(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -228(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -224(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -220(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -216(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -212(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -208(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -204(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -200(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -196(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -192(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -188(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -184(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -180(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -176(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -172(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -168(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 4(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -164(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 0(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    .cfi_def_cfa sp, 256
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi sp, sp, 48
@@ -3508,49 +3508,49 @@ define void @test_spill_call_nonest() "interrupt"="qci-nonest" {
 ; QCI-FP-NEXT:    lui s1, %hi(var)
 ; QCI-FP-NEXT:    addi s1, s1, %lo(var)
 ; QCI-FP-NEXT:    lw a0, 0(s1)
-; QCI-FP-NEXT:    sw a0, -144(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 96(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 4(s1)
-; QCI-FP-NEXT:    sw a0, -148(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 8(s1)
-; QCI-FP-NEXT:    sw a0, -152(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 12(s1)
-; QCI-FP-NEXT:    sw a0, -156(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 16(s1)
-; QCI-FP-NEXT:    sw a0, -160(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 20(s1)
-; QCI-FP-NEXT:    sw a0, -164(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 24(s1)
-; QCI-FP-NEXT:    sw a0, -168(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 28(s1)
-; QCI-FP-NEXT:    sw a0, -172(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 32(s1)
-; QCI-FP-NEXT:    sw a0, -176(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 36(s1)
-; QCI-FP-NEXT:    sw a0, -180(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 40(s1)
-; QCI-FP-NEXT:    sw a0, -184(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 44(s1)
-; QCI-FP-NEXT:    sw a0, -188(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 48(s1)
-; QCI-FP-NEXT:    sw a0, -192(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 52(s1)
-; QCI-FP-NEXT:    sw a0, -196(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 56(s1)
-; QCI-FP-NEXT:    sw a0, -200(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 60(s1)
-; QCI-FP-NEXT:    sw a0, -204(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 64(s1)
-; QCI-FP-NEXT:    sw a0, -208(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 68(s1)
-; QCI-FP-NEXT:    sw a0, -212(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 72(s1)
-; QCI-FP-NEXT:    sw a0, -216(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 76(s1)
-; QCI-FP-NEXT:    sw a0, -220(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 80(s1)
-; QCI-FP-NEXT:    sw a0, -224(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw a0, 84(s1)
-; QCI-FP-NEXT:    sw a0, -228(s0) # 4-byte Folded Spill
+; QCI-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; QCI-FP-NEXT:    lw s4, 88(s1)
 ; QCI-FP-NEXT:    lw s5, 92(s1)
 ; QCI-FP-NEXT:    lw s6, 96(s1)
@@ -3583,49 +3583,49 @@ define void @test_spill_call_nonest() "interrupt"="qci-nonest" {
 ; QCI-FP-NEXT:    sw s6, 96(s1)
 ; QCI-FP-NEXT:    sw s5, 92(s1)
 ; QCI-FP-NEXT:    sw s4, 88(s1)
-; QCI-FP-NEXT:    lw a0, -228(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 84(s1)
-; QCI-FP-NEXT:    lw a0, -224(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 80(s1)
-; QCI-FP-NEXT:    lw a0, -220(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 76(s1)
-; QCI-FP-NEXT:    lw a0, -216(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 72(s1)
-; QCI-FP-NEXT:    lw a0, -212(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 68(s1)
-; QCI-FP-NEXT:    lw a0, -208(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 64(s1)
-; QCI-FP-NEXT:    lw a0, -204(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 60(s1)
-; QCI-FP-NEXT:    lw a0, -200(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 56(s1)
-; QCI-FP-NEXT:    lw a0, -196(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 52(s1)
-; QCI-FP-NEXT:    lw a0, -192(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 48(s1)
-; QCI-FP-NEXT:    lw a0, -188(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 44(s1)
-; QCI-FP-NEXT:    lw a0, -184(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 40(s1)
-; QCI-FP-NEXT:    lw a0, -180(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 36(s1)
-; QCI-FP-NEXT:    lw a0, -176(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 32(s1)
-; QCI-FP-NEXT:    lw a0, -172(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 28(s1)
-; QCI-FP-NEXT:    lw a0, -168(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 24(s1)
-; QCI-FP-NEXT:    lw a0, -164(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 20(s1)
-; QCI-FP-NEXT:    lw a0, -160(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 16(s1)
-; QCI-FP-NEXT:    lw a0, -156(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 12(s1)
-; QCI-FP-NEXT:    lw a0, -152(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 8(s1)
-; QCI-FP-NEXT:    lw a0, -148(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 4(s1)
-; QCI-FP-NEXT:    lw a0, -144(s0) # 4-byte Folded Reload
+; QCI-FP-NEXT:    lw a0, 96(sp) # 4-byte Folded Reload
 ; QCI-FP-NEXT:    sw a0, 0(s1)
 ; QCI-FP-NEXT:    .cfi_def_cfa sp, 240
 ; QCI-FP-NEXT:    lw s1, 140(sp) # 4-byte Folded Reload
@@ -4040,49 +4040,49 @@ define void @test_spill_call_nonest() "interrupt"="qci-nonest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lui s1, %hi(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi s1, s1, %lo(var)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 0(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -164(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 4(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -168(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -172(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -176(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -180(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -184(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -188(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -192(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -196(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -200(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -204(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -208(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -212(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -216(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -220(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -224(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -228(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -232(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -236(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -240(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -244(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, -248(s0) # 4-byte Folded Spill
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s4, 88(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s5, 92(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw s6, 96(s1)
@@ -4115,49 +4115,49 @@ define void @test_spill_call_nonest() "interrupt"="qci-nonest" {
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s6, 96(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s5, 92(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw s4, 88(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -248(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 84(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -244(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 80(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -240(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 76(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -236(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 72(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -232(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 68(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -228(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 64(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -224(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 60(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -220(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 56(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -216(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 52(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -212(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 48(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -208(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 44(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -204(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 40(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -200(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 36(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -196(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 32(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -192(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 28(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -188(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 24(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -184(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 20(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -180(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 16(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -176(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 12(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -172(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 8(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -168(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 4(s1)
-; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, -164(s0) # 4-byte Folded Reload
+; QCI-QCCMP-PUSH-POP-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    sw a0, 0(s1)
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    .cfi_def_cfa sp, 256
 ; QCI-QCCMP-PUSH-POP-FP-NEXT:    addi sp, sp, 48

--- a/llvm/test/CodeGen/RISCV/rv64-statepoint-call-lowering-x2.ll
+++ b/llvm/test/CodeGen/RISCV/rv64-statepoint-call-lowering-x2.ll
@@ -9,7 +9,7 @@ declare void @consume(ptr addrspace(1) %obj)
 define i1 @test(ptr addrspace(1) %a) "frame-pointer"="all" gc "statepoint-example" {
 entry:
   %safepoint_token = tail call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 0, i32 0, ptr elementtype(i1 ()) @return_i1, i32 0, i32 0, i32 0, i32 0) ["gc-live" (ptr addrspace(1) %a)]
-; CHECK: STATEPOINT 0, 0, 0, target-flags(riscv-call) @return_i1, 2, 0, 2, 0, 2, 0, 2, 1, 1, 8, $x8, -32, 2, 0, 2, 1, 0, 0
+; CHECK: STATEPOINT 0, 0, 0, target-flags(riscv-call) @return_i1, 2, 0, 2, 0, 2, 0, 2, 1, 1, 8, $x2, 0, 2, 0, 2, 1, 0, 0
   %call1 = call ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token %safepoint_token,  i32 0, i32 0)
   %call2 = call zeroext i1 @llvm.experimental.gc.result.i1(token %safepoint_token)
   call void @consume(ptr addrspace(1) %call1)

--- a/llvm/test/CodeGen/RISCV/rvv/addi-scalable-offset.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/addi-scalable-offset.mir
@@ -41,10 +41,8 @@ body: |
     ; CHECK-NEXT: $x2 = frame-setup SUB $x2, killed $x12
     ; CHECK-NEXT: dead $x0 = PseudoVSETVLI killed renamable $x11, 216 /* e64, m1, ta, ma */, implicit-def $vl, implicit-def $vtype
     ; CHECK-NEXT: renamable $v8 = PseudoVLE64_V_M1 undef renamable $v8, killed renamable $x10, $noreg, 6 /* e64 */, 0 /* tu, mu */, implicit $vl, implicit $vtype :: (load unknown-size from %ir.pa, align 8)
-    ; CHECK-NEXT: $x10 = PseudoReadVLENB
-    ; CHECK-NEXT: $x10 = SUB $x8, killed $x10
-    ; CHECK-NEXT: $x10 = ADDI killed $x10, -2048
-    ; CHECK-NEXT: $x10 = ADDI killed $x10, -224
+    ; CHECK-NEXT: $x10 = ADDI $x2, 2047
+    ; CHECK-NEXT: $x10 = ADDI killed $x10, 209
     ; CHECK-NEXT: VS1R_V killed renamable $v8, killed renamable $x10
     ; CHECK-NEXT: $x2 = frame-destroy ADDI $x8, -2032
     ; CHECK-NEXT: frame-destroy CFI_INSTRUCTION def_cfa $x2, 2032

--- a/llvm/test/CodeGen/RISCV/rvv/callee-saved-regs.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/callee-saved-regs.ll
@@ -251,8 +251,8 @@ define riscv_vector_cc void @local_stack_allocation_frame_pointer() "frame-point
 ; SPILL-O2-NEXT:    addi s0, sp, 2032
 ; SPILL-O2-NEXT:    .cfi_def_cfa s0, 0
 ; SPILL-O2-NEXT:    addi sp, sp, -480
-; SPILL-O2-NEXT:    lbu a0, -1912(s0)
-; SPILL-O2-NEXT:    sb a0, -1912(s0)
+; SPILL-O2-NEXT:    lbu a0, 600(sp)
+; SPILL-O2-NEXT:    sb a0, 600(sp)
 ; SPILL-O2-NEXT:    addi sp, s0, -2032
 ; SPILL-O2-NEXT:    .cfi_def_cfa sp, 2032
 ; SPILL-O2-NEXT:    lw ra, 2028(sp) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/rvv/debug-info-rvv-dbg-value.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/debug-info-rvv-dbg-value.mir
@@ -33,22 +33,22 @@
 # CHECK5-PLUS: : DW_OP_breg2 X2+32)
 # CHECK5-PLUS: DW_AT_type {{.*}}vbool1_t
 
-# CHECK0-MINUS: : DW_OP_breg8 X8-40)
+# CHECK0-MINUS: : DW_OP_breg2 X2+8)
 # CHECK0-MINUS: DW_AT_type {{.*}}int32_t
 #
-# CHECK1-MINUS: : DW_OP_breg8 X8-48)
+# CHECK1-MINUS: : DW_OP_breg2 X2+0)
 # CHECK1-MINUS: DW_AT_type {{.*}}int32_t
 #
-# CHECK2-MINUS: : DW_OP_breg8 X8-48, DW_OP_lit1, DW_OP_bregx VLENB+0, DW_OP_mul, DW_OP_minus)
+# CHECK2-MINUS: : DW_OP_breg2 X2+32, DW_OP_lit3, DW_OP_bregx VLENB+0, DW_OP_mul, DW_OP_plus)
 # CHECK2-MINUS: DW_AT_type {{.*}}vint32m1_t
 #
-# CHECK3-MINUS: : DW_OP_breg8 X8-48, DW_OP_lit2, DW_OP_bregx VLENB+0, DW_OP_mul, DW_OP_minus)
+# CHECK3-MINUS: : DW_OP_breg2 X2+32, DW_OP_lit2, DW_OP_bregx VLENB+0, DW_OP_mul, DW_OP_plus)
 # CHECK3-MINUS: DW_AT_type {{.*}}vint32m1_t
 #
-# CHECK4-MINUS: : DW_OP_breg8 X8-48, DW_OP_lit3, DW_OP_bregx VLENB+0, DW_OP_mul, DW_OP_minus)
+# CHECK4-MINUS: : DW_OP_breg2 X2+32, DW_OP_lit1, DW_OP_bregx VLENB+0, DW_OP_mul, DW_OP_plus)
 # CHECK4-MINUS: DW_AT_type {{.*}}vbool1_t
 #
-# CHECK5-MINUS: : DW_OP_breg8 X8-48, DW_OP_lit4, DW_OP_bregx VLENB+0, DW_OP_mul, DW_OP_minus)
+# CHECK5-MINUS: : DW_OP_breg2 X2+32)
 # CHECK5-MINUS: DW_AT_type {{.*}}vbool1_t
 
 --- |

--- a/llvm/test/CodeGen/RISCV/rvv/rvv-cfi-info.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rvv-cfi-info.ll
@@ -90,20 +90,17 @@ define riscv_vector_cc <vscale x 1 x i32> @test_vector_callee_cfi(<vscale x 1 x 
 ; NO-OMIT-FP-NEXT:    sub a0, a1, a0
 ; NO-OMIT-FP-NEXT:    sub sp, sp, a0
 ; NO-OMIT-FP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-NEXT:    li a1, 6
+; NO-OMIT-FP-NEXT:    mul a0, a0, a1
+; NO-OMIT-FP-NEXT:    add a0, sp, a0
+; NO-OMIT-FP-NEXT:    addi a0, a0, 24
 ; NO-OMIT-FP-NEXT:    vs1r.v v1, (a0) # vscale x 8-byte Folded Spill
 ; NO-OMIT-FP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-NEXT:    slli a1, a0, 1
-; NO-OMIT-FP-NEXT:    add a0, a1, a0
-; NO-OMIT-FP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-NEXT:    slli a0, a0, 2
+; NO-OMIT-FP-NEXT:    add a0, sp, a0
+; NO-OMIT-FP-NEXT:    addi a0, a0, 24
 ; NO-OMIT-FP-NEXT:    vs2r.v v2, (a0) # vscale x 16-byte Folded Spill
-; NO-OMIT-FP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-NEXT:    slli a1, a0, 3
-; NO-OMIT-FP-NEXT:    sub a0, a1, a0
-; NO-OMIT-FP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-NEXT:    addi a0, sp, 24
 ; NO-OMIT-FP-NEXT:    vs4r.v v4, (a0) # vscale x 32-byte Folded Spill
 ; NO-OMIT-FP-NEXT:    .cfi_escape 0x10, 0x61, 0x0b, 0x11, 0x50, 0x22, 0x11, 0x7f, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # $v1 @ cfa - 48 - 1 * vlenb
 ; NO-OMIT-FP-NEXT:    .cfi_escape 0x10, 0x62, 0x0b, 0x11, 0x50, 0x22, 0x11, 0x7d, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # $v2 @ cfa - 48 - 3 * vlenb
@@ -115,20 +112,17 @@ define riscv_vector_cc <vscale x 1 x i32> @test_vector_callee_cfi(<vscale x 1 x 
 ; NO-OMIT-FP-NEXT:    #APP
 ; NO-OMIT-FP-NEXT:    #NO_APP
 ; NO-OMIT-FP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-NEXT:    li a1, 6
+; NO-OMIT-FP-NEXT:    mul a0, a0, a1
+; NO-OMIT-FP-NEXT:    add a0, sp, a0
+; NO-OMIT-FP-NEXT:    addi a0, a0, 24
 ; NO-OMIT-FP-NEXT:    vl1r.v v1, (a0) # vscale x 8-byte Folded Reload
 ; NO-OMIT-FP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-NEXT:    slli a1, a0, 1
-; NO-OMIT-FP-NEXT:    add a0, a1, a0
-; NO-OMIT-FP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-NEXT:    slli a0, a0, 2
+; NO-OMIT-FP-NEXT:    add a0, sp, a0
+; NO-OMIT-FP-NEXT:    addi a0, a0, 24
 ; NO-OMIT-FP-NEXT:    vl2r.v v2, (a0) # vscale x 16-byte Folded Reload
-; NO-OMIT-FP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-NEXT:    slli a1, a0, 3
-; NO-OMIT-FP-NEXT:    sub a0, a1, a0
-; NO-OMIT-FP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-NEXT:    addi a0, sp, 24
 ; NO-OMIT-FP-NEXT:    vl4r.v v4, (a0) # vscale x 32-byte Folded Reload
 ; NO-OMIT-FP-NEXT:    .cfi_restore v1
 ; NO-OMIT-FP-NEXT:    .cfi_restore v2
@@ -225,20 +219,17 @@ define riscv_vector_cc <vscale x 1 x i32> @test_vector_callee_cfi(<vscale x 1 x 
 ; NO-OMIT-FP-ZCMP-NEXT:    sub a0, a1, a0
 ; NO-OMIT-FP-ZCMP-NEXT:    sub sp, sp, a0
 ; NO-OMIT-FP-ZCMP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-ZCMP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-ZCMP-NEXT:    li a1, 6
+; NO-OMIT-FP-ZCMP-NEXT:    mul a0, a0, a1
+; NO-OMIT-FP-ZCMP-NEXT:    add a0, a0, sp
+; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, 24
 ; NO-OMIT-FP-ZCMP-NEXT:    vs1r.v v1, (a0) # vscale x 8-byte Folded Spill
 ; NO-OMIT-FP-ZCMP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-ZCMP-NEXT:    slli a1, a0, 1
-; NO-OMIT-FP-ZCMP-NEXT:    add a0, a0, a1
-; NO-OMIT-FP-ZCMP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-ZCMP-NEXT:    slli a0, a0, 2
+; NO-OMIT-FP-ZCMP-NEXT:    add a0, a0, sp
+; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, 24
 ; NO-OMIT-FP-ZCMP-NEXT:    vs2r.v v2, (a0) # vscale x 16-byte Folded Spill
-; NO-OMIT-FP-ZCMP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-ZCMP-NEXT:    slli a1, a0, 3
-; NO-OMIT-FP-ZCMP-NEXT:    sub a0, a1, a0
-; NO-OMIT-FP-ZCMP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-ZCMP-NEXT:    addi a0, sp, 24
 ; NO-OMIT-FP-ZCMP-NEXT:    vs4r.v v4, (a0) # vscale x 32-byte Folded Spill
 ; NO-OMIT-FP-ZCMP-NEXT:    .cfi_escape 0x10, 0x61, 0x0b, 0x11, 0x50, 0x22, 0x11, 0x7f, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # $v1 @ cfa - 48 - 1 * vlenb
 ; NO-OMIT-FP-ZCMP-NEXT:    .cfi_escape 0x10, 0x62, 0x0b, 0x11, 0x50, 0x22, 0x11, 0x7d, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # $v2 @ cfa - 48 - 3 * vlenb
@@ -250,20 +241,17 @@ define riscv_vector_cc <vscale x 1 x i32> @test_vector_callee_cfi(<vscale x 1 x 
 ; NO-OMIT-FP-ZCMP-NEXT:    #APP
 ; NO-OMIT-FP-ZCMP-NEXT:    #NO_APP
 ; NO-OMIT-FP-ZCMP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-ZCMP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-ZCMP-NEXT:    li a1, 6
+; NO-OMIT-FP-ZCMP-NEXT:    mul a0, a0, a1
+; NO-OMIT-FP-ZCMP-NEXT:    add a0, a0, sp
+; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, 24
 ; NO-OMIT-FP-ZCMP-NEXT:    vl1r.v v1, (a0) # vscale x 8-byte Folded Reload
 ; NO-OMIT-FP-ZCMP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-ZCMP-NEXT:    slli a1, a0, 1
-; NO-OMIT-FP-ZCMP-NEXT:    add a0, a0, a1
-; NO-OMIT-FP-ZCMP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-ZCMP-NEXT:    slli a0, a0, 2
+; NO-OMIT-FP-ZCMP-NEXT:    add a0, a0, sp
+; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, 24
 ; NO-OMIT-FP-ZCMP-NEXT:    vl2r.v v2, (a0) # vscale x 16-byte Folded Reload
-; NO-OMIT-FP-ZCMP-NEXT:    csrr a0, vlenb
-; NO-OMIT-FP-ZCMP-NEXT:    slli a1, a0, 3
-; NO-OMIT-FP-ZCMP-NEXT:    sub a0, a1, a0
-; NO-OMIT-FP-ZCMP-NEXT:    sub a0, s0, a0
-; NO-OMIT-FP-ZCMP-NEXT:    addi a0, a0, -48
+; NO-OMIT-FP-ZCMP-NEXT:    addi a0, sp, 24
 ; NO-OMIT-FP-ZCMP-NEXT:    vl4r.v v4, (a0) # vscale x 32-byte Folded Reload
 ; NO-OMIT-FP-ZCMP-NEXT:    .cfi_restore v1
 ; NO-OMIT-FP-ZCMP-NEXT:    .cfi_restore v2

--- a/llvm/test/CodeGen/RISCV/rvv/rvv-out-arguments.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rvv-out-arguments.ll
@@ -12,24 +12,27 @@ define dso_local void @lots_args(i32 signext %x0, i32 signext %x1, <vscale x 16 
 ; CHECK-NEXT:    csrr t0, vlenb
 ; CHECK-NEXT:    slli t0, t0, 3
 ; CHECK-NEXT:    sub sp, sp, t0
-; CHECK-NEXT:    ld t0, 8(s0)
-; CHECK-NEXT:    ld t1, 0(s0)
-; CHECK-NEXT:    sw a0, -28(s0)
-; CHECK-NEXT:    sw a1, -32(s0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 3
-; CHECK-NEXT:    sub a0, s0, a0
-; CHECK-NEXT:    addi a0, a0, -64
+; CHECK-NEXT:    csrr t0, vlenb
+; CHECK-NEXT:    slli t0, t0, 3
+; CHECK-NEXT:    add t0, sp, t0
+; CHECK-NEXT:    ld t0, 72(t0)
+; CHECK-NEXT:    csrr t1, vlenb
+; CHECK-NEXT:    slli t1, t1, 3
+; CHECK-NEXT:    add t1, sp, t1
+; CHECK-NEXT:    ld t1, 64(t1)
+; CHECK-NEXT:    sw a0, 36(sp)
+; CHECK-NEXT:    sw a1, 32(sp)
+; CHECK-NEXT:    addi a0, sp, 48
 ; CHECK-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
 ; CHECK-NEXT:    vse32.v v8, (a0)
-; CHECK-NEXT:    sw a2, -36(s0)
-; CHECK-NEXT:    sw a3, -40(s0)
-; CHECK-NEXT:    sw a4, -44(s0)
-; CHECK-NEXT:    sw a5, -48(s0)
-; CHECK-NEXT:    sw a6, -52(s0)
-; CHECK-NEXT:    sw a7, -56(s0)
-; CHECK-NEXT:    sw t1, -60(s0)
-; CHECK-NEXT:    sw t0, -64(s0)
+; CHECK-NEXT:    sw a2, 28(sp)
+; CHECK-NEXT:    sw a3, 24(sp)
+; CHECK-NEXT:    sw a4, 20(sp)
+; CHECK-NEXT:    sw a5, 16(sp)
+; CHECK-NEXT:    sw a6, 12(sp)
+; CHECK-NEXT:    sw a7, 8(sp)
+; CHECK-NEXT:    sw t1, 4(sp)
+; CHECK-NEXT:    sw t0, 0(sp)
 ; CHECK-NEXT:    addi sp, s0, -64
 ; CHECK-NEXT:    ld ra, 56(sp) # 8-byte Folded Reload
 ; CHECK-NEXT:    ld s0, 48(sp) # 8-byte Folded Reload
@@ -72,61 +75,58 @@ define dso_local signext i32 @main() #0 {
 ; CHECK-NEXT:    csrr a0, vlenb
 ; CHECK-NEXT:    slli a0, a0, 3
 ; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    sw zero, -36(s0)
+; CHECK-NEXT:    sw zero, 76(sp)
 ; CHECK-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; CHECK-NEXT:    vmv.v.i v8, 0
-; CHECK-NEXT:    addi a0, s0, -64
+; CHECK-NEXT:    addi a0, sp, 48
 ; CHECK-NEXT:    vse64.v v8, (a0)
 ; CHECK-NEXT:    vsetivli a1, 4, e32, m8, ta, ma
-; CHECK-NEXT:    sd a1, -72(s0)
-; CHECK-NEXT:    ld a1, -72(s0)
+; CHECK-NEXT:    sd a1, 40(sp)
+; CHECK-NEXT:    ld a1, 40(sp)
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
 ; CHECK-NEXT:    vle32.v v8, (a0)
-; CHECK-NEXT:    csrr s1, vlenb
-; CHECK-NEXT:    slli s1, s1, 3
-; CHECK-NEXT:    sub s1, s0, s1
-; CHECK-NEXT:    addi s1, s1, -112
+; CHECK-NEXT:    addi s1, sp, 88
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m8, ta, ma
 ; CHECK-NEXT:    vse32.v v8, (s1)
 ; CHECK-NEXT:    li a0, 1
-; CHECK-NEXT:    sw a0, -76(s0)
-; CHECK-NEXT:    sw a0, -80(s0)
-; CHECK-NEXT:    sw a0, -84(s0)
-; CHECK-NEXT:    sw a0, -88(s0)
-; CHECK-NEXT:    sw a0, -92(s0)
-; CHECK-NEXT:    sw a0, -96(s0)
-; CHECK-NEXT:    sw a0, -100(s0)
-; CHECK-NEXT:    sw a0, -104(s0)
-; CHECK-NEXT:    sw a0, -108(s0)
-; CHECK-NEXT:    sw a0, -112(s0)
-; CHECK-NEXT:    lw a0, -76(s0)
-; CHECK-NEXT:    lw a1, -80(s0)
+; CHECK-NEXT:    sw a0, 36(sp)
+; CHECK-NEXT:    sw a0, 32(sp)
+; CHECK-NEXT:    sw a0, 28(sp)
+; CHECK-NEXT:    sw a0, 24(sp)
+; CHECK-NEXT:    sw a0, 20(sp)
+; CHECK-NEXT:    sw a0, 16(sp)
+; CHECK-NEXT:    sw a0, 12(sp)
+; CHECK-NEXT:    sw a0, 8(sp)
+; CHECK-NEXT:    sw a0, 4(sp)
+; CHECK-NEXT:    sw a0, 0(sp)
+; CHECK-NEXT:    lw a0, 36(sp)
+; CHECK-NEXT:    lw a1, 32(sp)
 ; CHECK-NEXT:    vle32.v v8, (s1)
-; CHECK-NEXT:    lw a2, -84(s0)
-; CHECK-NEXT:    lw a3, -88(s0)
-; CHECK-NEXT:    lw a4, -92(s0)
-; CHECK-NEXT:    lw a5, -96(s0)
-; CHECK-NEXT:    lw a6, -100(s0)
-; CHECK-NEXT:    lw a7, -104(s0)
-; CHECK-NEXT:    lw t0, -108(s0)
-; CHECK-NEXT:    lw t1, -112(s0)
+; CHECK-NEXT:    lw a2, 28(sp)
+; CHECK-NEXT:    lw a3, 24(sp)
+; CHECK-NEXT:    lw a4, 20(sp)
+; CHECK-NEXT:    lw a5, 16(sp)
+; CHECK-NEXT:    lw a6, 12(sp)
+; CHECK-NEXT:    lw a7, 8(sp)
+; CHECK-NEXT:    lw t0, 4(sp)
+; CHECK-NEXT:    lw t1, 0(sp)
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    sd t1, 8(sp)
 ; CHECK-NEXT:    sd t0, 0(sp)
 ; CHECK-NEXT:    call lots_args
 ; CHECK-NEXT:    addi sp, sp, 16
-; CHECK-NEXT:    lw a0, -76(s0)
-; CHECK-NEXT:    lw a1, -80(s0)
+; CHECK-NEXT:    lw a0, 36(sp)
+; CHECK-NEXT:    lw a1, 32(sp)
 ; CHECK-NEXT:    vsetvli a2, zero, e32, m8, ta, ma
 ; CHECK-NEXT:    vle32.v v8, (s1)
-; CHECK-NEXT:    lw a2, -84(s0)
-; CHECK-NEXT:    lw a3, -88(s0)
-; CHECK-NEXT:    lw a4, -92(s0)
-; CHECK-NEXT:    lw a5, -96(s0)
-; CHECK-NEXT:    lw a6, -100(s0)
-; CHECK-NEXT:    lw a7, -104(s0)
-; CHECK-NEXT:    lw t0, -108(s0)
-; CHECK-NEXT:    lw t1, -112(s0)
+; CHECK-NEXT:    lw a2, 28(sp)
+; CHECK-NEXT:    lw a3, 24(sp)
+; CHECK-NEXT:    lw a4, 20(sp)
+; CHECK-NEXT:    lw a5, 16(sp)
+; CHECK-NEXT:    lw a6, 12(sp)
+; CHECK-NEXT:    lw a7, 8(sp)
+; CHECK-NEXT:    lw t0, 4(sp)
+; CHECK-NEXT:    lw t1, 0(sp)
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    sd t1, 8(sp)
 ; CHECK-NEXT:    sd t0, 0(sp)

--- a/llvm/test/CodeGen/RISCV/vararg-ilp32e.ll
+++ b/llvm/test/CodeGen/RISCV/vararg-ilp32e.ll
@@ -108,17 +108,17 @@ define void @va_double(i32 %n, ...) {
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa s0, 24
 ; ILP32E-WITHFP-NEXT:    .cfi_remember_state
-; ILP32E-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32E-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32E-WITHFP-NEXT:    addi a0, s0, 4
-; ILP32E-WITHFP-NEXT:    addi a1, s0, 11
-; ILP32E-WITHFP-NEXT:    sw a0, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a5, 32(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 24(sp)
+; ILP32E-WITHFP-NEXT:    sw a4, 28(sp)
+; ILP32E-WITHFP-NEXT:    addi a0, sp, 16
+; ILP32E-WITHFP-NEXT:    addi a1, sp, 23
+; ILP32E-WITHFP-NEXT:    sw a0, 0(sp)
 ; ILP32E-WITHFP-NEXT:    andi a1, a1, -8
 ; ILP32E-WITHFP-NEXT:    addi a0, a1, 8
-; ILP32E-WITHFP-NEXT:    sw a0, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a0, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lw a0, 0(a1)
 ; ILP32E-WITHFP-NEXT:    lw a1, 4(a1)
 ; ILP32E-WITHFP-NEXT:    lui a3, 262144

--- a/llvm/test/CodeGen/RISCV/vararg.ll
+++ b/llvm/test/CodeGen/RISCV/vararg.ll
@@ -76,15 +76,15 @@ define i32 @va1(ptr %fmt, ...) {
 ; ILP32-ILP32F-WITHFP-NEXT:    addi s0, sp, 16
 ; ILP32-ILP32F-WITHFP-NEXT:    .cfi_def_cfa s0, 32
 ; ILP32-ILP32F-WITHFP-NEXT:    mv a0, a1
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 24(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 28(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    addi a1, s0, 8
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 36(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 40(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 44(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 20(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 24(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 28(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 32(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    addi a1, sp, 24
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    .cfi_def_cfa sp, 48
 ; ILP32-ILP32F-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; ILP32-ILP32F-WITHFP-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
@@ -139,13 +139,13 @@ define i32 @va1(ptr %fmt, ...) {
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa s0, 24
 ; ILP32E-WITHFP-NEXT:    mv a0, a1
-; ILP32E-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32E-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32E-WITHFP-NEXT:    addi a1, s0, 8
-; ILP32E-WITHFP-NEXT:    sw a1, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a5, 32(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 24(sp)
+; ILP32E-WITHFP-NEXT:    sw a4, 28(sp)
+; ILP32E-WITHFP-NEXT:    addi a1, sp, 20
+; ILP32E-WITHFP-NEXT:    sw a1, 0(sp)
 ; ILP32E-WITHFP-NEXT:    .cfi_def_cfa sp, 36
 ; ILP32E-WITHFP-NEXT:    lw ra, 8(sp) # 4-byte Folded Reload
 ; ILP32E-WITHFP-NEXT:    lw s0, 4(sp) # 4-byte Folded Reload
@@ -183,16 +183,16 @@ define i32 @va1(ptr %fmt, ...) {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    .cfi_offset s0, -80
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi s0, sp, 32
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    .cfi_def_cfa s0, 64
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a0, s0, 12
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, -24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    lw a0, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 48(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 56(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 32(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 40(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a0, sp, 44
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, 8(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lw a0, 40(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 72(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 80(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 88(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 48(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 56(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 64(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    .cfi_def_cfa sp, 96
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
@@ -228,14 +228,14 @@ define i32 @va1(ptr %fmt, ...) {
 ; LP64E-WITHFP-NEXT:    .cfi_offset s0, -64
 ; LP64E-WITHFP-NEXT:    addi s0, sp, 24
 ; LP64E-WITHFP-NEXT:    .cfi_def_cfa s0, 48
-; LP64E-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64E-WITHFP-NEXT:    addi a0, s0, 12
-; LP64E-WITHFP-NEXT:    sd a0, -24(s0)
-; LP64E-WITHFP-NEXT:    lw a0, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64E-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64E-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64E-WITHFP-NEXT:    sd a4, 32(s0)
+; LP64E-WITHFP-NEXT:    sd a1, 32(sp)
+; LP64E-WITHFP-NEXT:    addi a0, sp, 36
+; LP64E-WITHFP-NEXT:    sd a0, 0(sp)
+; LP64E-WITHFP-NEXT:    lw a0, 32(sp)
+; LP64E-WITHFP-NEXT:    sd a5, 64(sp)
+; LP64E-WITHFP-NEXT:    sd a2, 40(sp)
+; LP64E-WITHFP-NEXT:    sd a3, 48(sp)
+; LP64E-WITHFP-NEXT:    sd a4, 56(sp)
 ; LP64E-WITHFP-NEXT:    .cfi_def_cfa sp, 72
 ; LP64E-WITHFP-NEXT:    ld ra, 16(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    ld s0, 8(sp) # 8-byte Folded Reload
@@ -278,15 +278,15 @@ define i32 @va1_va_arg(ptr %fmt, ...) nounwind {
 ; ILP32-ILP32F-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    addi s0, sp, 16
 ; ILP32-ILP32F-WITHFP-NEXT:    mv a0, a1
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 24(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 28(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    addi a1, s0, 8
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 36(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 40(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 44(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 20(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 24(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 28(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 32(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    addi a1, sp, 24
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; ILP32-ILP32F-WITHFP-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; ILP32-ILP32F-WITHFP-NEXT:    addi sp, sp, 48
@@ -329,13 +329,13 @@ define i32 @va1_va_arg(ptr %fmt, ...) nounwind {
 ; ILP32E-WITHFP-NEXT:    sw s0, 4(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 12
 ; ILP32E-WITHFP-NEXT:    mv a0, a1
-; ILP32E-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32E-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32E-WITHFP-NEXT:    addi a1, s0, 8
-; ILP32E-WITHFP-NEXT:    sw a1, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a5, 32(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 24(sp)
+; ILP32E-WITHFP-NEXT:    sw a4, 28(sp)
+; ILP32E-WITHFP-NEXT:    addi a1, sp, 20
+; ILP32E-WITHFP-NEXT:    sw a1, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lw ra, 8(sp) # 4-byte Folded Reload
 ; ILP32E-WITHFP-NEXT:    lw s0, 4(sp) # 4-byte Folded Reload
 ; ILP32E-WITHFP-NEXT:    addi sp, sp, 36
@@ -364,15 +364,15 @@ define i32 @va1_va_arg(ptr %fmt, ...) nounwind {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi s0, sp, 32
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    mv a0, a1
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 48(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 56(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, s0, 16
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, -24(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 72(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 80(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 88(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 40(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 48(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 56(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 64(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, sp, 48
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi sp, sp, 96
@@ -399,13 +399,13 @@ define i32 @va1_va_arg(ptr %fmt, ...) nounwind {
 ; LP64E-WITHFP-NEXT:    sd s0, 8(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    addi s0, sp, 24
 ; LP64E-WITHFP-NEXT:    mv a0, a1
-; LP64E-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64E-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64E-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64E-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64E-WITHFP-NEXT:    addi a1, s0, 16
-; LP64E-WITHFP-NEXT:    sd a1, -24(s0)
+; LP64E-WITHFP-NEXT:    sd a5, 64(sp)
+; LP64E-WITHFP-NEXT:    sd a1, 32(sp)
+; LP64E-WITHFP-NEXT:    sd a2, 40(sp)
+; LP64E-WITHFP-NEXT:    sd a3, 48(sp)
+; LP64E-WITHFP-NEXT:    sd a4, 56(sp)
+; LP64E-WITHFP-NEXT:    addi a1, sp, 40
+; LP64E-WITHFP-NEXT:    sd a1, 0(sp)
 ; LP64E-WITHFP-NEXT:    ld ra, 16(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    ld s0, 8(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    addi sp, sp, 72
@@ -854,19 +854,19 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; ILP32-ILP32F-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    addi s0, sp, 16
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 24(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 28(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    addi a0, s0, 4
-; ILP32-ILP32F-WITHFP-NEXT:    addi a1, s0, 11
-; ILP32-ILP32F-WITHFP-NEXT:    addi a2, s0, 19
-; ILP32-ILP32F-WITHFP-NEXT:    sw a0, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 36(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 40(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 44(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 20(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 24(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 28(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 32(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    addi a0, sp, 20
+; ILP32-ILP32F-WITHFP-NEXT:    addi a1, sp, 27
+; ILP32-ILP32F-WITHFP-NEXT:    addi a2, sp, 35
+; ILP32-ILP32F-WITHFP-NEXT:    sw a0, 4(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    andi a1, a1, -8
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 4(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a0, 0(a1)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a1, 4(a1)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -920,17 +920,17 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; ILP32E-WITHFP-NEXT:    sw ra, 8(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    sw s0, 4(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 12
-; ILP32E-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32E-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32E-WITHFP-NEXT:    addi a0, s0, 4
-; ILP32E-WITHFP-NEXT:    addi a1, s0, 11
-; ILP32E-WITHFP-NEXT:    addi a2, s0, 19
-; ILP32E-WITHFP-NEXT:    sw a0, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a5, 32(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 24(sp)
+; ILP32E-WITHFP-NEXT:    sw a4, 28(sp)
+; ILP32E-WITHFP-NEXT:    addi a0, sp, 16
+; ILP32E-WITHFP-NEXT:    addi a1, sp, 23
+; ILP32E-WITHFP-NEXT:    addi a2, sp, 31
+; ILP32E-WITHFP-NEXT:    sw a0, 0(sp)
 ; ILP32E-WITHFP-NEXT:    andi a1, a1, -8
-; ILP32E-WITHFP-NEXT:    sw a2, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a2, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lw a0, 0(a1)
 ; ILP32E-WITHFP-NEXT:    lw a1, 4(a1)
 ; ILP32E-WITHFP-NEXT:    lw ra, 8(sp) # 4-byte Folded Reload
@@ -961,15 +961,15 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi s0, sp, 32
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    mv a0, a1
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 48(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 56(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, s0, 23
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, -24(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 72(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 80(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 88(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 40(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 48(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 56(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 64(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, sp, 55
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi sp, sp, 96
@@ -996,13 +996,13 @@ define i64 @va2(ptr %fmt, ...) nounwind {
 ; LP64E-WITHFP-NEXT:    sd s0, 8(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    addi s0, sp, 24
 ; LP64E-WITHFP-NEXT:    mv a0, a1
-; LP64E-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64E-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64E-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64E-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64E-WITHFP-NEXT:    addi a1, s0, 23
-; LP64E-WITHFP-NEXT:    sd a1, -24(s0)
+; LP64E-WITHFP-NEXT:    sd a5, 64(sp)
+; LP64E-WITHFP-NEXT:    sd a1, 32(sp)
+; LP64E-WITHFP-NEXT:    sd a2, 40(sp)
+; LP64E-WITHFP-NEXT:    sd a3, 48(sp)
+; LP64E-WITHFP-NEXT:    sd a4, 56(sp)
+; LP64E-WITHFP-NEXT:    addi a1, sp, 47
+; LP64E-WITHFP-NEXT:    sd a1, 0(sp)
 ; LP64E-WITHFP-NEXT:    ld ra, 16(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    ld s0, 8(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    addi sp, sp, 72
@@ -1051,20 +1051,20 @@ define i64 @va2_va_arg(ptr %fmt, ...) nounwind {
 ; ILP32-ILP32F-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    addi s0, sp, 16
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 24(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 28(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    addi a0, s0, 11
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 36(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 40(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 44(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 20(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 24(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 28(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 32(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    addi a0, sp, 27
 ; ILP32-ILP32F-WITHFP-NEXT:    andi a1, a0, -8
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a0, a1, 4
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a2, a1, 8
-; ILP32-ILP32F-WITHFP-NEXT:    sw a0, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a0, 4(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a0, 0(a1)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 4(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a1, 4(a1)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; ILP32-ILP32F-WITHFP-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
@@ -1117,18 +1117,18 @@ define i64 @va2_va_arg(ptr %fmt, ...) nounwind {
 ; ILP32E-WITHFP-NEXT:    sw ra, 8(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    sw s0, 4(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 12
-; ILP32E-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32E-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32E-WITHFP-NEXT:    addi a0, s0, 11
+; ILP32E-WITHFP-NEXT:    sw a5, 32(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 24(sp)
+; ILP32E-WITHFP-NEXT:    sw a4, 28(sp)
+; ILP32E-WITHFP-NEXT:    addi a0, sp, 23
 ; ILP32E-WITHFP-NEXT:    andi a1, a0, -8
 ; ILP32E-WITHFP-NEXT:    addi a0, a1, 4
 ; ILP32E-WITHFP-NEXT:    addi a2, a1, 8
-; ILP32E-WITHFP-NEXT:    sw a0, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a0, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lw a0, 0(a1)
-; ILP32E-WITHFP-NEXT:    sw a2, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a2, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lw a1, 4(a1)
 ; ILP32E-WITHFP-NEXT:    lw ra, 8(sp) # 4-byte Folded Reload
 ; ILP32E-WITHFP-NEXT:    lw s0, 4(sp) # 4-byte Folded Reload
@@ -1158,15 +1158,15 @@ define i64 @va2_va_arg(ptr %fmt, ...) nounwind {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi s0, sp, 32
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    mv a0, a1
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 48(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 56(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, s0, 16
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, -24(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 72(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 80(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 88(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 40(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 48(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 56(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 64(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, sp, 48
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi sp, sp, 96
@@ -1193,13 +1193,13 @@ define i64 @va2_va_arg(ptr %fmt, ...) nounwind {
 ; LP64E-WITHFP-NEXT:    sd s0, 8(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    addi s0, sp, 24
 ; LP64E-WITHFP-NEXT:    mv a0, a1
-; LP64E-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64E-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64E-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64E-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64E-WITHFP-NEXT:    addi a1, s0, 16
-; LP64E-WITHFP-NEXT:    sd a1, -24(s0)
+; LP64E-WITHFP-NEXT:    sd a5, 64(sp)
+; LP64E-WITHFP-NEXT:    sd a1, 32(sp)
+; LP64E-WITHFP-NEXT:    sd a2, 40(sp)
+; LP64E-WITHFP-NEXT:    sd a3, 48(sp)
+; LP64E-WITHFP-NEXT:    sd a4, 56(sp)
+; LP64E-WITHFP-NEXT:    addi a1, sp, 40
+; LP64E-WITHFP-NEXT:    sd a1, 0(sp)
 ; LP64E-WITHFP-NEXT:    ld ra, 16(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    ld s0, 8(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    addi sp, sp, 72
@@ -1360,17 +1360,17 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; ILP32-ILP32F-WITHFP-NEXT:    sw ra, 20(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    addi s0, sp, 24
-; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 20(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 4(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 8(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 12(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    addi a0, s0, 4
-; ILP32-ILP32F-WITHFP-NEXT:    addi a3, s0, 11
-; ILP32-ILP32F-WITHFP-NEXT:    addi a4, s0, 19
-; ILP32-ILP32F-WITHFP-NEXT:    sw a0, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 44(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 28(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 32(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 36(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 40(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    addi a0, sp, 28
+; ILP32-ILP32F-WITHFP-NEXT:    addi a3, sp, 35
+; ILP32-ILP32F-WITHFP-NEXT:    addi a4, sp, 43
+; ILP32-ILP32F-WITHFP-NEXT:    sw a0, 12(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    andi a3, a3, -8
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 12(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a0, 4(a3)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a3, 0(a3)
 ; ILP32-ILP32F-WITHFP-NEXT:    add a2, a2, a0
@@ -1432,15 +1432,15 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; ILP32E-WITHFP-NEXT:    sw ra, 8(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    sw s0, 4(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 12
-; ILP32E-WITHFP-NEXT:    sw a3, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a4, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a5, 12(s0)
-; ILP32E-WITHFP-NEXT:    addi a0, s0, 4
-; ILP32E-WITHFP-NEXT:    addi a3, s0, 11
-; ILP32E-WITHFP-NEXT:    addi a4, s0, 19
-; ILP32E-WITHFP-NEXT:    sw a0, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a3, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a4, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a5, 24(sp)
+; ILP32E-WITHFP-NEXT:    addi a0, sp, 16
+; ILP32E-WITHFP-NEXT:    addi a3, sp, 23
+; ILP32E-WITHFP-NEXT:    addi a4, sp, 31
+; ILP32E-WITHFP-NEXT:    sw a0, 0(sp)
 ; ILP32E-WITHFP-NEXT:    andi a3, a3, -8
-; ILP32E-WITHFP-NEXT:    sw a4, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a4, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lw a0, 4(a3)
 ; ILP32E-WITHFP-NEXT:    lw a3, 0(a3)
 ; ILP32E-WITHFP-NEXT:    add a2, a2, a0
@@ -1473,15 +1473,15 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi s0, sp, 32
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 32(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 40(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 0(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 16(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a3, s0, 15
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 64(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 72(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 32(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 40(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 48(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 56(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a3, sp, 47
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    add a0, a1, a2
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, -24(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 8(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi sp, sp, 80
@@ -1506,13 +1506,13 @@ define i64 @va3(i32 %a, i64 %b, ...) nounwind {
 ; LP64E-WITHFP-NEXT:    sd ra, 16(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    sd s0, 8(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    addi s0, sp, 24
-; LP64E-WITHFP-NEXT:    sd a2, 0(s0)
-; LP64E-WITHFP-NEXT:    sd a3, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a4, 16(s0)
-; LP64E-WITHFP-NEXT:    sd a5, 24(s0)
-; LP64E-WITHFP-NEXT:    addi a3, s0, 15
+; LP64E-WITHFP-NEXT:    sd a2, 24(sp)
+; LP64E-WITHFP-NEXT:    sd a3, 32(sp)
+; LP64E-WITHFP-NEXT:    sd a4, 40(sp)
+; LP64E-WITHFP-NEXT:    sd a5, 48(sp)
+; LP64E-WITHFP-NEXT:    addi a3, sp, 39
 ; LP64E-WITHFP-NEXT:    add a0, a1, a2
-; LP64E-WITHFP-NEXT:    sd a3, -24(s0)
+; LP64E-WITHFP-NEXT:    sd a3, 0(sp)
 ; LP64E-WITHFP-NEXT:    ld ra, 16(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    ld s0, 8(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    addi sp, sp, 56
@@ -1564,18 +1564,18 @@ define i64 @va3_va_arg(i32 %a, i64 %b, ...) nounwind {
 ; ILP32-ILP32F-WITHFP-NEXT:    sw ra, 20(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    sw s0, 16(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    addi s0, sp, 24
-; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 20(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 4(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 8(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 12(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    addi a0, s0, 11
+; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 44(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 28(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 32(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 36(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 40(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    addi a0, sp, 35
 ; ILP32-ILP32F-WITHFP-NEXT:    andi a0, a0, -8
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a3, a0, 4
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a4, a0, 8
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 12(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a3, 0(a0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 12(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a4, 4(a0)
 ; ILP32-ILP32F-WITHFP-NEXT:    add a0, a1, a3
 ; ILP32-ILP32F-WITHFP-NEXT:    sltu a1, a0, a1
@@ -1636,16 +1636,16 @@ define i64 @va3_va_arg(i32 %a, i64 %b, ...) nounwind {
 ; ILP32E-WITHFP-NEXT:    sw ra, 8(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    sw s0, 4(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 12
-; ILP32E-WITHFP-NEXT:    sw a3, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a4, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a5, 12(s0)
-; ILP32E-WITHFP-NEXT:    addi a0, s0, 11
+; ILP32E-WITHFP-NEXT:    sw a3, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a4, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a5, 24(sp)
+; ILP32E-WITHFP-NEXT:    addi a0, sp, 23
 ; ILP32E-WITHFP-NEXT:    andi a0, a0, -8
 ; ILP32E-WITHFP-NEXT:    addi a3, a0, 4
 ; ILP32E-WITHFP-NEXT:    addi a4, a0, 8
-; ILP32E-WITHFP-NEXT:    sw a3, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a3, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lw a3, 0(a0)
-; ILP32E-WITHFP-NEXT:    sw a4, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a4, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lw a4, 4(a0)
 ; ILP32E-WITHFP-NEXT:    add a0, a1, a3
 ; ILP32E-WITHFP-NEXT:    sltu a1, a0, a1
@@ -1677,15 +1677,15 @@ define i64 @va3_va_arg(i32 %a, i64 %b, ...) nounwind {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi s0, sp, 32
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 32(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 40(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 0(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 16(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a3, s0, 8
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 64(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 72(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 32(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 40(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 48(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 56(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a3, sp, 40
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    add a0, a1, a2
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, -24(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 8(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi sp, sp, 80
@@ -1710,13 +1710,13 @@ define i64 @va3_va_arg(i32 %a, i64 %b, ...) nounwind {
 ; LP64E-WITHFP-NEXT:    sd ra, 16(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    sd s0, 8(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    addi s0, sp, 24
-; LP64E-WITHFP-NEXT:    sd a2, 0(s0)
-; LP64E-WITHFP-NEXT:    sd a3, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a4, 16(s0)
-; LP64E-WITHFP-NEXT:    sd a5, 24(s0)
-; LP64E-WITHFP-NEXT:    addi a3, s0, 8
+; LP64E-WITHFP-NEXT:    sd a2, 24(sp)
+; LP64E-WITHFP-NEXT:    sd a3, 32(sp)
+; LP64E-WITHFP-NEXT:    sd a4, 40(sp)
+; LP64E-WITHFP-NEXT:    sd a5, 48(sp)
+; LP64E-WITHFP-NEXT:    addi a3, sp, 32
 ; LP64E-WITHFP-NEXT:    add a0, a1, a2
-; LP64E-WITHFP-NEXT:    sd a3, -24(s0)
+; LP64E-WITHFP-NEXT:    sd a3, 0(sp)
 ; LP64E-WITHFP-NEXT:    ld ra, 16(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    ld s0, 8(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    addi sp, sp, 56
@@ -1918,32 +1918,32 @@ define i32 @va4_va_copy(i32 %argno, ...) nounwind {
 ; ILP32-ILP32F-WITHFP-NEXT:    sw s1, 20(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    addi s0, sp, 32
 ; ILP32-ILP32F-WITHFP-NEXT:    mv s1, a1
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 24(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 28(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    addi a0, s0, 8
-; ILP32-ILP32F-WITHFP-NEXT:    sw a0, -16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a0, -20(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 52(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 56(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 60(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 36(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 40(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 44(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 48(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    addi a0, sp, 40
+; ILP32-ILP32F-WITHFP-NEXT:    sw a0, 16(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a0, 12(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    call notdead
-; ILP32-ILP32F-WITHFP-NEXT:    lw a0, -16(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    lw a0, 16(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a0, a0, 3
 ; ILP32-ILP32F-WITHFP-NEXT:    andi a0, a0, -4
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a1, a0, 4
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a2, a0, 7
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, -16(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 16(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    andi a2, a2, -4
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a0, 0(a0)
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a1, a2, 4
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a3, a2, 7
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, -16(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 16(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    andi a3, a3, -4
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a1, 0(a2)
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a2, a3, 4
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, -16(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 16(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw a2, 0(a3)
 ; ILP32-ILP32F-WITHFP-NEXT:    add a0, a0, s1
 ; ILP32-ILP32F-WITHFP-NEXT:    add a0, a0, a1
@@ -2042,30 +2042,30 @@ define i32 @va4_va_copy(i32 %argno, ...) nounwind {
 ; ILP32E-WITHFP-NEXT:    sw s1, 8(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 20
 ; ILP32E-WITHFP-NEXT:    mv s1, a1
-; ILP32E-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32E-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32E-WITHFP-NEXT:    addi a0, s0, 8
-; ILP32E-WITHFP-NEXT:    sw a0, -16(s0)
-; ILP32E-WITHFP-NEXT:    sw a0, -20(s0)
+; ILP32E-WITHFP-NEXT:    sw a5, 40(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 24(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 28(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 32(sp)
+; ILP32E-WITHFP-NEXT:    sw a4, 36(sp)
+; ILP32E-WITHFP-NEXT:    addi a0, sp, 28
+; ILP32E-WITHFP-NEXT:    sw a0, 4(sp)
+; ILP32E-WITHFP-NEXT:    sw a0, 0(sp)
 ; ILP32E-WITHFP-NEXT:    call notdead
-; ILP32E-WITHFP-NEXT:    lw a0, -16(s0)
+; ILP32E-WITHFP-NEXT:    lw a0, 4(sp)
 ; ILP32E-WITHFP-NEXT:    addi a0, a0, 3
 ; ILP32E-WITHFP-NEXT:    andi a0, a0, -4
 ; ILP32E-WITHFP-NEXT:    addi a1, a0, 4
 ; ILP32E-WITHFP-NEXT:    addi a2, a0, 7
-; ILP32E-WITHFP-NEXT:    sw a1, -16(s0)
+; ILP32E-WITHFP-NEXT:    sw a1, 4(sp)
 ; ILP32E-WITHFP-NEXT:    andi a2, a2, -4
 ; ILP32E-WITHFP-NEXT:    lw a0, 0(a0)
 ; ILP32E-WITHFP-NEXT:    addi a1, a2, 4
 ; ILP32E-WITHFP-NEXT:    addi a3, a2, 7
-; ILP32E-WITHFP-NEXT:    sw a1, -16(s0)
+; ILP32E-WITHFP-NEXT:    sw a1, 4(sp)
 ; ILP32E-WITHFP-NEXT:    andi a3, a3, -4
 ; ILP32E-WITHFP-NEXT:    lw a1, 0(a2)
 ; ILP32E-WITHFP-NEXT:    addi a2, a3, 4
-; ILP32E-WITHFP-NEXT:    sw a2, -16(s0)
+; ILP32E-WITHFP-NEXT:    sw a2, 4(sp)
 ; ILP32E-WITHFP-NEXT:    lw a2, 0(a3)
 ; ILP32E-WITHFP-NEXT:    add a0, a0, s1
 ; ILP32E-WITHFP-NEXT:    add a0, a0, a1
@@ -2125,32 +2125,32 @@ define i32 @va4_va_copy(i32 %argno, ...) nounwind {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd s1, 24(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi s0, sp, 48
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    mv s1, a1
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 48(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 56(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a0, s0, 16
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, -32(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, -40(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 88(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 96(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 104(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 56(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 64(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 72(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 80(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a0, sp, 64
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, 16(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, 8(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    call notdead
-; LP64-LP64F-LP64D-WITHFP-NEXT:    ld a0, -32(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    ld a0, 16(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a0, a0, 3
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    andi a0, a0, -4
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, a0, 8
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a2, a0, 11
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, -32(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 16(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    andi a2, a2, -4
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld a0, 0(a0)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, a2, 8
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a3, a2, 11
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, -32(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 16(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    andi a3, a3, -4
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld a1, 0(a2)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a2, a3, 8
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, -32(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 16(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld a2, 0(a3)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    add a0, a0, s1
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    add a0, a0, a1
@@ -2208,30 +2208,30 @@ define i32 @va4_va_copy(i32 %argno, ...) nounwind {
 ; LP64E-WITHFP-NEXT:    sd s1, 16(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    addi s0, sp, 40
 ; LP64E-WITHFP-NEXT:    mv s1, a1
-; LP64E-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64E-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64E-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64E-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64E-WITHFP-NEXT:    addi a0, s0, 16
-; LP64E-WITHFP-NEXT:    sd a0, -32(s0)
-; LP64E-WITHFP-NEXT:    sd a0, -40(s0)
+; LP64E-WITHFP-NEXT:    sd a5, 80(sp)
+; LP64E-WITHFP-NEXT:    sd a1, 48(sp)
+; LP64E-WITHFP-NEXT:    sd a2, 56(sp)
+; LP64E-WITHFP-NEXT:    sd a3, 64(sp)
+; LP64E-WITHFP-NEXT:    sd a4, 72(sp)
+; LP64E-WITHFP-NEXT:    addi a0, sp, 56
+; LP64E-WITHFP-NEXT:    sd a0, 8(sp)
+; LP64E-WITHFP-NEXT:    sd a0, 0(sp)
 ; LP64E-WITHFP-NEXT:    call notdead
-; LP64E-WITHFP-NEXT:    ld a0, -32(s0)
+; LP64E-WITHFP-NEXT:    ld a0, 8(sp)
 ; LP64E-WITHFP-NEXT:    addi a0, a0, 3
 ; LP64E-WITHFP-NEXT:    andi a0, a0, -4
 ; LP64E-WITHFP-NEXT:    addi a1, a0, 8
 ; LP64E-WITHFP-NEXT:    addi a2, a0, 11
-; LP64E-WITHFP-NEXT:    sd a1, -32(s0)
+; LP64E-WITHFP-NEXT:    sd a1, 8(sp)
 ; LP64E-WITHFP-NEXT:    andi a2, a2, -4
 ; LP64E-WITHFP-NEXT:    ld a0, 0(a0)
 ; LP64E-WITHFP-NEXT:    addi a1, a2, 8
 ; LP64E-WITHFP-NEXT:    addi a3, a2, 11
-; LP64E-WITHFP-NEXT:    sd a1, -32(s0)
+; LP64E-WITHFP-NEXT:    sd a1, 8(sp)
 ; LP64E-WITHFP-NEXT:    andi a3, a3, -4
 ; LP64E-WITHFP-NEXT:    ld a1, 0(a2)
 ; LP64E-WITHFP-NEXT:    addi a2, a3, 8
-; LP64E-WITHFP-NEXT:    sd a2, -32(s0)
+; LP64E-WITHFP-NEXT:    sd a2, 8(sp)
 ; LP64E-WITHFP-NEXT:    ld a2, 0(a3)
 ; LP64E-WITHFP-NEXT:    add a0, a0, s1
 ; LP64E-WITHFP-NEXT:    add a0, a0, a1
@@ -2328,7 +2328,7 @@ define void @va5_aligned_stack_caller() nounwind {
 ; ILP32-ILP32F-WITHFP-NEXT:    lui t6, 688509
 ; ILP32-ILP32F-WITHFP-NEXT:    li a0, 1
 ; ILP32-ILP32F-WITHFP-NEXT:    li a1, 11
-; ILP32-ILP32F-WITHFP-NEXT:    addi a2, s0, -32
+; ILP32-ILP32F-WITHFP-NEXT:    addi a2, sp, 32
 ; ILP32-ILP32F-WITHFP-NEXT:    li a3, 12
 ; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 20(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 24(sp)
@@ -2345,10 +2345,10 @@ define void @va5_aligned_stack_caller() nounwind {
 ; ILP32-ILP32F-WITHFP-NEXT:    addi t1, t4, -328
 ; ILP32-ILP32F-WITHFP-NEXT:    addi t2, t5, 1311
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a6, t6, -2048
-; ILP32-ILP32F-WITHFP-NEXT:    sw t2, -32(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw t1, -28(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw t0, -24(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, -20(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw t2, 32(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw t1, 36(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw t0, 40(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 44(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    call va5_aligned_stack_callee
 ; ILP32-ILP32F-WITHFP-NEXT:    lw ra, 60(sp) # 4-byte Folded Reload
 ; ILP32-ILP32F-WITHFP-NEXT:    lw s0, 56(sp) # 4-byte Folded Reload
@@ -2658,16 +2658,16 @@ define i32 @va6_no_fixed_args(...) nounwind {
 ; ILP32-ILP32F-WITHFP-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; ILP32-ILP32F-WITHFP-NEXT:    addi s0, sp, 16
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 24(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 28(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a0, 0(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    addi a1, s0, 4
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, -12(s0)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 32(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 36(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 40(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 44(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a0, 16(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 20(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 24(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 28(sp)
+; ILP32-ILP32F-WITHFP-NEXT:    addi a1, sp, 20
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; ILP32-ILP32F-WITHFP-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
 ; ILP32-ILP32F-WITHFP-NEXT:    addi sp, sp, 48
@@ -2709,14 +2709,14 @@ define i32 @va6_no_fixed_args(...) nounwind {
 ; ILP32E-WITHFP-NEXT:    sw ra, 8(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    sw s0, 4(sp) # 4-byte Folded Spill
 ; ILP32E-WITHFP-NEXT:    addi s0, sp, 12
-; ILP32E-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32E-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32E-WITHFP-NEXT:    sw a0, 0(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32E-WITHFP-NEXT:    addi a1, s0, 4
-; ILP32E-WITHFP-NEXT:    sw a1, -12(s0)
+; ILP32E-WITHFP-NEXT:    sw a4, 28(sp)
+; ILP32E-WITHFP-NEXT:    sw a5, 32(sp)
+; ILP32E-WITHFP-NEXT:    sw a0, 12(sp)
+; ILP32E-WITHFP-NEXT:    sw a1, 16(sp)
+; ILP32E-WITHFP-NEXT:    sw a2, 20(sp)
+; ILP32E-WITHFP-NEXT:    sw a3, 24(sp)
+; ILP32E-WITHFP-NEXT:    addi a1, sp, 16
+; ILP32E-WITHFP-NEXT:    sw a1, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lw ra, 8(sp) # 4-byte Folded Reload
 ; ILP32E-WITHFP-NEXT:    lw s0, 4(sp) # 4-byte Folded Reload
 ; ILP32E-WITHFP-NEXT:    addi sp, sp, 36
@@ -2744,16 +2744,16 @@ define i32 @va6_no_fixed_args(...) nounwind {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd ra, 24(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi s0, sp, 32
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 48(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 56(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, 0(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, s0, 8
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, -24(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 64(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 72(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 80(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 88(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, 32(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 40(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 48(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 56(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, sp, 40
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(sp)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi sp, sp, 96
@@ -2779,14 +2779,14 @@ define i32 @va6_no_fixed_args(...) nounwind {
 ; LP64E-WITHFP-NEXT:    sd ra, 16(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    sd s0, 8(sp) # 8-byte Folded Spill
 ; LP64E-WITHFP-NEXT:    addi s0, sp, 24
-; LP64E-WITHFP-NEXT:    sd a4, 32(s0)
-; LP64E-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64E-WITHFP-NEXT:    sd a0, 0(s0)
-; LP64E-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64E-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64E-WITHFP-NEXT:    addi a1, s0, 8
-; LP64E-WITHFP-NEXT:    sd a1, -24(s0)
+; LP64E-WITHFP-NEXT:    sd a4, 56(sp)
+; LP64E-WITHFP-NEXT:    sd a5, 64(sp)
+; LP64E-WITHFP-NEXT:    sd a0, 24(sp)
+; LP64E-WITHFP-NEXT:    sd a1, 32(sp)
+; LP64E-WITHFP-NEXT:    sd a2, 40(sp)
+; LP64E-WITHFP-NEXT:    sd a3, 48(sp)
+; LP64E-WITHFP-NEXT:    addi a1, sp, 32
+; LP64E-WITHFP-NEXT:    sd a1, 0(sp)
 ; LP64E-WITHFP-NEXT:    ld ra, 16(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    ld s0, 8(sp) # 8-byte Folded Reload
 ; LP64E-WITHFP-NEXT:    addi sp, sp, 72
@@ -2853,17 +2853,31 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a0, a0, -1728
 ; ILP32-ILP32F-WITHFP-NEXT:    sub sp, sp, a0
 ; ILP32-ILP32F-WITHFP-NEXT:    mv a0, a1
-; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 24(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 28(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32-ILP32F-WITHFP-NEXT:    addi a1, s0, 8
-; ILP32-ILP32F-WITHFP-NEXT:    lui a2, 24414
-; ILP32-ILP32F-WITHFP-NEXT:    sub a2, s0, a2
-; ILP32-ILP32F-WITHFP-NEXT:    sw a1, -272(a2)
+; ILP32-ILP32F-WITHFP-NEXT:    lui t0, 24414
+; ILP32-ILP32F-WITHFP-NEXT:    add t0, sp, t0
+; ILP32-ILP32F-WITHFP-NEXT:    sw a5, 292(t0)
+; ILP32-ILP32F-WITHFP-NEXT:    lui a5, 24414
+; ILP32-ILP32F-WITHFP-NEXT:    add a5, sp, a5
+; ILP32-ILP32F-WITHFP-NEXT:    sw a6, 296(a5)
+; ILP32-ILP32F-WITHFP-NEXT:    lui a5, 24414
+; ILP32-ILP32F-WITHFP-NEXT:    add a5, sp, a5
+; ILP32-ILP32F-WITHFP-NEXT:    sw a7, 300(a5)
+; ILP32-ILP32F-WITHFP-NEXT:    lui a5, 24414
+; ILP32-ILP32F-WITHFP-NEXT:    add a5, sp, a5
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 276(a5)
+; ILP32-ILP32F-WITHFP-NEXT:    lui a1, 24414
+; ILP32-ILP32F-WITHFP-NEXT:    add a1, sp, a1
+; ILP32-ILP32F-WITHFP-NEXT:    sw a2, 280(a1)
+; ILP32-ILP32F-WITHFP-NEXT:    lui a1, 24414
+; ILP32-ILP32F-WITHFP-NEXT:    add a1, sp, a1
+; ILP32-ILP32F-WITHFP-NEXT:    sw a3, 284(a1)
+; ILP32-ILP32F-WITHFP-NEXT:    lui a1, 24414
+; ILP32-ILP32F-WITHFP-NEXT:    add a1, sp, a1
+; ILP32-ILP32F-WITHFP-NEXT:    sw a4, 288(a1)
+; ILP32-ILP32F-WITHFP-NEXT:    lui a1, 24414
+; ILP32-ILP32F-WITHFP-NEXT:    addi a1, a1, 280
+; ILP32-ILP32F-WITHFP-NEXT:    add a1, sp, a1
+; ILP32-ILP32F-WITHFP-NEXT:    sw a1, 0(sp)
 ; ILP32-ILP32F-WITHFP-NEXT:    lui a1, 24414
 ; ILP32-ILP32F-WITHFP-NEXT:    addi a1, a1, -1728
 ; ILP32-ILP32F-WITHFP-NEXT:    add sp, sp, a1
@@ -2960,15 +2974,25 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; ILP32E-WITHFP-NEXT:    addi a0, a0, -1748
 ; ILP32E-WITHFP-NEXT:    sub sp, sp, a0
 ; ILP32E-WITHFP-NEXT:    mv a0, a1
-; ILP32E-WITHFP-NEXT:    sw a5, 20(s0)
-; ILP32E-WITHFP-NEXT:    sw a1, 4(s0)
-; ILP32E-WITHFP-NEXT:    sw a2, 8(s0)
-; ILP32E-WITHFP-NEXT:    sw a3, 12(s0)
-; ILP32E-WITHFP-NEXT:    sw a4, 16(s0)
-; ILP32E-WITHFP-NEXT:    addi a1, s0, 8
-; ILP32E-WITHFP-NEXT:    lui a2, 24414
-; ILP32E-WITHFP-NEXT:    sub a2, s0, a2
-; ILP32E-WITHFP-NEXT:    sw a1, -272(a2)
+; ILP32E-WITHFP-NEXT:    lui a6, 24414
+; ILP32E-WITHFP-NEXT:    add a6, sp, a6
+; ILP32E-WITHFP-NEXT:    sw a5, 292(a6)
+; ILP32E-WITHFP-NEXT:    lui a5, 24414
+; ILP32E-WITHFP-NEXT:    add a5, sp, a5
+; ILP32E-WITHFP-NEXT:    sw a1, 276(a5)
+; ILP32E-WITHFP-NEXT:    lui a1, 24414
+; ILP32E-WITHFP-NEXT:    add a1, sp, a1
+; ILP32E-WITHFP-NEXT:    sw a2, 280(a1)
+; ILP32E-WITHFP-NEXT:    lui a1, 24414
+; ILP32E-WITHFP-NEXT:    add a1, sp, a1
+; ILP32E-WITHFP-NEXT:    sw a3, 284(a1)
+; ILP32E-WITHFP-NEXT:    lui a1, 24414
+; ILP32E-WITHFP-NEXT:    add a1, sp, a1
+; ILP32E-WITHFP-NEXT:    sw a4, 288(a1)
+; ILP32E-WITHFP-NEXT:    lui a1, 24414
+; ILP32E-WITHFP-NEXT:    addi a1, a1, 280
+; ILP32E-WITHFP-NEXT:    add a1, sp, a1
+; ILP32E-WITHFP-NEXT:    sw a1, 0(sp)
 ; ILP32E-WITHFP-NEXT:    lui a1, 24414
 ; ILP32E-WITHFP-NEXT:    addi a1, a1, -1748
 ; ILP32E-WITHFP-NEXT:    add sp, sp, a1
@@ -3034,18 +3058,34 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a0, 24414
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a0, a0, -1680
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    sub sp, sp, a0
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a0, s0, 12
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a0, 24414
+; LP64-LP64F-LP64D-WITHFP-NEXT:    add a0, sp, a0
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a1, 296(a0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a0, 24414
+; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a0, a0, 300
+; LP64-LP64F-LP64D-WITHFP-NEXT:    add a0, sp, a0
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, 0(sp)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a0, 24414
+; LP64-LP64F-LP64D-WITHFP-NEXT:    add a0, sp, a0
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lw a0, 296(a0)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a1, 24414
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sub a1, s0, a1
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a0, -288(a1)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    lw a0, 8(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 48(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 56(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 32(s0)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    add a1, sp, a1
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a5, 328(a1)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a1, 24414
+; LP64-LP64F-LP64D-WITHFP-NEXT:    add a1, sp, a1
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a6, 336(a1)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a1, 24414
+; LP64-LP64F-LP64D-WITHFP-NEXT:    add a1, sp, a1
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a7, 344(a1)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a1, 24414
+; LP64-LP64F-LP64D-WITHFP-NEXT:    add a1, sp, a1
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a2, 304(a1)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a1, 24414
+; LP64-LP64F-LP64D-WITHFP-NEXT:    add a1, sp, a1
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a3, 312(a1)
+; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a1, 24414
+; LP64-LP64F-LP64D-WITHFP-NEXT:    add a1, sp, a1
+; LP64-LP64F-LP64D-WITHFP-NEXT:    sd a4, 320(a1)
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    lui a1, 24414
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    addi a1, a1, -1680
 ; LP64-LP64F-LP64D-WITHFP-NEXT:    add sp, sp, a1
@@ -3105,16 +3145,28 @@ define i32 @va_large_stack(ptr %fmt, ...) {
 ; LP64E-WITHFP-NEXT:    lui a0, 24414
 ; LP64E-WITHFP-NEXT:    addi a0, a0, -1704
 ; LP64E-WITHFP-NEXT:    sub sp, sp, a0
-; LP64E-WITHFP-NEXT:    sd a1, 8(s0)
-; LP64E-WITHFP-NEXT:    addi a0, s0, 12
+; LP64E-WITHFP-NEXT:    lui a0, 24414
+; LP64E-WITHFP-NEXT:    add a0, sp, a0
+; LP64E-WITHFP-NEXT:    sd a1, 296(a0)
+; LP64E-WITHFP-NEXT:    lui a0, 24414
+; LP64E-WITHFP-NEXT:    addi a0, a0, 300
+; LP64E-WITHFP-NEXT:    add a0, sp, a0
+; LP64E-WITHFP-NEXT:    sd a0, 0(sp)
+; LP64E-WITHFP-NEXT:    lui a0, 24414
+; LP64E-WITHFP-NEXT:    add a0, sp, a0
+; LP64E-WITHFP-NEXT:    lw a0, 296(a0)
 ; LP64E-WITHFP-NEXT:    lui a1, 24414
-; LP64E-WITHFP-NEXT:    sub a1, s0, a1
-; LP64E-WITHFP-NEXT:    sd a0, -288(a1)
-; LP64E-WITHFP-NEXT:    lw a0, 8(s0)
-; LP64E-WITHFP-NEXT:    sd a5, 40(s0)
-; LP64E-WITHFP-NEXT:    sd a2, 16(s0)
-; LP64E-WITHFP-NEXT:    sd a3, 24(s0)
-; LP64E-WITHFP-NEXT:    sd a4, 32(s0)
+; LP64E-WITHFP-NEXT:    add a1, sp, a1
+; LP64E-WITHFP-NEXT:    sd a5, 328(a1)
+; LP64E-WITHFP-NEXT:    lui a1, 24414
+; LP64E-WITHFP-NEXT:    add a1, sp, a1
+; LP64E-WITHFP-NEXT:    sd a2, 304(a1)
+; LP64E-WITHFP-NEXT:    lui a1, 24414
+; LP64E-WITHFP-NEXT:    add a1, sp, a1
+; LP64E-WITHFP-NEXT:    sd a3, 312(a1)
+; LP64E-WITHFP-NEXT:    lui a1, 24414
+; LP64E-WITHFP-NEXT:    add a1, sp, a1
+; LP64E-WITHFP-NEXT:    sd a4, 320(a1)
 ; LP64E-WITHFP-NEXT:    lui a1, 24414
 ; LP64E-WITHFP-NEXT:    addi a1, a1, -1704
 ; LP64E-WITHFP-NEXT:    add sp, sp, a1

--- a/llvm/test/CodeGen/RISCV/varargs-with-fp-and-second-adj.ll
+++ b/llvm/test/CodeGen/RISCV/varargs-with-fp-and-second-adj.ll
@@ -15,16 +15,36 @@ define dso_local void @_Z3fooPKcz(ptr noundef %0, ...) "frame-pointer"="all" {
 ; RV64V-NEXT:    lui t0, 2
 ; RV64V-NEXT:    addi t0, t0, -576
 ; RV64V-NEXT:    sub sp, sp, t0
-; RV64V-NEXT:    sd a5, 40(s0)
-; RV64V-NEXT:    sd a6, 48(s0)
-; RV64V-NEXT:    sd a7, 56(s0)
-; RV64V-NEXT:    sd a1, 8(s0)
-; RV64V-NEXT:    sd a2, 16(s0)
-; RV64V-NEXT:    sd a3, 24(s0)
-; RV64V-NEXT:    sd a4, 32(s0)
-; RV64V-NEXT:    sd a0, -32(s0)
-; RV64V-NEXT:    addi a0, s0, 8
-; RV64V-NEXT:    sd a0, -40(s0)
+; RV64V-NEXT:    lui t0, 2
+; RV64V-NEXT:    add t0, t0, sp
+; RV64V-NEXT:    sd a5, -104(t0)
+; RV64V-NEXT:    lui a5, 2
+; RV64V-NEXT:    add a5, a5, sp
+; RV64V-NEXT:    sd a6, -96(a5)
+; RV64V-NEXT:    lui a5, 2
+; RV64V-NEXT:    add a5, a5, sp
+; RV64V-NEXT:    sd a7, -88(a5)
+; RV64V-NEXT:    lui a5, 2
+; RV64V-NEXT:    add a5, a5, sp
+; RV64V-NEXT:    sd a1, -136(a5)
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    add a1, a1, sp
+; RV64V-NEXT:    sd a2, -128(a1)
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    add a1, a1, sp
+; RV64V-NEXT:    sd a3, -120(a1)
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    add a1, a1, sp
+; RV64V-NEXT:    sd a4, -112(a1)
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    add a1, a1, sp
+; RV64V-NEXT:    sd a0, -176(a1)
+; RV64V-NEXT:    lui a0, 2
+; RV64V-NEXT:    addi a0, a0, -136
+; RV64V-NEXT:    add a0, a0, sp
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    add a1, a1, sp
+; RV64V-NEXT:    sd a0, -184(a1)
 ; RV64V-NEXT:    addi sp, s0, -432
 ; RV64V-NEXT:    .cfi_def_cfa sp, 496
 ; RV64V-NEXT:    ld ra, 424(sp) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/xqccmp-callee-saved-gprs.ll
+++ b/llvm/test/CodeGen/RISCV/xqccmp-callee-saved-gprs.ll
@@ -130,17 +130,17 @@ define void @callee() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, -68(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, -72(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, -76(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, -80(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, -84(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 20(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, -88(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw t4, 24(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw t5, 28(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw t6, 32(a0)
@@ -193,17 +193,17 @@ define void @callee() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw t6, 32(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw t5, 28(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw t4, 24(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, -88(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, -84(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, -80(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, -76(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, -72(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 4(a0)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, -68(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 96
 ; RV32IXQCCMP-WITH-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 96
@@ -324,17 +324,17 @@ define void @callee() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    lui a0, %hi(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    addi a0, a0, %lo(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 0(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, -120(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 4(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, -128(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 8(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, -136(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 12(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, -144(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 16(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, -152(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a1, 20(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, -160(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 0(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw t4, 24(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw t5, 28(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw t6, 32(a0)
@@ -387,17 +387,17 @@ define void @callee() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw t6, 32(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw t5, 28(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw t4, 24(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, -160(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 0(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 20(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, -152(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 16(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, -144(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 12(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, -136(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 8(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, -128(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 4(a0)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, -120(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a1, 0(a0)
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV64IXQCCMP-WITH-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
@@ -565,49 +565,49 @@ define void @caller() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -68(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 92(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -72(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -76(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -80(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -84(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -88(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -92(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -96(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -100(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -104(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -108(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -112(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -116(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -120(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -124(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -128(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -132(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -136(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -140(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -144(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -148(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, -152(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -629,49 +629,49 @@ define void @caller() {
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -152(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -148(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -144(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -140(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -136(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -132(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -128(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -124(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -120(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -116(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -112(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -108(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -104(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -100(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -96(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -92(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -88(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -84(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -80(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -76(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -72(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 4(s1)
-; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, -68(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-WITH-FP-NEXT:    lw a0, 92(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV32IXQCCMP-WITH-FP-NEXT:    addi sp, sp, 48
@@ -833,49 +833,49 @@ define void @caller() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    lui s1, %hi(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    addi s1, s1, %lo(var)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 0(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -120(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 4(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -128(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 8(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -136(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 12(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -144(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 16(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -152(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 20(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -160(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 24(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -168(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 28(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -176(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 32(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -184(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 36(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -192(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 40(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -200(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 44(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -208(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 48(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -216(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 52(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -224(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 56(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -232(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 60(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -240(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 64(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -248(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 68(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -256(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 72(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -264(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 76(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -272(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 80(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -280(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw a0, 84(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, -288(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 0(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s4, 88(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s5, 92(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    lw s6, 96(s1)
@@ -897,49 +897,49 @@ define void @caller() {
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s6, 96(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s5, 92(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw s4, 88(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -288(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 0(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 84(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -280(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 80(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -272(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 76(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -264(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 72(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -256(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 68(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -248(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 64(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -240(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 60(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -232(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 56(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -224(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 52(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -216(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 48(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -208(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 44(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -200(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 40(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -192(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 36(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -184(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 32(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -176(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 28(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -168(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 24(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -160(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 20(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -152(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 16(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -144(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 12(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -136(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 8(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -128(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 4(s1)
-; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, -120(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-WITH-FP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-WITH-FP-NEXT:    sw a0, 0(s1)
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 288
 ; RV64IXQCCMP-WITH-FP-NEXT:    addi sp, sp, 128
@@ -1092,14 +1092,14 @@ define void @varargs(...) {
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_offset s0, -40
 ; RV32IXQCCMP-WITH-FP-NEXT:    addi s0, sp, 16
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa s0, 32
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a4, 16(s0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a5, 20(s0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a6, 24(s0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a7, 28(s0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 0(s0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 4(s0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a2, 8(s0)
-; RV32IXQCCMP-WITH-FP-NEXT:    sw a3, 12(s0)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a4, 32(sp)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a5, 36(sp)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a6, 40(sp)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a7, 44(sp)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a0, 16(sp)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a1, 20(sp)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a2, 24(sp)
+; RV32IXQCCMP-WITH-FP-NEXT:    sw a3, 28(sp)
 ; RV32IXQCCMP-WITH-FP-NEXT:    call callee
 ; RV32IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 48
 ; RV32IXQCCMP-WITH-FP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
@@ -1141,14 +1141,14 @@ define void @varargs(...) {
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_offset s0, -80
 ; RV64IXQCCMP-WITH-FP-NEXT:    addi s0, sp, 16
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa s0, 64
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a4, 32(s0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a5, 40(s0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a6, 48(s0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a7, 56(s0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 0(s0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 8(s0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a2, 16(s0)
-; RV64IXQCCMP-WITH-FP-NEXT:    sd a3, 24(s0)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a4, 48(sp)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a5, 56(sp)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a6, 64(sp)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a7, 72(sp)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a0, 16(sp)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a1, 24(sp)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a2, 32(sp)
+; RV64IXQCCMP-WITH-FP-NEXT:    sd a3, 40(sp)
 ; RV64IXQCCMP-WITH-FP-NEXT:    call callee
 ; RV64IXQCCMP-WITH-FP-NEXT:    .cfi_def_cfa sp, 80
 ; RV64IXQCCMP-WITH-FP-NEXT:    ld ra, 8(sp) # 8-byte Folded Reload

--- a/llvm/test/CodeGen/RISCV/xqccmp-push-pop-popret.ll
+++ b/llvm/test/CodeGen/RISCV/xqccmp-push-pop-popret.ll
@@ -52,7 +52,7 @@ define i32 @foo() {
 ; RV32IXQCCMP-FP-NEXT:    addi sp, sp, -464
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 528
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
-; RV32IXQCCMP-FP-NEXT:    addi a0, s0, -528
+; RV32IXQCCMP-FP-NEXT:    mv a0, sp
 ; RV32IXQCCMP-FP-NEXT:    call test
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 528
 ; RV32IXQCCMP-FP-NEXT:    addi sp, sp, 464
@@ -68,7 +68,7 @@ define i32 @foo() {
 ; RV64IXQCCMP-FP-NEXT:    addi sp, sp, -464
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa_offset 528
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
-; RV64IXQCCMP-FP-NEXT:    addi a0, s0, -528
+; RV64IXQCCMP-FP-NEXT:    mv a0, sp
 ; RV64IXQCCMP-FP-NEXT:    call test
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 528
 ; RV64IXQCCMP-FP-NEXT:    addi sp, sp, 464
@@ -1036,15 +1036,15 @@ define i32 @varargs(ptr %fmt, ...) {
 ; RV32IXQCCMP-FP-NEXT:    addi s0, sp, 16
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 32
 ; RV32IXQCCMP-FP-NEXT:    mv a0, a1
-; RV32IXQCCMP-FP-NEXT:    sw a5, 20(s0)
-; RV32IXQCCMP-FP-NEXT:    sw a6, 24(s0)
-; RV32IXQCCMP-FP-NEXT:    sw a7, 28(s0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, 4(s0)
-; RV32IXQCCMP-FP-NEXT:    sw a2, 8(s0)
-; RV32IXQCCMP-FP-NEXT:    sw a3, 12(s0)
-; RV32IXQCCMP-FP-NEXT:    sw a4, 16(s0)
-; RV32IXQCCMP-FP-NEXT:    addi a1, s0, 8
-; RV32IXQCCMP-FP-NEXT:    sw a1, -12(s0)
+; RV32IXQCCMP-FP-NEXT:    sw a5, 36(sp)
+; RV32IXQCCMP-FP-NEXT:    sw a6, 40(sp)
+; RV32IXQCCMP-FP-NEXT:    sw a7, 44(sp)
+; RV32IXQCCMP-FP-NEXT:    sw a1, 20(sp)
+; RV32IXQCCMP-FP-NEXT:    sw a2, 24(sp)
+; RV32IXQCCMP-FP-NEXT:    sw a3, 28(sp)
+; RV32IXQCCMP-FP-NEXT:    sw a4, 32(sp)
+; RV32IXQCCMP-FP-NEXT:    addi a1, sp, 24
+; RV32IXQCCMP-FP-NEXT:    sw a1, 4(sp)
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 48
 ; RV32IXQCCMP-FP-NEXT:    lw ra, 12(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    lw s0, 8(sp) # 4-byte Folded Reload
@@ -1064,16 +1064,16 @@ define i32 @varargs(ptr %fmt, ...) {
 ; RV64IXQCCMP-FP-NEXT:    .cfi_offset s0, -80
 ; RV64IXQCCMP-FP-NEXT:    addi s0, sp, 32
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 64
-; RV64IXQCCMP-FP-NEXT:    sd a1, 8(s0)
-; RV64IXQCCMP-FP-NEXT:    addi a0, s0, 12
-; RV64IXQCCMP-FP-NEXT:    sd a0, -24(s0)
-; RV64IXQCCMP-FP-NEXT:    lw a0, 8(s0)
-; RV64IXQCCMP-FP-NEXT:    sd a5, 40(s0)
-; RV64IXQCCMP-FP-NEXT:    sd a6, 48(s0)
-; RV64IXQCCMP-FP-NEXT:    sd a7, 56(s0)
-; RV64IXQCCMP-FP-NEXT:    sd a2, 16(s0)
-; RV64IXQCCMP-FP-NEXT:    sd a3, 24(s0)
-; RV64IXQCCMP-FP-NEXT:    sd a4, 32(s0)
+; RV64IXQCCMP-FP-NEXT:    sd a1, 40(sp)
+; RV64IXQCCMP-FP-NEXT:    addi a0, sp, 44
+; RV64IXQCCMP-FP-NEXT:    sd a0, 8(sp)
+; RV64IXQCCMP-FP-NEXT:    lw a0, 40(sp)
+; RV64IXQCCMP-FP-NEXT:    sd a5, 72(sp)
+; RV64IXQCCMP-FP-NEXT:    sd a6, 80(sp)
+; RV64IXQCCMP-FP-NEXT:    sd a7, 88(sp)
+; RV64IXQCCMP-FP-NEXT:    sd a2, 48(sp)
+; RV64IXQCCMP-FP-NEXT:    sd a3, 56(sp)
+; RV64IXQCCMP-FP-NEXT:    sd a4, 64(sp)
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 96
 ; RV64IXQCCMP-FP-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload
@@ -2488,17 +2488,17 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-FP-NEXT:    lui a0, %hi(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    addi a0, a0, %lo(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 0(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -128(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 32(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 4(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -132(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 8(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -136(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 12(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -140(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 16(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -144(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 20(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -148(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw t4, 24(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw t5, 28(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw t6, 32(a0)
@@ -2551,17 +2551,17 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IXQCCMP-FP-NEXT:    sw t6, 32(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw t5, 28(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw t4, 24(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -148(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 20(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -144(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 16(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -140(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 12(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -136(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 8(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -132(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 4(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -128(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 32(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 0(a0)
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV32IXQCCMP-FP-NEXT:    lw t0, 92(sp) # 4-byte Folded Reload
@@ -2666,17 +2666,17 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IXQCCMP-FP-NEXT:    lui a0, %hi(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    addi a0, a0, %lo(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 0(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -240(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 48(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 4(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -248(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 8(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -256(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 12(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -264(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 16(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -272(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 20(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -280(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw t4, 24(a0)
 ; RV64IXQCCMP-FP-NEXT:    lw t5, 28(a0)
 ; RV64IXQCCMP-FP-NEXT:    lw t6, 32(a0)
@@ -2729,17 +2729,17 @@ define void @callee_with_irq() "interrupt"="machine" {
 ; RV64IXQCCMP-FP-NEXT:    sw t6, 32(a0)
 ; RV64IXQCCMP-FP-NEXT:    sw t5, 28(a0)
 ; RV64IXQCCMP-FP-NEXT:    sw t4, 24(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -280(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 20(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -272(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 16(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -264(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 12(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -256(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 8(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -248(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 4(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -240(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 48(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 0(a0)
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 288
 ; RV64IXQCCMP-FP-NEXT:    ld t0, 168(sp) # 8-byte Folded Reload
@@ -3355,17 +3355,17 @@ define void @callee_no_irq() {
 ; RV32IXQCCMP-FP-NEXT:    lui a0, %hi(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    addi a0, a0, %lo(var_test_irq)
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 0(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -68(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 28(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 4(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -72(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 24(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 8(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -76(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 20(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 12(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -80(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 16(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 16(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -84(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw a1, 20(a0)
-; RV32IXQCCMP-FP-NEXT:    sw a1, -88(s0) # 4-byte Folded Spill
+; RV32IXQCCMP-FP-NEXT:    sw a1, 8(sp) # 4-byte Folded Spill
 ; RV32IXQCCMP-FP-NEXT:    lw t4, 24(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw t5, 28(a0)
 ; RV32IXQCCMP-FP-NEXT:    lw t6, 32(a0)
@@ -3418,17 +3418,17 @@ define void @callee_no_irq() {
 ; RV32IXQCCMP-FP-NEXT:    sw t6, 32(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw t5, 28(a0)
 ; RV32IXQCCMP-FP-NEXT:    sw t4, 24(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -88(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 8(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 20(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -84(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 12(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 16(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -80(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 16(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 12(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -76(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 20(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 8(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -72(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 24(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 4(a0)
-; RV32IXQCCMP-FP-NEXT:    lw a1, -68(s0) # 4-byte Folded Reload
+; RV32IXQCCMP-FP-NEXT:    lw a1, 28(sp) # 4-byte Folded Reload
 ; RV32IXQCCMP-FP-NEXT:    sw a1, 0(a0)
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 96
 ; RV32IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 96
@@ -3454,17 +3454,17 @@ define void @callee_no_irq() {
 ; RV64IXQCCMP-FP-NEXT:    lui a0, %hi(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    addi a0, a0, %lo(var_test_irq)
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 0(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -120(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 40(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 4(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -128(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 32(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 8(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -136(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 24(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 12(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -144(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 16(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 16(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -152(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 8(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw a1, 20(a0)
-; RV64IXQCCMP-FP-NEXT:    sd a1, -160(s0) # 8-byte Folded Spill
+; RV64IXQCCMP-FP-NEXT:    sd a1, 0(sp) # 8-byte Folded Spill
 ; RV64IXQCCMP-FP-NEXT:    lw t4, 24(a0)
 ; RV64IXQCCMP-FP-NEXT:    lw t5, 28(a0)
 ; RV64IXQCCMP-FP-NEXT:    lw t6, 32(a0)
@@ -3517,17 +3517,17 @@ define void @callee_no_irq() {
 ; RV64IXQCCMP-FP-NEXT:    sw t6, 32(a0)
 ; RV64IXQCCMP-FP-NEXT:    sw t5, 28(a0)
 ; RV64IXQCCMP-FP-NEXT:    sw t4, 24(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -160(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 0(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 20(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -152(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 8(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 16(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -144(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 16(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 12(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -136(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 24(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 8(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -128(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 32(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 4(a0)
-; RV64IXQCCMP-FP-NEXT:    ld a1, -120(s0) # 8-byte Folded Reload
+; RV64IXQCCMP-FP-NEXT:    ld a1, 40(sp) # 8-byte Folded Reload
 ; RV64IXQCCMP-FP-NEXT:    sw a1, 0(a0)
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 160
 ; RV64IXQCCMP-FP-NEXT:    qc.cm.popret {ra, s0-s11}, 160
@@ -3738,8 +3738,8 @@ define i32 @use_fp(i32 %x) {
 ; RV32IXQCCMP-NEXT:    .cfi_offset s1, -12
 ; RV32IXQCCMP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-NEXT:    mv s1, a0
-; RV32IXQCCMP-NEXT:    addi a1, s0, -20
-; RV32IXQCCMP-NEXT:    mv a0, s0
+; RV32IXQCCMP-NEXT:    mv a0, sp
+; RV32IXQCCMP-NEXT:    addi a1, sp, 12
 ; RV32IXQCCMP-NEXT:    call bar
 ; RV32IXQCCMP-NEXT:    mv a0, s1
 ; RV32IXQCCMP-NEXT:    .cfi_def_cfa sp, 32
@@ -3754,8 +3754,8 @@ define i32 @use_fp(i32 %x) {
 ; RV64IXQCCMP-NEXT:    .cfi_offset s1, -24
 ; RV64IXQCCMP-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IXQCCMP-NEXT:    mv s1, a0
-; RV64IXQCCMP-NEXT:    addi a1, s0, -36
-; RV64IXQCCMP-NEXT:    mv a0, s0
+; RV64IXQCCMP-NEXT:    mv a0, sp
+; RV64IXQCCMP-NEXT:    addi a1, sp, 12
 ; RV64IXQCCMP-NEXT:    call bar
 ; RV64IXQCCMP-NEXT:    mv a0, s1
 ; RV64IXQCCMP-NEXT:    .cfi_def_cfa sp, 48
@@ -3770,8 +3770,8 @@ define i32 @use_fp(i32 %x) {
 ; RV32IXQCCMP-FP-NEXT:    .cfi_offset s1, -12
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-FP-NEXT:    mv s1, a0
-; RV32IXQCCMP-FP-NEXT:    addi a1, s0, -20
-; RV32IXQCCMP-FP-NEXT:    mv a0, s0
+; RV32IXQCCMP-FP-NEXT:    mv a0, sp
+; RV32IXQCCMP-FP-NEXT:    addi a1, sp, 12
 ; RV32IXQCCMP-FP-NEXT:    call bar
 ; RV32IXQCCMP-FP-NEXT:    mv a0, s1
 ; RV32IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 32
@@ -3786,8 +3786,8 @@ define i32 @use_fp(i32 %x) {
 ; RV64IXQCCMP-FP-NEXT:    .cfi_offset s1, -24
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IXQCCMP-FP-NEXT:    mv s1, a0
-; RV64IXQCCMP-FP-NEXT:    addi a1, s0, -36
-; RV64IXQCCMP-FP-NEXT:    mv a0, s0
+; RV64IXQCCMP-FP-NEXT:    mv a0, sp
+; RV64IXQCCMP-FP-NEXT:    addi a1, sp, 12
 ; RV64IXQCCMP-FP-NEXT:    call bar
 ; RV64IXQCCMP-FP-NEXT:    mv a0, s1
 ; RV64IXQCCMP-FP-NEXT:    .cfi_def_cfa sp, 48
@@ -3802,8 +3802,8 @@ define i32 @use_fp(i32 %x) {
 ; RV32IXQCCMP-SR-NEXT:    .cfi_offset s1, -12
 ; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa s0, 0
 ; RV32IXQCCMP-SR-NEXT:    mv s1, a0
-; RV32IXQCCMP-SR-NEXT:    addi a1, s0, -20
-; RV32IXQCCMP-SR-NEXT:    mv a0, s0
+; RV32IXQCCMP-SR-NEXT:    mv a0, sp
+; RV32IXQCCMP-SR-NEXT:    addi a1, sp, 12
 ; RV32IXQCCMP-SR-NEXT:    call bar
 ; RV32IXQCCMP-SR-NEXT:    mv a0, s1
 ; RV32IXQCCMP-SR-NEXT:    .cfi_def_cfa sp, 32
@@ -3818,8 +3818,8 @@ define i32 @use_fp(i32 %x) {
 ; RV64IXQCCMP-SR-NEXT:    .cfi_offset s1, -24
 ; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa s0, 0
 ; RV64IXQCCMP-SR-NEXT:    mv s1, a0
-; RV64IXQCCMP-SR-NEXT:    addi a1, s0, -36
-; RV64IXQCCMP-SR-NEXT:    mv a0, s0
+; RV64IXQCCMP-SR-NEXT:    mv a0, sp
+; RV64IXQCCMP-SR-NEXT:    addi a1, sp, 12
 ; RV64IXQCCMP-SR-NEXT:    call bar
 ; RV64IXQCCMP-SR-NEXT:    mv a0, s1
 ; RV64IXQCCMP-SR-NEXT:    .cfi_def_cfa sp, 48


### PR DESCRIPTION
Before this change, we would use `fp`/`s0`/`x8` for most stack accesses when frame pointers were present. However, this is an over-approximation.

We only need to use `fp`-based accesses if `sp` is going to be realigned or if there are variable sized objects. The main reason to favour using `sp` is because we can compress `sp`-relative access instructions more easily than the `fp`-relative access instructions.

For instance, on RV32 (similar applies to RV64, and the Zcf/Zcd access instructions):
- `c.lwsp xN, imm(sp)` can be used for immediates 0-252, and any GPR
- `c.lw xN, imm(fp)` can be used for immediates 0-124, and only RVC registers (x8-x15)

Another advantage is that arguments passed on the stack were accessed using a negative offset from `fp` before this change, which was never compressible, but the equivalent offset using `sp` will always be positive, so should be more compressible.

In the interests of keeping the stack management code simpler, we always do this optimisation, not just when Zca/C are available.