### PR TITLE
[InstSimplify] Remove redundant icmp+ptrtoint fold

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -4077,14 +4077,6 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
   if (LHS->getType()->isPointerTy())
     if (auto *C = computePointerICmp(Pred, LHS, RHS, Q))
       return C;
-  if (auto *CLHS = dyn_cast<PtrToIntOperator>(LHS))
-    if (auto *CRHS = dyn_cast<PtrToIntOperator>(RHS))
-      if (CLHS->getPointerOperandType() == CRHS->getPointerOperandType() &&
-          Q.DL.getTypeSizeInBits(CLHS->getPointerOperandType()) ==
-              Q.DL.getTypeSizeInBits(CLHS->getType()))
-        if (auto *C = computePointerICmp(Pred, CLHS->getPointerOperand(),
-                                         CRHS->getPointerOperand(), Q))
-          return C;
 
   // If the comparison is with the result of a select instruction, check whether
   // comparing with either branch of the select always yields the same value.


### PR DESCRIPTION
There is a generic fold for recursively calling simplifyICmpInst with the ptrtoint cast stripped:
https://github.com/llvm/llvm-project/blob/9b6b52b534ba592d7d6b5863e3d9a240119a74d9/llvm/lib/Analysis/InstructionSimplify.cpp#L3850-L3867

As such, we shouldn't have to explicitly do this for the computePointerICmp() fold.

This is not strictly NFC because the recursion limit applies to the generic fold, though I wouldn't expect this to matter in practice.