### PR TITLE
llvm: Add missing `VirtualFileSystem.h` include

### DIFF
--- a/llvm/lib/CodeGen/SanitizerBinaryMetadata.cpp
+++ b/llvm/lib/CodeGen/SanitizerBinaryMetadata.cpp
@@ -20,6 +20,7 @@
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Transforms/Instrumentation/SanitizerBinaryMetadata.h"
 #include <algorithm>
 


### PR DESCRIPTION
`vfs::FileSystem` is forward-declared in `SanitizerBinaryMetadata.h`. The corresponding header must be included in any source file that includes that header, or we risk issues when building with `LLVM_BUILD_LLVM_DYLIB` to build LLVM as a DLL on Windows.

This effort is tracked in #109483.