### PR TITLE
[Clang][Sema] Support 'counted_by' attribute on FAM/pointers in anonymous unions

### DIFF
--- a/clang/test/Sema/attr-counted-by-or-null-struct-ptrs.c
+++ b/clang/test/Sema/attr-counted-by-or-null-struct-ptrs.c
@@ -222,3 +222,49 @@ struct on_void_ty {
   // expected-error@+1{{field has incomplete type 'void'}}
   void wrong_ty __counted_by_or_null(count);
 };
+
+//==============================================================================
+// __counted_by_or_null on pointer members in unions
+//==============================================================================
+
+// Pointer in anonymous union with count in parent struct - OK
+struct ptr_in_anon_union_count_in_parent {
+  int count;
+  union {
+    int a;
+    struct size_known *buf __counted_by_or_null(count);
+  };
+};
+
+// Pointer in named union - ERROR
+union ptr_in_named_union {
+  int count;
+  struct size_known *buf __counted_by_or_null(count); // expected-error {{'counted_by_or_null' cannot be applied to a union member}}
+};
+
+// Both pointer and count in same anonymous union - ERROR (they share storage)
+struct ptr_and_count_in_same_anon_union {
+  union {
+    int count;
+    struct size_known *buf __counted_by_or_null(count); // expected-error {{'counted_by_or_null' cannot be applied to a union member}}
+  };
+};
+
+// Count in anonymous union, pointer in parent struct - ERROR (count in union)
+struct count_in_anon_union_ptr_in_parent {
+  union {
+    int count;
+    int x;
+  };
+  struct size_known *buf __counted_by_or_null(count); // expected-error {{'counted_by_or_null' argument cannot refer to a union member}}
+};
+
+// Count in anonymous union, but hidden by struct - ERROR (count in union)
+struct count_in_deep_anon_union {
+  union {
+    struct {
+      int count;
+    };
+  };
+  struct size_known *buf __counted_by_or_null(count); // expected-error {{'counted_by_or_null' argument cannot refer to a union member}}
+};

--- a/clang/test/Sema/attr-counted-by-struct-ptrs.c
+++ b/clang/test/Sema/attr-counted-by-struct-ptrs.c
@@ -221,3 +221,49 @@ struct on_void_ty {
   // expected-error@+1{{field has incomplete type 'void'}}
   void wrong_ty __counted_by(count);
 };
+
+//==============================================================================
+// __counted_by on pointer members in unions
+//==============================================================================
+
+// Pointer in anonymous union with count in parent struct - OK
+struct ptr_in_anon_union_count_in_parent {
+  int count;
+  union {
+    int a;
+    struct size_known *buf __counted_by(count);
+  };
+};
+
+// Pointer in named union - ERROR
+union ptr_in_named_union {
+  int count;
+  struct size_known *buf __counted_by(count); // expected-error {{'counted_by' cannot be applied to a union member}}
+};
+
+// Both pointer and count in same anonymous union - ERROR (they share storage)
+struct ptr_and_count_in_same_anon_union {
+  union {
+    int count;
+    struct size_known *buf __counted_by(count); // expected-error {{'counted_by' cannot be applied to a union member}}
+  };
+};
+
+// Count in anonymous union, pointer in parent struct - ERROR (count in union)
+struct count_in_anon_union_ptr_in_parent {
+  union {
+    int count;
+    int x;
+  };
+  struct size_known *buf __counted_by(count); // expected-error {{'counted_by' argument cannot refer to a union member}}
+};
+
+// Count in anonymous union, but hidden by struct - ERROR (count in union)
+struct on_deep_member_pointer_complete {
+  union {
+    struct {
+      int count;
+    };
+  };
+  struct size_known *buf __counted_by(count); // expected-error {{'counted_by' argument cannot refer to a union member}}
+};


### PR DESCRIPTION
The 'counted_by' attribute was previously rejected on flexible array members (FAMs) and pointers that were inside any union. This change allows them when the FAM/pointer is in an anonymous union and the count field is in the parent struct.

This pattern is useful for representing tagged unions where different array types share the same count:

    struct buffer {
        int count;
        union {
            char *bytes __counted_by(count);
            int *ints __counted_by(count);
        };
    };

The union cases are handled as such:

Allowed (this patch):
 - FAM/pointer in anonymous union, count in parent struct: the count field is in stable storage outside the union.

Rejected (unchanged):
 - FAM/pointer in named union: named unions are not part of the parent struct's namespace.

 - Both FAM/pointer and count in same anonymous union: they share storage, making the count unreliable.

 - Count in anonymous union: the count field itself cannot be in a union (shared storage).

Provides parity with GCC, which has just been fixed:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122495
https://gcc.gnu.org/pipermail/gcc-patches/2025-December/703480.html