### PR TITLE
[lldb] Still echo the command if we print the error.

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -3289,9 +3289,8 @@ void CommandInterpreter::IOHandlerInputComplete(IOHandler &io_handler,
     // from a file) we need to echo the command out so we don't just see the
     // command output and no command...
     if (EchoCommandNonInteractive(line, io_handler.GetFlags())) {
-      LockedStreamFile locked_stream =
-          io_handler.GetOutputStreamFileSP()->Lock();
-      locked_stream.Printf("%s%s\n", io_handler.GetPrompt(), line.c_str());
+      io_handler.GetOutputStreamFileSP()->Lock()
+          << io_handler.GetPrompt() << line << '\n';
       echoed_command = true;
     }
   }
@@ -3323,9 +3322,8 @@ void CommandInterpreter::IOHandlerInputComplete(IOHandler &io_handler,
     // If the command failed and we didn't echo it, echo it now so the user
     // knows which command produced the error.
     if (!echoed_command && !result.Succeeded() && print_error) {
-      LockedStreamFile locked_stream =
-          io_handler.GetOutputStreamFileSP()->Lock();
-      locked_stream.Printf("%s%s\n", io_handler.GetPrompt(), line.c_str());
+      io_handler.GetOutputStreamFileSP()->Lock()
+          << io_handler.GetPrompt() << line << '\n';
     }
 
     auto DefaultPrintCallback = [&](const CommandReturnObject &result) {

--- a/lldb/test/Shell/Settings/Inputs/FailedCommand.in
+++ b/lldb/test/Shell/Settings/Inputs/FailedCommand.in
@@ -1,0 +1,4 @@
+# This should succeed and not be echoed.
+expr 1+2
+# This should fail and be echoed.
+bogus_command

--- a/lldb/test/Shell/Settings/TestEchoFailedCommands.test
+++ b/lldb/test/Shell/Settings/TestEchoFailedCommands.test
@@ -1,0 +1,10 @@
+# Test that failed commands are echoed even when echoing is disabled.
+# This ensures users can see which command produced an error.
+
+RUN: mkdir -p %t.home
+RUN: cp %S/Inputs/FailedCommand.in %t.home/.lldbinit
+RUN: env HOME=%t.home %lldb-init -b 2>&1 | FileCheck %s
+
+CHECK-NOT: expr 1+2
+CHECK: (lldb) bogus_command
+CHECK: error: 'bogus_command' is not a valid command


### PR DESCRIPTION
When the command interpreter is asked to not echo commands but still print errors, a user has no idea what command caused the error.

For example, when I add `bogus` in my `~/.lldbinit`:

```
$ lldb
error: 'bogus' is not a valid command.
```

Things are even more confusing when we have inline diagnostics, which point to nothing. For example, when I add `settings set target.run-args -foo` to my `~/.lldbinit`:

```
❯ lldb
                                    ˄˜˜˜
                                    ╰─ error: unknown or ambiguous option
```

We should still echo the command if the command fails, making it obvious which command caused the failure and fixing the inline diagnostics.

Fixes #171514