### PR TITLE
[clang][index] Index implicit destructor invocations from local vars and delete

### DIFF
--- a/clang-tools-extra/clangd/unittests/XRefsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/XRefsTests.cpp
@@ -110,7 +110,7 @@ TEST(HighlightsTest, All) {
           [[~]]Foo() {};
         };
         void foo() {
-          Foo f;
+          Foo [[f]];
           f.[[^~]]Foo();
         }
       )cpp",
@@ -2242,13 +2242,30 @@ TEST(FindReferences, WithinAST) {
        class $def[[Foo]] {};
        void func($(func)[[Fo^o]]<int>);
       )cpp",
-      R"cpp(// Not touching any identifiers.
+      R"cpp(// Destructor not referenced by static identifiers.
         struct Foo {
           $def(Foo)[[~]]Foo() {};
         };
         void foo() {
-          Foo f;
+          static Foo f;
           f.$(foo)[[^~]]Foo();
+        }
+      )cpp",
+      R"cpp(// Destructor referenced by local varable.
+        struct Foo {
+          $def(Foo)[[^~]]Foo() {};
+        };
+        void foo() {
+          Foo $(foo)[[f]];
+        }
+      )cpp",
+      R"cpp(// Destructor referenced by temporary.
+        struct Foo {
+          $def(Foo)[[^~]]Foo() {};
+        };
+        void foo(Foo f) {
+          $(foo)[[Foo]]();
+          foo($(foo)[[f]]);
         }
       )cpp",
       R"cpp(// Lambda capture initializer

--- a/clang/lib/Index/IndexDecl.cpp
+++ b/clang/lib/Index/IndexDecl.cpp
@@ -307,6 +307,17 @@ public:
     gatherTemplatePseudoOverrides(D, Relations);
     TRY_DECL(D, IndexCtx.handleDecl(D, SymbolRoleSet(), Relations));
     handleDeclarator(D);
+    // handle destructor reference for local variables
+    if (D->hasLocalStorage() && D->needsDestruction(D->getASTContext())) {
+      if (const auto *RecordTy = D->getType()->getAsCXXRecordDecl()) {
+        const auto *Dtor = RecordTy->getDestructor();
+        const Expr *InitExpr = D->getInit();
+        if (Dtor && InitExpr) {
+          IndexCtx.handleReference(Dtor, InitExpr->getExprLoc(), D,
+                                   D->getLexicalDeclContext());
+        }
+      }
+    }
     IndexCtx.indexBody(D->getInit(), D);
     return true;
   }


### PR DESCRIPTION
For https://github.com/llvm/llvm-project/issues/169824. The main purpose is to complete call hierarchy and reference links.

Local variables is marked at their init expression's beginning, which is intended for better understanding than marking at the end of the scope.

Current limitation is that it assumes a BindTemporaryExpr will always lead to a destructor invocation, which is not true when the temporary is elided, say at return statement.