### PR TITLE
[mlir][vector] Remove hooks deprecated pre Release/22 branch

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -711,11 +711,6 @@ def Vector_ExtractOp :
     bool hasDynamicPosition() {
       return !getDynamicPosition().empty();
     }
-
-    /// Wrapper for getSource, which replaced getVector.
-    [[deprecated("Use getSource instead!")]] ::mlir::Value getVector() {
-      return getSource();
-    }
   }];
 
   let assemblyFormat = [{
@@ -1031,10 +1026,6 @@ def Vector_ScalableExtractOp :
     VectorType getResultVectorType() {
       return ::llvm::cast<VectorType>(getResult().getType());
     }
-    /// Wrapper for getSource, which replaced getVector.
-    [[deprecated("Use getSource instead!")]] ::mlir::Value getVector() {
-      return getSource();
-    }
   }];
 }
 
@@ -1228,10 +1219,6 @@ def Vector_ExtractStridedSliceOp :
       return llvm::any_of(getStrides(), [](Attribute attr) {
         return ::llvm::cast<IntegerAttr>(attr).getInt() != 1;
       });
-    }
-    /// Wrapper for getSource, which replaced getVector.
-    [[deprecated("Use getSource instead!")]] ::mlir::Value getVector() {
-      return getSource();
     }
   }];
   let hasCanonicalizer = 1;


### PR DESCRIPTION
As mentioned on Discourse,
  * https://discourse.llvm.org/t/psa-vector-standardise-operand-naming

I am removing the deprecated Vector hooks near the creation of the
release/22 branch. These hooks were introduced in #158258 (~September
'25, ~3 months ago), so I assume folks have enough time to transition
away.
