### PR TITLE
[CIR] Upstream handling for data member pointer casts

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4177,6 +4177,58 @@ def CIR_DerivedClassAddrOp : CIR_Op<"derived_class_addr"> {
 }
 
 //===----------------------------------------------------------------------===//
+// BaseDataMemberOp & DerivedDataMemberOp
+//===----------------------------------------------------------------------===//
+
+def CIR_BaseDataMemberOp : CIR_Op<"base_data_member", [Pure]> {
+  let summary =
+    "Cast a derived class data member pointer to a base class data member "
+    "pointer";
+  let description = [{
+    The `cir.base_data_member` operation casts a data member pointer of type
+    `T Derived::*` to a data member pointer of type `T Base::*`, where `Base`
+    is an accessible non-ambiguous non-virtual base class of `Derived`.
+
+    The `offset` parameter gives the offset in bytes of the `Base` base class
+    subobject within a `Derived` object.
+  }];
+
+  let arguments = (ins CIR_DataMemberType:$src, IndexAttr:$offset);
+  let results = (outs CIR_DataMemberType:$result);
+
+  let assemblyFormat = [{
+    $src `:` qualified(type($src))
+    ` ` `[` $offset `]` `->` qualified(type($result)) attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+def CIR_DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
+  let summary =
+    "Cast a base class data member pointer to a derived class data member "
+    "pointer";
+  let description = [{
+    The `cir.derived_data_member` operation casts a data member pointer of type
+    `T Base::*` to a data member pointer of type `T Derived::*`, where `Base`
+    is an accessible non-ambiguous non-virtual base class of `Derived`.
+
+    The `offset` parameter gives the offset in bytes of the `Base` base class
+    subobject within a `Derived` object.
+  }];
+
+  let arguments = (ins CIR_DataMemberType:$src, IndexAttr:$offset);
+  let results = (outs CIR_DataMemberType:$result);
+
+  let assemblyFormat = [{
+    $src `:` qualified(type($src))
+    ` ` `[` $offset `]` `->` qualified(type($result)) attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // ComplexCreateOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4202,6 +4202,7 @@ def CIR_BaseDataMemberOp : CIR_Op<"base_data_member", [Pure]> {
 
   let hasVerifier = 1;
   let hasLLVMLowering = false;
+  let hasCXXABILowering = true;  
 }
 
 def CIR_DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
@@ -4226,6 +4227,7 @@ def CIR_DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
 
   let hasVerifier = 1;
   let hasLLVMLowering = false;
+  let hasCXXABILowering = true;  
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4197,8 +4197,7 @@ def CIR_BaseDataMemberOp : CIR_Op<"base_data_member", [Pure]> {
   let results = (outs CIR_DataMemberType:$result);
 
   let assemblyFormat = [{
-    $src `:` qualified(type($src))
-    ` ` `[` $offset `]` `->` qualified(type($result)) attr-dict
+    $src `[` $offset `]` `:` qualified(type($src)) `->` qualified(type($result)) attr-dict
   }];
 
   let hasVerifier = 1;
@@ -4222,8 +4221,7 @@ def CIR_DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
   let results = (outs CIR_DataMemberType:$result);
 
   let assemblyFormat = [{
-    $src `:` qualified(type($src))
-    ` ` `[` $offset `]` `->` qualified(type($result)) attr-dict
+    $src `[` $offset `]` `:` qualified(type($src)) `->` qualified(type($result)) attr-dict
   }];
 
   let hasVerifier = 1;

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -4202,6 +4202,7 @@ def CIR_BaseDataMemberOp : CIR_Op<"base_data_member", [Pure]> {
   }];
 
   let hasVerifier = 1;
+  let hasLLVMLowering = false;
 }
 
 def CIR_DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
@@ -4226,6 +4227,7 @@ def CIR_DerivedDataMemberOp : CIR_Op<"derived_data_member", [Pure]> {
   }];
 
   let hasVerifier = 1;
+  let hasLLVMLowering = false;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -302,6 +302,8 @@ struct MissingFeatures {
   static bool makeTripleAlwaysPresent() { return false; }
   static bool maybeHandleStaticInExternC() { return false; }
   static bool mergeAllConstants() { return false; }
+  static bool memberFuncPtrAuthInfo() { return false; }
+  static bool memberFuncPtrCast() { return false; }
   static bool metaDataNode() { return false; }
   static bool moduleNameHash() { return false; }
   static bool msabi() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2243,6 +2243,40 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
     return builder.getNullDataMemberPtr(ty, cgf.getLoc(subExpr->getExprLoc()));
   }
 
+  case CK_BaseToDerivedMemberPointer:
+  case CK_DerivedToBaseMemberPointer: {
+    mlir::Value src = Visit(subExpr);
+
+    assert(!cir::MissingFeatures::memberFuncPtrAuthInfo());
+
+    QualType derivedTy =
+        kind == CK_DerivedToBaseMemberPointer ? subExpr->getType() : destTy;
+    const auto *mpType = derivedTy->castAs<MemberPointerType>();
+    NestedNameSpecifier qualifier = mpType->getQualifier();
+    assert(qualifier && "member pointer without class qualifier");
+    const Type *qualifierType = qualifier.getAsType();
+    assert(qualifierType && "member pointer qualifier is not a type");
+    const CXXRecordDecl *derivedClass = qualifierType->getAsCXXRecordDecl();
+    CharUnits offset = cgf.cgm.computeNonVirtualBaseClassOffset(
+        derivedClass, ce->path());
+
+    mlir::Location loc = cgf.getLoc(subExpr->getExprLoc());
+    mlir::Type resultTy = cgf.convertType(destTy);
+    mlir::IntegerAttr offsetAttr = builder.getIndexAttr(offset.getQuantity());
+
+    if (subExpr->getType()->isMemberFunctionPointerType()) {
+      cgf.cgm.errorNYI(subExpr->getSourceRange(),
+                       "VisitCastExpr: member function pointer");
+      return {};
+    }
+
+    if (kind == CK_BaseToDerivedMemberPointer)
+      return cir::DerivedDataMemberOp::create(builder, loc, resultTy, src,
+                                              offsetAttr);
+    return cir::BaseDataMemberOp::create(builder, loc, resultTy, src,
+                                         offsetAttr);
+  }
+
   case CK_LValueToRValue:
     assert(cgf.getContext().hasSameUnqualifiedType(subExpr->getType(), destTy));
     assert(subExpr->isGLValue() && "lvalue-to-rvalue applied to r-value!");

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2257,8 +2257,8 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
     const Type *qualifierType = qualifier.getAsType();
     assert(qualifierType && "member pointer qualifier is not a type");
     const CXXRecordDecl *derivedClass = qualifierType->getAsCXXRecordDecl();
-    CharUnits offset = cgf.cgm.computeNonVirtualBaseClassOffset(
-        derivedClass, ce->path());
+    CharUnits offset =
+        cgf.cgm.computeNonVirtualBaseClassOffset(derivedClass, ce->path());
 
     mlir::Location loc = cgf.getLoc(subExpr->getExprLoc());
     mlir::Type resultTy = cgf.convertType(destTy);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -59,6 +59,18 @@ public:
   lowerGetRuntimeMember(cir::GetRuntimeMemberOp op, mlir::Type loweredResultTy,
                         mlir::Value loweredAddr, mlir::Value loweredMember,
                         mlir::OpBuilder &builder) const = 0;
+
+  /// Lower the given cir.base_data_member op to a sequence of more "primitive"
+  /// CIR operations that act on the ABI types.
+  virtual mlir::Value lowerBaseDataMember(cir::BaseDataMemberOp op,
+                                          mlir::Value loweredSrc,
+                                          mlir::OpBuilder &builder) const = 0;
+
+  /// Lower the given cir.derived_data_member op to a sequence of more
+  /// "primitive" CIR operations that act on the ABI types.
+  virtual mlir::Value
+  lowerDerivedDataMember(cir::DerivedDataMemberOp op, mlir::Value loweredSrc,
+                         mlir::OpBuilder &builder) const = 0;
 };
 
 /// Creates an Itanium-family ABI.

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CMakeLists.txt
@@ -17,4 +17,5 @@ add_clang_library(MLIRCIRTargetLowering
   MLIRDLTIDialect
   MLIRCIR
   MLIRCIRInterfaces
+  MLIRLLVMDialect
 )

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -161,11 +161,16 @@ static mlir::Value lowerDataMemberCast(mlir::Operation *op,
       builder, loc, ty, mlir::IntegerAttr::get(ty, offset));
   mlir::Value adjustedPtr;
   if (isDerivedToBase)
-    adjustedPtr = mlir::LLVM::SubOp::create(builder, loc, loweredSrc, offsetValue, mlir::LLVM::IntegerOverflowFlags::nsw);
+    adjustedPtr =
+        mlir::LLVM::SubOp::create(builder, loc, loweredSrc, offsetValue,
+                                  mlir::LLVM::IntegerOverflowFlags::nsw);
   else
-    adjustedPtr = mlir::LLVM::AddOp::create(builder, loc, loweredSrc, offsetValue, mlir::LLVM::IntegerOverflowFlags::nsw);
+    adjustedPtr =
+        mlir::LLVM::AddOp::create(builder, loc, loweredSrc, offsetValue,
+                                  mlir::LLVM::IntegerOverflowFlags::nsw);
 
-  return mlir::LLVM::SelectOp::create(builder, loc, isNull, loweredSrc, adjustedPtr);
+  return mlir::LLVM::SelectOp::create(builder, loc, isNull, loweredSrc,
+                                      adjustedPtr);
 }
 
 mlir::Value

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1528,24 +1528,6 @@ mlir::LogicalResult CIRToLLVMDerivedClassAddrOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
-mlir::LogicalResult CIRToLLVMBaseDataMemberOpLowering::matchAndRewrite(
-    cir::BaseDataMemberOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  mlir::Value loweredResult =
-      lowerMod->getCXXABI().lowerBaseDataMember(op, adaptor.getSrc(), rewriter);
-  rewriter.replaceOp(op, loweredResult);
-  return mlir::success();
-}
-
-mlir::LogicalResult CIRToLLVMDerivedDataMemberOpLowering::matchAndRewrite(
-    cir::DerivedDataMemberOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  mlir::Value loweredResult = lowerMod->getCXXABI().lowerDerivedDataMember(
-      op, adaptor.getSrc(), rewriter);
-  rewriter.replaceOp(op, loweredResult);
-  return mlir::success();
-}
-
 mlir::LogicalResult CIRToLLVMATanOpLowering::matchAndRewrite(
     cir::ATanOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1528,6 +1528,24 @@ mlir::LogicalResult CIRToLLVMDerivedClassAddrOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
+mlir::LogicalResult CIRToLLVMBaseDataMemberOpLowering::matchAndRewrite(
+    cir::BaseDataMemberOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult =
+      lowerMod->getCXXABI().lowerBaseDataMember(op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRToLLVMDerivedDataMemberOpLowering::matchAndRewrite(
+    cir::DerivedDataMemberOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  mlir::Value loweredResult = lowerMod->getCXXABI().lowerDerivedDataMember(
+      op, adaptor.getSrc(), rewriter);
+  rewriter.replaceOp(op, loweredResult);
+  return mlir::success();
+}
+
 mlir::LogicalResult CIRToLLVMATanOpLowering::matchAndRewrite(
     cir::ATanOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
@@ -24,7 +24,7 @@ auto base_to_derived(int Base2::*ptr) -> int Derived::* {
 
 // CIR-BEFORE: cir.func {{.*}} @_Z15base_to_derivedM5Base2i
 // CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
-// CIR-BEFORE:   %[[RET:.*]] = cir.derived_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Base2> [4] -> !cir.data_member<!s32i in !rec_Derived>
+// CIR-BEFORE:   %[[RET:.*]] = cir.derived_data_member %[[PTR]][4] : !cir.data_member<!s32i in !rec_Base2> -> !cir.data_member<!s32i in !rec_Derived>
 
 // CIR-AFTER: cir.func {{.*}} @_Z15base_to_derivedM5Base2i
 // CIR-AFTER:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i
@@ -52,7 +52,7 @@ auto derived_to_base(int Derived::*ptr) -> int Base2::* {
 
 // CIR-BEFORE: cir.func {{.*}} @_Z15derived_to_baseM7Derivedi
 // CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
-// CIR-BEFORE:   %[[RET:.*]] = cir.base_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Derived> [4] -> !cir.data_member<!s32i in !rec_Base2>
+// CIR-BEFORE:   %[[RET:.*]] = cir.base_data_member %[[PTR]][4] : !cir.data_member<!s32i in !rec_Derived> -> !cir.data_member<!s32i in !rec_Base2>
 
 // CIR-AFTER: cir.func {{.*}} @_Z15derived_to_baseM7Derivedi
 // CIR-AFTER:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i
@@ -80,7 +80,7 @@ auto base_to_derived_zero_offset(int Base1::*ptr) -> int Derived::* {
 
 // CIR-BEFORE: cir.func {{.*}} @_Z27base_to_derived_zero_offsetM5Base1i
 // CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
-// CIR-BEFORE:   %[[RET:.*]] = cir.derived_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Base1> [0] -> !cir.data_member<!s32i in !rec_Derived>
+// CIR-BEFORE:   %[[RET:.*]] = cir.derived_data_member %[[PTR]][0] : !cir.data_member<!s32i in !rec_Base1> -> !cir.data_member<!s32i in !rec_Derived>
 
 // CIR-AFTER: cir.func {{.*}} @_Z27base_to_derived_zero_offsetM5Base1i
 // CIR-AFTER:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i
@@ -110,7 +110,7 @@ auto derived_to_base_zero_offset(int Derived::*ptr) -> int Base1::* {
 
 // CIR-BEFORE: cir.func {{.*}} @_Z27derived_to_base_zero_offsetM7Derivedi
 // CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
-// CIR-BEFORE:   %[[RET:.*]] = cir.base_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Derived> [0] -> !cir.data_member<!s32i in !rec_Base1>
+// CIR-BEFORE:   %[[RET:.*]] = cir.base_data_member %[[PTR]][0] : !cir.data_member<!s32i in !rec_Derived> -> !cir.data_member<!s32i in !rec_Base1>
 
 // CIR-AFTER: cir.func {{.*}} @_Z27derived_to_base_zero_offsetM7Derivedi
 // CIR-AFTER:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
@@ -1,0 +1,110 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll --check-prefix=LLVM %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll --check-prefix=OGCG %s
+
+struct Base1 {
+  int base1_data;
+};
+
+struct Base2 {
+  int base2_data;
+};
+
+struct Derived : Base1, Base2 {
+  int derived_data;
+};
+
+auto base_to_derived(int Base2::*ptr) -> int Derived::* {
+  return ptr;
+}
+
+// CIR: cir.func {{.*}} @_Z15base_to_derivedM5Base2i
+// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR:   %[[RET:.*]] = cir.derived_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Base2> [4] -> !cir.data_member<!s32i in !rec_Derived>
+
+// LLVM: define {{.*}} i64 @_Z15base_to_derivedM5Base2i
+// LLVM:   %[[PTR:.*]] = load i64, ptr %{{.*}}
+// LLVM:   %[[IS_NULL:.*]] = icmp eq i64 %[[PTR]], -1
+// LLVM:   %[[DERIVED:.*]] = add nsw i64 %[[PTR]], 4
+// LLVM:   %[[RET:.*]] = select i1 %[[IS_NULL]], i64 %[[PTR]], i64 %[[DERIVED]]
+
+// OGCG: define {{.*}} i64 @_Z15base_to_derivedM5Base2i
+// OGCG:   %[[PTR:.*]] = load i64, ptr %{{.*}}
+// OGCG:   %[[DERIVED:.*]] = add nsw i64 %[[PTR]], 4
+// OGCG:   %[[IS_NULL:.*]] = icmp eq i64 %[[PTR]], -1
+// OGCG:   %[[RET:.*]] = select i1 %[[IS_NULL]], i64 %[[PTR]], i64 %[[DERIVED]]
+
+auto derived_to_base(int Derived::*ptr) -> int Base2::* {
+  return static_cast<int Base2::*>(ptr);
+}
+
+// CIR: cir.func {{.*}} @_Z15derived_to_baseM7Derivedi
+// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR:   %[[RET:.*]] = cir.base_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Derived> [4] -> !cir.data_member<!s32i in !rec_Base2>
+
+// LLVM: define {{.*}} i64 @_Z15derived_to_baseM7Derivedi
+// LLVM:   %[[PTR:.*]] = load i64, ptr %{{.*}}
+// LLVM:   %[[IS_NULL:.*]] = icmp eq i64 %[[PTR]], -1
+// LLVM:   %[[BASE:.*]] = sub nsw i64 %[[PTR]], 4
+// LLVM:   %[[RET:.*]] = select i1 %[[IS_NULL]], i64 %[[PTR]], i64 %[[BASE]]
+
+// OGCG: define {{.*}} i64 @_Z15derived_to_baseM7Derivedi
+// OGCG:   %[[PTR:.*]] = load i64, ptr %{{.*}}
+// OGCG:   %[[BASE:.*]] = sub nsw i64 %[[PTR]], 4
+// OGCG:   %[[IS_NULL:.*]] = icmp eq i64 %[[PTR]], -1
+// OGCG:   %[[RET:.*]] = select i1 %[[IS_NULL]], i64 %[[PTR]], i64 %[[BASE]]
+
+auto base_to_derived_zero_offset(int Base1::*ptr) -> int Derived::* {
+  return ptr;
+}
+
+// CIR: cir.func {{.*}} @_Z27base_to_derived_zero_offsetM5Base1i
+// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR:   %[[RET:.*]] = cir.derived_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Base1> [0] -> !cir.data_member<!s32i in !rec_Derived>
+
+// No LLVM instructions emitted for performing a zero-offset cast.
+
+// LLVM:      define {{.*}} i64 @_Z27base_to_derived_zero_offsetM5Base1i
+// LLVM-NEXT:   %[[PTR_ADDR:.*]] = alloca i64
+// LLVM-NEXT:   %[[RETVAL:.*]] = alloca i64
+// LLVM-NEXT:   store i64 %{{.*}}, ptr %[[PTR_ADDR]]
+// LLVM-NEXT:   %[[TEMP:.*]] = load i64, ptr %[[PTR_ADDR]]
+// LLVM-NEXT:   store i64 %[[TEMP]], ptr %[[RETVAL]]
+// LLVM-NEXT:   %[[RET:.*]] = load i64, ptr %[[RETVAL]]
+// LLVM-NEXT:   ret i64 %[[RET]]
+
+// OGCG:      define {{.*}} i64 @_Z27base_to_derived_zero_offsetM5Base1i
+// OGCG-NEXT: entry:
+// OGCG-NEXT:   %[[PTR_ADDR:.*]] = alloca i64
+// OGCG-NEXT:   store i64 %{{.*}}, ptr %[[PTR_ADDR]]
+// OGCG-NEXT:   %[[RET:.*]] = load i64, ptr %[[PTR_ADDR]]
+// OGCG-NEXT:   ret i64 %[[RET]]
+
+auto derived_to_base_zero_offset(int Derived::*ptr) -> int Base1::* {
+  return static_cast<int Base1::*>(ptr);
+}
+
+// CIR: cir.func {{.*}} @_Z27derived_to_base_zero_offsetM7Derivedi
+// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR:   %[[RET:.*]] = cir.base_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Derived> [0] -> !cir.data_member<!s32i in !rec_Base1>
+
+// No LLVM instructions emitted for performing a zero-offset cast.
+
+// LLVM:      define {{.*}} i64 @_Z27derived_to_base_zero_offsetM7Derivedi
+// LLVM-NEXT:   %[[PTR_ADDR:.*]] = alloca i64
+// LLVM-NEXT:   %[[RETVAL:.*]] = alloca i64
+// LLVM-NEXT:   store i64 %{{.*}}, ptr %[[PTR_ADDR]]
+// LLVM-NEXT:   %[[TEMP:.*]] = load i64, ptr %[[PTR_ADDR]]
+// LLVM-NEXT:   store i64 %[[TEMP]], ptr %[[RETVAL]]
+// LLVM-NEXT:   %[[RET:.*]] = load i64, ptr %[[RETVAL]]
+// LLVM-NEXT:   ret i64 %[[RET]]
+
+// OGCG:      define {{.*}} i64 @_Z27derived_to_base_zero_offsetM7Derivedi
+// OGCG-NEXT: entry:
+// OGCG-NEXT:   %[[PTR_ADDR:.*]] = alloca i64
+// OGCG-NEXT:   store i64 %{{.*}}, ptr %[[PTR_ADDR]]
+// OGCG-NEXT:   %[[RET:.*]] = load i64, ptr %[[PTR_ADDR]]
+// OGCG-NEXT:   ret i64 %[[RET]]

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-cast.cpp
@@ -1,5 +1,6 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir --check-prefix=CIR %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-cir -mmlir -mlir-print-ir-before=cir-cxxabi-lowering %s -o %t.cir 2> %t-before.cir
+// RUN: FileCheck --check-prefix=CIR-BEFORE --input-file=%t-before.cir %s
+// RUN: FileCheck --check-prefix=CIR-AFTER --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll --check-prefix=LLVM %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -emit-llvm %s -o %t.ll
@@ -21,9 +22,17 @@ auto base_to_derived(int Base2::*ptr) -> int Derived::* {
   return ptr;
 }
 
-// CIR: cir.func {{.*}} @_Z15base_to_derivedM5Base2i
-// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
-// CIR:   %[[RET:.*]] = cir.derived_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Base2> [4] -> !cir.data_member<!s32i in !rec_Derived>
+// CIR-BEFORE: cir.func {{.*}} @_Z15base_to_derivedM5Base2i
+// CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR-BEFORE:   %[[RET:.*]] = cir.derived_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Base2> [4] -> !cir.data_member<!s32i in !rec_Derived>
+
+// CIR-AFTER: cir.func {{.*}} @_Z15base_to_derivedM5Base2i
+// CIR-AFTER:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i
+// CIR-AFTER:   %[[NULL_VALUE:.*]] = cir.const #cir.int<-1> : !s64i
+// CIR-AFTER:   %[[IS_NULL:.*]] = cir.cmp(eq, %[[PTR]], %[[NULL_VALUE]])
+// CIR-AFTER:   %[[OFFSET_VALUE:.*]] = cir.const #cir.int<4> : !s64i
+// CIR-AFTER:   %[[BINOP_KIND:.*]] = cir.binop(add, %[[PTR]], %[[OFFSET_VALUE]]) nsw : !s64i
+// CIR-AFTER:   %[[SELECT:.*]] = cir.select if %[[IS_NULL]] then %[[PTR]] else %[[BINOP_KIND]]
 
 // LLVM: define {{.*}} i64 @_Z15base_to_derivedM5Base2i
 // LLVM:   %[[PTR:.*]] = load i64, ptr %{{.*}}
@@ -41,9 +50,17 @@ auto derived_to_base(int Derived::*ptr) -> int Base2::* {
   return static_cast<int Base2::*>(ptr);
 }
 
-// CIR: cir.func {{.*}} @_Z15derived_to_baseM7Derivedi
-// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
-// CIR:   %[[RET:.*]] = cir.base_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Derived> [4] -> !cir.data_member<!s32i in !rec_Base2>
+// CIR-BEFORE: cir.func {{.*}} @_Z15derived_to_baseM7Derivedi
+// CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR-BEFORE:   %[[RET:.*]] = cir.base_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Derived> [4] -> !cir.data_member<!s32i in !rec_Base2>
+
+// CIR-AFTER: cir.func {{.*}} @_Z15derived_to_baseM7Derivedi
+// CIR-AFTER:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i
+// CIR-AFTER:   %[[NULL_VALUE:.*]] = cir.const #cir.int<-1> : !s64i
+// CIR-AFTER:   %[[IS_NULL:.*]] = cir.cmp(eq, %[[PTR]], %[[NULL_VALUE]])
+// CIR-AFTER:   %[[OFFSET_VALUE:.*]] = cir.const #cir.int<4> : !s64i
+// CIR-AFTER:   %[[BINOP_KIND:.*]] = cir.binop(sub, %[[PTR]], %[[OFFSET_VALUE]]) nsw : !s64i
+// CIR-AFTER:   %[[SELECT:.*]] = cir.select if %[[IS_NULL]] then %[[PTR]] else %[[BINOP_KIND]]
 
 // LLVM: define {{.*}} i64 @_Z15derived_to_baseM7Derivedi
 // LLVM:   %[[PTR:.*]] = load i64, ptr %{{.*}}
@@ -61,9 +78,13 @@ auto base_to_derived_zero_offset(int Base1::*ptr) -> int Derived::* {
   return ptr;
 }
 
-// CIR: cir.func {{.*}} @_Z27base_to_derived_zero_offsetM5Base1i
-// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
-// CIR:   %[[RET:.*]] = cir.derived_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Base1> [0] -> !cir.data_member<!s32i in !rec_Derived>
+// CIR-BEFORE: cir.func {{.*}} @_Z27base_to_derived_zero_offsetM5Base1i
+// CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR-BEFORE:   %[[RET:.*]] = cir.derived_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Base1> [0] -> !cir.data_member<!s32i in !rec_Derived>
+
+// CIR-AFTER: cir.func {{.*}} @_Z27base_to_derived_zero_offsetM5Base1i
+// CIR-AFTER:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i
+// CIR-AFTER:   cir.store %[[PTR]], %{{.*}} : !s64i, !cir.ptr<!s64i>
 
 // No LLVM instructions emitted for performing a zero-offset cast.
 
@@ -87,9 +108,13 @@ auto derived_to_base_zero_offset(int Derived::*ptr) -> int Base1::* {
   return static_cast<int Base1::*>(ptr);
 }
 
-// CIR: cir.func {{.*}} @_Z27derived_to_base_zero_offsetM7Derivedi
-// CIR:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
-// CIR:   %[[RET:.*]] = cir.base_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Derived> [0] -> !cir.data_member<!s32i in !rec_Base1>
+// CIR-BEFORE: cir.func {{.*}} @_Z27derived_to_base_zero_offsetM7Derivedi
+// CIR-BEFORE:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}}
+// CIR-BEFORE:   %[[RET:.*]] = cir.base_data_member %[[PTR]] : !cir.data_member<!s32i in !rec_Derived> [0] -> !cir.data_member<!s32i in !rec_Base1>
+
+// CIR-AFTER: cir.func {{.*}} @_Z27derived_to_base_zero_offsetM7Derivedi
+// CIR-AFTER:   %[[PTR:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s64i>, !s64i
+// CIR-AFTER:   cir.store %[[PTR]], %{{.*}} : !s64i, !cir.ptr<!s64i>
 
 // No LLVM instructions emitted for performing a zero-offset cast.
 


### PR DESCRIPTION
This adds the CIR basic handling for casts of data member pointers. Cast to bool and null, as well as member function pointer casts will be handled in followup PRs.