### PR TITLE
[lldb][test] Fix toolchain-msvc.test for native ARM64 MSVC environment

### DIFF
--- a/lldb/test/Shell/BuildScript/toolchain-msvc.test
+++ b/lldb/test/Shell/BuildScript/toolchain-msvc.test
@@ -23,15 +23,15 @@ RUN:    | FileCheck --check-prefix=64BIT %s
 32BIT: Cleaning {{.*}}toolchain-msvc.test.tmp\foo.pdb
 32BIT: Cleaning {{.*}}toolchain-msvc.test.tmp\foo.exe
 32BIT: compiling foobar.c -> foo.exe-foobar.obj
-32BIT:   Command Line: {{.*}}\{{[Hh]ost[Xx](64|86)}}\{{(x86|arm)}}\cl.{{EXE|exe}}
+32BIT:   Command Line: {{.*}}\{{[Hh]ost([Xx](64|86)|(arm64|ARM64))}}\{{(x86|arm)}}\cl.{{EXE|exe}}
 32BIT: linking foo.exe-foobar.obj -> foo.exe
-32BIT:   Command Line: {{.*}}\{{[Hh]ost[Xx](64|86)}}\{{(x86|arm)}}\link.{{EXE|exe}}
+32BIT:   Command Line: {{.*}}\{{[Hh]ost([Xx](64|86)|(arm64|ARM64))}}\{{(x86|arm)}}\link.{{EXE|exe}}
 32BIT:   Env
 32BIT:     LIB = {{.*}}\ATLMFC\lib\{{(x86|arm)}}
 32BIT:           {{.*}}\lib\{{(x86|arm)}}
 32BIT:           {{.*}}\ucrt\{{(x86|arm)}}
 32BIT:           {{.*}}\um\{{(x86|arm)}}
-32BIT:     PATH = {{.*}}\bin\{{[Hh]ost[Xx](64|86)}}\{{(x86|x64)}}
+32BIT:     PATH = {{.*}}\bin\{{[Hh]ost([Xx](64|86)|(arm64|ARM64))}}\{{(x86|x64|arm64)}}
 
 
 64BIT: Script Arguments:
@@ -51,12 +51,12 @@ RUN:    | FileCheck --check-prefix=64BIT %s
 64BIT: Cleaning {{.*}}toolchain-msvc.test.tmp\foo.pdb
 64BIT: Cleaning {{.*}}toolchain-msvc.test.tmp\foo.exe
 64BIT: compiling foobar.c -> foo.exe-foobar.obj
-64BIT:   Command Line: {{.*}}\{{[Hh]ost[Xx](64|86)}}\{{(x64|arm64)}}\cl.{{EXE|exe}}
+64BIT:   Command Line: {{.*}}\{{[Hh]ost([Xx](64|86)|(arm64|ARM64))}}\{{(x64|arm64)}}\cl.{{EXE|exe}}
 64BIT: linking foo.exe-foobar.obj -> foo.exe
-64BIT:   Command Line: {{.*}}\{{[Hh]ost[Xx](64|86)}}\{{(x64|arm64)}}\link.{{EXE|exe}}
+64BIT:   Command Line: {{.*}}\{{[Hh]ost([Xx](64|86)|(arm64|ARM64))}}\{{(x64|arm64)}}\link.{{EXE|exe}}
 64BIT:   Env
 64BIT:     LIB = {{.*}}\ATLMFC\lib\{{(x64|arm64)}}
 64BIT:           {{.*}}\lib\{{(x64|arm64)}}
 64BIT:           {{.*}}\ucrt\{{(x64|arm64)}}
 64BIT:           {{.*}}\um\{{(x64|arm64)}}
-64BIT:     PATH = {{.*}}\bin\{{[Hh]ost[Xx](64|86)}}\{{(x86|x64)}}
+64BIT:     PATH = {{.*}}\bin\{{[Hh]ost([Xx](64|86)|(arm64|ARM64))}}\{{(x86|x64|arm64)}}


### PR DESCRIPTION
This patch fixes toolchain-msvc.test on Windows ARM64 hosts running under native ARM64 environment via vcvarsarm64.bat. Our lab buildbot recently switched from using cross vcvarsamd64_arm64.bat environment to native vcvarsarm64.bat. This patch updates FileCheck patterns to also allow HostARM64 and arm64 PATH entries.

Changes:
-> Extend host regex to match HostARM64 (case-insensitive)
-> Allow arm64 in PATH tail.
-> Apply same fix in both 32-bit and 64-bit sections.