### PR TITLE
[lldb][NFCI] Make LookupInfo const

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -935,17 +935,11 @@ public:
 
     ConstString GetName() const { return m_name; }
 
-    void SetName(ConstString name) { m_name = name; }
-
     ConstString GetLookupName() const { return m_lookup_name; }
 
     void SetLookupName(ConstString name) { m_lookup_name = name; }
 
     lldb::FunctionNameType GetNameTypeMask() const { return m_name_type_mask; }
-
-    void SetNameTypeMask(lldb::FunctionNameType mask) {
-      m_name_type_mask = mask;
-    }
 
     lldb::LanguageType GetLanguageType() const { return m_language; }
 

--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -909,6 +909,9 @@ public:
   public:
     LookupInfo() = default;
 
+    /// Copies an existing LookupInfo with a different lookup name.
+    LookupInfo(const LookupInfo &lookup_info, ConstString lookup_name);
+
     /// Creates a vector of lookup infos for function name resolution.
     ///
     /// \param[in] name
@@ -925,19 +928,23 @@ public:
     ///     The language to create lookups for. If eLanguageTypeUnknown is
     ///     passed, creates one LookupInfo for each language plugin currently
     ///     available in LLDB. If a specific language is provided, creates only
-    //      a single LookupInfo for that language.
+    ///     a single LookupInfo for that language.
+    ///
+    /// \param[in] lookup_name_override
+    ///     Manually override the name used for lookup. This parameter is
+    ///     optional. If not provided, it will be set to the value of the name
+    ///     parameter.
     ///
     /// \return
     ///     A vector of LookupInfo objects, one per relevant language.
     static std::vector<LookupInfo>
     MakeLookupInfos(ConstString name, lldb::FunctionNameType name_type_mask,
-                    lldb::LanguageType lang_type);
+                    lldb::LanguageType lang_type,
+                    ConstString lookup_name_override = {});
 
     ConstString GetName() const { return m_name; }
 
     ConstString GetLookupName() const { return m_lookup_name; }
-
-    void SetLookupName(ConstString name) { m_lookup_name = name; }
 
     lldb::FunctionNameType GetNameTypeMask() const { return m_name_type_mask; }
 
@@ -968,7 +975,8 @@ public:
     bool m_match_name_after_lookup = false;
 
   private:
-    LookupInfo(ConstString name, lldb::FunctionNameType name_type_mask,
+    LookupInfo(ConstString name, ConstString lookup_name,
+               lldb::FunctionNameType name_type_mask,
                lldb::LanguageType lang_type);
   };
 

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -229,10 +229,8 @@ void BreakpointResolverName::AddNameLookup(ConstString name,
       if (variant.GetType() & lldb::eFunctionNameTypeFull) {
         std::vector<Module::LookupInfo> variant_lookups =
             Module::LookupInfo::MakeLookupInfos(name, variant.GetType(),
-                                                lang->GetLanguageType());
-        llvm::for_each(variant_lookups, [&](auto &variant_lookup) {
-          variant_lookup.SetLookupName(variant.GetName());
-        });
+                                                lang->GetLanguageType(),
+                                                variant.GetName());
         llvm::append_range(m_lookups, variant_lookups);
       }
     }

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2737,8 +2737,8 @@ void SymbolFileDWARF::FindFunctions(const Module::LookupInfo &lookup_info,
     if (it != llvm::StringRef::npos) {
       const llvm::StringRef name_no_template_params = name_ref.slice(0, it);
 
-      Module::LookupInfo no_tp_lookup_info(lookup_info);
-      no_tp_lookup_info.SetLookupName(ConstString(name_no_template_params));
+      Module::LookupInfo no_tp_lookup_info(
+          lookup_info, ConstString(name_no_template_params));
       m_index->GetFunctions(no_tp_lookup_info, *this, parent_decl_ctx,
                             [&](DWARFDIE die) {
                               if (resolved_dies.insert(die.GetDIE()).second)


### PR DESCRIPTION
Instead of changing an existing LookupInfo after creation, let's make them constant.