### PR TITLE
[Clang] [Lexer] Detect SSE4.2 availability at runtime in fastParseASCIIIdentifier

### DIFF
--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -1921,9 +1921,7 @@ bool Lexer::LexUnicodeIdentifierStart(Token &Result, uint32_t C,
   return true;
 }
 
-static const char *
-fastParseASCIIIdentifierScalar(const char *CurPtr,
-                               [[maybe_unused]] const char *BufferEnd) {
+static const char *fastParseASCIIIdentifierScalar(const char *CurPtr) {
   unsigned char C = *CurPtr;
   while (isAsciiIdentifierContinue(C))
     C = *++CurPtr;
@@ -1936,10 +1934,8 @@ fastParseASCIIIdentifierScalar(const char *CurPtr,
 // fall back to the scalar implementation.
 #if (defined(__i386__) || defined(__x86_64__)) && defined(__has_attribute) &&  \
     __has_attribute(target) && !defined(_MSC_VER)
-
 __attribute__((target("sse4.2"))) static const char *
-fastParseASCIIIdentifierSSE42(const char *CurPtr,
-                              [[maybe_unused]] const char *BufferEnd) {
+fastParseASCIIIdentifierSSE42(const char *CurPtr, const char *BufferEnd) {
   alignas(16) static constexpr char AsciiIdentifierRange[16] = {
       '_', '_', 'A', 'Z', 'a', 'z', '0', '9',
   };
@@ -1960,7 +1956,7 @@ fastParseASCIIIdentifierSSE42(const char *CurPtr,
     return CurPtr;
   }
 
-  return fastParseASCIIIdentifierScalar(CurPtr, BufferEnd);
+  return fastParseASCIIIdentifierScalar(CurPtr);
 }
 
 __attribute__((target("sse4.2"))) static const char *
@@ -1972,7 +1968,7 @@ __attribute__((target("default")))
 #endif
 static const char *fastParseASCIIIdentifier(const char *CurPtr,
                                             const char *BufferEnd) {
-  return fastParseASCIIIdentifierScalar(CurPtr, BufferEnd);
+  return fastParseASCIIIdentifierScalar(CurPtr);
 }
 
 bool Lexer::LexIdentifierContinue(Token &Result, const char *CurPtr) {

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -46,7 +46,9 @@
 #include <string>
 #include <tuple>
 
+#if defined(__i386__) || defined(__x86_64__)
 #include <nmmintrin.h>
+#endif
 
 using namespace clang;
 
@@ -1927,6 +1929,8 @@ fastParseASCIIIdentifierScalar(const char *CurPtr,
   return CurPtr;
 }
 
+#if defined(__i386__) || defined(__x86_64__)
+
 __attribute__((target("sse4.2"))) static const char *
 fastParseASCIIIdentifierSSE42(const char *CurPtr,
                               [[maybe_unused]] const char *BufferEnd) {
@@ -1958,14 +1962,22 @@ static bool supportsSSE42() {
   return SupportsSSE42;
 }
 
+#endif
+
 static const char *fastParseASCIIIdentifier(const char *CurPtr,
                                             const char *BufferEnd) {
+#if !defined(__i386__) && !defined(__x86_64__)
+  return fastParseASCIIIdentifierScalar(CurPtr, BufferEnd);
+#else
+
 #ifndef __SSE4_2__
   if (LLVM_UNLIKELY(!supportsSSE42()))
     return fastParseASCIIIdentifierScalar(CurPtr, BufferEnd);
 #endif
 
   return fastParseASCIIIdentifierSSE42(CurPtr, BufferEnd);
+
+#endif
 }
 
 bool Lexer::LexIdentifierContinue(Token &Result, const char *CurPtr) {

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -36,6 +36,7 @@
 #include "llvm/Support/NativeFormatting.h"
 #include "llvm/Support/Unicode.h"
 #include "llvm/Support/UnicodeCharRanges.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -1929,7 +1930,7 @@ fastParseASCIIIdentifierScalar(const char *CurPtr,
   return CurPtr;
 }
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(__x86_64__) && !defined(_WIN32)
 
 __attribute__((target("sse4.2"))) static const char *
 fastParseASCIIIdentifierSSE42(const char *CurPtr,
@@ -1966,7 +1967,7 @@ static bool supportsSSE42() {
 
 static const char *fastParseASCIIIdentifier(const char *CurPtr,
                                             const char *BufferEnd) {
-#if !defined(__i386__) && !defined(__x86_64__)
+#if !defined(__i386__) && !defined(__x86_64__) || defined(_WIN32)
   return fastParseASCIIIdentifierScalar(CurPtr, BufferEnd);
 #else
 

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -1935,7 +1935,7 @@ fastParseASCIIIdentifierScalar(const char *CurPtr,
 // the 'target' attribute, which is used for runtime dispatch. Otherwise, we
 // fall back to the scalar implementation.
 #if (defined(__i386__) || defined(__x86_64__)) && defined(__has_attribute) &&  \
-    __has_attribute(target)
+    __has_attribute(target) && !defined(_MSC_VER)
 
 __attribute__((target("sse4.2"))) static const char *
 fastParseASCIIIdentifierSSE42(const char *CurPtr,


### PR DESCRIPTION
This change attempts to maximize usage of the SSE fast path in `fastParseASCIIIdentifier`.

If the binary is compiled with SSE4.2 enabled, or if we are not compiling for x86, then the behavior is the exact same, ensuring we have no regressions.

If not, we compile both the SSE fast path and the scalar loop. At runtime, we check if SSE4.2 is available and dispatch to the right function by using the `target` attribute. If it _is_ available, this allows a net performance improvement. Otherwise, there's a very slight but negligible regression... I believe that's perfectly reasonable for a non-SSE4.2-supporting processor.

I checked locally on an old x86 processor with QEMU to ensure this doesn't break compatibility; I'll need help to write the real tests though.

The benchmark results are available at [llvm-compile-time-tracker](https://llvm-compile-time-tracker.com/compare.php?from=f88d060c4176d17df56587a083944637ca865cb3&to=d5485438edd460892bf210916827e0d92fc24065&stat=instructions%3Au).