### PR TITLE
[sanitizer_common][test-only] Remove xfail for darwin ubsan on dedup_token_length_test

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/dedup_token_length_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/dedup_token_length_test.cpp
@@ -15,7 +15,6 @@
 // XFAIL: (darwin && ubsan && (arm64-target-arch || arm64e-target-arch))
 
 // XFAIL: target={{.*netbsd.*}} && !asan
-// XFAIL: darwin && ubsan
 
 volatile int *null = 0;
 


### PR DESCRIPTION
This test is currently XPASSing on the iossim CI.

rdar://166219043