### PR TITLE
[flang] add includes to AbstractConverter.h after #171501

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -15,9 +15,11 @@
 
 #include "flang/Lower/LoweringOptions.h"
 #include "flang/Lower/PFTDefs.h"
+#include "flang/Lower/StatementContext.h"
 #include "flang/Lower/Support/Utils.h"
 #include "flang/Lower/SymbolMap.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
+#include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"
 #include "flang/Semantics/symbol.h"
 #include "flang/Support/Fortran.h"
@@ -34,7 +36,6 @@ class StateStack;
 
 namespace fir {
 class KindMapping;
-class FirOpBuilder;
 } // namespace fir
 
 namespace Fortran {


### PR DESCRIPTION
Utils.h included StatementContext.h and FIRBuilder.h indirectly in AbstractConverter.h.
Makes these includes direct.