### PR TITLE
[llvm][dwarfdump] Print the name (if available) of entities referenced by DW_AT_import

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -246,7 +246,7 @@ static void dumpAttribute(raw_ostream &OS, const DWARFDie &Die,
   // having both the raw value and the pretty-printed value is
   // interesting. These attributes are handled below.
   if (Attr == DW_AT_specification || Attr == DW_AT_abstract_origin ||
-      Attr == DW_AT_call_origin) {
+      Attr == DW_AT_call_origin || Attr == DW_AT_import) {
     if (const char *Name =
             Die.getAttributeValueAsReferencedDie(FormValue).getName(
                 DINameKind::LinkageName))

--- a/llvm/test/DebugInfo/Generic/import-inlined-declaration.ll
+++ b/llvm/test/DebugInfo/Generic/import-inlined-declaration.ll
@@ -30,7 +30,7 @@
 ; CHECK:       DW_TAG_variable
 ; CHECK:       NULL
 ; CHECK:     DW_TAG_imported_declaration
-; CHECK:       DW_AT_import ([[FOO]])
+; CHECK:       DW_AT_import ([[FOO]] "_ZN2ns3fooEv")
 ; CHECK:     NULL
 ; CHECK:   NULL
 

--- a/llvm/test/DebugInfo/Generic/namespace.ll
+++ b/llvm/test/DebugInfo/Generic/namespace.ll
@@ -52,7 +52,7 @@
 ; CHECK: DW_TAG_imported_module
 ; CHECK:   DW_AT_decl_file ([[F2:.*]])
 ; CHECK:   DW_AT_decl_line (15)
-; CHECK:   DW_AT_import ([[NS2]])
+; CHECK:   DW_AT_import ([[NS2]] "B")
 ; CHECK: DW_TAG_imported_declaration
 ; CHECK: NULL
 
@@ -72,60 +72,60 @@
 ; CHECK:   DW_TAG_imported_module
 ; CHECK:     DW_AT_decl_file ([[F2:.*]])
 ; CHECK:     DW_AT_decl_line (26)
-; CHECK:     DW_AT_import ([[NS1]])
+; CHECK:     DW_AT_import ([[NS1]] "A")
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (27)
-; CHECK:     DW_AT_import ([[FOO]])
+; CHECK:     DW_AT_import ([[FOO]] "foo")
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (28)
-; CHECK:     DW_AT_import ([[BAR]])
+; CHECK:     DW_AT_import ([[BAR]] "bar")
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (29)
-; CHECK:     DW_AT_import ([[FUNC1]])
+; CHECK:     DW_AT_import ([[FUNC1]] {{.*}})
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (30)
-; CHECK:     DW_AT_import ([[I]])
+; CHECK:     DW_AT_import ([[I]] "_ZN1A1B1iE")
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (31)
-; CHECK:     DW_AT_import ([[BAZ]])
+; CHECK:     DW_AT_import ([[BAZ]] "baz")
 ; CHECK:   [[X:0x[0-9a-f]*]]:{{ *}}DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (32)
-; CHECK:     DW_AT_import ([[NS1]])
+; CHECK:     DW_AT_import ([[NS1]] "A")
 ; CHECK:     DW_AT_name ("X")
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (33)
-; CHECK:     DW_AT_import ([[X]])
+; CHECK:     DW_AT_import ([[X]] "X")
 ; CHECK:     DW_AT_name ("Y")
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (34)
-; CHECK:     DW_AT_import ([[VAR_DECL]])
+; CHECK:     DW_AT_import ([[VAR_DECL]] "_ZN1A1B8var_declE")
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (35)
-; CHECK:     DW_AT_import ([[FUNC_DECL]])
+; CHECK:     DW_AT_import ([[FUNC_DECL]] "_ZN1A1B9func_declEv")
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (36)
-; CHECK:     DW_AT_import ([[VAR_FWD]])
+; CHECK:     DW_AT_import ([[VAR_FWD]] "_ZN1A1B7var_fwdE")
 ; CHECK:   DW_TAG_imported_declaration
 ; CHECK:     DW_AT_decl_file ([[F2]])
 ; CHECK:     DW_AT_decl_line (37)
-; CHECK:     DW_AT_import ([[FUNC_FWD]])
+; CHECK:     DW_AT_import ([[FUNC_FWD]] "_ZN1A1B8func_fwdEv")
 ; CHECK:   NULL
 
 ; CHECK: DW_TAG_subprogram
 ; CHECK: DW_TAG_imported_module
 ; CHECK:   DW_AT_decl_file ([[F2:.*]])
 ; CHECK:   DW_AT_decl_line (18)
-; CHECK:   DW_AT_import ([[NS1]])
+; CHECK:   DW_AT_import ([[NS1]] "A")
 ; CHECK: DW_TAG_imported_declaration
 ; CHECK: DW_TAG_base_type
 ; CHECK: NULL

--- a/llvm/test/DebugInfo/Generic/split-dwarf-local-import3.ll
+++ b/llvm/test/DebugInfo/Generic/split-dwarf-local-import3.ll
@@ -21,7 +21,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; CHECK:   [[ABSTRACT_FOO:0x[0-9a-f]+]]: DW_TAG_subprogram
 ; CHECK:     DW_AT_name	("foo")
 ; CHECK:     DW_TAG_imported_declaration
-; CHECK:       DW_AT_import  ([[A:0x[0-9a-f]+]])
+; CHECK:       DW_AT_import  ([[A:0x[0-9a-f]+]]
 ; CHECK:     NULL
 
 ; CHECK:   DW_TAG_base_type

--- a/llvm/test/DebugInfo/X86/dimodule-external-fortran.ll
+++ b/llvm/test/DebugInfo/X86/dimodule-external-fortran.ll
@@ -29,7 +29,7 @@
 ; CHECK:      DW_TAG_imported_module
 ; CHECK-NEXT:   DW_AT_decl_file
 ; CHECK-NEXT:   DW_AT_decl_line
-; CHECK-NEXT:   DW_AT_import  ([[DIE_ID]])
+; CHECK-NEXT:   DW_AT_import  ([[DIE_ID]] "external_module")
 
 ; When the debugger sees the module being imported is a declaration,
 ; it should go to the global scope to find the module's definition.

--- a/llvm/test/DebugInfo/X86/dwarfdump-DIImportedEntity_elements.ll
+++ b/llvm/test/DebugInfo/X86/dwarfdump-DIImportedEntity_elements.ll
@@ -13,9 +13,9 @@
 ; CHECK:   DW_TAG_subprogram
 ; CHECK:     DW_AT_name      ("use_renamed")
 ; CHECK:     DW_TAG_imported_module
-; CHECK:       DW_AT_import ([[MYMOD]])
+; CHECK:       DW_AT_import ([[MYMOD]] "mymod")
 ; CHECK:       DW_TAG_imported_declaration
-; CHECK:         DW_AT_import ([[VAR1]])
+; CHECK:         DW_AT_import ([[VAR1]] "var1")
 ; CHECK:         DW_AT_name        ("var4")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/llvm/test/tools/dsymutil/X86/modules-empty.m
+++ b/llvm/test/tools/dsymutil/X86/modules-empty.m
@@ -30,5 +30,5 @@ int main() {
 
 // The empty CU from the pcm should not get copied into the dSYM.
 // Check that module name occured only once.
-// CHECK: "Empty"
-// CHECK-NOT: "Empty"
+// CHECK: DW_AT_name ("Empty")
+// CHECK-NOT: DW_AT_name ("Empty")

--- a/llvm/test/tools/llvm-dwarfdump/AArch64/DW_AT_import.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/AArch64/DW_AT_import.yaml
@@ -1,0 +1,73 @@
+# RUN: yaml2obj %s | llvm-dwarfdump -verify - | FileCheck %s --check-prefix=VERIFY
+# VERIFY: No errors.
+#
+# RUN: yaml2obj %s | llvm-dwarfdump - | FileCheck %s
+# CHECK: DW_AT_import ({{.*}} "Foo")
+# CHECK: DW_AT_import ({{.*}} "")
+# CHECK: DW_AT_import ({{.*}})
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_AARCH64
+DWARF:
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_data2
+        - Code:            0x2
+          Tag:             DW_TAG_imported_declaration
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_import
+              Form:      DW_FORM_ref4
+        - Code:            0x3
+          Tag:             DW_TAG_module
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_name
+              Form:      DW_FORM_string
+        - Code:            0x4
+          Tag:             DW_TAG_module
+          Children:        DW_CHILDREN_no
+
+  debug_info:
+     - Version:  5
+       UnitType: DW_UT_compile
+       AddrSize: 8
+       Entries:
+
+        - AbbrCode: 0x1
+          Values:
+            - Value: 0x04
+
+        - AbbrCode: 0x2
+          Values:
+            - Value: 0x1e
+
+        - AbbrCode: 0x2
+          Values:
+            - Value: 0x23
+
+        - AbbrCode: 0x2
+          Values:
+            - Value: 0x19
+
+        - AbbrCode: 0x3
+          Values:
+            - CStr: Foo
+
+        - AbbrCode: 0x3
+          Values:
+            - CStr: ''
+
+        - AbbrCode: 0x4
+        - AbbrCode: 0x0
+...

--- a/llvm/test/tools/llvm-dwarfdump/AArch64/DW_AT_import.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/AArch64/DW_AT_import.yaml
@@ -5,6 +5,9 @@
 # CHECK: DW_AT_import ({{.*}} "Foo")
 # CHECK: DW_AT_import ({{.*}} "")
 # CHECK: DW_AT_import ({{.*}})
+# CHECK: DW_AT_import ({{.*}} "FooLinkage")
+# CHECK: DW_AT_import ({{.*}} "JustLinkage")
+# CHECK: DW_AT_import ({{.*}} "NoLinkage")
 
 --- !ELF
 FileHeader:
@@ -37,6 +40,26 @@ DWARF:
         - Code:            0x4
           Tag:             DW_TAG_module
           Children:        DW_CHILDREN_no
+        - Code:            0x5
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_name
+              Form:      DW_FORM_string
+            - Attribute: DW_AT_linkage_name
+              Form:      DW_FORM_string
+        - Code:            0x6
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_linkage_name
+              Form:      DW_FORM_string
+        - Code:            0x7
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_name
+              Form:      DW_FORM_string
 
   debug_info:
      - Version:  5
@@ -50,15 +73,27 @@ DWARF:
 
         - AbbrCode: 0x2
           Values:
-            - Value: 0x1e
+            - Value: 0x2d
 
         - AbbrCode: 0x2
           Values:
-            - Value: 0x23
+            - Value: 0x32
 
         - AbbrCode: 0x2
           Values:
-            - Value: 0x19
+            - Value: 0x34
+
+        - AbbrCode: 0x2
+          Values:
+            - Value: 0x35
+
+        - AbbrCode: 0x2
+          Values:
+            - Value: 0x45
+
+        - AbbrCode: 0x2
+          Values:
+            - Value: 0x52
 
         - AbbrCode: 0x3
           Values:
@@ -69,5 +104,19 @@ DWARF:
             - CStr: ''
 
         - AbbrCode: 0x4
+
+        - AbbrCode: 0x5
+          Values:
+            - CStr: Foo
+            - CStr: FooLinkage
+
+        - AbbrCode: 0x6
+          Values:
+            - CStr: JustLinkage
+
+        - AbbrCode: 0x7
+          Values:
+            - CStr: NoLinkage
+
         - AbbrCode: 0x0
 ...


### PR DESCRIPTION
Instead of this:
```
0x00018cff:   DW_TAG_imported_declaration
                DW_AT_decl_line (12)
                DW_AT_import    (0x0000000000018cfb)
```
print:
```
0x00018cff:   DW_TAG_imported_declaration
                DW_AT_decl_line (12)
                DW_AT_import    (0x0000000000018cfb "platform")
```

Where `0x0000000000018cfb` in this example could be a `DW_TAG_module` with `DW_AT_name ("platform")`