### PR TITLE
[flang] add missing headers in ConvertVariable.h after #171501

### DIFF
--- a/flang/include/flang/Lower/ConvertVariable.h
+++ b/flang/include/flang/Lower/ConvertVariable.h
@@ -18,6 +18,8 @@
 #define FORTRAN_LOWER_CONVERT_VARIABLE_H
 
 #include "flang/Lower/Support/Utils.h"
+#include "flang/Lower/SymbolMap.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"
 #include "flang/Semantics/symbol.h"
 #include "mlir/IR/Value.h"
@@ -26,13 +28,6 @@
 namespace cuf {
 class DataAttributeAttr;
 }
-
-namespace fir {
-class ExtendedValue;
-class FirOpBuilder;
-class GlobalOp;
-class FortranVariableFlagsAttr;
-} // namespace fir
 
 namespace Fortran {
 namespace semantics {


### PR DESCRIPTION
Missing headers were caught by windows build bots:
- https://lab.llvm.org/buildbot/#/builders/222/builds/817/steps/6/logs/stdio
- https://lab.llvm.org/buildbot/#/builders/207/builds/10970/steps/5/logs/stdio

In #171501, I removed IterationSpace.h include from Utils.h, and IterationSpace.h was itself including SymbolMap.h and FIRBuilder.h that are required here.