### PR TITLE
[LifetimeSafety] Bailout CFGs based on Origin Count

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Checker.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Checker.h
@@ -28,8 +28,7 @@ namespace clang::lifetimes::internal {
 void runLifetimeChecker(const LoanPropagationAnalysis &LoanPropagation,
                         const LiveOriginsAnalysis &LiveOrigins,
                         const FactManager &FactMgr, AnalysisDeclContext &ADC,
-                        LifetimeSafetyReporter *Reporter,
-                        uint32_t BlockFactNumThreshold);
+                        LifetimeSafetyReporter *Reporter);
 
 } // namespace clang::lifetimes::internal
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Checker.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Checker.h
@@ -28,7 +28,8 @@ namespace clang::lifetimes::internal {
 void runLifetimeChecker(const LoanPropagationAnalysis &LoanPropagation,
                         const LiveOriginsAnalysis &LiveOrigins,
                         const FactManager &FactMgr, AnalysisDeclContext &ADC,
-                        LifetimeSafetyReporter *Reporter);
+                        LifetimeSafetyReporter *Reporter,
+                    uint32_t BlockFactNumThreshold);
 
 } // namespace clang::lifetimes::internal
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Checker.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Checker.h
@@ -29,7 +29,7 @@ void runLifetimeChecker(const LoanPropagationAnalysis &LoanPropagation,
                         const LiveOriginsAnalysis &LiveOrigins,
                         const FactManager &FactMgr, AnalysisDeclContext &ADC,
                         LifetimeSafetyReporter *Reporter,
-                    uint32_t BlockFactNumThreshold);
+                        uint32_t BlockFactNumThreshold);
 
 } // namespace clang::lifetimes::internal
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -245,6 +245,9 @@ public:
   void setBlockNumThreshold(uint32_t Threshold) {
     BlockNumThreshold = Threshold;
   }
+  void setCfgOriginCountThreshold(uint32_t Threshold) {
+    CfgOriginCountThreshold = Threshold;
+  }
 
 private:
   FactID NextFactID{0};
@@ -254,6 +257,7 @@ private:
   llvm::SmallVector<llvm::SmallVector<const Fact *>> BlockToFacts;
   llvm::BumpPtrAllocator FactAllocator;
   uint32_t BlockNumThreshold = 0;
+  uint32_t CfgOriginCountThreshold = 0;
 };
 } // namespace clang::lifetimes::internal
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -242,8 +242,8 @@ public:
   const LoanManager &getLoanMgr() const { return LoanMgr; }
   OriginManager &getOriginMgr() { return OriginMgr; }
   const OriginManager &getOriginMgr() const { return OriginMgr; }
-  void setBlockFactNumThreshold(uint32_t Threshold) {
-    BlockFactNumThreshold = Threshold;
+  void setBlockNumThreshold(uint32_t Threshold) {
+    BlockNumThreshold = Threshold;
   }
 
 private:
@@ -253,7 +253,7 @@ private:
   /// Facts for each CFG block, indexed by block ID.
   llvm::SmallVector<llvm::SmallVector<const Fact *>> BlockToFacts;
   llvm::BumpPtrAllocator FactAllocator;
-  uint32_t BlockFactNumThreshold = 0;
+  uint32_t BlockNumThreshold = 0;
 };
 } // namespace clang::lifetimes::internal
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -218,7 +218,8 @@ public:
 
   void dump(const CFG &Cfg, AnalysisDeclContext &AC) const;
 
-  // A utility function to print the size of the CFG blocks in the analysis context.
+  // A utility function to print the size of the CFG blocks in the analysis
+  // context.
   void dumpBlockSizes(const CFG &Cfg, AnalysisDeclContext &AC) const;
 
   /// Retrieves program points that were specially marked in the source code

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -218,6 +218,9 @@ public:
 
   void dump(const CFG &Cfg, AnalysisDeclContext &AC) const;
 
+  // A utility function to print the size of the CFG blocks in the analysis context.
+  void dumpBlockSizes(const CFG &Cfg, AnalysisDeclContext &AC) const;
+
   /// Retrieves program points that were specially marked in the source code
   /// for testing.
   ///
@@ -238,6 +241,9 @@ public:
   const LoanManager &getLoanMgr() const { return LoanMgr; }
   OriginManager &getOriginMgr() { return OriginMgr; }
   const OriginManager &getOriginMgr() const { return OriginMgr; }
+  void setBlockFactNumThreshold(uint32_t Threshold) {
+    BlockFactNumThreshold = Threshold;
+  }
 
 private:
   FactID NextFactID{0};
@@ -246,6 +252,7 @@ private:
   /// Facts for each CFG block, indexed by block ID.
   llvm::SmallVector<llvm::SmallVector<const Fact *>> BlockToFacts;
   llvm::BumpPtrAllocator FactAllocator;
+  uint32_t BlockFactNumThreshold = 0;
 };
 } // namespace clang::lifetimes::internal
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -25,6 +25,7 @@
 #include "clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include <cstdint>
+#include <sys/types.h>
 
 namespace clang::lifetimes {
 
@@ -53,7 +54,8 @@ public:
 /// The main entry point for the analysis.
 void runLifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                                LifetimeSafetyReporter *Reporter,
-                               uint32_t CfgBlocknumThreshold);
+                               uint32_t CfgBlocknumThreshold,
+                              uint32_t CfgOriginCountThreshold);
 
 namespace internal {
 /// An object to hold the factories for immutable collections, ensuring
@@ -70,7 +72,8 @@ class LifetimeSafetyAnalysis {
 public:
   LifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                          LifetimeSafetyReporter *Reporter,
-                         uint32_t CfgBlocknumThreshold);
+                         uint32_t CfgBlocknumThreshold,
+                        uint32_t CfgOriginCountThreshold);
 
   void run();
 
@@ -83,7 +86,9 @@ public:
 
 private:
   bool shouldBailOutCFGPreFactGeneration(const CFG &Cfg) const;
+  bool shouldBailOutCFGPostFactGeneration(const CFG &Cfg) const;
   uint32_t CfgBlocknumThreshold;
+  uint32_t CfgOriginCountThreshold;
   AnalysisDeclContext &AC;
   LifetimeSafetyReporter *Reporter;
   LifetimeFactory Factory;

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -55,7 +55,7 @@ public:
 void runLifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                                LifetimeSafetyReporter *Reporter,
                                uint32_t CfgBlocknumThreshold,
-                              uint32_t CfgOriginCountThreshold);
+                               uint32_t CfgOriginCountThreshold);
 
 namespace internal {
 /// An object to hold the factories for immutable collections, ensuring
@@ -73,7 +73,7 @@ public:
   LifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                          LifetimeSafetyReporter *Reporter,
                          uint32_t CfgBlocknumThreshold,
-                        uint32_t CfgOriginCountThreshold);
+                         uint32_t CfgOriginCountThreshold);
 
   void run();
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -53,8 +53,7 @@ public:
 /// The main entry point for the analysis.
 void runLifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                                LifetimeSafetyReporter *Reporter,
-                               uint32_t CfgBlocknumThreshold,
-                                              uint32_t CfgOriginCountThreshold);
+                               uint32_t CfgBlocknumThreshold);
 
 namespace internal {
 /// An object to hold the factories for immutable collections, ensuring
@@ -71,8 +70,7 @@ class LifetimeSafetyAnalysis {
 public:
   LifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                          LifetimeSafetyReporter *Reporter,
-                         uint32_t CfgBlocknumThreshold,
-                                              uint32_t CfgOriginCountThreshold);
+                         uint32_t CfgBlocknumThreshold);
 
   void run();
 
@@ -84,10 +82,8 @@ public:
   FactManager &getFactManager() { return FactMgr; }
 
 private:
-  bool shouldBailOutCFGPreFactGeneration(const CFG& Cfg) const;
-  bool shouldBailOutCFGPostFactGeneration(const CFG& Cfg) const;
+  bool shouldBailOutCFGPreFactGeneration(const CFG &Cfg) const;
   uint32_t CfgBlocknumThreshold;
-  uint32_t CfgOriginCountThreshold;
   AnalysisDeclContext &AC;
   LifetimeSafetyReporter *Reporter;
   LifetimeFactory Factory;

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -24,6 +24,7 @@
 #include "clang/Analysis/Analyses/LifetimeSafety/LiveOrigins.h"
 #include "clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
+#include <cstdint>
 
 namespace clang::lifetimes {
 
@@ -52,7 +53,8 @@ public:
 /// The main entry point for the analysis.
 void runLifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                                LifetimeSafetyReporter *Reporter,
-                               uint32_t BlockFactNumThreshold);
+                               uint32_t CfgBlocknumThreshold,
+                                              uint32_t CfgOriginCountThreshold);
 
 namespace internal {
 /// An object to hold the factories for immutable collections, ensuring
@@ -69,7 +71,8 @@ class LifetimeSafetyAnalysis {
 public:
   LifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                          LifetimeSafetyReporter *Reporter,
-                         uint32_t BlockFactNumThreshold);
+                         uint32_t CfgBlocknumThreshold,
+                                              uint32_t CfgOriginCountThreshold);
 
   void run();
 
@@ -81,7 +84,10 @@ public:
   FactManager &getFactManager() { return FactMgr; }
 
 private:
-  uint32_t BlockFactNumThreshold;
+  bool shouldBailOutCFGPreFactGeneration(const CFG& Cfg) const;
+  bool shouldBailOutCFGPostFactGeneration(const CFG& Cfg) const;
+  uint32_t CfgBlocknumThreshold;
+  uint32_t CfgOriginCountThreshold;
   AnalysisDeclContext &AC;
   LifetimeSafetyReporter *Reporter;
   LifetimeFactory Factory;

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -52,7 +52,7 @@ public:
 /// The main entry point for the analysis.
 void runLifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                                LifetimeSafetyReporter *Reporter,
-                              uint32_t BlockFactNumThreshold);
+                               uint32_t BlockFactNumThreshold);
 
 namespace internal {
 /// An object to hold the factories for immutable collections, ensuring
@@ -69,7 +69,7 @@ class LifetimeSafetyAnalysis {
 public:
   LifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                          LifetimeSafetyReporter *Reporter,
-                        uint32_t BlockFactNumThreshold);
+                         uint32_t BlockFactNumThreshold);
 
   void run();
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -51,7 +51,8 @@ public:
 
 /// The main entry point for the analysis.
 void runLifetimeSafetyAnalysis(AnalysisDeclContext &AC,
-                               LifetimeSafetyReporter *Reporter);
+                               LifetimeSafetyReporter *Reporter,
+                              uint32_t BlockFactNumThreshold);
 
 namespace internal {
 /// An object to hold the factories for immutable collections, ensuring
@@ -67,7 +68,8 @@ struct LifetimeFactory {
 class LifetimeSafetyAnalysis {
 public:
   LifetimeSafetyAnalysis(AnalysisDeclContext &AC,
-                         LifetimeSafetyReporter *Reporter);
+                         LifetimeSafetyReporter *Reporter,
+                        uint32_t BlockFactNumThreshold);
 
   void run();
 
@@ -79,6 +81,7 @@ public:
   FactManager &getFactManager() { return FactMgr; }
 
 private:
+  uint32_t BlockFactNumThreshold;
   AnalysisDeclContext &AC;
   LifetimeSafetyReporter *Reporter;
   LifetimeFactory Factory;

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -503,6 +503,7 @@ LANGOPT(PreserveVec3Type, 1, 0, NotCompatible, "Preserve 3-component vector type
 
 LANGOPT(CfgBlocknumThreshold, 32, 0, NotCompatible, "Experimental CFG bailout size threshold for C++")
 
+LANGOPT(CfgOriginCountThreshold, 32, 0, NotCompatible, "Experimental CFG bailout origin count threshold for C++")
 
 #undef LANGOPT
 #undef ENUM_LANGOPT

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -501,7 +501,7 @@ LANGOPT(EnableLifetimeSafety, 1, 0, NotCompatible, "Experimental lifetime safety
 
 LANGOPT(PreserveVec3Type, 1, 0, NotCompatible, "Preserve 3-component vector type")
 
-LANGOPT(BlockFactNumThreshold, 32, 0, NotCompatible, "Experimental CFG bailout size threshold for C++")
+LANGOPT(CfgBlocknumThreshold, 32, 0, NotCompatible, "Experimental CFG bailout size threshold for C++")
 
 
 #undef LANGOPT

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -501,6 +501,9 @@ LANGOPT(EnableLifetimeSafety, 1, 0, NotCompatible, "Experimental lifetime safety
 
 LANGOPT(PreserveVec3Type, 1, 0, NotCompatible, "Preserve 3-component vector type")
 
+LANGOPT(BlockFactNumThreshold, 32, 0, NotCompatible, "Experimental CFG bailout size threshold for C++")
+
+
 #undef LANGOPT
 #undef ENUM_LANGOPT
 #undef VALUE_LANGOPT

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5178,9 +5178,9 @@ def fcfg_origin_count_threshold
     : Joined<["-"], "fcfg-origin-count-threshold=">,
       Group<m_Group>,
       Visibility<[ClangOption, CC1Option]>,
-      HelpText<
-          "Set Threshold for count of origins in a CFG after fact generation above which lifetime analysis "
-          "will be skipped for the CFG">,
+      HelpText<"Set Threshold for count of origins in a CFG after fact "
+               "generation above which lifetime analysis "
+               "will be skipped for the CFG">,
       MarshallingInfoInt<LangOpts<"CfgOriginCountThreshold">>;
 def mmacos_version_min_EQ : Joined<["-"], "mmacos-version-min=">,
   Visibility<[ClangOption, CC1Option, FlangOption]>,

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5174,6 +5174,14 @@ def fcfg_block_num_threshold
           "Set Threshold for number of blocks above which lifetime analysis "
           "will be skipped for a CFG">,
       MarshallingInfoInt<LangOpts<"CfgBlocknumThreshold">>;
+def fcfg_origin_count_threshold
+    : Joined<["-"], "fcfg-origin-count-threshold=">,
+      Group<m_Group>,
+      Visibility<[ClangOption, CC1Option]>,
+      HelpText<
+          "Set Threshold for count of origins in a CFG after fact generation above which lifetime analysis "
+          "will be skipped for the CFG">,
+      MarshallingInfoInt<LangOpts<"CfgOriginCountThreshold">>;
 def mmacos_version_min_EQ : Joined<["-"], "mmacos-version-min=">,
   Visibility<[ClangOption, CC1Option, FlangOption]>,
   Group<m_Group>, HelpText<"Set macOS deployment target">;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5170,16 +5170,10 @@ def fcfg_block_num_threshold
     : Joined<["-"], "fcfg-block-num-threshold=">,
       Group<m_Group>,
       Visibility<[ClangOption, CC1Option]>,
-      HelpText<"Set Threshold for number of blocks above which lifetime analysis "
-               "will be skipped for a CFG">,
+      HelpText<
+          "Set Threshold for number of blocks above which lifetime analysis "
+          "will be skipped for a CFG">,
       MarshallingInfoInt<LangOpts<"CfgBlocknumThreshold">>;
-def fcfg_origin_count_threshold
-    : Joined<["-"], "fcfg-origin-count-threshold=">,
-      Group<m_Group>,
-      Visibility<[ClangOption, CC1Option]>,
-      HelpText<"Set Threshold for number of origins after fact generation after which lifetime analysis "
-               "will be skipped for a CFG">,
-      MarshallingInfoInt<LangOpts<"CfgOriginCountThreshold">>;
 def mmacos_version_min_EQ : Joined<["-"], "mmacos-version-min=">,
   Visibility<[ClangOption, CC1Option, FlangOption]>,
   Group<m_Group>, HelpText<"Set macOS deployment target">;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5166,13 +5166,20 @@ def ffuchsia_api_level_EQ : Joined<["-"], "ffuchsia-api-level=">,
   Group<m_Group>, Visibility<[ClangOption, CC1Option]>,
   HelpText<"Set Fuchsia API level">,
   MarshallingInfoInt<LangOpts<"FuchsiaAPILevel">>;
-def fblock_size_threshold
-    : Joined<["-"], "fblock-size-threshold=">,
+def fcfg_block_num_threshold
+    : Joined<["-"], "fcfg-block-num-threshold=">,
       Group<m_Group>,
       Visibility<[ClangOption, CC1Option]>,
-      HelpText<"Set Threshold for block size above which lifetime analysis "
-               "will be skipped">,
-      MarshallingInfoInt<LangOpts<"BlockFactNumThreshold">>;
+      HelpText<"Set Threshold for number of blocks above which lifetime analysis "
+               "will be skipped for a CFG">,
+      MarshallingInfoInt<LangOpts<"CfgBlocknumThreshold">>;
+def fcfg_origin_count_threshold
+    : Joined<["-"], "fcfg-origin-count-threshold=">,
+      Group<m_Group>,
+      Visibility<[ClangOption, CC1Option]>,
+      HelpText<"Set Threshold for number of origins after fact generation after which lifetime analysis "
+               "will be skipped for a CFG">,
+      MarshallingInfoInt<LangOpts<"CfgOriginCountThreshold">>;
 def mmacos_version_min_EQ : Joined<["-"], "mmacos-version-min=">,
   Visibility<[ClangOption, CC1Option, FlangOption]>,
   Group<m_Group>, HelpText<"Set macOS deployment target">;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5166,10 +5166,13 @@ def ffuchsia_api_level_EQ : Joined<["-"], "ffuchsia-api-level=">,
   Group<m_Group>, Visibility<[ClangOption, CC1Option]>,
   HelpText<"Set Fuchsia API level">,
   MarshallingInfoInt<LangOpts<"FuchsiaAPILevel">>;
-def fblock_size_threshold : Joined<["-"], "fblock-size-threshold=">,
-  Group<m_Group>, Visibility<[ClangOption, CC1Option]>,
-  HelpText<"Set Threshold for block size above which lifetime analysis will be skipped">,
-  MarshallingInfoInt<LangOpts<"BlockFactNumThreshold">>;
+def fblock_size_threshold
+    : Joined<["-"], "fblock-size-threshold=">,
+      Group<m_Group>,
+      Visibility<[ClangOption, CC1Option]>,
+      HelpText<"Set Threshold for block size above which lifetime analysis "
+               "will be skipped">,
+      MarshallingInfoInt<LangOpts<"BlockFactNumThreshold">>;
 def mmacos_version_min_EQ : Joined<["-"], "mmacos-version-min=">,
   Visibility<[ClangOption, CC1Option, FlangOption]>,
   Group<m_Group>, HelpText<"Set macOS deployment target">;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5166,6 +5166,10 @@ def ffuchsia_api_level_EQ : Joined<["-"], "ffuchsia-api-level=">,
   Group<m_Group>, Visibility<[ClangOption, CC1Option]>,
   HelpText<"Set Fuchsia API level">,
   MarshallingInfoInt<LangOpts<"FuchsiaAPILevel">>;
+def fblock_size_threshold : Joined<["-"], "fblock-size-threshold=">,
+  Group<m_Group>, Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Set Threshold for block size above which lifetime analysis will be skipped">,
+  MarshallingInfoInt<LangOpts<"BlockFactNumThreshold">>;
 def mmacos_version_min_EQ : Joined<["-"], "mmacos-version-min=">,
   Visibility<[ClangOption, CC1Option, FlangOption]>,
   Group<m_Group>, HelpText<"Set macOS deployment target">;

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -58,15 +58,17 @@ private:
 public:
   LifetimeChecker(const LoanPropagationAnalysis &LoanPropagation,
                   const LiveOriginsAnalysis &LiveOrigins, const FactManager &FM,
-                  AnalysisDeclContext &ADC, LifetimeSafetyReporter *Reporter, uint32_t BlockFactNumThreshold)
+                  AnalysisDeclContext &ADC, LifetimeSafetyReporter *Reporter,
+                  uint32_t BlockFactNumThreshold)
       : LoanPropagation(LoanPropagation), LiveOrigins(LiveOrigins), FactMgr(FM),
         Reporter(Reporter) {
     if (BlockFactNumThreshold <= 0) {
       llvm::errs() << "Warning: BlockFactNumThreshold should be positive.\n";
     }
     for (const CFGBlock *B : *ADC.getAnalysis<PostOrderCFGView>()) {
-      const auto& BlockFacts = FactMgr.getFacts(B);
-      if (BlockFactNumThreshold > 0 && BlockFacts.size() > BlockFactNumThreshold)
+      const auto &BlockFacts = FactMgr.getFacts(B);
+      if (BlockFactNumThreshold > 0 &&
+          BlockFacts.size() > BlockFactNumThreshold)
         continue;
       for (const Fact *F : FactMgr.getFacts(B))
         if (const auto *EF = F->getAs<ExpireFact>())
@@ -146,9 +148,10 @@ void runLifetimeChecker(const LoanPropagationAnalysis &LP,
                         const LiveOriginsAnalysis &LO,
                         const FactManager &FactMgr, AnalysisDeclContext &ADC,
                         LifetimeSafetyReporter *Reporter,
-                      uint32_t BlockFactNumThreshold) {
+                        uint32_t BlockFactNumThreshold) {
   llvm::TimeTraceScope TimeProfile("LifetimeChecker");
-  LifetimeChecker Checker(LP, LO, FactMgr, ADC, Reporter, BlockFactNumThreshold);
+  LifetimeChecker Checker(LP, LO, FactMgr, ADC, Reporter,
+                          BlockFactNumThreshold);
 }
 
 } // namespace clang::lifetimes::internal

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -58,15 +58,10 @@ private:
 public:
   LifetimeChecker(const LoanPropagationAnalysis &LoanPropagation,
                   const LiveOriginsAnalysis &LiveOrigins, const FactManager &FM,
-                  AnalysisDeclContext &ADC, LifetimeSafetyReporter *Reporter,
-                  uint32_t BlockFactNumThreshold)
+                  AnalysisDeclContext &ADC, LifetimeSafetyReporter *Reporter)
       : LoanPropagation(LoanPropagation), LiveOrigins(LiveOrigins), FactMgr(FM),
         Reporter(Reporter) {
     for (const CFGBlock *B : *ADC.getAnalysis<PostOrderCFGView>()) {
-      const auto &BlockFacts = FactMgr.getFacts(B);
-      if (BlockFactNumThreshold > 0 &&
-          BlockFacts.size() > BlockFactNumThreshold)
-        continue;
       for (const Fact *F : FactMgr.getFacts(B))
         if (const auto *EF = F->getAs<ExpireFact>())
           checkExpiry(EF);
@@ -144,11 +139,9 @@ public:
 void runLifetimeChecker(const LoanPropagationAnalysis &LP,
                         const LiveOriginsAnalysis &LO,
                         const FactManager &FactMgr, AnalysisDeclContext &ADC,
-                        LifetimeSafetyReporter *Reporter,
-                        uint32_t BlockFactNumThreshold) {
+                        LifetimeSafetyReporter *Reporter) {
   llvm::TimeTraceScope TimeProfile("LifetimeChecker");
-  LifetimeChecker Checker(LP, LO, FactMgr, ADC, Reporter,
-                          BlockFactNumThreshold);
+  LifetimeChecker Checker(LP, LO, FactMgr, ADC, Reporter);
 }
 
 } // namespace clang::lifetimes::internal

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -62,9 +62,6 @@ public:
                   uint32_t BlockFactNumThreshold)
       : LoanPropagation(LoanPropagation), LiveOrigins(LiveOrigins), FactMgr(FM),
         Reporter(Reporter) {
-    if (BlockFactNumThreshold <= 0) {
-      llvm::errs() << "Warning: BlockFactNumThreshold should be positive.\n";
-    }
     for (const CFGBlock *B : *ADC.getAnalysis<PostOrderCFGView>()) {
       const auto &BlockFacts = FactMgr.getFacts(B);
       if (BlockFactNumThreshold > 0 &&

--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -103,16 +103,19 @@ void FactManager::dumpBlockSizes(const CFG &Cfg,
   if (const Decl *D = AC.getDecl())
     if (const auto *ND = dyn_cast<NamedDecl>(D))
       llvm::dbgs() << "Function: " << ND->getQualifiedNameAsString() << "\n";
+  llvm::dbgs() << "Number of CFG Blocks: " << Cfg.getNumBlockIDs() << "\n";
+  if (BlockNumThreshold > 0 && Cfg.getNumBlockIDs() > BlockNumThreshold) {
+    llvm::dbgs() << "CFG Block Number Threshold: " << BlockNumThreshold << "\n";
+    llvm::dbgs() << "Bailed out before generating facts.\n";
+    return;
+  }
   // Print blocks in the order as they appear in code for a stable ordering.
   for (const CFGBlock *B : *AC.getAnalysis<PostOrderCFGView>()) {
-    if (BlockFactNumThreshold > 0 && getFacts(B).size() > BlockFactNumThreshold)
-      continue;
-    if (B->getLabel()) {
+    if (B->getLabel())
       llvm::dbgs() << "  Block: " << B->getLabel()->getStmtClassName();
-    } else {
+    else
       llvm::dbgs() << "  Block B" << B->getBlockID();
-    }
-    llvm::dbgs() << ": Number of facts = " << getFacts(B).size() << "\n";
+    llvm::dbgs() << ": Number of elements = " << B->size() << "\n";
   }
 }
 

--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -112,8 +112,13 @@ void FactManager::dumpBlockSizes(const CFG &Cfg,
     llvm::dbgs() << "Bailed out before generating facts.\n";
     return;
   }
-  if (CfgOriginCountThreshold > 0 && OriginMgr.getNumOrigins() > CfgOriginCountThreshold) {
-    LLVM_DEBUG(llvm::dbgs() << "Number of origins exceeded CFG Origin Count Threshold. Number of Origins: " << OriginMgr.getNumOrigins() << ", threshold: " << BlockNumThreshold << "\n" << "Bailed out after generating facts.\n");
+  if (CfgOriginCountThreshold > 0 &&
+      OriginMgr.getNumOrigins() > CfgOriginCountThreshold) {
+    LLVM_DEBUG(llvm::dbgs() << "Number of origins exceeded CFG Origin Count "
+                               "Threshold. Number of Origins: "
+                            << OriginMgr.getNumOrigins()
+                            << ", threshold: " << BlockNumThreshold << "\n"
+                            << "Bailed out after generating facts.\n");
     return;
   }
   llvm::dbgs() << "Number of CFG Blocks: " << Cfg.getNumBlockIDs() << "\n";

--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -95,6 +95,27 @@ void FactManager::dump(const CFG &Cfg, AnalysisDeclContext &AC) const {
   }
 }
 
+void FactManager::dumpBlockSizes(const CFG &Cfg,
+                                 AnalysisDeclContext &AC) const {
+  llvm::dbgs() << "==========================================\n";
+  llvm::dbgs() << "       Lifetime Analysis CFG Block Sizes:\n";
+  llvm::dbgs() << "==========================================\n";
+  if (const Decl *D = AC.getDecl())
+    if (const auto *ND = dyn_cast<NamedDecl>(D))
+      llvm::dbgs() << "Function: " << ND->getQualifiedNameAsString() << "\n";
+  // Print blocks in the order as they appear in code for a stable ordering.
+  for (const CFGBlock *B : *AC.getAnalysis<PostOrderCFGView>()) {
+    if (getFacts(B).size() > BlockFactNumThreshold)
+      continue;
+    if (B->getLabel()) {
+      llvm::dbgs() << "  Block: " << B->getLabel()->getStmtClassName();
+    } else {
+      llvm::dbgs() << "  Block B" << B->getBlockID();
+    }
+    llvm::dbgs() << ": Number of facts = " << getFacts(B).size() << "\n";
+  }
+}
+
 llvm::ArrayRef<const Fact *>
 FactManager::getBlockContaining(ProgramPoint P) const {
   for (const auto &BlockToFactsVec : BlockToFacts) {

--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -105,7 +105,7 @@ void FactManager::dumpBlockSizes(const CFG &Cfg,
       llvm::dbgs() << "Function: " << ND->getQualifiedNameAsString() << "\n";
   // Print blocks in the order as they appear in code for a stable ordering.
   for (const CFGBlock *B : *AC.getAnalysis<PostOrderCFGView>()) {
-    if (getFacts(B).size() > BlockFactNumThreshold)
+    if (BlockFactNumThreshold > 0 && getFacts(B).size() > BlockFactNumThreshold)
       continue;
     if (B->getLabel()) {
       llvm::dbgs() << "  Block: " << B->getLabel()->getStmtClassName();

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeSafety.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeSafety.cpp
@@ -37,8 +37,10 @@ namespace internal {
 LifetimeSafetyAnalysis::LifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                                                LifetimeSafetyReporter *Reporter,
                                                uint32_t CfgBlocknumThreshold,
-                                              uint32_t CfgOriginCountThreshold)
-    : CfgBlocknumThreshold(CfgBlocknumThreshold), CfgOriginCountThreshold(CfgOriginCountThreshold), AC(AC), Reporter(Reporter) {
+                                               uint32_t CfgOriginCountThreshold)
+    : CfgBlocknumThreshold(CfgBlocknumThreshold),
+      CfgOriginCountThreshold(CfgOriginCountThreshold), AC(AC),
+      Reporter(Reporter) {
   FactMgr.setBlockNumThreshold(CfgBlocknumThreshold);
   FactMgr.setCfgOriginCountThreshold(CfgOriginCountThreshold);
 }
@@ -55,11 +57,14 @@ bool LifetimeSafetyAnalysis::shouldBailOutCFGPreFactGeneration(const CFG& Cfg) c
   return false;
 }
 
-bool LifetimeSafetyAnalysis::shouldBailOutCFGPostFactGeneration(const CFG &Cfg) const {
-  if (CfgOriginCountThreshold > 0 && FactMgr.getOriginMgr().getNumOrigins() > CfgOriginCountThreshold) {
+bool LifetimeSafetyAnalysis::shouldBailOutCFGPostFactGeneration(
+    const CFG &Cfg) const {
+  if (CfgOriginCountThreshold > 0 &&
+      FactMgr.getOriginMgr().getNumOrigins() > CfgOriginCountThreshold) {
     LLVM_DEBUG(llvm::dbgs()
                << "Aborting Lifetime Safety analysis for current CFG as it has "
-                  "origins exceeding the thresold of " << CfgOriginCountThreshold << ". Number of origins: "
+                  "origins exceeding the thresold of "
+               << CfgOriginCountThreshold << ". Number of origins: "
                << FactMgr.getOriginMgr().getNumOrigins() << "\n");
     return true;
   }
@@ -112,7 +117,8 @@ void runLifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                                LifetimeSafetyReporter *Reporter,
                                uint32_t CfgBlocknumThreshold,
                                uint32_t CfgOriginCountThreshold) {
-  internal::LifetimeSafetyAnalysis Analysis(AC, Reporter, CfgBlocknumThreshold, CfgOriginCountThreshold);
+  internal::LifetimeSafetyAnalysis Analysis(AC, Reporter, CfgBlocknumThreshold,
+                                            CfgOriginCountThreshold);
   Analysis.run();
 }
 } // namespace clang::lifetimes

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeSafety.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeSafety.cpp
@@ -33,10 +33,10 @@ namespace internal {
 
 LifetimeSafetyAnalysis::LifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                                                LifetimeSafetyReporter *Reporter,
-                                              uint32_t BlockFactNumThreshold)
+                                               uint32_t BlockFactNumThreshold)
     : BlockFactNumThreshold(BlockFactNumThreshold), AC(AC), Reporter(Reporter) {
   FactMgr.setBlockFactNumThreshold(BlockFactNumThreshold);
-    }
+}
 
 void LifetimeSafetyAnalysis::run() {
   llvm::TimeTraceScope TimeProfile("LifetimeSafetyAnalysis");
@@ -70,14 +70,16 @@ void LifetimeSafetyAnalysis::run() {
   DEBUG_WITH_TYPE("LiveOrigins",
                   LiveOrigins->dump(llvm::dbgs(), FactMgr.getTestPoints()));
 
-  runLifetimeChecker(*LoanPropagation, *LiveOrigins, FactMgr, AC, Reporter, BlockFactNumThreshold);
+  runLifetimeChecker(*LoanPropagation, *LiveOrigins, FactMgr, AC, Reporter,
+                     BlockFactNumThreshold);
 }
 } // namespace internal
 
 void runLifetimeSafetyAnalysis(AnalysisDeclContext &AC,
                                LifetimeSafetyReporter *Reporter,
-                              uint32_t BlockFactNumThreshold) {
-  internal::LifetimeSafetyAnalysis Analysis(AC, Reporter, BlockFactNumThreshold);
+                               uint32_t BlockFactNumThreshold) {
+  internal::LifetimeSafetyAnalysis Analysis(AC, Reporter,
+                                            BlockFactNumThreshold);
   Analysis.run();
 }
 } // namespace clang::lifetimes

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -3108,7 +3108,8 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
     if (AC.getCFG()) {
       lifetimes::LifetimeSafetyReporterImpl LifetimeSafetyReporter(S);
       lifetimes::runLifetimeSafetyAnalysis(
-          AC, &LifetimeSafetyReporter, S.getLangOpts().CfgBlocknumThreshold);
+          AC, &LifetimeSafetyReporter, S.getLangOpts().CfgBlocknumThreshold,
+        S.getLangOpts().CfgOriginCountThreshold);
     }
   }
   // Check for violations of "called once" parameter properties.

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -3108,7 +3108,7 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
     if (AC.getCFG()) {
       lifetimes::LifetimeSafetyReporterImpl LifetimeSafetyReporter(S);
       lifetimes::runLifetimeSafetyAnalysis(
-          AC, &LifetimeSafetyReporter, S.getLangOpts().CfgBlocknumThreshold, S.getLangOpts().CfgOriginCountThreshold);
+          AC, &LifetimeSafetyReporter, S.getLangOpts().CfgBlocknumThreshold);
     }
   }
   // Check for violations of "called once" parameter properties.

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -3109,7 +3109,7 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
       lifetimes::LifetimeSafetyReporterImpl LifetimeSafetyReporter(S);
       lifetimes::runLifetimeSafetyAnalysis(
           AC, &LifetimeSafetyReporter, S.getLangOpts().CfgBlocknumThreshold,
-        S.getLangOpts().CfgOriginCountThreshold);
+          S.getLangOpts().CfgOriginCountThreshold);
     }
   }
   // Check for violations of "called once" parameter properties.

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -3107,7 +3107,8 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
   if (EnableLifetimeSafetyAnalysis && S.getLangOpts().CPlusPlus) {
     if (AC.getCFG()) {
       lifetimes::LifetimeSafetyReporterImpl LifetimeSafetyReporter(S);
-      lifetimes::runLifetimeSafetyAnalysis(AC, &LifetimeSafetyReporter, S.getLangOpts().BlockFactNumThreshold);
+      lifetimes::runLifetimeSafetyAnalysis(
+          AC, &LifetimeSafetyReporter, S.getLangOpts().BlockFactNumThreshold);
     }
   }
   // Check for violations of "called once" parameter properties.

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -3108,7 +3108,7 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
     if (AC.getCFG()) {
       lifetimes::LifetimeSafetyReporterImpl LifetimeSafetyReporter(S);
       lifetimes::runLifetimeSafetyAnalysis(
-          AC, &LifetimeSafetyReporter, S.getLangOpts().BlockFactNumThreshold);
+          AC, &LifetimeSafetyReporter, S.getLangOpts().CfgBlocknumThreshold, S.getLangOpts().CfgOriginCountThreshold);
     }
   }
   // Check for violations of "called once" parameter properties.

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -3107,7 +3107,7 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
   if (EnableLifetimeSafetyAnalysis && S.getLangOpts().CPlusPlus) {
     if (AC.getCFG()) {
       lifetimes::LifetimeSafetyReporterImpl LifetimeSafetyReporter(S);
-      lifetimes::runLifetimeSafetyAnalysis(AC, &LifetimeSafetyReporter);
+      lifetimes::runLifetimeSafetyAnalysis(AC, &LifetimeSafetyReporter, S.getLangOpts().BlockFactNumThreshold);
     }
   }
   // Check for violations of "called once" parameter properties.

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -63,7 +63,7 @@ public:
 
     // Run the main analysis.
     Analysis =
-        std::make_unique<LifetimeSafetyAnalysis>(*AnalysisCtx, nullptr, 0);
+        std::make_unique<LifetimeSafetyAnalysis>(*AnalysisCtx, nullptr, 0, 0);
     Analysis->run();
 
     AnnotationToPointMap = Analysis->getFactManager().getTestPoints();

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -62,7 +62,8 @@ public:
     BuildOptions.AddLifetime = true;
 
     // Run the main analysis.
-    Analysis = std::make_unique<LifetimeSafetyAnalysis>(*AnalysisCtx, nullptr, 0, 0);
+    Analysis =
+        std::make_unique<LifetimeSafetyAnalysis>(*AnalysisCtx, nullptr, 0);
     Analysis->run();
 
     AnnotationToPointMap = Analysis->getFactManager().getTestPoints();

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -62,7 +62,7 @@ public:
     BuildOptions.AddLifetime = true;
 
     // Run the main analysis.
-    Analysis = std::make_unique<LifetimeSafetyAnalysis>(*AnalysisCtx, nullptr);
+    Analysis = std::make_unique<LifetimeSafetyAnalysis>(*AnalysisCtx, nullptr, 0, 0);
     Analysis->run();
 
     AnnotationToPointMap = Analysis->getFactManager().getTestPoints();


### PR DESCRIPTION
This is a followup of [pull/170444](https://github.com/llvm/llvm-project/pull/170444). This PR adds the support for bailing out large CFGs based on the origin count.

As the lattice join operation is the most expensive step in lifetime analysis, it is important to stop analysis of large CFGs based on certain criteria to avoid regression in compilation time.

This PR adds an integer option for setting the threshold of origin count above which a CFG will be discarded from lifetime analysis and it also makes necessary modification to print the origin count information with the debug-only `LifetimeCFGSizes` option.