### PR TITLE
[llvm][clang] Enable IO sandbox for assert builds

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -704,7 +704,7 @@ else()
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()
 
-option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" OFF)
+option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" ${LLVM_ENABLE_ASSERTIONS})
 option(LLVM_ENABLE_EXPENSIVE_CHECKS "Enable expensive checks" OFF)
 
 set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS" CACHE STRING


### PR DESCRIPTION
This PR enables the IO sandbox for supported tools (currently `clang -cc1` and `clang -cc1as`) in assert builds. More details are in the RFC here: https://discourse.llvm.org/t/rfc-file-system-sandboxing-in-clang-llvm/88791