### PR TITLE
The C++ dynamic typing tests are failing on Windows, skip for now.

### DIFF
--- a/lldb/test/API/functionalities/expr-result-var/TestCPPExprResult.py
+++ b/lldb/test/API/functionalities/expr-result-var/TestCPPExprResult.py
@@ -95,9 +95,11 @@ class TestCPPResultVariables(TestBase):
         )
         self.assertEqual(method_result.signed, 500, "Got the right result value")
 
+    @skipIfWindows # Dynamic type resolution on Windows doesn't work
     def test_virtual_dynamic_results(self):
         self.do_test_dynamic_results(True)
 
+    @skipIfWindows # Dynamic type resolution on Windows doesn't work
     def test_non_virtual_dynamic_results(self):
         self.do_test_dynamic_results(False)
 


### PR DESCRIPTION
This is a follow-on to:

https://github.com/llvm/llvm-project/pull/168611

which added a bunch of tests for detecting dynamic types of C++ result variables.  I don't actually know how well dynamic type detection works on Windows if at all.  It would require Windows support, since the Linux/Darwin version is specific to the Itanium ABI.