### PR TITLE
[ExtractAPI] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -179,7 +179,7 @@
 /clang/tools/clang-installapi/ @cyndyishida
 
 # ExtractAPI
-/clang/**/ExtractAPI @daniel-grumberg @QuietMisdreavus
+/clang/**/ExtractAPI @QuietMisdreavus @snprajwal
 
 # DWARFLinker, dwarfutil, dsymutil
 /llvm/**/DWARFLinker/ @JDevlieghere


### PR DESCRIPTION
Daniel Grumberg is no longer a maintainer for Clang ExtractAPI. I have updated the code owners list accordingly and added myself in his stead.