### PR TITLE
[Sanitizer] show configure.log for libz build

### DIFF
--- a/compiler-rt/lib/sanitizer_common/symbolizer/scripts/build_symbolizer.sh
+++ b/compiler-rt/lib/sanitizer_common/symbolizer/scripts/build_symbolizer.sh
@@ -84,6 +84,8 @@ fi
 
 cd ${ZLIB_BUILD}
 AR="${AR}" CC="${CC}" CFLAGS="$FLAGS -Wno-deprecated-non-prototype" RANLIB=/bin/true ./configure --static
+# TODO: remove this. this is for debugging buildbot problems
+cat configure.log
 make -j libz.a
 
 # Build and install libcxxabi and libcxx.


### PR DESCRIPTION
This is for debugging the failures on the aarch64 buildbot
