### PR TITLE
Revert: check-builtins target for LLVM_ENABLE_RUNTIMES

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -284,11 +284,6 @@ macro(darwin_add_builtin_library name suffix)
     ${ARGN})
   set(libname "${name}.${suffix}_${LIB_ARCH}_${LIB_OS}")
   add_library(${libname} STATIC ${LIB_SOURCES})
-  
-  # Write out the sources that were used to compile the builtins so that tests can be run in
-  # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
-  file(WRITE "${CMAKE_BINARY_DIR}/${libname}.sources.txt" "${LIB_SOURCES}")
-
   if(DARWIN_${LIB_OS}_SYSROOT)
     set(sysroot_flag -isysroot ${DARWIN_${LIB_OS}_SYSROOT})
   endif()

--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -280,14 +280,6 @@ else()
   # Architectures supported by compiler-rt libraries.
   filter_available_targets(BUILTIN_SUPPORTED_ARCH
     ${ALL_BUILTIN_SUPPORTED_ARCH})
-
-  # COMPILER_RT_HAS_${arch}_* defines that are shared between lib/builtins/ and test/builtins/
-  foreach (arch ${BUILTIN_SUPPORTED_ARCH})
-    # NOTE: The corresponding check for if(APPLE) is in CompilerRTDarwinUtils.cmake
-    check_c_source_compiles("_Float16 foo(_Float16 x) { return x; }
-                              int main(void) { return 0; }"
-                            COMPILER_RT_HAS_${arch}_FLOAT16)
-  endforeach()
 endif()
 
 if(OS_NAME MATCHES "Linux|SerenityOS" AND NOT LLVM_USE_SANITIZER AND NOT

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -990,6 +990,9 @@ else ()
           endif()
         endif()
       endif()
+      check_c_source_compiles("_Float16 foo(_Float16 x) { return x; }
+                               int main(void) { return 0; }"
+                              COMPILER_RT_HAS_${arch}_FLOAT16)
       append_list_if(COMPILER_RT_HAS_${arch}_FLOAT16 -DCOMPILER_RT_HAS_FLOAT16 BUILTIN_CFLAGS_${arch})
       check_c_source_compiles("__bf16 foo(__bf16 x) { return x; }
                                int main(void) { return 0; }"
@@ -1025,9 +1028,6 @@ else ()
                               C_STANDARD 11
                               CXX_STANDARD 17
                               PARENT_TARGET builtins)
-      # Write out the sources that were used to compile the builtins so that tests can be run in
-      # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
-      file(WRITE "${CMAKE_BINARY_DIR}/clang_rt.builtins-${arch}.sources.txt" "${${arch}_SOURCES}")
       cmake_pop_check_state()
     endif ()
   endforeach ()

--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -73,10 +73,7 @@ endfunction()
 # Run sanitizer tests only if we're sure that clang would produce
 # working binaries.
 if(COMPILER_RT_CAN_EXECUTE_TESTS)
-  # COMPILER_RT_TEST_BUILTINS_DIR allows running tests against builtins built
-  # in an independent build. This option is only indended to be used by
-  # LLVM_ENABLE_RUNTIMES-based builds.
-  if(COMPILER_RT_BUILD_BUILTINS OR COMPILER_RT_TEST_BUILTINS_DIR)
+  if(COMPILER_RT_BUILD_BUILTINS)
     add_subdirectory(builtins)
   endif()
   if(COMPILER_RT_BUILD_SANITIZERS)

--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -1,16 +1,6 @@
 set(BUILTINS_LIT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-# If COMPILER_RT_TEST_BUILTINS_DIR is set, the builtins
-# were already built and we are just going to test them.
-# NOTE: This is currently an LLVM-internal option which should
-# only be used by the LLVM_ENABLE_RUNTIMES build configured
-# in llvm/runtimes/CMakeLists.txt
-if(COMPILER_RT_TEST_BUILTINS_DIR)
-  set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS})
-else()
-  set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS} builtins)
-endif()
-
+set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS} builtins)
 set(BUILTINS_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/TestCases)
 
 # Test cases.
@@ -94,19 +84,10 @@ foreach(arch ${BUILTIN_TEST_ARCH})
   else()
     set(BUILTIN_LIB_TARGET_NAME "clang_rt.builtins-${arch}")
   endif()
-  # Normally, we can just inspect the target directly to get the sources, but if
-  # we are testing an externally-built builtins library, we expect
-  # COMPILER_RT_TEST_BUILTINS_DIR to be set and contain a file named
-  # ${BUILTIN_LIB_TARGET_NAME}.sources.txt from the builtins build. This file
-  # is created by compiler-rt/lib/builtins/CMakeLists.txt
-  if(NOT COMPILER_RT_TEST_BUILTINS_DIR)
-    if (NOT TARGET "${BUILTIN_LIB_TARGET_NAME}")
-      message(FATAL_ERROR "Target ${BUILTIN_LIB_TARGET_NAME} does not exist")
-    endif()
-    get_target_property(BUILTIN_LIB_SOURCES "${BUILTIN_LIB_TARGET_NAME}" SOURCES)
-  else()
-    file(READ "${COMPILER_RT_TEST_BUILTINS_DIR}/${BUILTIN_LIB_TARGET_NAME}.sources.txt" BUILTIN_LIB_SOURCES)
+  if (NOT TARGET "${BUILTIN_LIB_TARGET_NAME}")
+    message(FATAL_ERROR "Target ${BUILTIN_LIB_TARGET_NAME} does not exist")
   endif()
+  get_target_property(BUILTIN_LIB_SOURCES "${BUILTIN_LIB_TARGET_NAME}" SOURCES)
   list(LENGTH BUILTIN_LIB_SOURCES BUILTIN_LIB_SOURCES_LENGTH)
   if (BUILTIN_LIB_SOURCES_LENGTH EQUAL 0)
     message(FATAL_ERROR "Failed to find source files for ${arch} builtin library")

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -262,10 +262,7 @@ function(runtime_default_target)
 
   if(LLVM_INCLUDE_TESTS)
     set_property(GLOBAL APPEND PROPERTY LLVM_ALL_LIT_TESTSUITES "@${LLVM_BINARY_DIR}/runtimes/runtimes-bins/lit.tests")
-    list(APPEND test_targets runtimes-test-depends check-runtimes check-builtins)
-
-    # The default runtimes target can run tests the default builtins target
-    list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_FORCE_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-bins/")
+    list(APPEND test_targets runtimes-test-depends check-runtimes)
   endif()
 
   set_enable_per_target_runtime_dir()
@@ -372,15 +369,6 @@ function(runtime_register_target name)
       list(APPEND ${name}_test_targets ${target}-${name})
       list(APPEND test_targets ${target}-${name})
     endforeach()
-
-    # If a builtins-${name} target exists, we'll test those builtins
-    # with this runtimes build
-    if(TARGET builtins-${name})
-      list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_FORCE_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-${name}-bins/")
-      set(check-builtins-${name} check-builtins)
-      list(APPEND ${name}_test_targets check-builtins-${name})
-      list(APPEND test_targets check-builtins-${name})
-    endif()
     set(test_targets "${test_targets}" PARENT_SCOPE)
   endif()
 
@@ -446,9 +434,6 @@ function(runtime_register_target name)
   if(LLVM_INCLUDE_TESTS)
     add_dependencies(check-runtimes check-runtimes-${name})
     add_dependencies(runtimes-test-depends runtimes-test-depends-${name})
-    if(TARGET builtins-${name})
-      add_dependencies(check-builtins check-builtins-${name})
-    endif()
   endif()
   foreach(runtime_name ${runtime_names})
     if(NOT TARGET ${runtime_name})
@@ -624,17 +609,6 @@ if(build_runtimes)
           PROPERTIES FOLDER "Runtimes"
         )
         set(test_targets "")
-
-        # NOTE: Currently, the builtins tests are run with the runtimes build,
-        # and the default runtimes target installs a check-builtins target
-        # which forwards to the default builtins build. If the default runtimes
-        # target is not used, we create a custom target which will depend on
-        # each check-builtins-${name}.
-        add_custom_target(check-builtins)
-        set_target_properties(
-          check-builtins
-          PROPERTIES FOLDER "Compiler-RT"
-        )
       endif()
       if(LLVM_RUNTIME_DISTRIBUTION_COMPONENTS)
         foreach(component ${LLVM_RUNTIME_DISTRIBUTION_COMPONENTS})

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -265,7 +265,7 @@ function(runtime_default_target)
     list(APPEND test_targets runtimes-test-depends check-runtimes check-builtins)
 
     # The default runtimes target can run tests the default builtins target
-    list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-bins/")
+    list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_FORCE_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-bins/")
   endif()
 
   set_enable_per_target_runtime_dir()
@@ -376,7 +376,7 @@ function(runtime_register_target name)
     # If a builtins-${name} target exists, we'll test those builtins
     # with this runtimes build
     if(TARGET builtins-${name})
-      list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-${name}-bins/")
+      list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_FORCE_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-${name}-bins/")
       set(check-builtins-${name} check-builtins)
       list(APPEND ${name}_test_targets check-builtins-${name})
       list(APPEND test_targets check-builtins-${name})


### PR DESCRIPTION
Revert #171741 and #166837.

@petrhosek reported issues with some builders using this feature

