### PR TITLE
[CIR][X86] Implement lowering for `_AddressOfReturnAddress` builtin

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3281,15 +3281,7 @@ def CIR_CopyOp : CIR_Op<"copy",[
 // ReturnAddrOp and FrameAddrOp
 //===----------------------------------------------------------------------===//
 
-class CIR_FuncAddrBuiltinOp<string mnemonic> : CIR_Op<mnemonic, []> {
-  let arguments = (ins CIR_UInt32:$level);
-  let results = (outs CIR_VoidPtrType:$result);
-  let assemblyFormat = [{
-    `(` $level `)` attr-dict
-  }];
-}
-
-def CIR_ReturnAddrOp : CIR_FuncAddrBuiltinOp<"return_address"> {
+def CIR_ReturnAddrOp : CIR_Op<"return_address"> {
   let summary =
       "The return address of the current function, or of one of its callers";
 
@@ -3306,12 +3298,16 @@ def CIR_ReturnAddrOp : CIR_FuncAddrBuiltinOp<"return_address"> {
     Examples:
 
     ```mlir
-    %p = return_address(%level) -> !cir.ptr<!void>
+    %p = return_address(%level) : !cir.ptr<!void>
     ```
   }];
+
+  let arguments = (ins CIR_UInt32:$level);
+  let results = (outs CIR_VoidPtrType:$result);
+  let assemblyFormat = "`(` $level `)` attr-dict";
 }
 
-def CIR_FrameAddrOp : CIR_FuncAddrBuiltinOp<"frame_address"> {
+def CIR_FrameAddrOp : CIR_Op<"frame_address"> {
   let summary =
       "The frame address of the current function, or of one of its callers";
 
@@ -3334,9 +3330,13 @@ def CIR_FrameAddrOp : CIR_FuncAddrBuiltinOp<"frame_address"> {
     Examples:
 
     ```mlir
-    %p = frame_address(%level) -> !cir.ptr<!void>
+    %p = frame_address(%level) : !cir.ptr<!u8i>
     ```
   }];
+
+  let arguments = (ins CIR_UInt32:$level);
+  let results = (outs CIR_PointerType:$result);
+  let assemblyFormat = "`(` $level `)` attr-dict `:` qualified(type($result))";
 }
 
 //===----------------------------------------------------------------------===//
@@ -3354,7 +3354,7 @@ def CIR_AddrOfReturnAddrOp : CIR_Op<"address_of_return_address"> {
     Examples:
 
     ```mlir
-    %addr = address_of_return_address() : !cir.ptr<!cir.int<u, 8>>
+    %addr = address_of_return_address() : !cir.ptr<!u8i>
     ```
   }];
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3340,6 +3340,29 @@ def CIR_FrameAddrOp : CIR_FuncAddrBuiltinOp<"frame_address"> {
 }
 
 //===----------------------------------------------------------------------===//
+// AddrOfReturnAddrOp
+//===----------------------------------------------------------------------===//
+
+def CIR_AddrOfReturnAddrOp : CIR_Op<"address_of_return_address"> {
+  let summary = "The place stores the return address of the current function";
+
+  let description = [{
+    Represents a call to builtin function `_AddressOfReturnAddress` in CIR.
+    This builtin function returns a pointer to the place in the stack frame
+    where the return address of the current function is stored.
+
+    Examples:
+
+    ```mlir
+    %addr = address_of_return_address() : !cir.ptr<!cir.int<u, 8>>
+    ```
+  }];
+
+  let results = (outs CIR_PointerType:$result);
+  let assemblyFormat = "attr-dict `:` qualified(type($result))";
+}
+
+//===----------------------------------------------------------------------===//
 // StackSaveOp & StackRestoreOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -1706,7 +1706,12 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
                                     cir::SyncScopeKind::SingleThread));
     return mlir::Value{};
   }
-  case X86::BI_AddressOfReturnAddress:
+  case X86::BI_AddressOfReturnAddress: {
+    mlir::Location loc = getLoc(expr->getExprLoc());
+    mlir::Value addr =
+        cir::AddrOfReturnAddrOp::create(builder, loc, allocaInt8PtrTy);
+    return builder.createCast(loc, cir::CastKind::bitcast, addr, voidPtrTy);
+  }
   case X86::BI__stosb:
   case X86::BI__ud2:
   case X86::BI__int2c:

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1638,7 +1638,7 @@ mlir::LogicalResult CIRToLLVMCallOpLowering::matchAndRewrite(
 mlir::LogicalResult CIRToLLVMReturnAddrOpLowering::matchAndRewrite(
     cir::ReturnAddrOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
-  auto llvmPtrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+  const mlir::Type llvmPtrTy = getTypeConverter()->convertType(op.getType());
   replaceOpWithCallLLVMIntrinsicOp(rewriter, op, "llvm.returnaddress",
                                    llvmPtrTy, adaptor.getOperands());
   return mlir::success();
@@ -1647,7 +1647,7 @@ mlir::LogicalResult CIRToLLVMReturnAddrOpLowering::matchAndRewrite(
 mlir::LogicalResult CIRToLLVMFrameAddrOpLowering::matchAndRewrite(
     cir::FrameAddrOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
-  auto llvmPtrTy = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+  const mlir::Type llvmPtrTy = getTypeConverter()->convertType(op.getType());
   replaceOpWithCallLLVMIntrinsicOp(rewriter, op, "llvm.frameaddress", llvmPtrTy,
                                    adaptor.getOperands());
   return mlir::success();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1653,6 +1653,15 @@ mlir::LogicalResult CIRToLLVMFrameAddrOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
+mlir::LogicalResult CIRToLLVMAddrOfReturnAddrOpLowering::matchAndRewrite(
+    cir::AddrOfReturnAddrOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  const mlir::Type llvmPtrTy = getTypeConverter()->convertType(op.getType());
+  replaceOpWithCallLLVMIntrinsicOp(rewriter, op, "llvm.addressofreturnaddress",
+                                   llvmPtrTy, adaptor.getOperands());
+  return mlir::success();
+}
+
 mlir::LogicalResult CIRToLLVMLoadOpLowering::matchAndRewrite(
     cir::LoadOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {

--- a/clang/test/CIR/CodeGen/ms-intrinsics.c
+++ b/clang/test/CIR/CodeGen/ms-intrinsics.c
@@ -23,9 +23,24 @@
 // CIR shall be able to support fully.
 
 void *_AddressOfReturnAddress(void);
+void *_ReturnAddress(void);
+
+void *test_ReturnAddress(void) {
+  return _ReturnAddress();
+  // CIR-LABEL: test_ReturnAddress
+  // CIR: [[ARG:%.*]] = cir.const #cir.int<0> : !u32i
+  // CIR: {{%.*}} = cir.return_address([[ARG]])
+
+  // LLVM-LABEL: test_ReturnAddress
+  // LLVM: {{%.*}} = call ptr @llvm.returnaddress(i32 0)
+
+  // OGCG-LABEL: test_ReturnAddress
+  // OGCG: {{%.*}} = call ptr @llvm.returnaddress(i32 0)
+}
 
 #if defined(__i386__) || defined(__x86_64__) || defined (__aarch64__)
 void *test_AddressOfReturnAddress(void) {
+  return _AddressOfReturnAddress();
   // CIR-LABEL: test_AddressOfReturnAddress
   // CIR: %[[ADDR:.*]] = cir.address_of_return_address : !cir.ptr<!u8i>
   // CIR: %{{.*}} = cir.cast bitcast %[[ADDR]] : !cir.ptr<!u8i> -> !cir.ptr<!void>
@@ -35,6 +50,5 @@ void *test_AddressOfReturnAddress(void) {
 
   // OGCG-LABEL: test_AddressOfReturnAddress
   // OGCG: call ptr @llvm.addressofreturnaddress.p0()
-  return _AddressOfReturnAddress();
 }
 #endif

--- a/clang/test/CIR/CodeGen/ms-intrinsics.c
+++ b/clang/test/CIR/CodeGen/ms-intrinsics.c
@@ -1,0 +1,40 @@
+// RUN: %clang_cc1 -x c -ffreestanding -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 \
+// RUN:   -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -x c++ -ffreestanding -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 \
+// RUN:   -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-cir -o %t.cir %s
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+
+// RUN: %clang_cc1 -x c -ffreestanding -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 \
+// RUN:   -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+// RUN: %clang_cc1 -x c++ -ffreestanding -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 \
+// RUN:   -triple x86_64-unknown-linux -Wno-implicit-function-declaration -fclangir -emit-llvm -o %t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+// RUN: %clang_cc1 -x c -ffreestanding -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 \
+// RUN:   -triple x86_64-unknown-linux -emit-llvm -Wall -Werror %s -o - \
+// RUN:   | FileCheck %s -check-prefix=OGCG
+// RUN: %clang_cc1 -x c++ -ffreestanding -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 \
+// RUN:   -triple x86_64-unknown-linux -emit-llvm -Wall -Werror %s -o - \
+// RUN:   | FileCheck %s -check-prefix=OGCG
+
+// This test mimics clang/test/CodeGen/ms-intrinsics.c, which eventually
+// CIR shall be able to support fully.
+
+void *_AddressOfReturnAddress(void);
+
+#if defined(__i386__) || defined(__x86_64__) || defined (__aarch64__)
+void *test_AddressOfReturnAddress(void) {
+  // CIR-LABEL: test_AddressOfReturnAddress
+  // CIR: %[[ADDR:.*]] = cir.address_of_return_address : !cir.ptr<!u8i>
+  // CIR: %{{.*}} = cir.cast bitcast %[[ADDR]] : !cir.ptr<!u8i> -> !cir.ptr<!void>
+
+  // LLVM-LABEL: test_AddressOfReturnAddress
+  // LLVM: call ptr @llvm.addressofreturnaddress.p0()
+
+  // OGCG-LABEL: test_AddressOfReturnAddress
+  // OGCG: call ptr @llvm.addressofreturnaddress.p0()
+  return _AddressOfReturnAddress();
+}
+#endif

--- a/clang/test/CIR/CodeGenBuiltins/builtins.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtins.cpp
@@ -32,7 +32,8 @@ extern "C" void *test_frame_address(void) {
 
   // CIR-LABEL: test_frame_address
   // CIR: [[ARG:%.*]] = cir.const #cir.int<1> : !u32i
-  // CIR: {{%.*}} = cir.frame_address([[ARG]])
+  // CIR: %[[ADDR:.*]] = cir.frame_address([[ARG]]) : !cir.ptr<!u8i>
+  // CIR: {{%.*}} = cir.cast bitcast %[[ADDR]] : !cir.ptr<!u8i> -> !cir.ptr<!void>
 
   // LLVM-LABEL: @test_frame_address
   // LLVM: {{%.*}} = call ptr @llvm.frameaddress.p0(i32 1)


### PR DESCRIPTION
- Add new `CIR_AddrOfReturnAddrOp` and support lowering it to LLVMIR
- Add CIR CodeGen for `_AddressOfReturnAddress` X86 builtin
- Fix error return type of `FrameAddrOp`, and add missing test for `_ReturnAddress`

Part of https://github.com/llvm/llvm-project/issues/167765