### PR TITLE
[AMDGPU][GCNHazardRecognizer] Remove instances of hardcoded S_WAITCNT_DEPCTR operand values

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -3659,10 +3659,10 @@ bool GCNHazardRecognizer::fixDsAtomicAsyncBarrierArriveB64(MachineInstr *MI) {
   const SIInstrInfo *TII = ST.getInstrInfo();
   BuildMI(*MI->getParent(), MI, MI->getDebugLoc(),
           TII->get(AMDGPU::S_WAITCNT_DEPCTR))
-      .addImm(0xFFE3);
+      .addImm(AMDGPU::DepCtr::encodeFieldVmVsrc(0, ST));
   BuildMI(*MI->getParent(), std::next(MI->getIterator()), MI->getDebugLoc(),
           TII->get(AMDGPU::S_WAITCNT_DEPCTR))
-      .addImm(0xFFE3);
+      .addImm(AMDGPU::DepCtr::encodeFieldVmVsrc(0, ST));
 
   return true;
 }

--- a/llvm/test/CodeGen/AMDGPU/hazards-gfx1250.mir
+++ b/llvm/test/CodeGen/AMDGPU/hazards-gfx1250.mir
@@ -10,9 +10,9 @@ body: |
     ; GCN-LABEL: name: ds_atomic_async_barrier_arrive_b64
     ; GCN: liveins: $vgpr0, $vgpr1
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAITCNT_DEPCTR 65507
+    ; GCN-NEXT: S_WAITCNT_DEPCTR 65411
     ; GCN-NEXT: DS_ATOMIC_ASYNC_BARRIER_ARRIVE_B64 $vgpr1, 0, 0, implicit-def $asynccnt, implicit $asynccnt, implicit $exec
-    ; GCN-NEXT: S_WAITCNT_DEPCTR 65507
+    ; GCN-NEXT: S_WAITCNT_DEPCTR 65411
     DS_ATOMIC_ASYNC_BARRIER_ARRIVE_B64 $vgpr1, 0, 0, implicit-def $asynccnt, implicit $asynccnt, implicit $exec
 ...
 


### PR DESCRIPTION
Two S_WAITCNT_DEPCTR instructions are constructed with hardcoded operand values. Replace these with appropriate calls to AMDGPU::DepCtr::encodeFieldVmVsrc().

NFC, except that the original code was setting reserved operand bits that should-be-zero, and this is now corrected.