### PR TITLE
[OpenMP][CIR] Add basic infrastructure for CIR lowering

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -744,11 +744,6 @@ void CIRGenFunction::emitDecl(const Decl &d, bool evaluateConditionDecl) {
   case Decl::Import:
   case Decl::MSGuid: // __declspec(uuid("..."))
   case Decl::TemplateParamObject:
-  case Decl::OMPThreadPrivate:
-  case Decl::OMPGroupPrivate:
-  case Decl::OMPAllocate:
-  case Decl::OMPCapturedExpr:
-  case Decl::OMPRequires:
   case Decl::Empty:
   case Decl::Concept:
   case Decl::LifetimeExtendedTemporary:
@@ -782,6 +777,27 @@ void CIRGenFunction::emitDecl(const Decl &d, bool evaluateConditionDecl) {
   case Decl::OpenACCRoutine:
     emitOpenACCRoutine(cast<OpenACCRoutineDecl>(d));
     return;
+  case Decl::OMPThreadPrivate:
+    emitOMPThreadPrivateDecl(cast<OMPThreadPrivateDecl>(d));
+    return;
+  case Decl::OMPGroupPrivate:
+    emitOMPGroupPrivateDecl(cast<OMPGroupPrivateDecl>(d));
+    return;
+  case Decl::OMPAllocate:
+    emitOMPAllocateDecl(cast<OMPAllocateDecl>(d));
+    return;
+  case Decl::OMPCapturedExpr:
+    emitOMPCapturedExpr(cast<OMPCapturedExprDecl>(d));
+    return;
+  case Decl::OMPRequires:
+    emitOMPRequiresDecl(cast<OMPRequiresDecl>(d));
+    return;
+  case Decl::OMPDeclareMapper:
+    emitOMPDeclareMapper(cast<OMPDeclareMapperDecl>(d));
+    return;
+  case Decl::OMPDeclareReduction:
+    emitOMPDeclareReduction(cast<OMPDeclareReductionDecl>(d));
+    return;
   case Decl::Typedef:     // typedef int X;
   case Decl::TypeAlias: { // using X = int; [C++0x]
     QualType ty = cast<TypedefNameDecl>(d).getUnderlyingType();
@@ -793,8 +809,6 @@ void CIRGenFunction::emitDecl(const Decl &d, bool evaluateConditionDecl) {
   case Decl::ImplicitConceptSpecialization:
   case Decl::TopLevelStmt:
   case Decl::UsingPack:
-  case Decl::OMPDeclareMapper:
-  case Decl::OMPDeclareReduction:
     cgm.errorNYI(d.getSourceRange(),
                  std::string("emitDecl: unhandled decl type: ") +
                      d.getDeclKindName());

--- a/clang/lib/CIR/CodeGen/CIRGenDeclOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDeclOpenMP.cpp
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains code to emit Decl nodes as CIR code.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenFunction.h"
+#include "clang/AST/DeclOpenMP.h"
+
+using namespace clang;
+using namespace clang::CIRGen;
+
+void CIRGenModule::emitOMPThreadPrivateDecl(const OMPThreadPrivateDecl *d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  errorNYI(d->getSourceRange(), "OpenMP OMPThreadPrivateDecl");
+}
+
+void CIRGenFunction::emitOMPThreadPrivateDecl(const OMPThreadPrivateDecl &d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  getCIRGenModule().errorNYI(d.getSourceRange(), "OpenMP OMPThreadPrivateDecl");
+}
+
+void CIRGenModule::emitOMPGroupPrivateDecl(const OMPGroupPrivateDecl *d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  errorNYI(d->getSourceRange(), "OpenMP OMPGroupPrivateDecl");
+}
+
+void CIRGenFunction::emitOMPGroupPrivateDecl(const OMPGroupPrivateDecl &d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  getCIRGenModule().errorNYI(d.getSourceRange(), "OpenMP OMPGroupPrivateDecl");
+}
+
+void CIRGenModule::emitOMPCapturedExpr(const OMPCapturedExprDecl *d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  errorNYI(d->getSourceRange(), "OpenMP OMPCapturedExpr");
+}
+
+void CIRGenFunction::emitOMPCapturedExpr(const OMPCapturedExprDecl &d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  getCIRGenModule().errorNYI(d.getSourceRange(), "OpenMP OMPCapturedExpr");
+}
+
+void CIRGenModule::emitOMPAllocateDecl(const OMPAllocateDecl *d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  errorNYI(d->getSourceRange(), "OpenMP OMPAllocateDecl");
+}
+
+void CIRGenFunction::emitOMPAllocateDecl(const OMPAllocateDecl &d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  getCIRGenModule().errorNYI(d.getSourceRange(), "OpenMP OMPAllocateDecl");
+}
+
+void CIRGenModule::emitOMPDeclareReduction(const OMPDeclareReductionDecl *d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  errorNYI(d->getSourceRange(), "OpenMP OMPDeclareReduction");
+}
+
+void CIRGenFunction::emitOMPDeclareReduction(const OMPDeclareReductionDecl &d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  getCIRGenModule().errorNYI(d.getSourceRange(), "OpenMP OMPDeclareReduction");
+}
+
+void CIRGenModule::emitOMPDeclareMapper(const OMPDeclareMapperDecl *d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  errorNYI(d->getSourceRange(), "OpenMP OMPDeclareMapper");
+}
+
+void CIRGenFunction::emitOMPDeclareMapper(const OMPDeclareMapperDecl &d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  getCIRGenModule().errorNYI(d.getSourceRange(), "OpenMP OMPDeclareMapper");
+}
+
+void CIRGenModule::emitOMPRequiresDecl(const OMPRequiresDecl *d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  errorNYI(d->getSourceRange(), "OpenMP OMPRequiresDecl");
+}
+
+void CIRGenFunction::emitOMPRequiresDecl(const OMPRequiresDecl &d) {
+  // TODO(OpenMP): We don't properly differentiate between 'emitDecl' and
+  // 'emitGlobal' and 'emitTopLevelDecl' in CIRGenDecl.cpp/CIRGenModule.cpp, so
+  // if this decl requires we differentiate those, we probably need to split
+  // this function into multiples.
+  getCIRGenModule().errorNYI(d.getSourceRange(), "OpenMP OMPRequiresDecl");
+}

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -2023,6 +2023,139 @@ public:
                         mlir::OpBuilder::InsertPoint ip = {});
 
   //===--------------------------------------------------------------------===//
+  //                         OpenMP Emission
+  //===--------------------------------------------------------------------===//
+public:
+  mlir::LogicalResult emitOMPScopeDirective(const OMPScopeDirective &s);
+  mlir::LogicalResult emitOMPErrorDirective(const OMPErrorDirective &s);
+  mlir::LogicalResult emitOMPParallelDirective(const OMPParallelDirective &s);
+  mlir::LogicalResult emitOMPTaskwaitDirective(const OMPTaskwaitDirective &s);
+  mlir::LogicalResult emitOMPTaskyieldDirective(const OMPTaskyieldDirective &s);
+  mlir::LogicalResult emitOMPBarrierDirective(const OMPBarrierDirective &s);
+  mlir::LogicalResult emitOMPMetaDirective(const OMPMetaDirective &s);
+  mlir::LogicalResult emitOMPCanonicalLoop(const OMPCanonicalLoop &s);
+  mlir::LogicalResult emitOMPSimdDirective(const OMPSimdDirective &s);
+  mlir::LogicalResult emitOMPTileDirective(const OMPTileDirective &s);
+  mlir::LogicalResult emitOMPUnrollDirective(const OMPUnrollDirective &s);
+  mlir::LogicalResult emitOMPFuseDirective(const OMPFuseDirective &s);
+  mlir::LogicalResult emitOMPForDirective(const OMPForDirective &s);
+  mlir::LogicalResult emitOMPForSimdDirective(const OMPForSimdDirective &s);
+  mlir::LogicalResult emitOMPSectionsDirective(const OMPSectionsDirective &s);
+  mlir::LogicalResult emitOMPSectionDirective(const OMPSectionDirective &s);
+  mlir::LogicalResult emitOMPSingleDirective(const OMPSingleDirective &s);
+  mlir::LogicalResult emitOMPMasterDirective(const OMPMasterDirective &s);
+  mlir::LogicalResult emitOMPCriticalDirective(const OMPCriticalDirective &s);
+  mlir::LogicalResult
+  emitOMPParallelForDirective(const OMPParallelForDirective &s);
+  mlir::LogicalResult
+  emitOMPParallelForSimdDirective(const OMPParallelForSimdDirective &s);
+  mlir::LogicalResult
+  emitOMPParallelMasterDirective(const OMPParallelMasterDirective &s);
+  mlir::LogicalResult
+  emitOMPParallelSectionsDirective(const OMPParallelSectionsDirective &s);
+  mlir::LogicalResult emitOMPTaskDirective(const OMPTaskDirective &s);
+  mlir::LogicalResult emitOMPTaskgroupDirective(const OMPTaskgroupDirective &s);
+  mlir::LogicalResult emitOMPFlushDirective(const OMPFlushDirective &s);
+  mlir::LogicalResult emitOMPDepobjDirective(const OMPDepobjDirective &s);
+  mlir::LogicalResult emitOMPScanDirective(const OMPScanDirective &s);
+  mlir::LogicalResult emitOMPOrderedDirective(const OMPOrderedDirective &s);
+  mlir::LogicalResult emitOMPAtomicDirective(const OMPAtomicDirective &s);
+  mlir::LogicalResult emitOMPTargetDirective(const OMPTargetDirective &s);
+  mlir::LogicalResult emitOMPTeamsDirective(const OMPTeamsDirective &s);
+  mlir::LogicalResult
+  emitOMPCancellationPointDirective(const OMPCancellationPointDirective &s);
+  mlir::LogicalResult emitOMPCancelDirective(const OMPCancelDirective &s);
+  mlir::LogicalResult
+  emitOMPTargetDataDirective(const OMPTargetDataDirective &s);
+  mlir::LogicalResult
+  emitOMPTargetEnterDataDirective(const OMPTargetEnterDataDirective &s);
+  mlir::LogicalResult
+  emitOMPTargetExitDataDirective(const OMPTargetExitDataDirective &s);
+  mlir::LogicalResult
+  emitOMPTargetParallelDirective(const OMPTargetParallelDirective &s);
+  mlir::LogicalResult
+  emitOMPTargetParallelForDirective(const OMPTargetParallelForDirective &s);
+  mlir::LogicalResult emitOMPTaskLoopDirective(const OMPTaskLoopDirective &s);
+  mlir::LogicalResult
+  emitOMPTaskLoopSimdDirective(const OMPTaskLoopSimdDirective &s);
+  mlir::LogicalResult
+  emitOMPMaskedTaskLoopDirective(const OMPMaskedTaskLoopDirective &s);
+  mlir::LogicalResult
+  emitOMPMaskedTaskLoopSimdDirective(const OMPMaskedTaskLoopSimdDirective &s);
+  mlir::LogicalResult
+  emitOMPMasterTaskLoopDirective(const OMPMasterTaskLoopDirective &s);
+  mlir::LogicalResult
+  emitOMPMasterTaskLoopSimdDirective(const OMPMasterTaskLoopSimdDirective &s);
+  mlir::LogicalResult
+  emitOMPParallelGenericLoopDirective(const OMPParallelGenericLoopDirective &s);
+  mlir::LogicalResult
+  emitOMPParallelMaskedDirective(const OMPParallelMaskedDirective &s);
+  mlir::LogicalResult emitOMPParallelMaskedTaskLoopDirective(
+      const OMPParallelMaskedTaskLoopDirective &s);
+  mlir::LogicalResult emitOMPParallelMaskedTaskLoopSimdDirective(
+      const OMPParallelMaskedTaskLoopSimdDirective &s);
+  mlir::LogicalResult emitOMPParallelMasterTaskLoopDirective(
+      const OMPParallelMasterTaskLoopDirective &s);
+  mlir::LogicalResult emitOMPParallelMasterTaskLoopSimdDirective(
+      const OMPParallelMasterTaskLoopSimdDirective &s);
+  mlir::LogicalResult
+  emitOMPDistributeDirective(const OMPDistributeDirective &s);
+  mlir::LogicalResult emitOMPDistributeParallelForDirective(
+      const OMPDistributeParallelForDirective &s);
+  mlir::LogicalResult emitOMPDistributeParallelForSimdDirective(
+      const OMPDistributeParallelForSimdDirective &s);
+  mlir::LogicalResult
+  emitOMPDistributeSimdDirective(const OMPDistributeSimdDirective &s);
+  mlir::LogicalResult emitOMPTargetParallelGenericLoopDirective(
+      const OMPTargetParallelGenericLoopDirective &s);
+  mlir::LogicalResult emitOMPTargetParallelForSimdDirective(
+      const OMPTargetParallelForSimdDirective &s);
+  mlir::LogicalResult
+  emitOMPTargetSimdDirective(const OMPTargetSimdDirective &s);
+  mlir::LogicalResult emitOMPTargetTeamsGenericLoopDirective(
+      const OMPTargetTeamsGenericLoopDirective &s);
+  mlir::LogicalResult
+  emitOMPTargetUpdateDirective(const OMPTargetUpdateDirective &s);
+  mlir::LogicalResult
+  emitOMPTeamsDistributeDirective(const OMPTeamsDistributeDirective &s);
+  mlir::LogicalResult
+  emitOMPTeamsDistributeSimdDirective(const OMPTeamsDistributeSimdDirective &s);
+  mlir::LogicalResult emitOMPTeamsDistributeParallelForSimdDirective(
+      const OMPTeamsDistributeParallelForSimdDirective &s);
+  mlir::LogicalResult emitOMPTeamsDistributeParallelForDirective(
+      const OMPTeamsDistributeParallelForDirective &s);
+  mlir::LogicalResult
+  emitOMPTeamsGenericLoopDirective(const OMPTeamsGenericLoopDirective &s);
+  mlir::LogicalResult
+  emitOMPTargetTeamsDirective(const OMPTargetTeamsDirective &s);
+  mlir::LogicalResult emitOMPTargetTeamsDistributeDirective(
+      const OMPTargetTeamsDistributeDirective &s);
+  mlir::LogicalResult emitOMPTargetTeamsDistributeParallelForDirective(
+      const OMPTargetTeamsDistributeParallelForDirective &s);
+  mlir::LogicalResult emitOMPTargetTeamsDistributeParallelForSimdDirective(
+      const OMPTargetTeamsDistributeParallelForSimdDirective &s);
+  mlir::LogicalResult emitOMPTargetTeamsDistributeSimdDirective(
+      const OMPTargetTeamsDistributeSimdDirective &s);
+  mlir::LogicalResult emitOMPInteropDirective(const OMPInteropDirective &s);
+  mlir::LogicalResult emitOMPDispatchDirective(const OMPDispatchDirective &s);
+  mlir::LogicalResult
+  emitOMPGenericLoopDirective(const OMPGenericLoopDirective &s);
+  mlir::LogicalResult emitOMPReverseDirective(const OMPReverseDirective &s);
+  mlir::LogicalResult
+  emitOMPInterchangeDirective(const OMPInterchangeDirective &s);
+  mlir::LogicalResult emitOMPAssumeDirective(const OMPAssumeDirective &s);
+  mlir::LogicalResult emitOMPMaskedDirective(const OMPMaskedDirective &s);
+  mlir::LogicalResult emitOMPStripeDirective(const OMPStripeDirective &s);
+
+  void emitOMPThreadPrivateDecl(const OMPThreadPrivateDecl &d);
+  void emitOMPGroupPrivateDecl(const OMPGroupPrivateDecl &d);
+  void emitOMPCapturedExpr(const OMPCapturedExprDecl &d);
+  void emitOMPAllocateDecl(const OMPAllocateDecl &d);
+  void emitOMPDeclareReduction(const OMPDeclareReductionDecl &d);
+  void emitOMPDeclareMapper(const OMPDeclareMapperDecl &d);
+  void emitOMPRequiresDecl(const OMPRequiresDecl &d);
+
+  //===--------------------------------------------------------------------===//
   //                         OpenACC Emission
   //===--------------------------------------------------------------------===//
 private:

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -360,6 +360,12 @@ void CIRGenModule::emitGlobal(clang::GlobalDecl gd) {
     return;
   }
 
+  // TODO(OMP): The logic in this function for the 'rest' of the OpenMP
+  // declarative declarations is complicated and needs to be done on a per-kind
+  // basis, so all of that needs to be added when we implement the individual
+  // global-allowed declarations. See uses of `cir::MissingFeatures::openMP
+  // throughout this function.
+
   const auto *global = cast<ValueDecl>(gd.getDecl());
 
   if (const auto *fd = dyn_cast<FunctionDecl>(global)) {
@@ -1543,6 +1549,27 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
     break;
   case Decl::OpenACCDeclare:
     emitGlobalOpenACCDeclareDecl(cast<OpenACCDeclareDecl>(decl));
+    break;
+  case Decl::OMPThreadPrivate:
+    emitOMPThreadPrivateDecl(cast<OMPThreadPrivateDecl>(decl));
+    break;
+  case Decl::OMPGroupPrivate:
+    emitOMPGroupPrivateDecl(cast<OMPGroupPrivateDecl>(decl));
+    break;
+  case Decl::OMPAllocate:
+    emitOMPAllocateDecl(cast<OMPAllocateDecl>(decl));
+    break;
+  case Decl::OMPCapturedExpr:
+    emitOMPCapturedExpr(cast<OMPCapturedExprDecl>(decl));
+    break;
+  case Decl::OMPDeclareReduction:
+    emitOMPDeclareReduction(cast<OMPDeclareReductionDecl>(decl));
+    break;
+  case Decl::OMPDeclareMapper:
+    emitOMPDeclareMapper(cast<OMPDeclareMapperDecl>(decl));
+    break;
+  case Decl::OMPRequires:
+    emitOMPRequiresDecl(cast<OMPRequiresDecl>(decl));
     break;
   case Decl::Enum:
   case Decl::Using:          // using X; [C++]

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -491,6 +491,14 @@ public:
                               cir::FuncOp func, SourceLocation pragmaLoc,
                               ArrayRef<const OpenACCClause *> clauses);
 
+  void emitOMPThreadPrivateDecl(const OMPThreadPrivateDecl *d);
+  void emitOMPGroupPrivateDecl(const OMPGroupPrivateDecl *d);
+  void emitOMPCapturedExpr(const OMPCapturedExprDecl *d);
+  void emitOMPAllocateDecl(const OMPAllocateDecl *d);
+  void emitOMPDeclareReduction(const OMPDeclareReductionDecl *d);
+  void emitOMPDeclareMapper(const OMPDeclareMapperDecl *d);
+  void emitOMPRequiresDecl(const OMPRequiresDecl *d);
+
   // C++ related functions.
   void emitDeclContext(const DeclContext *dc);
 

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -19,6 +19,7 @@
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/StmtOpenACC.h"
+#include "clang/AST/StmtOpenMP.h"
 #include "clang/CIR/MissingFeatures.h"
 
 using namespace clang;
@@ -195,7 +196,187 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
   case Stmt::MSAsmStmtClass:
     return emitAsmStmt(cast<AsmStmt>(*s));
   case Stmt::OMPScopeDirectiveClass:
+    return emitOMPScopeDirective(cast<OMPScopeDirective>(*s));
   case Stmt::OMPErrorDirectiveClass:
+    return emitOMPErrorDirective(cast<OMPErrorDirective>(*s));
+  case Stmt::OMPParallelDirectiveClass:
+    return emitOMPParallelDirective(cast<OMPParallelDirective>(*s));
+  case Stmt::OMPTaskwaitDirectiveClass:
+    return emitOMPTaskwaitDirective(cast<OMPTaskwaitDirective>(*s));
+  case Stmt::OMPTaskyieldDirectiveClass:
+    return emitOMPTaskyieldDirective(cast<OMPTaskyieldDirective>(*s));
+  case Stmt::OMPBarrierDirectiveClass:
+    return emitOMPBarrierDirective(cast<OMPBarrierDirective>(*s));
+  case Stmt::OMPMetaDirectiveClass:
+    return emitOMPMetaDirective(cast<OMPMetaDirective>(*s));
+  case Stmt::OMPCanonicalLoopClass:
+    return emitOMPCanonicalLoop(cast<OMPCanonicalLoop>(*s));
+  case Stmt::OMPSimdDirectiveClass:
+    return emitOMPSimdDirective(cast<OMPSimdDirective>(*s));
+  case Stmt::OMPTileDirectiveClass:
+    return emitOMPTileDirective(cast<OMPTileDirective>(*s));
+  case Stmt::OMPUnrollDirectiveClass:
+    return emitOMPUnrollDirective(cast<OMPUnrollDirective>(*s));
+  case Stmt::OMPFuseDirectiveClass:
+    return emitOMPFuseDirective(cast<OMPFuseDirective>(*s));
+  case Stmt::OMPForDirectiveClass:
+    return emitOMPForDirective(cast<OMPForDirective>(*s));
+  case Stmt::OMPForSimdDirectiveClass:
+    return emitOMPForSimdDirective(cast<OMPForSimdDirective>(*s));
+  case Stmt::OMPSectionsDirectiveClass:
+    return emitOMPSectionsDirective(cast<OMPSectionsDirective>(*s));
+  case Stmt::OMPSectionDirectiveClass:
+    return emitOMPSectionDirective(cast<OMPSectionDirective>(*s));
+  case Stmt::OMPSingleDirectiveClass:
+    return emitOMPSingleDirective(cast<OMPSingleDirective>(*s));
+  case Stmt::OMPMasterDirectiveClass:
+    return emitOMPMasterDirective(cast<OMPMasterDirective>(*s));
+  case Stmt::OMPCriticalDirectiveClass:
+    return emitOMPCriticalDirective(cast<OMPCriticalDirective>(*s));
+  case Stmt::OMPParallelForDirectiveClass:
+    return emitOMPParallelForDirective(cast<OMPParallelForDirective>(*s));
+  case Stmt::OMPParallelForSimdDirectiveClass:
+    return emitOMPParallelForSimdDirective(
+        cast<OMPParallelForSimdDirective>(*s));
+  case Stmt::OMPParallelMasterDirectiveClass:
+    return emitOMPParallelMasterDirective(cast<OMPParallelMasterDirective>(*s));
+  case Stmt::OMPParallelSectionsDirectiveClass:
+    return emitOMPParallelSectionsDirective(
+        cast<OMPParallelSectionsDirective>(*s));
+  case Stmt::OMPTaskDirectiveClass:
+    return emitOMPTaskDirective(cast<OMPTaskDirective>(*s));
+  case Stmt::OMPTaskgroupDirectiveClass:
+    return emitOMPTaskgroupDirective(cast<OMPTaskgroupDirective>(*s));
+  case Stmt::OMPFlushDirectiveClass:
+    return emitOMPFlushDirective(cast<OMPFlushDirective>(*s));
+  case Stmt::OMPDepobjDirectiveClass:
+    return emitOMPDepobjDirective(cast<OMPDepobjDirective>(*s));
+  case Stmt::OMPScanDirectiveClass:
+    return emitOMPScanDirective(cast<OMPScanDirective>(*s));
+  case Stmt::OMPOrderedDirectiveClass:
+    return emitOMPOrderedDirective(cast<OMPOrderedDirective>(*s));
+  case Stmt::OMPAtomicDirectiveClass:
+    return emitOMPAtomicDirective(cast<OMPAtomicDirective>(*s));
+  case Stmt::OMPTargetDirectiveClass:
+    return emitOMPTargetDirective(cast<OMPTargetDirective>(*s));
+  case Stmt::OMPTeamsDirectiveClass:
+    return emitOMPTeamsDirective(cast<OMPTeamsDirective>(*s));
+  case Stmt::OMPCancellationPointDirectiveClass:
+    return emitOMPCancellationPointDirective(
+        cast<OMPCancellationPointDirective>(*s));
+  case Stmt::OMPCancelDirectiveClass:
+    return emitOMPCancelDirective(cast<OMPCancelDirective>(*s));
+  case Stmt::OMPTargetDataDirectiveClass:
+    return emitOMPTargetDataDirective(cast<OMPTargetDataDirective>(*s));
+  case Stmt::OMPTargetEnterDataDirectiveClass:
+    return emitOMPTargetEnterDataDirective(
+        cast<OMPTargetEnterDataDirective>(*s));
+  case Stmt::OMPTargetExitDataDirectiveClass:
+    return emitOMPTargetExitDataDirective(cast<OMPTargetExitDataDirective>(*s));
+  case Stmt::OMPTargetParallelDirectiveClass:
+    return emitOMPTargetParallelDirective(cast<OMPTargetParallelDirective>(*s));
+  case Stmt::OMPTargetParallelForDirectiveClass:
+    return emitOMPTargetParallelForDirective(
+        cast<OMPTargetParallelForDirective>(*s));
+  case Stmt::OMPTaskLoopDirectiveClass:
+    return emitOMPTaskLoopDirective(cast<OMPTaskLoopDirective>(*s));
+  case Stmt::OMPTaskLoopSimdDirectiveClass:
+    return emitOMPTaskLoopSimdDirective(cast<OMPTaskLoopSimdDirective>(*s));
+  case Stmt::OMPMaskedTaskLoopDirectiveClass:
+    return emitOMPMaskedTaskLoopDirective(cast<OMPMaskedTaskLoopDirective>(*s));
+  case Stmt::OMPMaskedTaskLoopSimdDirectiveClass:
+    return emitOMPMaskedTaskLoopSimdDirective(
+        cast<OMPMaskedTaskLoopSimdDirective>(*s));
+  case Stmt::OMPMasterTaskLoopDirectiveClass:
+    return emitOMPMasterTaskLoopDirective(cast<OMPMasterTaskLoopDirective>(*s));
+  case Stmt::OMPMasterTaskLoopSimdDirectiveClass:
+    return emitOMPMasterTaskLoopSimdDirective(
+        cast<OMPMasterTaskLoopSimdDirective>(*s));
+  case Stmt::OMPParallelGenericLoopDirectiveClass:
+    return emitOMPParallelGenericLoopDirective(
+        cast<OMPParallelGenericLoopDirective>(*s));
+  case Stmt::OMPParallelMaskedDirectiveClass:
+    return emitOMPParallelMaskedDirective(cast<OMPParallelMaskedDirective>(*s));
+  case Stmt::OMPParallelMaskedTaskLoopDirectiveClass:
+    return emitOMPParallelMaskedTaskLoopDirective(
+        cast<OMPParallelMaskedTaskLoopDirective>(*s));
+  case Stmt::OMPParallelMaskedTaskLoopSimdDirectiveClass:
+    return emitOMPParallelMaskedTaskLoopSimdDirective(
+        cast<OMPParallelMaskedTaskLoopSimdDirective>(*s));
+  case Stmt::OMPParallelMasterTaskLoopDirectiveClass:
+    return emitOMPParallelMasterTaskLoopDirective(
+        cast<OMPParallelMasterTaskLoopDirective>(*s));
+  case Stmt::OMPParallelMasterTaskLoopSimdDirectiveClass:
+    return emitOMPParallelMasterTaskLoopSimdDirective(
+        cast<OMPParallelMasterTaskLoopSimdDirective>(*s));
+  case Stmt::OMPDistributeDirectiveClass:
+    return emitOMPDistributeDirective(cast<OMPDistributeDirective>(*s));
+  case Stmt::OMPDistributeParallelForDirectiveClass:
+    return emitOMPDistributeParallelForDirective(
+        cast<OMPDistributeParallelForDirective>(*s));
+  case Stmt::OMPDistributeParallelForSimdDirectiveClass:
+    return emitOMPDistributeParallelForSimdDirective(
+        cast<OMPDistributeParallelForSimdDirective>(*s));
+  case Stmt::OMPDistributeSimdDirectiveClass:
+    return emitOMPDistributeSimdDirective(cast<OMPDistributeSimdDirective>(*s));
+  case Stmt::OMPTargetParallelGenericLoopDirectiveClass:
+    return emitOMPTargetParallelGenericLoopDirective(
+        cast<OMPTargetParallelGenericLoopDirective>(*s));
+  case Stmt::OMPTargetParallelForSimdDirectiveClass:
+    return emitOMPTargetParallelForSimdDirective(
+        cast<OMPTargetParallelForSimdDirective>(*s));
+  case Stmt::OMPTargetSimdDirectiveClass:
+    return emitOMPTargetSimdDirective(cast<OMPTargetSimdDirective>(*s));
+  case Stmt::OMPTargetTeamsGenericLoopDirectiveClass:
+    return emitOMPTargetTeamsGenericLoopDirective(
+        cast<OMPTargetTeamsGenericLoopDirective>(*s));
+  case Stmt::OMPTargetUpdateDirectiveClass:
+    return emitOMPTargetUpdateDirective(cast<OMPTargetUpdateDirective>(*s));
+  case Stmt::OMPTeamsDistributeDirectiveClass:
+    return emitOMPTeamsDistributeDirective(
+        cast<OMPTeamsDistributeDirective>(*s));
+  case Stmt::OMPTeamsDistributeSimdDirectiveClass:
+    return emitOMPTeamsDistributeSimdDirective(
+        cast<OMPTeamsDistributeSimdDirective>(*s));
+  case Stmt::OMPTeamsDistributeParallelForSimdDirectiveClass:
+    return emitOMPTeamsDistributeParallelForSimdDirective(
+        cast<OMPTeamsDistributeParallelForSimdDirective>(*s));
+  case Stmt::OMPTeamsDistributeParallelForDirectiveClass:
+    return emitOMPTeamsDistributeParallelForDirective(
+        cast<OMPTeamsDistributeParallelForDirective>(*s));
+  case Stmt::OMPTeamsGenericLoopDirectiveClass:
+    return emitOMPTeamsGenericLoopDirective(
+        cast<OMPTeamsGenericLoopDirective>(*s));
+  case Stmt::OMPTargetTeamsDirectiveClass:
+    return emitOMPTargetTeamsDirective(cast<OMPTargetTeamsDirective>(*s));
+  case Stmt::OMPTargetTeamsDistributeDirectiveClass:
+    return emitOMPTargetTeamsDistributeDirective(
+        cast<OMPTargetTeamsDistributeDirective>(*s));
+  case Stmt::OMPTargetTeamsDistributeParallelForDirectiveClass:
+    return emitOMPTargetTeamsDistributeParallelForDirective(
+        cast<OMPTargetTeamsDistributeParallelForDirective>(*s));
+  case Stmt::OMPTargetTeamsDistributeParallelForSimdDirectiveClass:
+    return emitOMPTargetTeamsDistributeParallelForSimdDirective(
+        cast<OMPTargetTeamsDistributeParallelForSimdDirective>(*s));
+  case Stmt::OMPTargetTeamsDistributeSimdDirectiveClass:
+    return emitOMPTargetTeamsDistributeSimdDirective(
+        cast<OMPTargetTeamsDistributeSimdDirective>(*s));
+  case Stmt::OMPInteropDirectiveClass:
+    return emitOMPInteropDirective(cast<OMPInteropDirective>(*s));
+  case Stmt::OMPDispatchDirectiveClass:
+    return emitOMPDispatchDirective(cast<OMPDispatchDirective>(*s));
+  case Stmt::OMPGenericLoopDirectiveClass:
+    return emitOMPGenericLoopDirective(cast<OMPGenericLoopDirective>(*s));
+  case Stmt::OMPReverseDirectiveClass:
+    return emitOMPReverseDirective(cast<OMPReverseDirective>(*s));
+  case Stmt::OMPInterchangeDirectiveClass:
+    return emitOMPInterchangeDirective(cast<OMPInterchangeDirective>(*s));
+  case Stmt::OMPAssumeDirectiveClass:
+    return emitOMPAssumeDirective(cast<OMPAssumeDirective>(*s));
+  case Stmt::OMPMaskedDirectiveClass:
+    return emitOMPMaskedDirective(cast<OMPMaskedDirective>(*s));
+  case Stmt::OMPStripeDirectiveClass:
+    return emitOMPStripeDirective(cast<OMPStripeDirective>(*s));
   case Stmt::LabelStmtClass:
   case Stmt::AttributedStmtClass:
   case Stmt::GotoStmtClass:
@@ -204,10 +385,6 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
   case Stmt::SEHLeaveStmtClass:
   case Stmt::SYCLKernelCallStmtClass:
   case Stmt::CoreturnStmtClass:
-  case Stmt::OMPParallelDirectiveClass:
-  case Stmt::OMPTaskwaitDirectiveClass:
-  case Stmt::OMPTaskyieldDirectiveClass:
-  case Stmt::OMPBarrierDirectiveClass:
   case Stmt::CapturedStmtClass:
   case Stmt::ObjCAtTryStmtClass:
   case Stmt::ObjCAtThrowStmtClass:
@@ -215,78 +392,6 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
   case Stmt::ObjCForCollectionStmtClass:
   case Stmt::ObjCAutoreleasePoolStmtClass:
   case Stmt::SEHTryStmtClass:
-  case Stmt::OMPMetaDirectiveClass:
-  case Stmt::OMPCanonicalLoopClass:
-  case Stmt::OMPSimdDirectiveClass:
-  case Stmt::OMPTileDirectiveClass:
-  case Stmt::OMPUnrollDirectiveClass:
-  case Stmt::OMPFuseDirectiveClass:
-  case Stmt::OMPForDirectiveClass:
-  case Stmt::OMPForSimdDirectiveClass:
-  case Stmt::OMPSectionsDirectiveClass:
-  case Stmt::OMPSectionDirectiveClass:
-  case Stmt::OMPSingleDirectiveClass:
-  case Stmt::OMPMasterDirectiveClass:
-  case Stmt::OMPCriticalDirectiveClass:
-  case Stmt::OMPParallelForDirectiveClass:
-  case Stmt::OMPParallelForSimdDirectiveClass:
-  case Stmt::OMPParallelMasterDirectiveClass:
-  case Stmt::OMPParallelSectionsDirectiveClass:
-  case Stmt::OMPTaskDirectiveClass:
-  case Stmt::OMPTaskgroupDirectiveClass:
-  case Stmt::OMPFlushDirectiveClass:
-  case Stmt::OMPDepobjDirectiveClass:
-  case Stmt::OMPScanDirectiveClass:
-  case Stmt::OMPOrderedDirectiveClass:
-  case Stmt::OMPAtomicDirectiveClass:
-  case Stmt::OMPTargetDirectiveClass:
-  case Stmt::OMPTeamsDirectiveClass:
-  case Stmt::OMPCancellationPointDirectiveClass:
-  case Stmt::OMPCancelDirectiveClass:
-  case Stmt::OMPTargetDataDirectiveClass:
-  case Stmt::OMPTargetEnterDataDirectiveClass:
-  case Stmt::OMPTargetExitDataDirectiveClass:
-  case Stmt::OMPTargetParallelDirectiveClass:
-  case Stmt::OMPTargetParallelForDirectiveClass:
-  case Stmt::OMPTaskLoopDirectiveClass:
-  case Stmt::OMPTaskLoopSimdDirectiveClass:
-  case Stmt::OMPMaskedTaskLoopDirectiveClass:
-  case Stmt::OMPMaskedTaskLoopSimdDirectiveClass:
-  case Stmt::OMPMasterTaskLoopDirectiveClass:
-  case Stmt::OMPMasterTaskLoopSimdDirectiveClass:
-  case Stmt::OMPParallelGenericLoopDirectiveClass:
-  case Stmt::OMPParallelMaskedDirectiveClass:
-  case Stmt::OMPParallelMaskedTaskLoopDirectiveClass:
-  case Stmt::OMPParallelMaskedTaskLoopSimdDirectiveClass:
-  case Stmt::OMPParallelMasterTaskLoopDirectiveClass:
-  case Stmt::OMPParallelMasterTaskLoopSimdDirectiveClass:
-  case Stmt::OMPDistributeDirectiveClass:
-  case Stmt::OMPDistributeParallelForDirectiveClass:
-  case Stmt::OMPDistributeParallelForSimdDirectiveClass:
-  case Stmt::OMPDistributeSimdDirectiveClass:
-  case Stmt::OMPTargetParallelGenericLoopDirectiveClass:
-  case Stmt::OMPTargetParallelForSimdDirectiveClass:
-  case Stmt::OMPTargetSimdDirectiveClass:
-  case Stmt::OMPTargetTeamsGenericLoopDirectiveClass:
-  case Stmt::OMPTargetUpdateDirectiveClass:
-  case Stmt::OMPTeamsDistributeDirectiveClass:
-  case Stmt::OMPTeamsDistributeSimdDirectiveClass:
-  case Stmt::OMPTeamsDistributeParallelForSimdDirectiveClass:
-  case Stmt::OMPTeamsDistributeParallelForDirectiveClass:
-  case Stmt::OMPTeamsGenericLoopDirectiveClass:
-  case Stmt::OMPTargetTeamsDirectiveClass:
-  case Stmt::OMPTargetTeamsDistributeDirectiveClass:
-  case Stmt::OMPTargetTeamsDistributeParallelForDirectiveClass:
-  case Stmt::OMPTargetTeamsDistributeParallelForSimdDirectiveClass:
-  case Stmt::OMPTargetTeamsDistributeSimdDirectiveClass:
-  case Stmt::OMPInteropDirectiveClass:
-  case Stmt::OMPDispatchDirectiveClass:
-  case Stmt::OMPGenericLoopDirectiveClass:
-  case Stmt::OMPReverseDirectiveClass:
-  case Stmt::OMPInterchangeDirectiveClass:
-  case Stmt::OMPAssumeDirectiveClass:
-  case Stmt::OMPMaskedDirectiveClass:
-  case Stmt::OMPStripeDirectiveClass:
   case Stmt::ObjCAtCatchStmtClass:
   case Stmt::ObjCAtFinallyStmtClass:
   case Stmt::DeferStmtClass:

--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
@@ -1,0 +1,460 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Emit OpenMP Stmt nodes as CIR code.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenBuilder.h"
+#include "CIRGenFunction.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "clang/AST/StmtOpenMP.h"
+
+using namespace clang;
+using namespace clang::CIRGen;
+
+mlir::LogicalResult
+CIRGenFunction::emitOMPScopeDirective(const OMPScopeDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPScopeDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPErrorDirective(const OMPErrorDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPErrorDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPParallelDirective(const OMPParallelDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPParallelDirective");
+  return mlir::failure();
+}
+
+mlir::LogicalResult
+CIRGenFunction::emitOMPTaskwaitDirective(const OMPTaskwaitDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPTaskwaitDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTaskyieldDirective(const OMPTaskyieldDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTaskyieldDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPBarrierDirective(const OMPBarrierDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPBarrierDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPMetaDirective(const OMPMetaDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPMetaDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPCanonicalLoop(const OMPCanonicalLoop &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPCanonicalLoop");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPSimdDirective(const OMPSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTileDirective(const OMPTileDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPTileDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPUnrollDirective(const OMPUnrollDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPUnrollDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPFuseDirective(const OMPFuseDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPFuseDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPForDirective(const OMPForDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPForDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPForSimdDirective(const OMPForSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPForSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPSectionsDirective(const OMPSectionsDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPSectionsDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPSectionDirective(const OMPSectionDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPSectionDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPSingleDirective(const OMPSingleDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPSingleDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPMasterDirective(const OMPMasterDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPMasterDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPCriticalDirective(const OMPCriticalDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPCriticalDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPParallelForDirective(const OMPParallelForDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelForDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPParallelForSimdDirective(
+    const OMPParallelForSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelForSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPParallelMasterDirective(
+    const OMPParallelMasterDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelMasterDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPParallelSectionsDirective(
+    const OMPParallelSectionsDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelSectionsDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTaskDirective(const OMPTaskDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPTaskDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTaskgroupDirective(const OMPTaskgroupDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTaskgroupDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPFlushDirective(const OMPFlushDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPFlushDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPDepobjDirective(const OMPDepobjDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPDepobjDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPScanDirective(const OMPScanDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPScanDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPOrderedDirective(const OMPOrderedDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPOrderedDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPAtomicDirective(const OMPAtomicDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPAtomicDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTargetDirective(const OMPTargetDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPTargetDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTeamsDirective(const OMPTeamsDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPTeamsDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPCancellationPointDirective(
+    const OMPCancellationPointDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPCancellationPointDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPCancelDirective(const OMPCancelDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPCancelDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTargetDataDirective(const OMPTargetDataDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetDataDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetEnterDataDirective(
+    const OMPTargetEnterDataDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetEnterDataDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetExitDataDirective(
+    const OMPTargetExitDataDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetExitDataDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetParallelDirective(
+    const OMPTargetParallelDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetParallelDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetParallelForDirective(
+    const OMPTargetParallelForDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetParallelForDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTaskLoopDirective(const OMPTaskLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPTaskLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTaskLoopSimdDirective(
+    const OMPTaskLoopSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTaskLoopSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPMaskedTaskLoopDirective(
+    const OMPMaskedTaskLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPMaskedTaskLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPMaskedTaskLoopSimdDirective(
+    const OMPMaskedTaskLoopSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPMaskedTaskLoopSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPMasterTaskLoopDirective(
+    const OMPMasterTaskLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPMasterTaskLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPMasterTaskLoopSimdDirective(
+    const OMPMasterTaskLoopSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPMasterTaskLoopSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPParallelGenericLoopDirective(
+    const OMPParallelGenericLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelGenericLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPParallelMaskedDirective(
+    const OMPParallelMaskedDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelMaskedDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPParallelMaskedTaskLoopDirective(
+    const OMPParallelMaskedTaskLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelMaskedTaskLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPParallelMaskedTaskLoopSimdDirective(
+    const OMPParallelMaskedTaskLoopSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelMaskedTaskLoopSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPParallelMasterTaskLoopDirective(
+    const OMPParallelMasterTaskLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelMasterTaskLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPParallelMasterTaskLoopSimdDirective(
+    const OMPParallelMasterTaskLoopSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPParallelMasterTaskLoopSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPDistributeDirective(const OMPDistributeDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPDistributeDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPDistributeParallelForDirective(
+    const OMPDistributeParallelForDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPDistributeParallelForDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPDistributeParallelForSimdDirective(
+    const OMPDistributeParallelForSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPDistributeParallelForSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPDistributeSimdDirective(
+    const OMPDistributeSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPDistributeSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetParallelGenericLoopDirective(
+    const OMPTargetParallelGenericLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetParallelGenericLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetParallelForSimdDirective(
+    const OMPTargetParallelForSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetParallelForSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTargetSimdDirective(const OMPTargetSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetTeamsGenericLoopDirective(
+    const OMPTargetTeamsGenericLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetTeamsGenericLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetUpdateDirective(
+    const OMPTargetUpdateDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetUpdateDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTeamsDistributeDirective(
+    const OMPTeamsDistributeDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTeamsDistributeDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTeamsDistributeSimdDirective(
+    const OMPTeamsDistributeSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTeamsDistributeSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTeamsDistributeParallelForSimdDirective(
+    const OMPTeamsDistributeParallelForSimdDirective &s) {
+  getCIRGenModule().errorNYI(
+      s.getSourceRange(), "OpenMP OMPTeamsDistributeParallelForSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTeamsDistributeParallelForDirective(
+    const OMPTeamsDistributeParallelForDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTeamsDistributeParallelForDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTeamsGenericLoopDirective(
+    const OMPTeamsGenericLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTeamsGenericLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTargetTeamsDirective(const OMPTargetTeamsDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetTeamsDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetTeamsDistributeDirective(
+    const OMPTargetTeamsDistributeDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetTeamsDistributeDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTargetTeamsDistributeParallelForDirective(
+    const OMPTargetTeamsDistributeParallelForDirective &s) {
+  getCIRGenModule().errorNYI(
+      s.getSourceRange(),
+      "OpenMP OMPTargetTeamsDistributeParallelForDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPTargetTeamsDistributeParallelForSimdDirective(
+    const OMPTargetTeamsDistributeParallelForSimdDirective &s) {
+  getCIRGenModule().errorNYI(
+      s.getSourceRange(),
+      "OpenMP OMPTargetTeamsDistributeParallelForSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult CIRGenFunction::emitOMPTargetTeamsDistributeSimdDirective(
+    const OMPTargetTeamsDistributeSimdDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPTargetTeamsDistributeSimdDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPInteropDirective(const OMPInteropDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPInteropDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPDispatchDirective(const OMPDispatchDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPDispatchDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPGenericLoopDirective(const OMPGenericLoopDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPGenericLoopDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPReverseDirective(const OMPReverseDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPReverseDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPInterchangeDirective(const OMPInterchangeDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(),
+                             "OpenMP OMPInterchangeDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPAssumeDirective(const OMPAssumeDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPAssumeDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPMaskedDirective(const OMPMaskedDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPMaskedDirective");
+  return mlir::failure();
+}
+mlir::LogicalResult
+CIRGenFunction::emitOMPStripeDirective(const OMPStripeDirective &s) {
+  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPStripeDirective");
+  return mlir::failure();
+}

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -13,6 +13,7 @@
 #include "CIRGenModule.h"
 
 #include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Target/LLVMIR/Import.h"
 
@@ -53,6 +54,7 @@ void CIRGenerator::Initialize(ASTContext &astContext) {
   mlirContext->loadDialect<mlir::DLTIDialect>();
   mlirContext->loadDialect<cir::CIRDialect>();
   mlirContext->getOrLoadDialect<mlir::acc::OpenACCDialect>();
+  mlirContext->getOrLoadDialect<mlir::omp::OpenMPDialect>();
 
   // Register extensions to integrate CIR types with OpenACC.
   mlir::DialectRegistry registry;

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -23,6 +23,7 @@ add_clang_library(clangCIR
   CIRGenDecl.cpp
   CIRGenDeclCXX.cpp
   CIRGenDeclOpenACC.cpp
+  CIRGenDeclOpenMP.cpp
   CIRGenException.cpp
   CIRGenExpr.cpp
   CIRGenExprAggregate.cpp
@@ -41,6 +42,7 @@ add_clang_library(clangCIR
   CIRGenStmt.cpp
   CIRGenStmtOpenACC.cpp
   CIRGenStmtOpenACCLoop.cpp
+  CIRGenStmtOpenMP.cpp
   CIRGenTypes.cpp
   CIRGenVTables.cpp
   TargetInfo.cpp

--- a/clang/test/CIR/CodeGenOpenMP/decl-not-yet-implemented.c
+++ b/clang/test/CIR/CodeGenOpenMP/decl-not-yet-implemented.c
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -fopenmp -fclangir %s -verify -emit-cir -o -
+
+int a;
+// expected-error@+1{{ClangIR code gen Not Yet Implemented: OpenMP OMPThreadPrivateDecl}}
+#pragma omp threadprivate(a)

--- a/clang/test/CIR/CodeGenOpenMP/not-yet-implemented.c
+++ b/clang/test/CIR/CodeGenOpenMP/not-yet-implemented.c
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fopenmp -fclangir %s -verify -emit-cir -o -
+
+void do_things() {
+  // expected-error@+1{{ClangIR code gen Not Yet Implemented: OpenMP OMPCriticalDirective}}
+#pragma omp critical
+  {}
+
+  // expected-error@+1{{ClangIR code gen Not Yet Implemented: OpenMP OMPSingleDirective}}
+#pragma omp single
+  {}
+
+  int i;
+  // expected-error@+1{{ClangIR code gen Not Yet Implemented: OpenMP OMPParallelDirective}}
+#pragma omp parallel if(i)
+  {}
+}


### PR DESCRIPTION
This patch adds the basic infrastructure for lowering an OpenMP directive, which should enable someone to take over the OpenMP lowering in the future. It adds the lowering entry points to CIR in the same way as OpenACC.

Note that this does nothing with any of the directives, which will happen in a followup patch. No infrastructure for clauses is added either, but that will come in a followup patch as well.