### PR TITLE
[LifetimeSafety] Add support for tracking non-trivially destructed temporary objects

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
@@ -59,6 +59,8 @@ private:
 
   void handleLifetimeEnds(const CFGLifetimeEnds &LifetimeEnds);
 
+  void handleTemporaryDtor(const CFGTemporaryDtor &TemporaryDtor);
+
   void handleGSLPointerConstruction(const CXXConstructExpr *CCE);
 
   /// Checks if a call-like expression creates a borrow by passing a value to a

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -30,24 +30,24 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, LoanID ID) {
 /// variable.
 /// TODO: Model access paths of other types, e.g., s.field, heap and globals.
 struct AccessPath {
-  // Currently, an access path can be:
+  // An access path can be:
   // - ValueDecl * , to represent the storage location corresponding to the
   //   variable declared in ValueDecl.
-  // - CXXBindTemporaryExpr * , to represent the storage location of the
-  //   temporary object used for the binding in CXXBindTemporaryExpr.
+  // - MaterializeTemporaryExpr * , to represent the storage location of the
+  //   temporary object materialized via this MaterializeTemporaryExpr.
   const llvm::PointerUnion<const clang::ValueDecl *,
-                           const clang::CXXBindTemporaryExpr *>
+                           const clang::MaterializeTemporaryExpr *>
       P;
 
   AccessPath(const clang::ValueDecl *D) : P(D) {}
-  AccessPath(const clang::CXXBindTemporaryExpr *BTE) : P(BTE) {}
+  AccessPath(const clang::MaterializeTemporaryExpr *MTE) : P(MTE) {}
 
   const clang::ValueDecl *getAsValueDecl() const {
     return P.dyn_cast<const clang::ValueDecl *>();
   }
 
-  const clang::CXXBindTemporaryExpr *getAsCXXBindTemporaryExpr() const {
-    return P.dyn_cast<const clang::CXXBindTemporaryExpr *>();
+  const clang::MaterializeTemporaryExpr *getAsMaterializeTemporaryExpr() const {
+    return P.dyn_cast<const clang::MaterializeTemporaryExpr *>();
   }
 };
 

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -409,8 +409,8 @@ void FactsGenerator::handleTemporaryDtor(
   // Iterate through all loans to see if any expire.
   for (const auto *Loan : FactMgr.getLoanMgr().getLoans()) {
     if (const auto *PL = dyn_cast<PathLoan>(Loan)) {
-      // Check if the loan is for a temporary materialization and if that storage
-      // location is the one being destructed.
+      // Check if the loan is for a temporary materialization and if that
+      // storage location is the one being destructed.
       const AccessPath &AP = PL->getAccessPath();
       const MaterializeTemporaryExpr *Path = AP.getAsMaterializeTemporaryExpr();
       if (!Path)

--- a/clang/lib/Analysis/LifetimeSafety/Loans.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Loans.cpp
@@ -12,15 +12,14 @@ namespace clang::lifetimes::internal {
 
 void PathLoan::dump(llvm::raw_ostream &OS) const {
   OS << getID() << " (Path: ";
-  if (const clang::ValueDecl *VD = Path.getAsValueDecl()) {
+  if (const clang::ValueDecl *VD = Path.getAsValueDecl())
     OS << VD->getNameAsString();
-  } else if (const clang::MaterializeTemporaryExpr *MTE =
-                 Path.getAsMaterializeTemporaryExpr()) {
+  else if (const clang::MaterializeTemporaryExpr *MTE =
+               Path.getAsMaterializeTemporaryExpr())
     // No nice "name" for the temporary, so deferring to LLVM default
     OS << "MaterializeTemporaryExpr at " << MTE;
-  } else {
+  else
     llvm_unreachable("access path is not one of any supported types");
-  }
   OS << ")";
 }
 

--- a/clang/lib/Analysis/LifetimeSafety/Loans.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Loans.cpp
@@ -12,7 +12,16 @@ namespace clang::lifetimes::internal {
 
 void PathLoan::dump(llvm::raw_ostream &OS) const {
   OS << getID() << " (Path: ";
-  OS << Path.D->getNameAsString() << ")";
+  if (const clang::ValueDecl *VD = Path.getAsValueDecl()) {
+    OS << VD->getNameAsString();
+  } else if (const clang::CXXBindTemporaryExpr *BTE =
+                 Path.getAsCXXBindTemporaryExpr()) {
+    // No nice "name" for the temporary, so deferring to LLVM default
+    OS << "CXXBindTemporaryExpr at " << BTE;
+  } else {
+    llvm_unreachable("access path is not one of any supported types");
+  }
+  OS << ")";
 }
 
 void PlaceholderLoan::dump(llvm::raw_ostream &OS) const {

--- a/clang/lib/Analysis/LifetimeSafety/Loans.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Loans.cpp
@@ -14,10 +14,10 @@ void PathLoan::dump(llvm::raw_ostream &OS) const {
   OS << getID() << " (Path: ";
   if (const clang::ValueDecl *VD = Path.getAsValueDecl()) {
     OS << VD->getNameAsString();
-  } else if (const clang::CXXBindTemporaryExpr *BTE =
-                 Path.getAsCXXBindTemporaryExpr()) {
+  } else if (const clang::MaterializeTemporaryExpr *MTE =
+                 Path.getAsMaterializeTemporaryExpr()) {
     // No nice "name" for the temporary, so deferring to LLVM default
-    OS << "CXXBindTemporaryExpr at " << BTE;
+    OS << "MaterializeTemporaryExpr at " << MTE;
   } else {
     llvm_unreachable("access path is not one of any supported types");
   }

--- a/clang/lib/Analysis/LifetimeSafety/Origins.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Origins.cpp
@@ -14,7 +14,6 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/AST/ExprCXX.h"
 #include "clang/AST/TypeBase.h"
 #include "clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h"
 #include "clang/Analysis/Analyses/LifetimeSafety/LifetimeStats.h"

--- a/clang/lib/Analysis/LifetimeSafety/Origins.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Origins.cpp
@@ -126,9 +126,6 @@ OriginList *OriginManager::getOrCreateList(const Expr *E) {
   if (auto *ParenIgnored = E->IgnoreParens(); ParenIgnored != E)
     return getOrCreateList(ParenIgnored);
   // We do not see CFG stmts for ExprWithCleanups. Simply peel them.
-  if (auto *EC = dyn_cast<ExprWithCleanups>(E))
-    return getOrCreateList(EC->getSubExpr());
-
   if (const ExprWithCleanups *EWC = dyn_cast<ExprWithCleanups>(E))
     return getOrCreateList(EWC->getSubExpr());
 

--- a/clang/lib/Analysis/LifetimeSafety/Origins.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Origins.cpp
@@ -14,6 +14,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/TypeBase.h"
 #include "clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h"
 #include "clang/Analysis/Analyses/LifetimeSafety/LifetimeStats.h"
@@ -128,6 +129,9 @@ OriginList *OriginManager::getOrCreateList(const Expr *E) {
   // We do not see CFG stmts for ExprWithCleanups. Simply peel them.
   if (auto *EC = dyn_cast<ExprWithCleanups>(E))
     return getOrCreateList(EC->getSubExpr());
+
+  if (const ExprWithCleanups *EWC = dyn_cast<ExprWithCleanups>(E))
+    return getOrCreateList(EWC->getSubExpr());
 
   if (!hasOrigins(E))
     return nullptr;

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -10,8 +10,13 @@ struct [[gsl::Owner]] MyObj {
   View getView() const [[clang::lifetimebound]];
 };
 
+struct [[gsl::Owner]] MyTrivialObj {
+  int id;
+};
+
 struct [[gsl::Pointer()]] View {
   View(const MyObj&); // Borrows from MyObj
+  View(const MyTrivialObj &); // Borrows from MyTrivialObj
   View();
   void use() const;
 };
@@ -20,7 +25,11 @@ class TriviallyDestructedClass {
   View a, b;
 };
 
-MyObj temporary();
+MyObj non_trivially_destructed_temporary();
+MyTrivialObj trivially_destructed_temporary();
+View construct_view(const MyObj &obj [[clang::lifetimebound]]) {
+  return View(obj);
+}
 void use(View);
 
 //===----------------------------------------------------------------------===//
@@ -1071,11 +1080,25 @@ void parentheses(bool cond) {
 }
 
 void use_temporary_after_destruction() {
-    View a;
-    a = temporary(); // expected-warning {{object whose reference is captured does not live long enough}} \
-                    expected-note {{destroyed here}}
-    use(a); // expected-note {{later used here}}
-}  
+  View a;
+  a = non_trivially_destructed_temporary(); // expected-warning {{object whose reference is captured does not live long enough}} \
+                  expected-note {{destroyed here}}
+  use(a); // expected-note {{later used here}}
+}
+
+void passing_temporary_to_lifetime_bound_function() {
+  View a = construct_view(non_trivially_destructed_temporary()); // expected-warning {{object whose reference is captured does not live long enough}} \
+                expected-note {{destroyed here}}
+  use(a); // expected-note {{later used here}}
+}
+
+// FIXME: We expect to be warned of use-after-free at use(a), but this is not the
+// case as current analysis does not handle trivially destructed temporaries.
+void use_trivial_temporary_after_destruction() {
+  View a;
+  a = trivially_destructed_temporary();
+  use(a);
+}
 
 namespace GH162834 {
 // https://github.com/llvm/llvm-project/issues/162834

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -20,6 +20,9 @@ class TriviallyDestructedClass {
   View a, b;
 };
 
+MyObj temporary();
+void use(View);
+
 //===----------------------------------------------------------------------===//
 // Basic Definite Use-After-Free (-W...permissive)
 // These are cases where the pointer is guaranteed to be dangling at the use site.
@@ -1064,7 +1067,15 @@ void parentheses(bool cond) {
               : &(((cond ? c : d)))));  // expected-warning 2 {{object whose reference is captured does not live long enough}}.
   }  // expected-note 4 {{destroyed here}}
   (void)*p;  // expected-note 4 {{later used here}}
+
 }
+
+void use_temporary_after_destruction() {
+    View a;
+    a = temporary(); // expected-warning {{object whose reference is captured does not live long enough}} \
+                    expected-note {{destroyed here}}
+    use(a); // expected-note {{later used here}}
+}  
 
 namespace GH162834 {
 // https://github.com/llvm/llvm-project/issues/162834

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -1409,7 +1409,9 @@ void bar() {
     {
         S s;
         x = s.x(); // expected-warning {{object whose reference is captured does not live long enough}}
-        View y = S().x(); // FIXME: Handle temporaries.
+        View y = S().x(); // expected-warning {{object whose reference is captured does not live long enough}} \
+          expected-note {{destroyed here}}
+        (void)y; // expected-note {{later used here}}
     } // expected-note {{destroyed here}}
     (void)x; // expected-note {{used here}}
 }

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -1158,7 +1158,6 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundTemplateFunctionReturnVal) {
 
     void target() {
       MyObj a;
-      // FIXME: Captures a reference to temporary MyObj returned by Identity.
       View v1 = Identity(a);
       POINT(p1);
 
@@ -1169,7 +1168,7 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundTemplateFunctionReturnVal) {
       POINT(p2);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({}, "p1"));
+  EXPECT_THAT(Origin("v1"), HasLoanToATemporary("p1"));
 
   EXPECT_THAT(Origin("v2"), HasLoansTo({"b"}, "p2"));
   EXPECT_THAT(Origin("v3"), HasLoansTo({"v2"}, "p2"));

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -135,7 +135,7 @@ public:
   bool isLoanToATemporary(LoanID LID) {
     const Loan *L = Analysis.getFactManager().getLoanMgr().getLoan(LID);
     if (const auto *BL = dyn_cast<PathLoan>(L)) {
-      return BL->getAccessPath().getAsCXXBindTemporaryExpr() != nullptr;
+      return BL->getAccessPath().getAsMaterializeTemporaryExpr() != nullptr;
     }
     return false;
   }
@@ -847,7 +847,6 @@ TEST_F(LifetimeAnalysisTest, ExtraParenthesis) {
   EXPECT_THAT(Origin("p"), HasLoansTo({"a"}, "p1"));
 }
 
-// FIXME: Handle temporaries.
 TEST_F(LifetimeAnalysisTest, ViewFromTemporary) {
   SetupTest(R"(
     MyObj temporary();

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -437,10 +437,9 @@ MATCHER_P(HasLoanToATemporary, Annotation, "") {
 
   std::vector<LoanID> Loans(LoansSetOpt->begin(), LoansSetOpt->end());
 
-  for (LoanID LID : Loans) {
+  for (LoanID LID : Loans)
     if (Helper.isLoanToATemporary(LID))
       return true;
-  }
   *result_listener << "could not find loan to a temporary for '"
                    << Info.OriginVar.str() << "'";
   return false;


### PR DESCRIPTION
Add support for tracking loans to temporary materializations that require non-trivial destructors. We only support non-trivially destructed temporaries as they have a nice end-of-life marker via the `CFGTemporaryDtor`.

This small PR introduces the following changes:
1. AccessPaths can now also represent `MaterializeTemporaryExpr *` via `llvm::PointerUnion`
3.  `FactsGenerator::VisitMaterializeTemporaryExpr` now checks to see if the temporary materialization is such that it requires a non-trivial destructor (by checking for a child `CXXBindTemporaryExpr` node when all implicit casts are stripped away), and if so: creates a Loan whose AccessPath is a pointer to that `MaterializeTemporaryExpr`, and issues it to the origin represented by the `MaterializeTemporaryExpr` node we were called on. When we cannot find a child `CXXBindTemporaryExpr`, we fall-back to an `OriginFlow` as before.
4. `FactsGenerator::handleTemporaryDtor` is called from `FactsGenerator::run` when it encounters a `CFGTemporaryDtor`. It then issues an `ExpireFact` for loan to the corresponding destructed temporary by matching on `CXXBindTemporaryExpr *`
5. Unit tests are extended via the matcher `HasLoanToATemporary` which can check if an origin has a loan to at least 1 temporary. This is done as we are not nicely and reproducibly able to uniquely identify a loan with `AccessPath` `MaterializeTemporaryExpr *`, so we settle for checking the presence of at least a loan to a temporary.
6. A lit test is added for the case where an already destructed temporary is used.

Addresses: [#152514](https://github.com/llvm/llvm-project/issues/152514)