### PR TITLE
[flang] Fix: Reject OPTIONAL dummy arguments for DIM in ALL/ANY/COUNT

### DIFF
--- a/flang/test/Semantics/dim01.f90
+++ b/flang/test/Semantics/dim01.f90
@@ -16,21 +16,21 @@ module m
   function f1(a,d)
     real, intent(in) :: a(:)
     integer, optional, intent(in) :: d
-    !PORTABILITY: The actual argument for DIM= is optional, pointer, or allocatable, and it is assumed to be present and equal to 1 at execution time [-Woptional-must-be-present]
+    !ERROR: The actual argument for DIM= must not be OPTIONAL
     f1 = sum(a,dim=d)
-    !PORTABILITY: The actual argument for DIM= is optional, pointer, or allocatable, and it is assumed to be present and equal to 1 at execution time [-Woptional-must-be-present]
+    !ERROR: The actual argument for DIM= must not be OPTIONAL
     f1 = norm2(a,dim=d)
   end function
   function f2(a,d)
     real, intent(in) :: a(:)
     integer, pointer, intent(in) :: d
-    !PORTABILITY: The actual argument for DIM= is optional, pointer, or allocatable, and it is assumed to be present and equal to 1 at execution time [-Woptional-must-be-present]
+    !PORTABILITY: The actual argument for DIM= is pointer or allocatable, and it is assumed to be present and equal to 1 at execution time [-Woptional-must-be-present]
     f2 = sum(a,dim=d)
   end function
   function f3(a,d)
     real, intent(in) :: a(:)
     integer, allocatable, intent(in) :: d
-    !PORTABILITY: The actual argument for DIM= is optional, pointer, or allocatable, and it is assumed to be present and equal to 1 at execution time [-Woptional-must-be-present]
+    !PORTABILITY: The actual argument for DIM= is pointer or allocatable, and it is assumed to be present and equal to 1 at execution time [-Woptional-must-be-present]
     f3 = sum(a,dim=d)
   end function
   function f10a(a)
@@ -49,23 +49,23 @@ module m
     real, intent(in) :: a(:,:)
     integer, optional, intent(in) :: d
     real, allocatable :: f11(:)
-    !WARNING: The actual argument for DIM= is optional, pointer, or allocatable, and may not be absent during execution; parenthesize to silence this warning [-Woptional-must-be-present]
+    !ERROR: The actual argument for DIM= must not be OPTIONAL
     f11 = sum(a,dim=d)
-    !WARNING: The actual argument for DIM= is optional, pointer, or allocatable, and may not be absent during execution; parenthesize to silence this warning [-Woptional-must-be-present]
+    !ERROR: The actual argument for DIM= must not be OPTIONAL
     f11 = norm2(a,dim=d)
   end function
   function f12(a,d)
     real, intent(in) :: a(:,:)
     integer, pointer, intent(in) :: d
     real, allocatable :: f12(:)
-    !WARNING: The actual argument for DIM= is optional, pointer, or allocatable, and may not be absent during execution; parenthesize to silence this warning [-Woptional-must-be-present]
+    !WARNING: The actual argument for DIM= is pointer or allocatable, and may not be absent during execution; parenthesize to silence this warning [-Woptional-must-be-present]
     f12 = sum(a,dim=d)
   end function
   function f13(a,d)
     real, intent(in) :: a(:,:)
     integer, allocatable, intent(in) :: d
     real, allocatable :: f13(:)
-    !WARNING: The actual argument for DIM= is optional, pointer, or allocatable, and may not be absent during execution; parenthesize to silence this warning [-Woptional-must-be-present]
+    !WARNING: The actual argument for DIM= is pointer or allocatable, and may not be absent during execution; parenthesize to silence this warning [-Woptional-must-be-present]
     f13 = sum(a,dim=d)
   end function
 end module


### PR DESCRIPTION
Flang was incorrectly accepting OPTIONAL dummy arguments for the DIM parameter in intrinsic functions ALL, ANY, and COUNT. This violates the Fortran 2018 standard (Section 16.9.5) which explicitly requires that the DIM argument must not be an OPTIONAL dummy argument.

The root cause was a conditional check that only validated DIM arguments when the intrinsic parameter was marked as 'required'. However, ALL/ANY/COUNT define their DIM parameter as 'optional' (meaning the parameter itself is optional in the call), which prevented the OPTIONAL validation from running.

This fix removes the incorrect gate and properly checks whether the actual argument is an OPTIONAL dummy, issuing an error and rejecting the call as required by the standard.

Also updated test expectations in dim01.f90 to expect errors instead of warnings for OPTIONAL DIM arguments.