### PR TITLE
[NFC][OpenCL] Fix intel-unsupported-extensions.cl when cl_intel_subgroup_local_block_io is disabled

### DIFF
--- a/clang/test/SemaOpenCL/intel-unsupported-extensions.cl
+++ b/clang/test/SemaOpenCL/intel-unsupported-extensions.cl
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple spir-unknown-unknown -verify -finclude-default-header -cl-std=CL3.0 -cl-ext=-cl_intel_subgroups,-cl_intel_subgroup_buffer_prefetch,-cl_intel_subgroups_char,-cl_intel_subgroups_short,-cl_intel_subgroups_long,-cl_intel_bfloat16_conversions,-cl_intel_subgroup_local_block_io,-cl_intel_device_side_avc_motion_estimation %s
+// RUN: %clang_cc1 -triple spir-unknown-unknown -verify -finclude-default-header -cl-std=CL3.0 -cl-ext=-cl_intel_subgroup_local_block_io %s
 // RUN: %clang_cc1 -triple spir-unknown-unknown -verify -finclude-default-header -cl-std=CL3.0 %s
 
 #if defined(cl_intel_subgroups) && defined(cl_intel_subgroup_buffer_prefetch) && defined(cl_intel_subgroups_char) && defined(cl_intel_subgroups_short) && defined(cl_intel_subgroups_long) && defined(cl_intel_bfloat16_conversions) && defined(cl_intel_subgroup_local_block_io) && defined(cl_intel_device_side_avc_motion_estimation)
@@ -47,11 +48,17 @@ ushort test6(float f) {
 // expected-error@-3{{use of undeclared identifier 'intel_convert_bfloat16_as_ushort'}}
 #endif
 
-uint test7(const __local uint* p) {
-  return intel_sub_group_block_read(p);
+#if defined(cl_intel_subgroups_short) && !defined(cl_intel_subgroup_local_block_io)
+ushort test7(const __local ushort* p) {
+  return intel_sub_group_block_read_us(p); // expected-error{{no matching function for call to 'intel_sub_group_block_read_us'}} expected-error 0+{{}} // expected-note@* {{}} // expected-note@* {{}} // expected-note@* {{}}
+}
+#else
+ushort test7(const __local ushort* p) {
+  return intel_sub_group_block_read_us(p);
 }
 #if !defined(cl_intel_subgroup_local_block_io)
-// expected-error@-3{{use of undeclared identifier 'intel_sub_group_block_read'}}
+// expected-error@-3{{use of undeclared identifier 'intel_sub_group_block_read_us'}}
+#endif
 #endif
 
 uchar test8(uchar slice_type, uchar qp) {

--- a/clang/test/SemaOpenCL/intel-unsupported-extensions.cl
+++ b/clang/test/SemaOpenCL/intel-unsupported-extensions.cl
@@ -26,7 +26,7 @@ uchar test3(read_only image2d_t im, int2 i) {
 // expected-error@-3{{use of undeclared identifier 'intel_sub_group_block_read_uc'}}
 #endif
 
-ushort test4(const __local ushort* p) {
+ushort test4(const __global ushort* p) {
   return intel_sub_group_block_read_us(p);
 }
 #if !defined(cl_intel_subgroups_short)


### PR DESCRIPTION
__local address space function requires both cl_intel_subgroups_short and cl_intel_subgroup_local_block_io.
Change it to __global so that only cl_intel_subgroups_short is required.

This fixes test fail when cl_intel_subgroups_short is enabled but cl_intel_subgroup_local_block_io isn't.