### PR TITLE
[libc++] Remove _LIBCPP_CONSTINIT

### DIFF
--- a/libcxx/.clang-format
+++ b/libcxx/.clang-format
@@ -26,7 +26,6 @@ AttributeMacros: [
                   '_LIBCPP_CONSTEXPR_SINCE_CXX20',
                   '_LIBCPP_CONSTEXPR_SINCE_CXX23',
                   '_LIBCPP_CONSTEXPR',
-                  '_LIBCPP_CONSTINIT',
                   '_LIBCPP_DEPRECATED_IN_CXX11',
                   '_LIBCPP_DEPRECATED_IN_CXX14',
                   '_LIBCPP_DEPRECATED_IN_CXX17',

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -731,14 +731,6 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_NO_THREAD_SAFETY_ANALYSIS
 #  endif
 
-#  if _LIBCPP_STD_VER >= 20
-#    define _LIBCPP_CONSTINIT constinit
-#  elif __has_attribute(__require_constant_initialization__)
-#    define _LIBCPP_CONSTINIT __attribute__((__require_constant_initialization__))
-#  else
-#    define _LIBCPP_CONSTINIT
-#  endif
-
 #  if defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA_LIBDEVICE__)
 // The CUDA SDK contains an unfortunate definition for the __noinline__ macro,
 // which breaks the regular __attribute__((__noinline__)) syntax. Therefore,

--- a/libcxxabi/src/cxa_guard_impl.h
+++ b/libcxxabi/src/cxa_guard_impl.h
@@ -637,7 +637,7 @@ struct GlobalStatic {
   static T instance;
 };
 template <class T>
-_LIBCPP_CONSTINIT T GlobalStatic<T>::instance = {};
+constinit T GlobalStatic<T>::instance = {};
 
 enum class Implementation { NoThreads, GlobalMutex, Futex };
 

--- a/libcxxabi/src/fallback_malloc.cpp
+++ b/libcxxabi/src/fallback_malloc.cpp
@@ -35,9 +35,9 @@ namespace {
 
 // When POSIX threads are not available, make the mutex operations a nop
 #ifndef _LIBCXXABI_HAS_NO_THREADS
-static _LIBCPP_CONSTINIT std::__libcpp_mutex_t heap_mutex = _LIBCPP_MUTEX_INITIALIZER;
+static constinit std::__libcpp_mutex_t heap_mutex = _LIBCPP_MUTEX_INITIALIZER;
 #else
-static _LIBCPP_CONSTINIT void* heap_mutex = 0;
+static constinit void* heap_mutex = 0;
 #endif
 
 class mutexor {

--- a/libcxxabi/test/guard_test_basic.pass.cpp
+++ b/libcxxabi/test/guard_test_basic.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// UNSUPPORTED: c++03
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // Necessary because we include a private header of libc++abi, which
 // only understands _LIBCXXABI_HAS_NO_THREADS.

--- a/libcxxabi/test/guard_threaded_test.pass.cpp
+++ b/libcxxabi/test/guard_threaded_test.pass.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: no-threads
 // UNSUPPORTED: no-exceptions
 

--- a/libcxxabi/test/test_fallback_malloc.pass.cpp
+++ b/libcxxabi/test/test_fallback_malloc.pass.cpp
@@ -13,7 +13,7 @@
 
 #include <__thread/support.h>
 
-// UNSUPPORTED: c++03
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: modules-build && no-threads
 
 // Necessary because we include a private source file of libc++abi, which


### PR DESCRIPTION
`_LIBCPP_CONSTINIT` is only ever used inside `src/`, so we can just replace it with `constinit` instead.
