### PR TITLE
[flang][NFC] Strip trailing whitespace from tests (12 of 14)

### DIFF
--- a/flang/test/Semantics/modfile73.f90
+++ b/flang/test/Semantics/modfile73.f90
@@ -24,29 +24,29 @@
 ! RUN: cat %t/modfile73.mod | FileCheck %s
 
   use modfile73ba
-end  
+end
 module modfile73
   use modfile73bb
-  use modfile73c 
+  use modfile73c
   CONTAINS
    subroutine init_
-  end  
+  end
   subroutine delete_
-  end  
+  end
   subroutine assign_
-  end  
-  function initialized_ 
-  end  
-  function same_ 
-  end  
-  function refcount_ 
-  end  
-  function id_ 
-  end  
-  function name_ 
-  end  
+  end
+  function initialized_
+  end
+  function same_
+  end
+  function refcount_
+  end
+  function id_
+  end
+  function name_
+  end
   subroutine tag_new_object
-   end  
+   end
 end
 
 !      CHECK: !need$ {{.*}} n modfile73bb

--- a/flang/test/Semantics/num_images02.f90
+++ b/flang/test/Semantics/num_images02.f90
@@ -27,11 +27,11 @@ program num_images_with_team_type
 
   !___ non-conforming statements ___
 
-  ! non-scalar integer argument 
+  ! non-scalar integer argument
   !ERROR: unknown keyword argument to intrinsic 'num_images'
   n = num_images(team_number=array)
 
-  ! non-scalar team_type argument 
+  ! non-scalar team_type argument
   !ERROR: unknown keyword argument to intrinsic 'num_images'
   n = num_images(team=league)
 

--- a/flang/test/Semantics/resolve102.f90
+++ b/flang/test/Semantics/resolve102.f90
@@ -18,7 +18,7 @@ end subroutine circular
 !ERROR: Procedure 'foo' is recursively defined.  Procedures in the cycle: 'foo', 'r'
 function foo() result(r)
   !ERROR: Procedure 'r' is recursively defined.  Procedures in the cycle: 'foo', 'r'
-  procedure(foo), pointer :: r 
+  procedure(foo), pointer :: r
 end function foo
 
 subroutine iface

--- a/flang/test/Semantics/resolve104.f90
+++ b/flang/test/Semantics/resolve104.f90
@@ -1,11 +1,11 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 ! Test constant folding of type parameter values both a base value and a
 ! parameter name are supplied.
-! 
-! Type parameters are described in 7.5.3 and constant expressions are described 
-! in 10.1.12.  10.1.12, paragraph 4 defines whether a specification inquiry is 
-! a constant expression.  Section 10.1.11, paragraph 3, item (2) states that a 
-! type parameter inquiry is a specification inquiry.  
+!
+! Type parameters are described in 7.5.3 and constant expressions are described
+! in 10.1.12.  10.1.12, paragraph 4 defines whether a specification inquiry is
+! a constant expression.  Section 10.1.11, paragraph 3, item (2) states that a
+! type parameter inquiry is a specification inquiry.
 
 module m1
   type dtype(goodDefaultKind, badDefaultKind)

--- a/flang/test/Semantics/resolve33.f90
+++ b/flang/test/Semantics/resolve33.f90
@@ -6,7 +6,7 @@
 ! be one of the type-paramnames in the derived-type-stmt of that
 ! derived-type-def.
 ! C742 Each type-param-name in the derived-type-stmt in a derived-type-def
-! shall appear exactly once as a type-param-name in a type-param-def-stmt 
+! shall appear exactly once as a type-param-name in a type-param-def-stmt
 ! in that derived-type-def.
 
 module m

--- a/flang/test/Semantics/resolve58.f90
+++ b/flang/test/Semantics/resolve58.f90
@@ -58,11 +58,11 @@ subroutine s5()
 end subroutine
 
 subroutine s6()
-!C835   An object whose array bounds are specified by an 
+!C835   An object whose array bounds are specified by an
 !  implied-shape-or-assumed-size-spec shall be a dummy data object or a named
 !  constant.
 !
-!C843   An entity with the INTENT attribute shall be a dummy data object or a 
+!C843   An entity with the INTENT attribute shall be a dummy data object or a
 !  dummy procedure pointer.
 !
 !C849   An entity with the OPTIONAL attribute shall be a dummy argument.

--- a/flang/test/Semantics/resolve70.f90
+++ b/flang/test/Semantics/resolve70.f90
@@ -9,7 +9,7 @@
 !
 ! C796 (R756) The derived-type-spec shall not specify an abstract type (7.5.7).
 !
-! C705 (R703) In a declaration-type-spec that uses the CLASS keyword, 
+! C705 (R703) In a declaration-type-spec that uses the CLASS keyword,
 ! derived-type-spec shall specify an extensible type (7.5.7).
 subroutine s()
   type, abstract :: abstractType

--- a/flang/test/Semantics/resolve71.f90
+++ b/flang/test/Semantics/resolve71.f90
@@ -1,5 +1,5 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! C708 An entity declared with the CLASS keyword shall be a dummy argument 
+! C708 An entity declared with the CLASS keyword shall be a dummy argument
 ! or have the ALLOCATABLE or POINTER attribute.
 subroutine s()
   type :: parentType

--- a/flang/test/Semantics/resolve72.f90
+++ b/flang/test/Semantics/resolve72.f90
@@ -1,6 +1,6 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! C709 An assumed-type entity shall be a dummy data object that does not have 
-! the ALLOCATABLE, CODIMENSION, INTENT (OUT), POINTER, or VALUE attribute and 
+! C709 An assumed-type entity shall be a dummy data object that does not have
+! the ALLOCATABLE, CODIMENSION, INTENT (OUT), POINTER, or VALUE attribute and
 ! is not an explicit-shape array.
 subroutine s()
   !ERROR: Assumed-type entity 'starvar' must be a dummy argument
@@ -8,8 +8,8 @@ subroutine s()
 
     contains
       subroutine inner1(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
-        type(*) :: arg1 ! OK        
-        type(*), dimension(*) :: arg2 ! OK        
+        type(*) :: arg1 ! OK
+        type(*), dimension(*) :: arg2 ! OK
         !ERROR: Assumed-type argument 'arg3' cannot have the ALLOCATABLE attribute
         type(*), allocatable :: arg3
         !ERROR: Assumed-type argument 'arg4' cannot be a coarray

--- a/flang/test/Semantics/resolve74.f90
+++ b/flang/test/Semantics/resolve74.f90
@@ -1,6 +1,6 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! C722 A function name shall not be declared with an asterisk type-param-value 
-! unless it is of type CHARACTER and is the name of a dummy function or the 
+! C722 A function name shall not be declared with an asterisk type-param-value
+! unless it is of type CHARACTER and is the name of a dummy function or the
 ! name of the result of an external function.
 subroutine s()
 

--- a/flang/test/Semantics/resolve75.f90
+++ b/flang/test/Semantics/resolve75.f90
@@ -1,6 +1,6 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! C726 The length specified for a character statement function or for a 
-! statement function dummy argument of type character shall be a constant 
+! C726 The length specified for a character statement function or for a
+! statement function dummy argument of type character shall be a constant
 ! expression.
 subroutine s()
   implicit character(len=3) (c)

--- a/flang/test/Semantics/resolve78.f90
+++ b/flang/test/Semantics/resolve78.f90
@@ -1,13 +1,13 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 module m
-! C743 No component-attr-spec shall appear more than once in a 
+! C743 No component-attr-spec shall appear more than once in a
 ! given component-def-stmt.
 !
 ! R737 data-component-def-stmt ->
 !        declaration-type-spec [[, component-attr-spec-list] ::]
 !        component-decl-list
 !  component-attr-spec values are:
-!    PUBLIC, PRIVATE, ALLOCATABLE, CODIMENSION [*], CONTIGUOUS, DIMENSION(5), 
+!    PUBLIC, PRIVATE, ALLOCATABLE, CODIMENSION [*], CONTIGUOUS, DIMENSION(5),
 !      POINTER
 
   type :: derived

--- a/flang/test/Semantics/resolve79.f90
+++ b/flang/test/Semantics/resolve79.f90
@@ -1,8 +1,8 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 module m
-! C755 The same proc-component-attr-spec shall not appear more than once in a 
+! C755 The same proc-component-attr-spec shall not appear more than once in a
 ! given proc-component-def-stmt.
-! C759 PASS and NOPASS shall not both appear in the same 
+! C759 PASS and NOPASS shall not both appear in the same
 ! proc-component-attr-spec-list.
 !
 ! R741 proc-component-def-stmt ->

--- a/flang/test/Semantics/resolve82.f90
+++ b/flang/test/Semantics/resolve82.f90
@@ -1,12 +1,12 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! C815 An entity shall not be explicitly given any attribute more than once in 
+! C815 An entity shall not be explicitly given any attribute more than once in
 ! a scoping unit.
 !
 ! R1512 procedure-declaration-stmt ->
 !         PROCEDURE ( [proc-interface] ) [[, proc-attr-spec]... ::]
 !         proc-decl-list
 !  proc-attr-spec values are:
-!    PUBLIC, PRIVATE, BIND(C), INTENT (intent-spec), OPTIONAL, POINTER, 
+!    PUBLIC, PRIVATE, BIND(C), INTENT (intent-spec), OPTIONAL, POINTER,
 !    PROTECTED, SAVE
 module m
   abstract interface

--- a/flang/test/Semantics/resolve83.f90
+++ b/flang/test/Semantics/resolve83.f90
@@ -11,16 +11,16 @@ module m
 contains
 
 ! C1543 A prefix shall contain at most one of each prefix-spec.
-! 
-! R1535 subroutine-stmt is 
-!   [prefix] SUBROUTINE subroutine-name [ ( [dummy-arg-list] ) 
+!
+! R1535 subroutine-stmt is
+!   [prefix] SUBROUTINE subroutine-name [ ( [dummy-arg-list] )
 !   [proc-language-binding-spec] ]
-! 
+!
 ! R1526  prefix is
 !   prefix-spec[prefix-spec]...
-!   
+!
 !   prefix-spec values are:
-!      declaration-type-spec, ELEMENTAL, IMPURE, MODULE, NON_RECURSIVE, 
+!      declaration-type-spec, ELEMENTAL, IMPURE, MODULE, NON_RECURSIVE,
 !      PURE, RECURSIVE
 
     !ERROR: FUNCTION prefix cannot specify the type more than once

--- a/flang/test/Semantics/resolve84.f90
+++ b/flang/test/Semantics/resolve84.f90
@@ -1,5 +1,5 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! C729 A derived type type-name shall not be DOUBLEPRECISION or the same as 
+! C729 A derived type type-name shall not be DOUBLEPRECISION or the same as
 ! the name of any intrinsic type defined in this document.
 subroutine s()
   ! This one's OK

--- a/flang/test/Semantics/resolve86.f90
+++ b/flang/test/Semantics/resolve86.f90
@@ -1,5 +1,5 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! C736 If EXTENDS appears and the type being defined has a coarray ultimate 
+! C736 If EXTENDS appears and the type being defined has a coarray ultimate
 ! component, its parent type shall have a coarray ultimate component.
 !
 subroutine s()

--- a/flang/test/Semantics/resolve87.f90
+++ b/flang/test/Semantics/resolve87.f90
@@ -1,7 +1,7 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! C737 If EXTENDS appears and the type being defined has a potential 
-! subobject component of type EVENT_TYPE or LOCK_TYPE from the intrinsic 
-! module ISO_FORTRAN_ENV, its parent type shall be EVENT_TYPE or LOCK_TYPE 
+! C737 If EXTENDS appears and the type being defined has a potential
+! subobject component of type EVENT_TYPE or LOCK_TYPE from the intrinsic
+! module ISO_FORTRAN_ENV, its parent type shall be EVENT_TYPE or LOCK_TYPE
 ! or have a potential subobject component of type EVENT_TYPE or LOCK_TYPE.
 module not_iso_fortran_env
   type event_type

--- a/flang/test/Semantics/resolve88.f90
+++ b/flang/test/Semantics/resolve88.f90
@@ -21,7 +21,7 @@ module m
   end type testCoArrayType
 
   ! C747 If a coarray-spec appears, the component shall not be of type C_PTR or
-  ! C_FUNPTR from the intrinsic module ISO_C_BINDING (18.2), or of type 
+  ! C_FUNPTR from the intrinsic module ISO_C_BINDING (18.2), or of type
   ! TEAM_TYPE from the intrinsic module ISO_FORTRAN_ENV (16.10.2).
 
   type goodCoarrayType

--- a/flang/test/Semantics/resolve89.f90
+++ b/flang/test/Semantics/resolve89.f90
@@ -5,10 +5,10 @@
 ! or SAME_TYPE_AS, every specification inquiry reference is a constant
 ! expression, and the value does not depend on the value of a variable.
 !
-! C754 Each type-param-value within a component-def-stmt shall be a colon or 
-! a specification expression in which there are no references to specification 
+! C754 Each type-param-value within a component-def-stmt shall be a colon or
+! a specification expression in which there are no references to specification
 ! functions or the intrinsic functions ALLOCATED, ASSOCIATED, EXTENDS_TYPE_OF,
-! PRESENT, or SAME_TYPE_AS, every specification inquiry reference is a 
+! PRESENT, or SAME_TYPE_AS, every specification inquiry reference is a
 ! constant expression, and the value does not depend on the value of a variable.
 impure function impureFunc()
   integer :: impureFunc

--- a/flang/test/Semantics/resolve90.f90
+++ b/flang/test/Semantics/resolve90.f90
@@ -1,9 +1,9 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 ! Testing for pointer constant, along with :
 ! C751 A component shall not have both the ALLOCATABLE and POINTER attributes.
-! C752 If the CONTIGUOUS attribute is specified, the component shall be an 
+! C752 If the CONTIGUOUS attribute is specified, the component shall be an
 !   array with the POINTER attribute.
-! C753 The * char-length option is permitted only if the component is of type 
+! C753 The * char-length option is permitted only if the component is of type
 !   character.
 subroutine s()
   !ERROR: 'nullint' may not have both the POINTER and PARAMETER attributes

--- a/flang/test/Semantics/resolve94.f90
+++ b/flang/test/Semantics/resolve94.f90
@@ -1,5 +1,5 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! C929   No specifier shall appear more than once in a given 
+! C929   No specifier shall appear more than once in a given
 !   image-selector-spec-list.
 ! C930 TEAM and TEAM_NUMBER shall not both appear in the same
 !   image-selector-spec-list.

--- a/flang/test/Semantics/separate-mp01.f90
+++ b/flang/test/Semantics/separate-mp01.f90
@@ -47,7 +47,7 @@ submodule (m2) mb_submodule
   end subroutine mb_create_sub
 
   !ERROR: 'mb_create_new_sub' was not declared a separate module procedure
-  module SUBROUTINE  mb_create_new_sub() 
+  module SUBROUTINE  mb_create_new_sub()
     integer :: this
     i = 2
     j = 1

--- a/flang/test/Semantics/spec-expr.f90
+++ b/flang/test/Semantics/spec-expr.f90
@@ -13,7 +13,7 @@ subroutine s1()
   real, dimension(dConst%field) :: realVar2
 end subroutine s1
 
-! an object designator with a base object that is a dummy argument that has 
+! an object designator with a base object that is a dummy argument that has
 ! neither the OPTIONAL nor the INTENT (OUT) attribute,
 subroutine s2(inArg, inoutArg, outArg, optArg)
   integer, intent(in) :: inArg
@@ -61,7 +61,7 @@ subroutine s4()
   real, dimension(intVar) :: realVar
 end subroutine s4
 
-! an array constructor where each element and each scalar-int-expr of 
+! an array constructor where each element and each scalar-int-expr of
 !   each ac-implied-do-control is a restricted expression,
 subroutine s5()
   real, dimension(storage_size([1,2])) :: realVar
@@ -87,7 +87,7 @@ end subroutine s7a
 ! a specification inquiry where each designator or argument is
 !   (b) a variable that is not an optional dummy argument, and whose
 !     properties inquired about are not
-!     (i)   dependent on the upper bound of the last dimension of an 
+!     (i)   dependent on the upper bound of the last dimension of an
 !       assumed-size array,
 subroutine s7bi(assumedArg)
   integer, dimension(2, *) :: assumedArg
@@ -145,15 +145,15 @@ subroutine s10()
   real, dimension(bit_size(iVar)) :: realArray
 end subroutine s10
 
-! a reference to a transformational function from the intrinsic module 
-!   IEEE_ARITHMETIC, IEEE_EXCEPTIONS, or ISO_C_BINDING, where each argument 
+! a reference to a transformational function from the intrinsic module
+!   IEEE_ARITHMETIC, IEEE_EXCEPTIONS, or ISO_C_BINDING, where each argument
 !   is a restricted expression,
 subroutine s11()
   use ieee_exceptions
   real, dimension(merge(3, 4, ieee_support_halting(ieee_invalid))) :: realArray
 end subroutine s11
 
-! a reference to a specification function where each argument is a 
+! a reference to a specification function where each argument is a
 !   restricted expression,
 module m12
   contains
@@ -177,15 +177,15 @@ subroutine s13()
   end type dtype
 end subroutine s13
 
-! an ac-do-variable within an array constructor where each 
-!   scalar-int-expr of the corresponding ac-implied-do-control is a restricted 
+! an ac-do-variable within an array constructor where each
+!   scalar-int-expr of the corresponding ac-implied-do-control is a restricted
 !   expression, or
 subroutine s14()
   real, dimension(5) :: realField = [(i, i = 1, 5)]
 end subroutine s14
 
-! a restricted expression enclosed in parentheses,where each subscript, 
-!   section subscript, substring starting point, substring ending point, and 
+! a restricted expression enclosed in parentheses,where each subscript,
+!   section subscript, substring starting point, substring ending point, and
 !   type parameter value is a restricted expression
 subroutine s15()
   type :: dtype(param)

--- a/flang/test/Semantics/this_image02.f90
+++ b/flang/test/Semantics/this_image02.f90
@@ -86,7 +86,7 @@ program this_image_tests
   !ERROR: No explicit type declared for 'team'
   images = this_image(coarray=co_array, team)
 
-  ! non-scalar team_type argument 
+  ! non-scalar team_type argument
   !ERROR: missing mandatory 'coarray=' argument
   n = this_image(team=league)
 


### PR DESCRIPTION
Only some fortran sourcefiles in flang/test/Semantics have been modified. The remaining files will be cleaned up in subsequent commits.