### PR TITLE
[LLDB] Run MSVC variant test with PDB

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
@@ -119,8 +119,14 @@ bool formatters::MsvcStlVariantSummaryProvider(
     storage_type = storage_type.GetTypedefedType();
 
   CompilerType active_type = storage_type.GetTypeTemplateArgument(1, true);
-  if (!active_type)
-    return false;
+  if (!active_type) {
+    // PDB: get the type from the head as we don't have template arguments
+    // there.
+    ValueObjectSP head = GetHead(*storage);
+    active_type = head->GetCompilerType();
+    if (!active_type)
+      return false;
+  }
 
   stream << " Active Type = " << active_type.GetDisplayTypeName() << " ";
   return true;

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
@@ -123,6 +123,8 @@ bool formatters::MsvcStlVariantSummaryProvider(
     // PDB: get the type from the head as we don't have template arguments
     // there.
     ValueObjectSP head = GetHead(*storage);
+    if (!head)
+      return false;
     active_type = head->GetCompilerType();
     if (!active_type)
       return false;

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdVariantDataFormatterTestCase(TestBase):
+    TEST_WITH_PDB_DEBUG_INFO = True
+
     def do_test(self):
         """Test that that file and class static variables display correctly."""
 


### PR DESCRIPTION
Split off from #171489. This only adds the lookup of the active type for a `std::variant` based on the head type (since PDB doesn't have template info).