### PR TITLE
[ExpandFp] Fix incorrect ConstantInt construction

### DIFF
--- a/llvm/lib/CodeGen/ExpandFp.cpp
+++ b/llvm/lib/CodeGen/ExpandFp.cpp
@@ -811,7 +811,7 @@ static void expandIToFP(Instruction *IToFP) {
   Value *Sub24 = Builder.CreateAdd(
       FloatWidth == 128 ? Call : Cast,
       ConstantInt::getSigned(Builder.getIntNTy(BitWidthNew),
-                             -(BitWidth - FPMantissaWidth - 1)));
+                             -(int)(BitWidth - FPMantissaWidth - 1)));
   Value *ShProm25 = Builder.CreateZExt(Sub24, IntTy);
   Value *Shl26 = Builder.CreateShl(IsSigned ? Sub : IntVal,
                                    FloatWidth == 128 ? Sub24 : ShProm25);

--- a/llvm/test/Transforms/ExpandLargeFpConvert/X86/expand-large-fp-convert-si129tofp.ll
+++ b/llvm/test/Transforms/ExpandLargeFpConvert/X86/expand-large-fp-convert-si129tofp.ll
@@ -315,7 +315,7 @@ define x86_fp80 @si129tox86_fp80(i129 %a) {
 ; CHECK-NEXT:    [[TMP33:%.*]] = trunc i129 [[TMP6]] to i64
 ; CHECK-NEXT:    br label [[ITOFP_IF_END26]]
 ; CHECK:       itofp-if-else:
-; CHECK-NEXT:    [[TMP34:%.*]] = add i129 [[TMP4]], 4294967280
+; CHECK-NEXT:    [[TMP34:%.*]] = add i129 [[TMP4]], -16
 ; CHECK-NEXT:    [[TMP35:%.*]] = shl i129 [[TMP3]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = trunc i129 [[TMP35]] to i128
 ; CHECK-NEXT:    [[TMP37:%.*]] = lshr i129 [[TMP35]], 32
@@ -399,7 +399,7 @@ define fp128 @si129tofp128(i129 %a) {
 ; CHECK-NEXT:    [[TMP33:%.*]] = trunc i129 [[TMP6]] to i64
 ; CHECK-NEXT:    br label [[ITOFP_IF_END26]]
 ; CHECK:       itofp-if-else:
-; CHECK-NEXT:    [[TMP34:%.*]] = add i129 [[TMP4]], 4294967280
+; CHECK-NEXT:    [[TMP34:%.*]] = add i129 [[TMP4]], -16
 ; CHECK-NEXT:    [[TMP35:%.*]] = shl i129 [[TMP3]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = trunc i129 [[TMP35]] to i128
 ; CHECK-NEXT:    [[TMP37:%.*]] = lshr i129 [[TMP35]], 32

--- a/llvm/test/Transforms/ExpandLargeFpConvert/X86/expand-large-fp-convert-ui129tofp.ll
+++ b/llvm/test/Transforms/ExpandLargeFpConvert/X86/expand-large-fp-convert-ui129tofp.ll
@@ -315,7 +315,7 @@ define x86_fp80 @ui129tox86_fp80(i129 %a) {
 ; CHECK-NEXT:    [[TMP33:%.*]] = trunc i129 [[TMP6]] to i64
 ; CHECK-NEXT:    br label [[ITOFP_IF_END26]]
 ; CHECK:       itofp-if-else:
-; CHECK-NEXT:    [[TMP34:%.*]] = add i129 [[TMP4]], 4294967280
+; CHECK-NEXT:    [[TMP34:%.*]] = add i129 [[TMP4]], -16
 ; CHECK-NEXT:    [[TMP35:%.*]] = shl i129 [[A]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = trunc i129 [[TMP35]] to i128
 ; CHECK-NEXT:    [[TMP37:%.*]] = lshr i129 [[TMP35]], 32
@@ -399,7 +399,7 @@ define fp128 @ui129tofp128(i129 %a) {
 ; CHECK-NEXT:    [[TMP33:%.*]] = trunc i129 [[TMP6]] to i64
 ; CHECK-NEXT:    br label [[ITOFP_IF_END26]]
 ; CHECK:       itofp-if-else:
-; CHECK-NEXT:    [[TMP34:%.*]] = add i129 [[TMP4]], 4294967280
+; CHECK-NEXT:    [[TMP34:%.*]] = add i129 [[TMP4]], -16
 ; CHECK-NEXT:    [[TMP35:%.*]] = shl i129 [[A]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = trunc i129 [[TMP35]] to i128
 ; CHECK-NEXT:    [[TMP37:%.*]] = lshr i129 [[TMP35]], 32


### PR DESCRIPTION
Explicitly cast the value to (int) before negating, so it gets properly sign extended. Otherwise we end up with a large unsigned value instead of a negative value for large bit widths.

This was found while working on https://github.com/llvm/llvm-project/pull/171456.