### PR TITLE
[FastISel] Don't force SDAG fallback for libcalls

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -1565,14 +1565,6 @@ bool FastISel::selectInstruction(const Instruction *I) {
 
   if (const auto *Call = dyn_cast<CallInst>(I)) {
     const Function *F = Call->getCalledFunction();
-    LibFunc Func;
-
-    // As a special case, don't handle calls to builtin library functions that
-    // may be translated directly to target instructions.
-    if (F && !F->hasLocalLinkage() && F->hasName() &&
-        LibInfo->getLibFunc(F->getName(), Func) &&
-        LibInfo->hasOptimizedCodeGen(Func))
-      return false;
 
     // Don't handle Intrinsic::trap if a trap function is specified.
     if (F && F->getIntrinsicID() == Intrinsic::trap &&

--- a/llvm/test/CodeGen/X86/stack-protector-msvc-oz.ll
+++ b/llvm/test/CodeGen/X86/stack-protector-msvc-oz.ll
@@ -63,11 +63,10 @@ define void @test(ptr %a) nounwind ssp minsize {
 ; MSVC-X86-O0-NEXT:    movl ___security_cookie, %eax
 ; MSVC-X86-O0-NEXT:    xorl %esp, %eax
 ; MSVC-X86-O0-NEXT:    movl %eax, {{[0-9]+}}(%esp)
-; MSVC-X86-O0-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; MSVC-X86-O0-NEXT:    movl %esp, %eax
-; MSVC-X86-O0-NEXT:    movl %ecx, 4(%eax)
+; MSVC-X86-O0-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; MSVC-X86-O0-NEXT:    leal {{[0-9]+}}(%esp), %ecx
-; MSVC-X86-O0-NEXT:    movl %ecx, (%eax)
+; MSVC-X86-O0-NEXT:    movl %ecx, (%esp)
+; MSVC-X86-O0-NEXT:    movl %eax, {{[0-9]+}}(%esp)
 ; MSVC-X86-O0-NEXT:    calll _strcpy
 ; MSVC-X86-O0-NEXT:    leal LC, %ecx
 ; MSVC-X86-O0-NEXT:    leal {{[0-9]+}}(%esp), %eax

--- a/llvm/test/CodeGen/X86/stack-protector-msvc.ll
+++ b/llvm/test/CodeGen/X86/stack-protector-msvc.ll
@@ -75,11 +75,10 @@ define void @test(ptr %a) nounwind ssp {
 ; MSVC-X86-O0-NEXT:    movl ___security_cookie, %eax
 ; MSVC-X86-O0-NEXT:    xorl %esp, %eax
 ; MSVC-X86-O0-NEXT:    movl %eax, {{[0-9]+}}(%esp)
-; MSVC-X86-O0-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; MSVC-X86-O0-NEXT:    movl %esp, %eax
-; MSVC-X86-O0-NEXT:    movl %ecx, 4(%eax)
+; MSVC-X86-O0-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; MSVC-X86-O0-NEXT:    leal {{[0-9]+}}(%esp), %ecx
-; MSVC-X86-O0-NEXT:    movl %ecx, (%eax)
+; MSVC-X86-O0-NEXT:    movl %ecx, (%esp)
+; MSVC-X86-O0-NEXT:    movl %eax, {{[0-9]+}}(%esp)
 ; MSVC-X86-O0-NEXT:    calll _strcpy
 ; MSVC-X86-O0-NEXT:    leal LC, %ecx
 ; MSVC-X86-O0-NEXT:    leal {{[0-9]+}}(%esp), %eax


### PR DESCRIPTION
The fast instruction selector should should not force an SDAG fallback to potentially make use of optimized libcall implementations.

Looking at https://github.com/llvm/llvm-project/commit/3e6fa462f3c617ca8202162da2a3990c97b9ec36, part of the motivation was to avoid libcalls in unoptimized builds for targets that don't have them, but I believe this should be handled by Clang directly emitting intrinsics instead of libcalls (which it already does). FastISel should not second guess this.

Followup to https://github.com/llvm/llvm-project/pull/171288.