### PR TITLE
[MLIR][Python] Fix AffineIfOp insertion point

### DIFF
--- a/mlir/python/mlir/dialects/affine.py
+++ b/mlir/python/mlir/dialects/affine.py
@@ -198,7 +198,7 @@ class AffineIfOp(AffineIfOp):
         results = []
         results.extend(results_)
 
-        super().__init__(results, cond_operands, cond)
+        super().__init__(results, cond_operands, cond, loc=loc, ip=ip)
         self.regions[0].blocks.append(*[])
         if has_else:
             self.regions[1].blocks.append(*[])


### PR DESCRIPTION
This bug was introduced by #108323, where the loc and ip were not properly set. It may lead to errors when the operations are not linearly asserted to the IR.