### PR TITLE
[libc++] Fix std::for_each(associative-container) not using std:invoke and projections

### DIFF
--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -670,7 +670,7 @@ bool __tree_iterate_from_root(_Break __break, _NodePtr __root, _Func& __func, _P
   }
   if (__break(__root))
     return true;
-  __func(static_cast<_Reference>(__root->__get_value()));
+  std::__invoke(__func, std::__invoke(__proj, static_cast<_Reference>(__root->__get_value())));
   if (__root->__right_)
     return std::__tree_iterate_from_root<_Reference>(__break, static_cast<_NodePtr>(__root->__right_), __func, __proj);
   return false;
@@ -690,7 +690,7 @@ __tree_iterate_subrange(_NodeIter __first_it, _NodeIter __last_it, _Func& __func
     if (__first == __last)
       return;
     const auto __nfirst = static_cast<_NodePtr>(__first);
-    __func(static_cast<_Reference>(__nfirst->__get_value()));
+    std::__invoke(__func, std::__invoke(__proj, static_cast<_Reference>(__nfirst->__get_value())));
     if (__nfirst->__right_) {
       if (std::__tree_iterate_from_root<_Reference>(
               [&](_NodePtr __node) -> bool { return __node == __last; },


### PR DESCRIPTION
#164405 added specializations of `for_each` that didn't do the ranges call shenanigans, but instead just did what the classic algorithms have to do. This updates the calls to work for the ranges overloads as well.