### PR TITLE
[AArch64] Add ISel patterns for LDAPURS* instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrAtomics.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrAtomics.td
@@ -602,6 +602,8 @@ let Predicates = [HasRCPC3, HasNEON] in {
 // v8.4a FEAT_LRCPC2 patterns
 let Predicates = [HasRCPC_IMMO, UseLDAPUR] in {
   // Load-Acquire RCpc Register unscaled loads
+
+  // Zero-extended
   def : Pat<(acquiring_load<atomic_load_azext_8>
                (am_unscaled8 GPR64sp:$Rn, simm9:$offset)),
           (LDAPURBi GPR64sp:$Rn, simm9:$offset)>;
@@ -614,6 +616,26 @@ let Predicates = [HasRCPC_IMMO, UseLDAPUR] in {
   def : Pat<(acquiring_load<atomic_load_nonext_64>
                (am_unscaled64 GPR64sp:$Rn, simm9:$offset)),
           (LDAPURXi GPR64sp:$Rn, simm9:$offset)>;
+
+  // Sign-extended
+  def : Pat<(sext_inreg (acquiring_load<atomic_load_8>
+                (am_unscaled8 GPR64sp:$Rn, simm9:$offset)), i8),
+          (LDAPURSBWi GPR64sp:$Rn, i64:$offset)>;
+  def : Pat<(sext_inreg (i64 (anyext (i32
+                (acquiring_load<atomic_load_8>
+                    (am_unscaled8 GPR64sp:$Rn, simm9:$offset))))), i8),
+          (LDAPURSBXi GPR64sp:$Rn, i64:$offset)>;
+  def : Pat<(sext_inreg (acquiring_load<atomic_load_16>
+                (am_unscaled16 GPR64sp:$Rn, simm9:$offset)), i16),
+          (LDAPURSHWi GPR64sp:$Rn, i64:$offset)>;
+  def : Pat<(sext_inreg (i64 (anyext (i32
+                (acquiring_load<atomic_load_16>
+                    (am_unscaled16 GPR64sp:$Rn, simm9:$offset))))), i16),
+          (LDAPURSHXi GPR64sp:$Rn, i64:$offset)>;
+  def : Pat<(i64 (sext (i32
+                (acquiring_load<atomic_load_32>
+                    (am_unscaled32 GPR64sp:$Rn, simm9:$offset))))),
+          (LDAPURSWi GPR64sp:$Rn, i64:$offset)>;
 }
 
 let Predicates = [HasRCPC_IMMO] in {

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-load-rcpc_immo.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-load-rcpc_immo.ll
@@ -59,6 +59,44 @@ define i8 @load_atomic_i8_aligned_acquire(ptr %ptr) {
     ret i8 %r
 }
 
+define i32 @load_atomic_i8_aligned_acquire_sext_i32(ptr %ptr) {
+; GISEL-LABEL: load_atomic_i8_aligned_acquire_sext_i32:
+; GISEL:    add x8, x0, #4
+; GISEL:    ldaprb w8, [x8]
+; GISEL:    sxtb w0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire_sext_i32:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #4
+; SDAG-AVOIDLDAPUR:    ldaprb w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxtb w0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire_sext_i32:
+; SDAG-NOAVOIDLDAPUR:    ldapursb w0, [x0, #4]
+    %gep = getelementptr inbounds i8, ptr %ptr, i32 4
+    %r = load atomic i8, ptr %gep acquire, align 1
+    %r.sext = sext i8 %r to i32
+    ret i32 %r.sext
+}
+
+define i64 @load_atomic_i8_aligned_acquire_sext_i64(ptr %ptr) {
+; GISEL-LABEL: load_atomic_i8_aligned_acquire_sext_i64:
+; GISEL:    add x8, x0, #4
+; GISEL:    ldaprb w8, [x8]
+; GISEL:    sxtb x0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire_sext_i64:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #4
+; SDAG-AVOIDLDAPUR:    ldaprb w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxtb x0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire_sext_i64:
+; SDAG-NOAVOIDLDAPUR:    ldapursb x0, [x0, #4]
+    %gep = getelementptr inbounds i8, ptr %ptr, i32 4
+    %r = load atomic i8, ptr %gep acquire, align 1
+    %r.sext = sext i8 %r to i64
+    ret i64 %r.sext
+}
+
 define i8 @load_atomic_i8_aligned_acquire_const(ptr readonly %ptr) {
 ; GISEL-LABEL: load_atomic_i8_aligned_acquire_const:
 ; GISEL:    add x8, x0, #4
@@ -73,6 +111,44 @@ define i8 @load_atomic_i8_aligned_acquire_const(ptr readonly %ptr) {
     %gep = getelementptr inbounds i8, ptr %ptr, i32 4
     %r = load atomic i8, ptr %gep acquire, align 1
     ret i8 %r
+}
+
+define i32 @load_atomic_i8_aligned_acquire_const_sext_i32(ptr readonly %ptr) {
+; GISEL-LABEL: load_atomic_i8_aligned_acquire_const_sext_i32:
+; GISEL:    add x8, x0, #4
+; GISEL:    ldaprb w8, [x8]
+; GISEL:    sxtb w0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire_const_sext_i32:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #4
+; SDAG-AVOIDLDAPUR:    ldaprb w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxtb w0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire_const_sext_i32:
+; SDAG-NOAVOIDLDAPUR:    ldapursb w0, [x0, #4]
+    %gep = getelementptr inbounds i8, ptr %ptr, i32 4
+    %r = load atomic i8, ptr %gep acquire, align 1
+    %r.sext = sext i8 %r to i32
+    ret i32 %r.sext
+}
+
+define i64 @load_atomic_i8_aligned_acquire_const_sext_i64(ptr readonly %ptr) {
+; GISEL-LABEL: load_atomic_i8_aligned_acquire_const_sext_i64:
+; GISEL:    add x8, x0, #4
+; GISEL:    ldaprb w8, [x8]
+; GISEL:    sxtb x0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire_const_sext_i64:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #4
+; SDAG-AVOIDLDAPUR:    ldaprb w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxtb x0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire_const_sext_i64:
+; SDAG-NOAVOIDLDAPUR:    ldapursb x0, [x0, #4]
+    %gep = getelementptr inbounds i8, ptr %ptr, i32 4
+    %r = load atomic i8, ptr %gep acquire, align 1
+    %r.sext = sext i8 %r to i64
+    ret i64 %r.sext
 }
 
 define i8 @load_atomic_i8_aligned_seq_cst(ptr %ptr) {
@@ -141,6 +217,44 @@ define i16 @load_atomic_i16_aligned_acquire(ptr %ptr) {
     ret i16 %r
 }
 
+define i32 @load_atomic_i16_aligned_acquire_sext_i32(ptr %ptr) {
+; GISEL-LABEL: load_atomic_i16_aligned_acquire_sext_i32:
+; GISEL:    add x8, x0, #8
+; GISEL:    ldaprh w8, [x8]
+; GISEL:    sxth w0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire_sext_i32:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #8
+; SDAG-AVOIDLDAPUR:    ldaprh w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxth w0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire_sext_i32:
+; SDAG-NOAVOIDLDAPUR:    ldapursh w0, [x0, #8]
+    %gep = getelementptr inbounds i16, ptr %ptr, i32 4
+    %r = load atomic i16, ptr %gep acquire, align 2
+    %r.sext = sext i16 %r to i32
+    ret i32 %r.sext
+}
+
+define i64 @load_atomic_i16_aligned_acquire_sext_i64(ptr %ptr) {
+; GISEL-LABEL: load_atomic_i16_aligned_acquire_sext_i64:
+; GISEL:    add x8, x0, #8
+; GISEL:    ldaprh w8, [x8]
+; GISEL:    sxth x0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire_sext_i64:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #8
+; SDAG-AVOIDLDAPUR:    ldaprh w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxth x0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire_sext_i64:
+; SDAG-NOAVOIDLDAPUR:    ldapursh x0, [x0, #8]
+    %gep = getelementptr inbounds i16, ptr %ptr, i32 4
+    %r = load atomic i16, ptr %gep acquire, align 2
+    %r.sext = sext i16 %r to i64
+    ret i64 %r.sext
+}
+
 define i16 @load_atomic_i16_aligned_acquire_const(ptr readonly %ptr) {
 ; GISEL-LABEL: load_atomic_i16_aligned_acquire_const:
 ; GISEL:    add x8, x0, #8
@@ -155,6 +269,44 @@ define i16 @load_atomic_i16_aligned_acquire_const(ptr readonly %ptr) {
     %gep = getelementptr inbounds i16, ptr %ptr, i32 4
     %r = load atomic i16, ptr %gep acquire, align 2
     ret i16 %r
+}
+
+define i32 @load_atomic_i16_aligned_acquire_const_sext_i32(ptr readonly %ptr) {
+; GISEL-LABEL: load_atomic_i16_aligned_acquire_const_sext_i32:
+; GISEL:    add x8, x0, #8
+; GISEL:    ldaprh w8, [x8]
+; GISEL:    sxth w0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire_const_sext_i32:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #8
+; SDAG-AVOIDLDAPUR:    ldaprh w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxth w0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire_const_sext_i32:
+; SDAG-NOAVOIDLDAPUR:    ldapursh w0, [x0, #8]
+    %gep = getelementptr inbounds i16, ptr %ptr, i32 4
+    %r = load atomic i16, ptr %gep acquire, align 2
+    %r.sext = sext i16 %r to i32
+    ret i32 %r.sext
+}
+
+define i64 @load_atomic_i16_aligned_acquire_const_sext_i64(ptr readonly %ptr) {
+; GISEL-LABEL: load_atomic_i16_aligned_acquire_const_sext_i64:
+; GISEL:    add x8, x0, #8
+; GISEL:    ldaprh w8, [x8]
+; GISEL:    sxth x0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire_const_sext_i64:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #8
+; SDAG-AVOIDLDAPUR:    ldaprh w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxth x0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire_const_sext_i64:
+; SDAG-NOAVOIDLDAPUR:    ldapursh x0, [x0, #8]
+    %gep = getelementptr inbounds i16, ptr %ptr, i32 4
+    %r = load atomic i16, ptr %gep acquire, align 2
+    %r.sext = sext i16 %r to i64
+    ret i64 %r.sext
 }
 
 define i16 @load_atomic_i16_aligned_seq_cst(ptr %ptr) {
@@ -222,6 +374,24 @@ define i32 @load_atomic_i32_aligned_acquire(ptr %ptr) {
     ret i32 %r
 }
 
+define i64 @load_atomic_i32_aligned_acquire_sext_i64(ptr %ptr) {
+; GISEL-LABEL: load_atomic_i32_aligned_acquire_sext_i64:
+; GISEL:    ldapur w8, [x0, #16]
+; GISEL:    ldapursw x0, [x0, #16]
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i32_aligned_acquire_sext_i64:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #16
+; SDAG-AVOIDLDAPUR:    ldapr w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxtw x0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i32_aligned_acquire_sext_i64:
+; SDAG-NOAVOIDLDAPUR:    ldapursw x0, [x0, #16]
+    %gep = getelementptr inbounds i32, ptr %ptr, i32 4
+    %r = load atomic i32, ptr %gep acquire, align 4
+    %r.sext = sext i32 %r to i64
+    ret i64 %r.sext
+}
+
 define i32 @load_atomic_i32_aligned_acquire_const(ptr readonly %ptr) {
 ; GISEL-LABEL: load_atomic_i32_aligned_acquire_const:
 ; GISEL:    ldapur w0, [x0, #16]
@@ -235,6 +405,24 @@ define i32 @load_atomic_i32_aligned_acquire_const(ptr readonly %ptr) {
     %gep = getelementptr inbounds i32, ptr %ptr, i32 4
     %r = load atomic i32, ptr %gep acquire, align 4
     ret i32 %r
+}
+
+define i64 @load_atomic_i32_aligned_acquire_const_sext_i64(ptr readonly %ptr) {
+; GISEL-LABEL: load_atomic_i32_aligned_acquire_const_sext_i64:
+; GISEL:    ldapur w8, [x0, #16]
+; GISEL:    ldapursw x0, [x0, #16]
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i32_aligned_acquire_const_sext_i64:
+; SDAG-AVOIDLDAPUR:    add x8, x0, #16
+; SDAG-AVOIDLDAPUR:    ldapr w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxtw x0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i32_aligned_acquire_const_sext_i64:
+; SDAG-NOAVOIDLDAPUR:    ldapursw x0, [x0, #16]
+    %gep = getelementptr inbounds i32, ptr %ptr, i32 4
+    %r = load atomic i32, ptr %gep acquire, align 4
+    %r.sext = sext i32 %r to i64
+    ret i64 %r.sext
 }
 
 define i32 @load_atomic_i32_aligned_seq_cst(ptr %ptr) {
@@ -922,6 +1110,54 @@ define i8 @load_atomic_i8_from_gep() {
   ret i8 %l
 }
 
+define i32 @load_atomic_i8_from_gep_sext_i32() {
+; GISEL-LABEL: load_atomic_i8_from_gep_sext_i32:
+; GISEL:    bl init
+; GISEL:    add x8, x8, #1
+; GISEL:    ldaprb w8, [x8]
+; GISEL:    sxtb w0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_from_gep_sext_i32:
+; SDAG-AVOIDLDAPUR:    bl init
+; SDAG-AVOIDLDAPUR:    orr x8, x19, #0x1
+; SDAG-AVOIDLDAPUR:    ldaprb w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxtb w0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i8_from_gep_sext_i32:
+; SDAG-NOAVOIDLDAPUR:    bl init
+; SDAG-NOAVOIDLDAPUR:    ldapursb w0, [sp, #13]
+  %a = alloca [3 x i8]
+  call void @init(ptr %a)
+  %arrayidx  = getelementptr [3 x i8], ptr %a, i64 0, i64 1
+  %l = load atomic i8, ptr %arrayidx acquire, align 8
+  %l.sext = sext i8 %l to i32
+  ret i32 %l.sext
+}
+
+define i64 @load_atomic_i8_from_gep_sext_i64() {
+; GISEL-LABEL: load_atomic_i8_from_gep_sext_i64:
+; GISEL:    bl init
+; GISEL:    add x8, x8, #1
+; GISEL:    ldaprb w8, [x8]
+; GISEL:    sxtb x0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_from_gep_sext_i64:
+; SDAG-AVOIDLDAPUR:    bl init
+; SDAG-AVOIDLDAPUR:    orr x8, x19, #0x1
+; SDAG-AVOIDLDAPUR:    ldaprb w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxtb x0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i8_from_gep_sext_i64:
+; SDAG-NOAVOIDLDAPUR:    bl init
+; SDAG-NOAVOIDLDAPUR:    ldapursb x0, [sp, #13]
+  %a = alloca [3 x i8]
+  call void @init(ptr %a)
+  %arrayidx  = getelementptr [3 x i8], ptr %a, i64 0, i64 1
+  %l = load atomic i8, ptr %arrayidx acquire, align 8
+  %l.sext = sext i8 %l to i64
+  ret i64 %l.sext
+}
+
 define i16 @load_atomic_i16_from_gep() {
 ; GISEL-LABEL: load_atomic_i16_from_gep:
 ; GISEL:    bl init
@@ -943,6 +1179,54 @@ define i16 @load_atomic_i16_from_gep() {
   ret i16 %l
 }
 
+define i32 @load_atomic_i16_from_gep_sext_i32() {
+; GISEL-LABEL: load_atomic_i16_from_gep_sext_i32:
+; GISEL:    bl init
+; GISEL:    add x8, x8, #2
+; GISEL:    ldaprh w8, [x8]
+; GISEL:    sxth w0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i16_from_gep_sext_i32:
+; SDAG-AVOIDLDAPUR:    bl init
+; SDAG-AVOIDLDAPUR:    orr x8, x19, #0x2
+; SDAG-AVOIDLDAPUR:    ldaprh w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxth w0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i16_from_gep_sext_i32:
+; SDAG-NOAVOIDLDAPUR:    bl init
+; SDAG-NOAVOIDLDAPUR:    ldapursh w0, [sp, #10]
+  %a = alloca [3 x i16]
+  call void @init(ptr %a)
+  %arrayidx  = getelementptr [3 x i16], ptr %a, i64 0, i64 1
+  %l = load atomic i16, ptr %arrayidx acquire, align 8
+  %l.sext = sext i16 %l to i32
+  ret i32 %l.sext
+}
+
+define i64 @load_atomic_i16_from_gep_sext_i64() {
+; GISEL-LABEL: load_atomic_i16_from_gep_sext_i64:
+; GISEL:    bl init
+; GISEL:    add x8, x8, #2
+; GISEL:    ldaprh w8, [x8]
+; GISEL:    sxth x0, w8
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i16_from_gep_sext_i64:
+; SDAG-AVOIDLDAPUR:    bl init
+; SDAG-AVOIDLDAPUR:    orr x8, x19, #0x2
+; SDAG-AVOIDLDAPUR:    ldaprh w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxth x0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i16_from_gep_sext_i64:
+; SDAG-NOAVOIDLDAPUR:    bl init
+; SDAG-NOAVOIDLDAPUR:    ldapursh x0, [sp, #10]
+  %a = alloca [3 x i16]
+  call void @init(ptr %a)
+  %arrayidx  = getelementptr [3 x i16], ptr %a, i64 0, i64 1
+  %l = load atomic i16, ptr %arrayidx acquire, align 8
+  %l.sext = sext i16 %l to i64
+  ret i64 %l.sext
+}
+
 define i32 @load_atomic_i32_from_gep() {
 ; GISEL-LABEL: load_atomic_i32_from_gep:
 ; GISEL:    bl init
@@ -961,6 +1245,29 @@ define i32 @load_atomic_i32_from_gep() {
   %arrayidx  = getelementptr [3 x i32], ptr %a, i64 0, i64 1
   %l = load atomic i32, ptr %arrayidx acquire, align 8
   ret i32 %l
+}
+
+define i64 @load_atomic_i32_from_gep_sext_i64() {
+; GISEL-LABEL: load_atomic_i32_from_gep_sext_i64:
+; GISEL:    bl init
+; GISEL:    ldapur w9, [x8, #4]
+; GISEL:    ldapursw x0, [x8, #4]
+;
+; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i32_from_gep_sext_i64:
+; SDAG-AVOIDLDAPUR:    bl init
+; SDAG-AVOIDLDAPUR:    add x8, x19, #4
+; SDAG-AVOIDLDAPUR:    ldapr w8, [x8]
+; SDAG-AVOIDLDAPUR:    sxtw x0, w8
+;
+; SDAG-NOAVOIDLDAPUR-LABEL: load_atomic_i32_from_gep_sext_i64:
+; SDAG-NOAVOIDLDAPUR:    bl init
+; SDAG-NOAVOIDLDAPUR:    ldapursw x0, [sp, #8]
+  %a = alloca [3 x i32]
+  call void @init(ptr %a)
+  %arrayidx  = getelementptr [3 x i32], ptr %a, i64 0, i64 1
+  %l = load atomic i32, ptr %arrayidx acquire, align 8
+  %l.sext = sext i32 %l to i64
+  ret i64 %l.sext
 }
 
 define i64 @load_atomic_i64_from_gep() {

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N2-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N2-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -41,19 +41,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2]    [3.0]  [3.1]  [4]    [5]    [6.0]  [6.1]  [7]    [8]
-# CHECK-NEXT:  -      -     6.50   6.50    -     6.50   6.50    -      -      -      -      -      -
+# CHECK-NEXT:  -      -     2.00   2.00   3.00   5.00   5.00    -      -      -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2]    [3.0]  [3.1]  [4]    [5]    [6.0]  [6.1]  [7]    [8]    Instructions:
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N2-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N2-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	w7, [x8]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	x29, [x7]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	w17, [x19]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	x3, [x3]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursw	x3, [x18]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -41,19 +41,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2]    [3.0]  [3.1]  [4]    [5]    [6.0]  [6.1]  [7]    [8]
-# CHECK-NEXT:  -      -     2.00   2.00   3.00   5.00   5.00    -      -      -      -      -      -
+# CHECK-NEXT:  -      -     6.50   6.50    -     6.50   6.50    -      -      -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2]    [3.0]  [3.1]  [4]    [5]    [6.0]  [6.1]  [7]    [8]    Instructions:
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -41,19 +41,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2]    [3.0]  [3.1]  [4]    [5]    [6.0]  [6.1]  [7]    [8]
-# CHECK-NEXT:  -      -     6.50   6.50    -     6.50   6.50    -      -      -      -      -      -
+# CHECK-NEXT:  -      -     2.00   2.00   3.00   5.00   5.00    -      -      -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2]    [3.0]  [3.1]  [4]    [5]    [6.0]  [6.1]  [7]    [8]    Instructions:
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	w7, [x8]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	x29, [x7]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	w17, [x19]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	x3, [x3]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursw	x3, [x18]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -41,19 +41,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2]    [3.0]  [3.1]  [4]    [5]    [6.0]  [6.1]  [7]    [8]
-# CHECK-NEXT:  -      -     2.00   2.00   3.00   5.00   5.00    -      -      -      -      -      -
+# CHECK-NEXT:  -      -     6.50   6.50    -     6.50   6.50    -      -      -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2]    [3.0]  [3.1]  [4]    [5]    [6.0]  [6.1]  [7]    [8]    Instructions:
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -     0.50   0.50    -     0.50   0.50    -      -      -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -46,19 +46,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [3]    [4.0]  [4.1]  [5]    [6]    [7.0]  [7.1]  [8]    [9]    [10]   [11]
-# CHECK-NEXT:  -      -     6.50   6.50    -      -      -      -     6.50   6.50    -      -      -      -      -      -      -      -
+# CHECK-NEXT:  -      -     2.00   2.00    -      -      -     3.00   5.00   5.00    -      -      -      -      -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [3]    [4.0]  [4.1]  [5]    [6]    [7.0]  [7.1]  [8]    [9]    [10]   [11]   Instructions:
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	w7, [x8]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	x29, [x7]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	w17, [x19]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	x3, [x3]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursw	x3, [x18]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -46,19 +46,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [3]    [4.0]  [4.1]  [5]    [6]    [7.0]  [7.1]  [8]    [9]    [10]   [11]
-# CHECK-NEXT:  -      -     2.00   2.00    -      -      -     3.00   5.00   5.00    -      -      -      -      -      -      -      -
+# CHECK-NEXT:  -      -     6.50   6.50    -      -      -      -     6.50   6.50    -      -      -      -      -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [3]    [4.0]  [4.1]  [5]    [6]    [7.0]  [7.1]  [8]    [9]    [10]   [11]   Instructions:
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	w7, [x8]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	x29, [x7]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	w17, [x19]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	x3, [x3]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursw	x3, [x18]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -48,19 +48,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [3]    [4.0]  [4.1]  [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]
-# CHECK-NEXT:  -      -     2.00   2.00    -      -      -     3.00   5.00   5.00    -      -      -      -      -      -      -      -      -      -
+# CHECK-NEXT:  -      -     6.50   6.50    -      -      -      -     6.50   6.50    -      -      -      -      -      -      -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [3]    [4.0]  [4.1]  [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   Instructions:
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -48,19 +48,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [3]    [4.0]  [4.1]  [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]
-# CHECK-NEXT:  -      -     6.50   6.50    -      -      -      -     6.50   6.50    -      -      -      -      -      -      -      -      -      -
+# CHECK-NEXT:  -      -     2.00   2.00    -      -      -     3.00   5.00   5.00    -      -      -      -      -      -      -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [3]    [4.0]  [4.1]  [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   Instructions:
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     0.50   0.50    -      -      -      -      -      -      -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	w7, [x8]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	x29, [x7]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	w17, [x19]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	x3, [x3]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursw	x3, [x18]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -53,19 +53,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   [16]   [17]
-# CHECK-NEXT:  -      -      -     2.00   2.00    -      -      -      -     3.00   3.00   5.00    -      -      -      -      -      -      -      -     2.00    -      -      -      -
+# CHECK-NEXT:  -      -      -     6.50   6.50    -      -      -      -      -      -     6.50    -      -      -      -      -      -      -      -     6.50    -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   [16]   [17]   Instructions:
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -53,19 +53,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   [16]   [17]
-# CHECK-NEXT:  -      -      -     6.50   6.50    -      -      -      -      -      -     6.50    -      -      -      -      -      -      -      -     6.50    -      -      -      -
+# CHECK-NEXT:  -      -      -     2.00   2.00    -      -      -      -     3.00   3.00   5.00    -      -      -      -      -      -      -      -     2.00    -      -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   [16]   [17]   Instructions:
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -      -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	w7, [x8]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursb	x29, [x7]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	w17, [x19]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursh	x3, [x3]
-# CHECK-NEXT:  1      4     0.33    *             U     ldapursw	x3, [x18]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -51,19 +51,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -      -     2.00   2.00    -      -      -      -     3.00   3.00   5.00    -      -      -      -      -      -      -      -     2.00    -      -
+# CHECK-NEXT:  -      -      -     6.50   6.50    -      -      -      -      -      -     6.50    -      -      -      -      -      -      -      -     6.50    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     stlurb	w30, [x17]

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-rcpc-immo-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-rcpc-immo-instructions.s
@@ -10,15 +10,15 @@
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	w7, [x24]
-# CHECK-NEXT:  2      1     0.50    *                   ldapur	x20, [x13]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurb	w13, [x17]
-# CHECK-NEXT:  2      1     0.50    *                   ldapurh	w3, [x22]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	w7, [x8]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursb	x29, [x7]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	w17, [x19]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursh	x3, [x3]
-# CHECK-NEXT:  2      1     0.50    *                   ldapursw	x3, [x18]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	w7, [x24]
+# CHECK-NEXT:  1      4     0.33    *                   ldapur	x20, [x13]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurb	w13, [x17]
+# CHECK-NEXT:  1      4     0.33    *                   ldapurh	w3, [x22]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	w7, [x8]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursb	x29, [x7]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	w17, [x19]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursh	x3, [x3]
+# CHECK-NEXT:  1      4     0.33    *                   ldapursw	x3, [x18]
 # CHECK-NEXT:  2      1     0.50           *            stlur	w3, [x27]
 # CHECK-NEXT:  2      1     0.50           *            stlur	x23, [x25]
 # CHECK-NEXT:  2      1     0.50           *            stlurb	w30, [x17]
@@ -51,19 +51,19 @@
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -      -     6.50   6.50    -      -      -      -      -      -     6.50    -      -      -      -      -      -      -      -     6.50    -      -
+# CHECK-NEXT:  -      -      -     2.00   2.00    -      -      -      -     3.00   3.00   5.00    -      -      -      -      -      -      -      -     2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [0.2]  [1.0]  [1.1]  [2.0]  [2.1]  [2.2]  [2.3]  [3.0]  [3.1]  [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapur	w7, [x24]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapur	x20, [x13]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapurb	w13, [x17]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapurh	w3, [x22]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursb	w7, [x8]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursb	x29, [x7]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursh	w17, [x19]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursh	x3, [x3]
-# CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     ldapursw	x3, [x18]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapur	w7, [x24]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapur	x20, [x13]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapurb	w13, [x17]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapurh	w3, [x22]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursb	w7, [x8]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursb	x29, [x7]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursh	w17, [x19]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursh	x3, [x3]
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -     0.33   0.33   0.33    -      -      -      -      -      -      -      -      -      -      -     ldapursw	x3, [x18]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     stlur	w3, [x27]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     stlur	x23, [x25]
 # CHECK-NEXT:  -      -      -     0.50   0.50    -      -      -      -      -      -     0.50    -      -      -      -      -      -      -      -     0.50    -      -     stlurb	w30, [x17]


### PR DESCRIPTION
Adds ISel patterns for LDAPURS* instructions, from which the compiler is able to infer that these instructions may load.

Related to #171142