### PR TITLE
[Clang] Remove the early-check for anonymous struct in ShouldDeleteSpecialMember

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -587,6 +587,7 @@ Bug Fixes to C++ Support
 - Diagnose unresolved overload sets in non-dependent compound requirements. (#GH51246) (#GH97753)
 - Fix a crash when extracting unavailable member type from alias in template deduction. (#GH165560)
 - Fix incorrect diagnostics for lambdas with init-captures inside braced initializers. (#GH163498)
+- Fixed an issue where templates prevented nested anonymous records from checking the deletion of special members. (#GH167217)
 - Fixed spurious diagnoses of certain nested lambda expressions. (#GH149121) (#GH156579)
 
 Bug Fixes to AST Handling

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -9899,13 +9899,6 @@ bool Sema::ShouldDeleteSpecialMember(CXXMethodDecl *MD,
     return true;
   }
 
-  // For an anonymous struct or union, the copy and assignment special members
-  // will never be used, so skip the check. For an anonymous union declared at
-  // namespace scope, the constructor and destructor are used.
-  if (CSM != CXXSpecialMemberKind::DefaultConstructor &&
-      CSM != CXXSpecialMemberKind::Destructor && RD->isAnonymousStructOrUnion())
-    return false;
-
   // C++11 [class.copy]p7, p18:
   //   If the class definition declares a move constructor or move assignment
   //   operator, an implicitly declared copy constructor or copy assignment

--- a/clang/test/SemaCXX/anonymous-struct.cpp
+++ b/clang/test/SemaCXX/anonymous-struct.cpp
@@ -221,3 +221,34 @@ namespace ForwardDeclaredMember {
     };
   };
 }
+
+#if __cplusplus >= 201103L
+namespace GH167217 {
+
+struct NonMovable {
+  NonMovable(const NonMovable&) = delete;
+};
+
+struct Wrapper {
+  struct {
+    NonMovable v;
+  };
+};
+
+static_assert(!__is_constructible(Wrapper, const Wrapper&), "");
+static_assert(!__is_constructible(Wrapper, Wrapper), "");
+
+template<class T>
+struct WrapperTmpl {
+  struct {
+    NonMovable v;
+  };
+};
+
+using Wrapper2 = WrapperTmpl<NonMovable>;
+
+static_assert(!__is_constructible(Wrapper2, const Wrapper2&), "");
+static_assert(!__is_constructible(Wrapper2, Wrapper2), "");
+
+}
+#endif

--- a/clang/test/SemaObjCXX/arc-0x.mm
+++ b/clang/test/SemaObjCXX/arc-0x.mm
@@ -163,7 +163,7 @@ namespace test_union {
   struct S1 {
     union {
       union { // expected-note-re {{copy constructor of 'S1' is implicitly deleted because field 'test_union::S1::(anonymous union)::(anonymous union at {{.*}})' has a deleted copy constructor}} expected-note-re {{copy assignment operator of 'S1' is implicitly deleted because field 'test_union::S1::(anonymous union)::(anonymous union at {{.*}})' has a deleted copy assignment operator}} expected-note-re 4 {{'S1' is implicitly deleted because field 'test_union::S1::(anonymous union)::(anonymous union at {{.*}})' has a deleted}}
-        id f0; // expected-note-re 2 {{{{.*}} of '(anonymous union at {{.*}}' is implicitly deleted because variant field 'f0' is an ObjC pointer}}
+        id f0; // expected-note-re 6 {{{{.*}} of '(anonymous union at {{.*}}' is implicitly deleted because variant field 'f0' is an ObjC pointer}}
         char f1;
       };
       int f2;


### PR DESCRIPTION
That check doesn't seem very useful. For non-dependent context records, ShouldDeleteSpecialMember is called when checking implicitly defined member functions, before the anonymous flag which the check relies on is set. (One could notice that in `ParseCXXClassMemberDeclaration`, `ParseDeclarationSpecifiers` ends up calling `ShouldDeleteSpecialMember`, while the flag is only set later in `ParsedFreeStandingDeclSpec`.)

For dependent contexts, this check actually breaks correctness: since we don't create those special members until the template is instantiated, their deletion checks are skipped because of the anonymity.

There's only one regression in ObjC test about notes; we are more explanative now.

Fixes https://github.com/llvm/llvm-project/issues/167217