### PR TITLE
[clang-tidy] Add `IgnoreMacro` option to `bugprone-chained-comparison`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/ChainedComparisonCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ChainedComparisonCheck.cpp
@@ -112,6 +112,15 @@ void ChainedComparisonData::extract(const Expr *Op) {
   }
 }
 
+ChainedComparisonCheck::ChainedComparisonCheck(StringRef Name,
+                                               ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      IgnoreMacros(Options.get("IgnoreMacros", false)) {}
+
+void ChainedComparisonCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "IgnoreMacros", IgnoreMacros);
+}
+
 void ChainedComparisonCheck::registerMatchers(MatchFinder *Finder) {
   const auto OperatorMatcher = expr(anyOf(
       binaryOperator(isComparisonOperator(),
@@ -127,6 +136,9 @@ void ChainedComparisonCheck::registerMatchers(MatchFinder *Finder) {
 
 void ChainedComparisonCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *MatchedOperator = Result.Nodes.getNodeAs<Expr>("op");
+
+  if (IgnoreMacros && MatchedOperator->getBeginLoc().isMacroID())
+    return;
 
   ChainedComparisonData Data(MatchedOperator);
   if (Data.Operands.empty())

--- a/clang-tools-extra/clang-tidy/bugprone/ChainedComparisonCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/ChainedComparisonCheck.h
@@ -20,13 +20,16 @@ namespace clang::tidy::bugprone {
 /// https://clang.llvm.org/extra/clang-tidy/checks/bugprone/chained-comparison.html
 class ChainedComparisonCheck : public ClangTidyCheck {
 public:
-  ChainedComparisonCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  ChainedComparisonCheck(StringRef Name, ClangTidyContext *Context);
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   std::optional<TraversalKind> getCheckTraversalKind() const override {
     return TK_IgnoreUnlessSpelledInSource;
   }
+
+private:
+  const bool IgnoreMacros;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -331,6 +331,11 @@ New check aliases
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved :doc:`bugprone-chained-comparison
+  <clang-tidy/checks/bugprone/chained-comparison>` check by adding a
+  new option `IgnoreMacros` to suppress warnings within macro
+  expansions.
+
 - Improved :doc:`bugprone-easily-swappable-parameters
   <clang-tidy/checks/bugprone/easily-swappable-parameters>` check by
   correcting a spelling mistake on its option

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/chained-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/chained-comparison.rst
@@ -71,3 +71,11 @@ developer's intention more explicit and help avoid misunderstanding.
         // This block will be executed
     }
 
+Options
+-------
+
+.. option:: IgnoreMacros
+
+    If ``true``, the check will not warn on chained comparisons inside macros.
+    Default is ``false``.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/chained-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/chained-comparison.rst
@@ -76,6 +76,6 @@ Options
 
 .. option:: IgnoreMacros
 
-    If ``true``, the check will not warn on chained comparisons inside macros.
+    If `true`, the check will not warn on chained comparisons inside macros.
     Default is ``false``.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/chained-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/chained-comparison.rst
@@ -77,5 +77,5 @@ Options
 .. option:: IgnoreMacros
 
     If `true`, the check will not warn on chained comparisons inside macros.
-    Default is ``false``.
+    Default is `false`.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/chained-comparison-ignore-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/chained-comparison-ignore-macros.cpp
@@ -1,0 +1,12 @@
+// RUN: %check_clang_tidy -std=c++98-or-later --extra-arg=-Wno-error=parentheses %s bugprone-chained-comparison %t -- -config="{CheckOptions: {bugprone-chained-comparison.IgnoreMacros: true}}"
+
+#define CHAINED_COMPARE(a, b, c) (a < b < c)
+
+void macro_test(int x, int y, int z) {
+    bool result = CHAINED_COMPARE(x, y, z);
+}
+
+void normal_test(int x, int y, int z) {
+    bool result = x < y < z;
+    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: chained comparison 'v0 < v1 < v2' may generate unintended results
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/chained-comparison-ignore-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/chained-comparison-ignore-macros.cpp
@@ -6,7 +6,32 @@ void macro_test(int x, int y, int z) {
     bool result = CHAINED_COMPARE(x, y, z);
 }
 
-void normal_test(int x, int y, int z) {
-    bool result = x < y < z;
-    // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: chained comparison 'v0 < v1 < v2' may generate unintended results
+#define NESTED_LESS(a, b) a < b
+#define NESTED_CHAIN(a, b, c) NESTED_LESS(a, b) < c
+
+void nested_macro_test(int x, int y, int z) {
+    bool result = NESTED_CHAIN(x, y, z);
+}
+
+#define LESS_OP <
+
+void operator_macro_test(int x, int y, int z) {
+    bool result = x LESS_OP y LESS_OP z;
+}
+// CHECK-MESSAGES: :[[@LINE-2]]:19: warning: chained comparison 'v0 < v1 < v2' may generate unintended results
+
+#define PARTIAL_LESS(a, b) a < b
+
+void mixed_macro_test(int x, int y, int z) {
+    bool result = PARTIAL_LESS(x, y) < z;
+}
+
+void if_macro_test(int x, int y, int z) {
+    if (CHAINED_COMPARE(x, y, z)) {}
+}
+
+#define LONG_CHAIN_MACRO(v) v[0] < v[1] < v[2] < v[3]
+
+void long_chain_macro_test(int v[4]) {
+    bool result = LONG_CHAIN_MACRO(v);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/chained-comparison.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/chained-comparison.cpp
@@ -89,3 +89,44 @@ bool mixedBinaryAndCpp(Value a, Value b, bool c) {
     return a < b == c;
 }
 // CHECK-MESSAGES: :[[@LINE-2]]:12: warning: chained comparison 'v0 < v1 == v2' may generate unintended results, use parentheses to specify order of evaluation or a logical operator to separate comparison expressions [bugprone-chained-comparison]
+
+#define CHAINED_COMPARE(a, b, c) (a < b < c)
+
+void macro_test(int x, int y, int z) {
+    bool result = CHAINED_COMPARE(x, y, z);
+}
+// CHECK-MESSAGES: :[[@LINE-2]]:35: warning: chained comparison 'v0 < v1 < v2' may generate unintended results, use parentheses to specify order of evaluation or a logical operator to separate comparison expressions [bugprone-chained-comparison]
+
+#define NESTED_LESS(a, b) a < b
+#define NESTED_CHAIN(a, b, c) NESTED_LESS(a, b) < c
+
+void nested_macro_test(int x, int y, int z) {
+    bool result = NESTED_CHAIN(x, y, z);
+}
+// CHECK-MESSAGES: :[[@LINE-2]]:32: warning: chained comparison 'v0 < v1 < v2' may generate unintended results, use parentheses to specify order of evaluation or a logical operator to separate comparison expressions [bugprone-chained-comparison]
+
+#define LESS_OP <
+
+void operator_macro_test(int x, int y, int z) {
+    bool result = x LESS_OP y LESS_OP z;
+}
+// CHECK-MESSAGES: :[[@LINE-2]]:19: warning: chained comparison 'v0 < v1 < v2' may generate unintended results, use parentheses to specify order of evaluation or a logical operator to separate comparison expressions [bugprone-chained-comparison]
+
+#define PARTIAL_LESS(a, b) a < b
+
+void mixed_macro_test(int x, int y, int z) {
+    bool result = PARTIAL_LESS(x, y) < z;
+}
+// CHECK-MESSAGES: :[[@LINE-2]]:32: warning: chained comparison 'v0 < v1 < v2' may generate unintended results, use parentheses to specify order of evaluation or a logical operator to separate comparison expressions [bugprone-chained-comparison]
+
+void if_macro_test(int x, int y, int z) {
+    if (CHAINED_COMPARE(x, y, z)) {}
+}
+// CHECK-MESSAGES: :[[@LINE-2]]:25: warning: chained comparison 'v0 < v1 < v2' may generate unintended results, use parentheses to specify order of evaluation or a logical operator to separate comparison expressions [bugprone-chained-comparison]
+
+#define LONG_CHAIN_MACRO(v) v[0] < v[1] < v[2] < v[3]
+
+void long_chain_macro_test(int v[4]) {
+    bool result = LONG_CHAIN_MACRO(v);
+}
+// CHECK-MESSAGES: :[[@LINE-2]]:36: warning: chained comparison 'v0 < v1 < v2 < v3' may generate unintended results, use parentheses to specify order of evaluation or a logical operator to separate comparison expressions [bugprone-chained-comparison]


### PR DESCRIPTION
Closes #171130