### PR TITLE
[clang-tidy][NFC] Add misc-include-cleaner to clang-tidy codebase

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -15,6 +15,7 @@ Checks: >
   cppcoreguidelines-virtual-class-destructor,
   google-readability-casting,
   misc-const-correctness,
+  misc-include-cleaner,
   modernize-*,
   -modernize-avoid-c-arrays,
   -modernize-pass-by-value,
@@ -41,4 +42,6 @@ Checks: >
 
 CheckOptions:
   - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           false
+  - key:             misc-include-cleaner.MissingIncludes
     value:           false

--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -33,7 +33,7 @@
 #include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Rewrite/Frontend/FixItRewriter.h"
 #include "clang/Tooling/Core/Diagnostic.h"
-#include "clang/Tooling/DiagnosticsYaml.h"
+#include "clang/Tooling/DiagnosticsYaml.h" // IWYU pragma: keep
 #include "clang/Tooling/Refactoring.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/Support/Process.h"

--- a/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
@@ -10,7 +10,7 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGTIDYFORCELINKER_H
 
 #include "clang-tidy-config.h"
-#include "llvm/Support/Compiler.h"
+#include "llvm/Support/Compiler.h" // IWYU pragma: keep
 
 namespace clang::tidy {
 

--- a/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
@@ -10,7 +10,6 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGTIDYFORCELINKER_H
 
 #include "clang-tidy-config.h"
-#include "llvm/Support/Compiler.h" // IWYU pragma: keep
 
 namespace clang::tidy {
 

--- a/clang-tools-extra/clang-tidy/GlobList.cpp
+++ b/clang-tools-extra/clang-tidy/GlobList.cpp
@@ -31,7 +31,7 @@ static llvm::StringRef extractNextGlob(StringRef &GlobList) {
 }
 
 static llvm::Regex createRegexFromGlob(StringRef &Glob) {
-  SmallString<128> RegexText("^");
+  llvm::SmallString<128> RegexText("^");
   const StringRef MetaChars("()^$|*+?.[]\\{}");
   for (const char C : Glob) {
     if (C == '*')

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -27,7 +27,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FormatVariadic.h"
-#include "llvm/Support/MathExtras.h"
 #include <array>
 #include <cmath>
 #include <cstdint>

--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -16,7 +16,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/YAMLParser.h"
@@ -1363,9 +1362,8 @@ IdentifierNamingCheck::getFailureInfo(
   if (StringRef(Fixup) == Name) {
     if (!IgnoreFailedSplit) {
       LLVM_DEBUG(Location.print(llvm::dbgs(), SM);
-                 llvm::dbgs()
-                 << llvm::formatv(": unable to split words for {0} '{1}'\n",
-                                  KindName, Name));
+                 llvm::dbgs() << ": unable to split words for " << KindName
+                              << " '" << Name << "'\n");
     }
     return std::nullopt;
   }

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -16,13 +16,13 @@
 
 #include "ClangTidyMain.h"
 #include "../ClangTidy.h"
-#include "../ClangTidyForceLinker.h"
+#include "../ClangTidyForceLinker.h" // IWYU pragma: keep
 #include "../GlobList.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/PluginLoader.h"
+#include "llvm/Support/PluginLoader.h" // IWYU pragma: keep
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"


### PR DESCRIPTION
Enabling `misc-include-cleaner` with a couple of `IWYU pragma: keep` lines seems beneficial to me:

In my observation, we've made far more comments in reviews like "this header seems unused" than we've looked at includes of "top-level" files like `ClangTidy.cpp`, `ClangTidyForceLinker.h`, `ClangTidyMain.cpp` and so on. 
So I think it's a net benefit to keep check files clean from unused headers (which we review a lot) but make rarely-touched areas a little "polluted" with `IWYU pragma`'s