### PR TITLE
[SandboxIR] Fix ConstantInt::get() for vector types

### DIFF
--- a/llvm/include/llvm/SandboxIR/Constant.h
+++ b/llvm/include/llvm/SandboxIR/Constant.h
@@ -85,7 +85,7 @@ public:
 
   /// If Ty is a vector type, return a Constant with a splat of the given
   /// value. Otherwise return a ConstantInt for the given value.
-  LLVM_ABI static ConstantInt *get(Type *Ty, uint64_t V, bool IsSigned = false);
+  LLVM_ABI static Constant *get(Type *Ty, uint64_t V, bool IsSigned = false);
 
   /// Return a ConstantInt with the specified integer value for the specified
   /// type. If the type is wider than 64 bits, the value will be zero-extended

--- a/llvm/include/llvm/SandboxIR/Type.h
+++ b/llvm/include/llvm/SandboxIR/Type.h
@@ -269,11 +269,11 @@ public:
 
   // TODO: ADD MISSING
 
-  LLVM_ABI static Type *getInt64Ty(Context &Ctx);
-  LLVM_ABI static Type *getInt32Ty(Context &Ctx);
-  LLVM_ABI static Type *getInt16Ty(Context &Ctx);
-  LLVM_ABI static Type *getInt8Ty(Context &Ctx);
-  LLVM_ABI static Type *getInt1Ty(Context &Ctx);
+  LLVM_ABI static IntegerType *getInt64Ty(Context &Ctx);
+  LLVM_ABI static IntegerType *getInt32Ty(Context &Ctx);
+  LLVM_ABI static IntegerType *getInt16Ty(Context &Ctx);
+  LLVM_ABI static IntegerType *getInt8Ty(Context &Ctx);
+  LLVM_ABI static IntegerType *getInt1Ty(Context &Ctx);
   LLVM_ABI static Type *getDoubleTy(Context &Ctx);
   LLVM_ABI static Type *getFloatTy(Context &Ctx);
   LLVM_ABI static Type *getHalfTy(Context &Ctx);

--- a/llvm/lib/SandboxIR/Constant.cpp
+++ b/llvm/lib/SandboxIR/Constant.cpp
@@ -45,9 +45,9 @@ Constant *ConstantInt::getBool(Type *Ty, bool V) {
   auto *LLVMC = llvm::ConstantInt::getBool(Ty->LLVMTy, V);
   return Ty->getContext().getOrCreateConstant(LLVMC);
 }
-ConstantInt *ConstantInt::get(Type *Ty, uint64_t V, bool IsSigned) {
+Constant *ConstantInt::get(Type *Ty, uint64_t V, bool IsSigned) {
   auto *LLVMC = llvm::ConstantInt::get(Ty->LLVMTy, V, IsSigned);
-  return cast<ConstantInt>(Ty->getContext().getOrCreateConstant(LLVMC));
+  return Ty->getContext().getOrCreateConstant(LLVMC);
 }
 ConstantInt *ConstantInt::get(IntegerType *Ty, uint64_t V, bool IsSigned) {
   auto *LLVMC = llvm::ConstantInt::get(Ty->LLVMTy, V, IsSigned);

--- a/llvm/lib/SandboxIR/Type.cpp
+++ b/llvm/lib/SandboxIR/Type.cpp
@@ -15,20 +15,20 @@ Type *Type::getScalarType() const {
   return Ctx.getType(LLVMTy->getScalarType());
 }
 
-Type *Type::getInt64Ty(Context &Ctx) {
-  return Ctx.getType(llvm::Type::getInt64Ty(Ctx.LLVMCtx));
+IntegerType *Type::getInt64Ty(Context &Ctx) {
+  return cast<IntegerType>(Ctx.getType(llvm::Type::getInt64Ty(Ctx.LLVMCtx)));
 }
-Type *Type::getInt32Ty(Context &Ctx) {
-  return Ctx.getType(llvm::Type::getInt32Ty(Ctx.LLVMCtx));
+IntegerType *Type::getInt32Ty(Context &Ctx) {
+  return cast<IntegerType>(Ctx.getType(llvm::Type::getInt32Ty(Ctx.LLVMCtx)));
 }
-Type *Type::getInt16Ty(Context &Ctx) {
-  return Ctx.getType(llvm::Type::getInt16Ty(Ctx.LLVMCtx));
+IntegerType *Type::getInt16Ty(Context &Ctx) {
+  return cast<IntegerType>(Ctx.getType(llvm::Type::getInt16Ty(Ctx.LLVMCtx)));
 }
-Type *Type::getInt8Ty(Context &Ctx) {
-  return Ctx.getType(llvm::Type::getInt8Ty(Ctx.LLVMCtx));
+IntegerType *Type::getInt8Ty(Context &Ctx) {
+  return cast<IntegerType>(Ctx.getType(llvm::Type::getInt8Ty(Ctx.LLVMCtx)));
 }
-Type *Type::getInt1Ty(Context &Ctx) {
-  return Ctx.getType(llvm::Type::getInt1Ty(Ctx.LLVMCtx));
+IntegerType *Type::getInt1Ty(Context &Ctx) {
+  return cast<IntegerType>(Ctx.getType(llvm::Type::getInt1Ty(Ctx.LLVMCtx)));
 }
 Type *Type::getDoubleTy(Context &Ctx) {
   return Ctx.getType(llvm::Type::getDoubleTy(Ctx.LLVMCtx));

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -160,12 +160,20 @@ define void @foo(i32 %v0) {
 
   auto *Int32Ty = sandboxir::Type::getInt32Ty(Ctx);
   auto *LLVMInt32Ty = llvm::Type::getInt32Ty(C);
+  auto *Int32VecTy =
+      sandboxir::VectorType::get(Int32Ty, ElementCount::getFixed(2u));
+  auto *LLVMInt32VecTy = llvm::FixedVectorType::get(LLVMInt32Ty, 2);
   {
     // Check get(Type, V).
     auto *FortyThree = sandboxir::ConstantInt::get(Int32Ty, 43);
     auto *LLVMFortyThree = llvm::ConstantInt::get(LLVMInt32Ty, 43);
     EXPECT_NE(FortyThree, FortyTwo);
     EXPECT_EQ(FortyThree, Ctx.getValue(LLVMFortyThree));
+
+    // Check vector splat.
+    auto *FortyThreeVec = sandboxir::ConstantInt::get(Int32VecTy, 43);
+    auto *LLVMFortyThreeVec = llvm::ConstantInt::get(LLVMInt32VecTy, 43);
+    EXPECT_EQ(FortyThreeVec, Ctx.getValue(LLVMFortyThreeVec));
   }
   {
     // Check get(Type, V, IsSigned).


### PR DESCRIPTION
As the comment on the method indicates, this method is supposed to produce a splat for vector types. However, currently it has a ConstantInt return type that is incompatible with that. There is a separate overload on IntegerType -- only that one should return ConstantInt.

This also requires adjusting Type::getIntNTy() to return IntegerType (matching the normal Type API), so it uses the right overload.