### PR TITLE
[LangRef] Clarify specification for float min/max operations

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -842,20 +842,20 @@ of different sizes and signs is forbidden in binary and ternary builtins.
  T __builtin_elementwise_max(T x, T y)          return x or y, whichever is larger                                     integer and floating point types
                                                 For floating point types, follows semantics of maxNum
                                                 in IEEE 754-2008. See `LangRef
-                                                <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                                <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                                 for the comparison.
  T __builtin_elementwise_min(T x, T y)          return x or y, whichever is smaller                                    integer and floating point types
                                                 For floating point types, follows semantics of minNum
                                                 in IEEE 754-2008. See `LangRef
-                                                <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                                <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                                 for the comparison.
  T __builtin_elementwise_maxnum(T x, T y)       return x or y, whichever is larger. Follows IEEE 754-2008              floating point types
                                                 semantics (maxNum) with +0.0>-0.0. See `LangRef
-                                                <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                                <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                                 for the comparison.
  T __builtin_elementwise_minnum(T x, T y)       return x or y, whichever is smaller. Follows IEEE 754-2008             floating point types
                                                 semantics (minNum) with +0.0>-0.0. See `LangRef
-                                                <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                                <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                                 for the comparison.
  T __builtin_elementwise_add_sat(T x, T y)      return the sum of x and y, clamped to the range of                     integer types
                                                 representable values for the signed/unsigned integer type.
@@ -863,19 +863,19 @@ of different sizes and signs is forbidden in binary and ternary builtins.
                                                 representable values for the signed/unsigned integer type.
  T __builtin_elementwise_maximum(T x, T y)      return x or y, whichever is larger. Follows IEEE 754-2019              floating point types
                                                 semantics, see `LangRef
-                                                <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                                <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                                 for the comparison.
  T __builtin_elementwise_minimum(T x, T y)      return x or y, whichever is smaller. Follows IEEE 754-2019             floating point types
                                                 semantics, see `LangRef
-                                                <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                                <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                                 for the comparison.
  T __builtin_elementwise_maximumnum(T x, T y)   return x or y, whichever is larger. Follows IEEE 754-2019              floating point types
                                                 semantics, see `LangRef
-                                                <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                                <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                                 for the comparison.
  T __builtin_elementwise_minimumnum(T x, T y)   return x or y, whichever is smaller. Follows IEEE 754-2019             floating point types
                                                 semantics, see `LangRef
-                                                <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                                <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                                 for the comparison.
 T __builtin_elementwise_fshl(T x, T y, T z)     perform a funnel shift left. Concatenate x and y (x is the most        integer types
                                                 significant bits of the wide value), the combined value is shifted
@@ -940,11 +940,11 @@ Let ``VT`` be a vector type and ``ET`` the element type of ``VT``.
  ET __builtin_reduce_xor(VT a)           ^                                                                      integer types
  ET __builtin_reduce_maximum(VT a)       return the largest element of the vector. Follows IEEE 754-2019        floating point types
                                          semantics, see `LangRef
-                                         <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                         <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                          for the comparison.
  ET __builtin_reduce_minimum(VT a)       return the smallest element of the vector. Follows IEEE 754-2019       floating point types
                                          semantics, see `LangRef
-                                         <http://llvm.org/docs/LangRef.html#llvm-min-intrinsics-comparation>`_
+                                         <http://llvm.org/docs/LangRef.html#i-fminmax-family>`_
                                          for the comparison.
 ======================================= ====================================================================== ==================================
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17511,8 +17511,11 @@ Semantics:
 """"""""""
 If either operand is a NaN, returns a :ref:`NaN <floatnan>`. Otherwise returns
 the lesser of the two arguments. -0.0 is considered to be less than +0.0 for
-this intrinsic. Note that these are the semantics of minimum specified in
-IEEE 754-2019, with the usual :ref:`signaling NaN <floatnan>` exception.
+this intrinsic.
+
+This intrinsic follows the semantics of ``fminimum`` in C23 and ``minimum`` in
+IEEE 754-2019, except for signaling NaN inputs, which follow
+:ref:`LLVM's usual signaling NaN behavior <floatnan>` instead.
 
 If the ``nsz`` flag is specified, ``llvm.maximum`` with one +0.0 and one
 -0.0 operand may non-deterministically return either operand. Contrary to normal
@@ -17556,8 +17559,11 @@ Semantics:
 """"""""""
 If either operand is a NaN, returns a :ref:`NaN <floatnan>`. Otherwise returns
 the greater of the two arguments. -0.0 is considered to be less than +0.0 for
-this intrinsic. Note that these are the semantics of maximum specified in
-IEEE 754-2019, with the usual :ref:`signaling NaN <floatnan>` exception.
+this intrinsic.
+
+This intrinsic follows the semantics of ``fmaximum`` in C23 and ``maximum`` in
+IEEE 754-2019, except for signaling NaN inputs, which follow
+:ref:`LLVM's usual signaling NaN behavior <floatnan>` instead.
 
 If the ``nsz`` flag is specified, ``llvm.maximum`` with one +0.0 and one
 -0.0 operand may non-deterministically return either operand. Contrary to normal
@@ -17610,8 +17616,9 @@ If the ``nsz`` flag is specified, ``llvm.minimumnum`` with one +0.0 and one
 ``nsz`` semantics, if both operands have the same sign, the result must also
 have the same sign.
 
-Note that these are the semantics of minimumNumber specified in
-IEEE-754-2019 with the usual :ref:`signaling NaN <floatnan>` exception.
+This intrinsic follows the semantics of ``fminimum_num`` in C23 and
+``minimumNumber`` in IEEE 754-2019, except for signaling NaN inputs, which
+follow :ref:`LLVM's usual signaling NaN behavior <floatnan>` instead.
 
 This intrinsic behaves the same as ``llvm.minnum`` other than its treatment of
 sNaN inputs.
@@ -17663,8 +17670,9 @@ If the ``nsz`` flag is specified, ``llvm.maximumnum`` with one +0.0 and one
 ``nsz`` semantics, if both operands have the same sign, the result must also
 have the same sign.
 
-Note that these are the semantics of maximumNumber specified in
-IEEE-754-2019  with the usual :ref:`signaling NaN <floatnan>` exception.
+This intrinsic follows the semantics of ``fmaximum_num`` in C23 and
+``maximumNumber`` in IEEE 754-2019, except for signaling NaN inputs, which
+follow :ref:`LLVM's usual signaling NaN behavior <floatnan>` instead.
 
 This intrinsic behaves the same as ``llvm.maxnum`` other than its treatment of
 sNaN inputs.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17343,8 +17343,8 @@ Semantics:
 
 If both operands are qNaNs, returns a :ref:`NaN <floatnan>`. If one operand is
 qNaN and another operand is a number, returns the number. If both operands are
-numbers, returns the lesser of the two arguments. -0.0 is considered to be less
-than +0.0 for this intrinsic.
+numbers, returns the lesser of the two arguments. If both operands compare equal
+(for example +0.0 and -0.0), non-deterministially returns either operand.
 
 If an operand is a signaling NaN, then the intrinsic will non-deterministically
 either:
@@ -17352,14 +17352,8 @@ either:
  * Return a :ref:`NaN <floatnan>`.
  * Or treat the signaling NaN as a quiet NaN.
 
-If the ``nsz`` flag is specified, ``llvm.minnum`` with one +0.0 and one
--0.0 operand may non-deterministically return either operand. Contrary to normal
-``nsz`` semantics, if both operands have the same sign, the result must also
-have the same sign.
-
-When used with the ``nsz`` flag, this intrinsics follows the semantics of
-``fmin`` in C and ``maxNum`` in IEEE 754-2008 with the usual
-:ref:`signaling NaN <floatnan>` exception.
+This intrinsics follows the semantics of ``fmin`` in C and ``maxNum`` in
+IEEE 754-2008 with the usual :ref:`signaling NaN <floatnan>` exception.
 
 The ``llvm.minnum`` intrinsic can be refined into ``llvm.minimumnum``, as the
 latter exhibits a subset of behaviors of the former.
@@ -17402,8 +17396,8 @@ Semantics:
 
 If both operands are qNaNs, returns a :ref:`NaN <floatnan>`. If one operand is
 qNaN and another operand is a number, returns the number. If both operands are
-numbers, returns the greater of the two arguments. -0.0 is considered to be
-less than +0.0 for this intrinsic.
+numbers, returns the greater of the two arguments. If both operands compare
+equal (for example +0.0 and -0.0), non-deterministically returns either operand.
 
 If an operand is a signaling NaN, then the intrinsic will non-deterministically
 either:
@@ -17411,14 +17405,8 @@ either:
  * Return a :ref:`NaN <floatnan>`.
  * Or treat the signaling NaN as a quiet NaN.
 
-If the ``nsz`` flag is specified, ``llvm.maxnum`` with one +0.0 and one
--0.0 operand may non-deterministically return either operand. Contrary to normal
-``nsz`` semantics, if both operands have the same sign, the result must also
-have the same sign.
-
-When used with the ``nsz`` flag, this intrinsics follows the semantics of
-``fmax`` in C and ``maxNum`` in IEEE 754-2008 with the usual
-:ref:`signaling NaN <floatnan>` exception.
+This intrinsics follows the semantics of ``fmax`` in C and ``maxNum`` in
+IEEE 754-2008 with the usual :ref:`signaling NaN <floatnan>` exception.
 
 The ``llvm.maxnum`` intrinsic can be refined into ``llvm.maximumnum``, as the
 latter exhibits a subset of behaviors of the former.
@@ -20371,8 +20359,8 @@ The '``llvm.vector.reduce.fmax.*``' intrinsics do a floating-point
 ``MAX`` reduction of a vector, returning the result as a scalar. The return type
 matches the element-type of the vector input.
 
-This instruction has the same comparison and ``nsz`` semantics as the
-'``llvm.maxnum.*``' intrinsic.
+This instruction has the same comparison semantics as the '``llvm.maxnum.*``'
+intrinsic.
 
 If any of the vector elements is a signaling NaN, the intrinsic will
 non-deterministically either:
@@ -20405,8 +20393,8 @@ The '``llvm.vector.reduce.fmin.*``' intrinsics do a floating-point
 ``MIN`` reduction of a vector, returning the result as a scalar. The return type
 matches the element-type of the vector input.
 
-This instruction has the same comparison and ``nsz`` semantics as the
-'``llvm.minnum.*``' intrinsic.
+This instruction has the same comparison semantics as the '``llvm.minnum.*``'
+intrinsic.
 
 If any of the vector elements is a signaling NaN, the intrinsic will
 non-deterministically either:

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17396,7 +17396,7 @@ If the ``nsz`` flag is specified, ``llvm.minnum`` with one +0.0 and one
 ``nsz`` semantics, if both operands have the same sign, the result must also
 have the same sign.
 
-When used with the ``nsz`` flag, this intrinsics follows the semantics of
+When used with the ``nsz`` flag, this intrinsic follows the semantics of
 ``fmin`` in C and ``maxNum`` in IEEE 754-2008 with the usual
 :ref:`signaling NaN <floatnan>` exception.
 
@@ -17461,7 +17461,7 @@ If the ``nsz`` flag is specified, ``llvm.maxnum`` with one +0.0 and one
 ``nsz`` semantics, if both operands have the same sign, the result must also
 have the same sign.
 
-When used with the ``nsz`` flag, this intrinsics follows the semantics of
+When used with the ``nsz`` flag, this intrinsic follows the semantics of
 ``fmax`` in C and ``maxNum`` in IEEE 754-2008 with the usual
 :ref:`signaling NaN <floatnan>` exception.
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17350,8 +17350,7 @@ If an operand is a signaling NaN, then the intrinsic will non-deterministically
 either:
 
  * Return a :ref:`NaN <floatnan>`.
- * Or treat the signaling NaN as a quiet NaN. In this case the intrinsic will
-   behave the same as ``llvm.minimumnum``.
+ * Or treat the signaling NaN as a quiet NaN.
 
 If the ``nsz`` flag is specified, ``llvm.minnum`` with one +0.0 and one
 -0.0 operand may non-deterministically return either operand. Contrary to normal
@@ -17360,6 +17359,9 @@ have the same sign.
 
 When used with the ``nsz`` flag, this intrinsics follows the semantics of
 ``fmin`` in C.
+
+The ``llvm.minnum`` intrinsic can be refined into ``llvm.minimumnum``, as the
+latter exhibits a subset of behaviors of the former.
 
 .. _i_maxnum:
 
@@ -17406,8 +17408,7 @@ If an operand is a signaling NaN, then the intrinsic will non-deterministically
 either:
 
  * Return a :ref:`NaN <floatnan>`.
- * Or treat the signaling NaN as a quiet NaN. In this case the intrinsic will
-   behave the same as ``llvm.maximumnum``.
+ * Or treat the signaling NaN as a quiet NaN.
 
 If the ``nsz`` flag is specified, ``llvm.maxnum`` with one +0.0 and one
 -0.0 operand may non-deterministically return either operand. Contrary to normal
@@ -17416,6 +17417,9 @@ have the same sign.
 
 When used with the ``nsz`` flag, this intrinsics follows the semantics of
 ``fmax`` in C.
+
+The ``llvm.maxnum`` intrinsic can be refined into ``llvm.maximumnum``, as the
+latter exhibits a subset of behaviors of the former.
 
 .. _i_minimum:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -20376,9 +20376,6 @@ non-deterministically either:
  * Return a :ref:`NaN <floatnan>`.
  * Treat the signaling NaN as a quiet NaN.
 
-If the intrinsic call has the ``nnan`` fast-math flag, then the operation can
-assume that NaNs are not present in the input vector.
-
 Arguments:
 """"""""""
 The argument to this intrinsic must be a vector of floating-point values.
@@ -20412,9 +20409,6 @@ non-deterministically either:
 
  * Return a :ref:`NaN <floatnan>`.
  * Treat the signaling NaN as a quiet NaN.
-
-If the intrinsic call has the ``nnan`` fast-math flag, then the operation can
-assume that NaNs are not present in the input vector.
 
 Arguments:
 """"""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17364,6 +17364,12 @@ When used with the ``nsz`` flag, this intrinsics follows the semantics of
 The ``llvm.minnum`` intrinsic can be refined into ``llvm.minimumnum``, as the
 latter exhibits a subset of behaviors of the former.
 
+.. warning::
+
+  If the intrinsic is used without nsz, not all backends currently respect the
+  specified signed zero ordering. Do not rely on it until this warning has
+  been removed.
+
 .. _i_maxnum:
 
 '``llvm.maxnum.*``' Intrinsic
@@ -17422,6 +17428,12 @@ When used with the ``nsz`` flag, this intrinsics follows the semantics of
 
 The ``llvm.maxnum`` intrinsic can be refined into ``llvm.maximumnum``, as the
 latter exhibits a subset of behaviors of the former.
+
+.. warning::
+
+  If the intrinsic is used without nsz, not all backends currently respect the
+  specified signed zero ordering. Do not rely on it until this warning has
+  been removed.
 
 .. _i_minimum:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17397,8 +17397,8 @@ If the ``nsz`` flag is specified, ``llvm.minnum`` with one +0.0 and one
 have the same sign.
 
 When used with the ``nsz`` flag, this intrinsic follows the semantics of
-``fmin`` in C and ``maxNum`` in IEEE 754-2008 with the usual
-:ref:`signaling NaN <floatnan>` exception.
+``fmin`` in C and ``minNum`` in IEEE 754-2008, except for signaling NaN inputs,
+which follow :ref:`LLVM's usual signaling NaN behavior <floatnan>` instead.
 
 The ``llvm.minnum`` intrinsic can be refined into ``llvm.minimumnum``, as the
 latter exhibits a subset of behaviors of the former.
@@ -17462,8 +17462,8 @@ If the ``nsz`` flag is specified, ``llvm.maxnum`` with one +0.0 and one
 have the same sign.
 
 When used with the ``nsz`` flag, this intrinsic follows the semantics of
-``fmax`` in C and ``maxNum`` in IEEE 754-2008 with the usual
-:ref:`signaling NaN <floatnan>` exception.
+``fmax`` in C and ``maxNum`` in IEEE 754-2008, except for signaling NaN inputs,
+which follow :ref:`LLVM's usual signaling NaN behavior <floatnan>` instead.
 
 The ``llvm.maxnum`` intrinsic can be refined into ``llvm.maximumnum``, as the
 latter exhibits a subset of behaviors of the former.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17407,7 +17407,8 @@ latter exhibits a subset of behaviors of the former.
 
   If the intrinsic is used without nsz, not all backends currently respect the
   specified signed zero ordering. Do not rely on it until this warning has
-  been removed.
+  been removed. See `issue #174730
+  <https://github.com/llvm/llvm-project/issues/174730>`_.
 
 .. _i_maxnum:
 
@@ -17472,7 +17473,8 @@ latter exhibits a subset of behaviors of the former.
 
   If the intrinsic is used without nsz, not all backends currently respect the
   specified signed zero ordering. Do not rely on it until this warning has
-  been removed.
+  been removed. See `issue #174730
+  <https://github.com/llvm/llvm-project/issues/174730>`_.
 
 .. _i_minimum:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17456,9 +17456,9 @@ type.
 
 Semantics:
 """"""""""
-If either operand is a NaN, returns NaN. Otherwise returns the lesser
-of the two arguments. -0.0 is considered to be less than +0.0 for this
-intrinsic. Note that these are the semantics of minimum specified in
+If either operand is a NaN, returns a :ref:`NaN <floatnan>`. Otherwise returns
+the lesser of the two arguments. -0.0 is considered to be less than +0.0 for
+this intrinsic. Note that these are the semantics of minimum specified in
 IEEE 754-2019, with the usual :ref:`signaling NaN <floatnan>` exception.
 
 If the ``nsz`` flag is specified, ``llvm.maximum`` with one +0.0 and one
@@ -17501,9 +17501,9 @@ type.
 
 Semantics:
 """"""""""
-If either operand is a NaN, returns NaN. Otherwise returns the greater
-of the two arguments. -0.0 is considered to be less than +0.0 for this
-intrinsic. Note that these are the semantics of maximum specified in
+If either operand is a NaN, returns a :ref:`NaN <floatnan>`. Otherwise returns
+the greater of the two arguments. -0.0 is considered to be less than +0.0 for
+this intrinsic. Note that these are the semantics of maximum specified in
 IEEE 754-2019, with the usual :ref:`signaling NaN <floatnan>` exception.
 
 If the ``nsz`` flag is specified, ``llvm.maximum`` with one +0.0 and one

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17454,8 +17454,8 @@ Semantics:
 """"""""""
 If either operand is a NaN, returns NaN. Otherwise returns the lesser
 of the two arguments. -0.0 is considered to be less than +0.0 for this
-intrinsic. Note that these are the semantics specified in the draft of
-IEEE 754-2019.
+intrinsic. Note that these are the semantics of minimum specified in
+IEEE 754-2019, with the usual :ref:`signaling NaN <floatnan>` exception.
 
 If the ``nsz`` flag is specified, ``llvm.maximum`` with one +0.0 and one
 -0.0 operand may non-deterministically return either operand. Contrary to normal
@@ -17499,8 +17499,8 @@ Semantics:
 """"""""""
 If either operand is a NaN, returns NaN. Otherwise returns the greater
 of the two arguments. -0.0 is considered to be less than +0.0 for this
-intrinsic. Note that these are the semantics specified in the draft of
-IEEE 754-2019.
+intrinsic. Note that these are the semantics of maximum specified in
+IEEE 754-2019, with the usual :ref:`signaling NaN <floatnan>` exception.
 
 If the ``nsz`` flag is specified, ``llvm.maximum`` with one +0.0 and one
 -0.0 operand may non-deterministically return either operand. Contrary to normal

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17305,6 +17305,45 @@ The returned value is completely identical to the input except for the sign bit;
 in particular, if the input is a NaN, then the quiet/signaling bit and payload
 are perfectly preserved.
 
+Floating-point min/max intrinsics comparison
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+LLVM supports three pairs of floating-point min/max intrinsics, which differ
+in their handling of :ref:`NaN values <floatnan>`:
+
+ * ``llvm.minimum`` and ``llvm.maximum``: Return NaN if one the arguments is
+   NaN.
+ * ``llvm.minimumnum`` and ``llvm.maximumnum``: Return the other argument if
+   one of the arguments is NaN.
+ * ``llvm.minnum`` and ``llvm.maxnum``: For quiet NaNs behaves like
+   minimumnum/maximumnum. For signaling NaNs, non-deterministically returns
+   NaN or the other operand.
+
+Additionally, each of these intrinsics supports two behaviors for signed zeroes.
+By default, -0.0 is considered smaller than +0.0. If the ``nsz`` flag is
+specified, the order is non-deterministic.
+
+The mapping between the LLVM intrinsics, C functions and IEEE-754 functions is
+as follows (up to divergences permitted by the usual `NaN rules <floatnan>`):
+
+.. list-table::
+   :header-rows: 1
+
+   * - LLVM intrinsic
+     - llvm.minnum with nsz flag
+     - llvm.minimum
+     - llvm.minimumnum
+
+   * - C function
+     - fmin
+     - fminimum
+     - fminimum_num
+
+   * - IEEE-754 function
+     - minNum (2008)
+     - minimum (2019)
+     - minimumNumber (2019)
+
 .. _i_minnum:
 
 '``llvm.minnum.*``' Intrinsic

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17358,7 +17358,8 @@ If the ``nsz`` flag is specified, ``llvm.minnum`` with one +0.0 and one
 have the same sign.
 
 When used with the ``nsz`` flag, this intrinsics follows the semantics of
-``fmin`` in C.
+``fmin`` in C and ``maxNum`` in IEEE 754-2008 with the usual
+:ref:`signaling NaN <floatnan>` exception.
 
 The ``llvm.minnum`` intrinsic can be refined into ``llvm.minimumnum``, as the
 latter exhibits a subset of behaviors of the former.
@@ -17416,7 +17417,8 @@ If the ``nsz`` flag is specified, ``llvm.maxnum`` with one +0.0 and one
 have the same sign.
 
 When used with the ``nsz`` flag, this intrinsics follows the semantics of
-``fmax`` in C.
+``fmax`` in C and ``maxNum`` in IEEE 754-2008 with the usual
+:ref:`signaling NaN <floatnan>` exception.
 
 The ``llvm.maxnum`` intrinsic can be refined into ``llvm.maximumnum``, as the
 latter exhibits a subset of behaviors of the former.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17323,7 +17323,7 @@ Additionally, each of these intrinsics supports two behaviors for signed zeroes.
 By default, -0.0 is considered smaller than +0.0. If the ``nsz`` flag is
 specified, the order is non-deterministic.
 
-The mapping between the LLVM intrinsics, C functions and IEEE-754 functions is
+The mapping between the LLVM intrinsics, C functions and IEEE 754 functions is
 as follows (up to divergences permitted by the usual `NaN rules <floatnan>`):
 
 .. list-table::
@@ -17339,7 +17339,7 @@ as follows (up to divergences permitted by the usual `NaN rules <floatnan>`):
      - fminimum
      - fminimum_num
 
-   * - IEEE-754 function
+   * - IEEE 754 function
      - minNum (2008)
      - minimum (2019)
      - minimumNumber (2019)

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17560,9 +17560,8 @@ have the same sign.
 Note that these are the semantics of minimumNumber specified in
 IEEE-754-2019 with the usual :ref:`signaling NaN <floatnan>` exception.
 
-This intrinsic differs from ``llvm.minnum`` in that it is guaranteed to treat
-sNaN the same way as qNaN. ``llvm.minnum`` will instead non-deterministically
-either act like ``llvm.minimumnum`` or return a :ref:`NaN <floatnan>`.
+This intrinsic behaves the same as ``llvm.minnum`` other than its treatment of
+sNaN inputs.
 
 .. _i_maximumnum:
 
@@ -17614,9 +17613,8 @@ have the same sign.
 Note that these are the semantics of maximumNumber specified in
 IEEE-754-2019  with the usual :ref:`signaling NaN <floatnan>` exception.
 
-This intrinsic differs from ``llvm.maxnum`` in that it is guaranteed to treat
-sNaN the same way as qNaN. ``llvm.maxnum`` will instead non-deterministically
-either act like ``llvm.maximumnum`` or return a :ref:`NaN <floatnan>`.
+This intrinsic behaves the same as ``llvm.maxnum`` other than its treatment of
+sNaN inputs.
 
 .. _int_copysign:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17343,8 +17343,8 @@ Semantics:
 
 If both operands are qNaNs, returns a :ref:`NaN <floatnan>`. If one operand is
 qNaN and another operand is a number, returns the number. If both operands are
-numbers, returns the lesser of the two arguments. If both operands compare equal
-(for example +0.0 and -0.0), non-deterministially returns either operand.
+numbers, returns the lesser of the two arguments. -0.0 is considered to be less
+than +0.0 for this intrinsic.
 
 If an operand is a signaling NaN, then the intrinsic will non-deterministically
 either:
@@ -17352,8 +17352,14 @@ either:
  * Return a :ref:`NaN <floatnan>`.
  * Or treat the signaling NaN as a quiet NaN.
 
-This intrinsics follows the semantics of ``fmin`` in C and ``maxNum`` in
-IEEE 754-2008 with the usual :ref:`signaling NaN <floatnan>` exception.
+If the ``nsz`` flag is specified, ``llvm.minnum`` with one +0.0 and one
+-0.0 operand may non-deterministically return either operand. Contrary to normal
+``nsz`` semantics, if both operands have the same sign, the result must also
+have the same sign.
+
+When used with the ``nsz`` flag, this intrinsics follows the semantics of
+``fmin`` in C and ``maxNum`` in IEEE 754-2008 with the usual
+:ref:`signaling NaN <floatnan>` exception.
 
 The ``llvm.minnum`` intrinsic can be refined into ``llvm.minimumnum``, as the
 latter exhibits a subset of behaviors of the former.
@@ -17396,8 +17402,8 @@ Semantics:
 
 If both operands are qNaNs, returns a :ref:`NaN <floatnan>`. If one operand is
 qNaN and another operand is a number, returns the number. If both operands are
-numbers, returns the greater of the two arguments. If both operands compare
-equal (for example +0.0 and -0.0), non-deterministically returns either operand.
+numbers, returns the greater of the two arguments. -0.0 is considered to be
+less than +0.0 for this intrinsic.
 
 If an operand is a signaling NaN, then the intrinsic will non-deterministically
 either:
@@ -17405,8 +17411,14 @@ either:
  * Return a :ref:`NaN <floatnan>`.
  * Or treat the signaling NaN as a quiet NaN.
 
-This intrinsics follows the semantics of ``fmax`` in C and ``maxNum`` in
-IEEE 754-2008 with the usual :ref:`signaling NaN <floatnan>` exception.
+If the ``nsz`` flag is specified, ``llvm.maxnum`` with one +0.0 and one
+-0.0 operand may non-deterministically return either operand. Contrary to normal
+``nsz`` semantics, if both operands have the same sign, the result must also
+have the same sign.
+
+When used with the ``nsz`` flag, this intrinsics follows the semantics of
+``fmax`` in C and ``maxNum`` in IEEE 754-2008 with the usual
+:ref:`signaling NaN <floatnan>` exception.
 
 The ``llvm.maxnum`` intrinsic can be refined into ``llvm.maximumnum``, as the
 latter exhibits a subset of behaviors of the former.
@@ -20359,8 +20371,8 @@ The '``llvm.vector.reduce.fmax.*``' intrinsics do a floating-point
 ``MAX`` reduction of a vector, returning the result as a scalar. The return type
 matches the element-type of the vector input.
 
-This instruction has the same comparison semantics as the '``llvm.maxnum.*``'
-intrinsic.
+This instruction has the same comparison and ``nsz`` semantics as the
+'``llvm.maxnum.*``' intrinsic.
 
 If any of the vector elements is a signaling NaN, the intrinsic will
 non-deterministically either:
@@ -20393,8 +20405,8 @@ The '``llvm.vector.reduce.fmin.*``' intrinsics do a floating-point
 ``MIN`` reduction of a vector, returning the result as a scalar. The return type
 matches the element-type of the vector input.
 
-This instruction has the same comparison semantics as the '``llvm.minnum.*``'
-intrinsic.
+This instruction has the same comparison and ``nsz`` semantics as the
+'``llvm.minnum.*``' intrinsic.
 
 If any of the vector elements is a signaling NaN, the intrinsic will
 non-deterministically either:

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17305,6 +17305,8 @@ The returned value is completely identical to the input except for the sign bit;
 in particular, if the input is a NaN, then the quiet/signaling bit and payload
 are perfectly preserved.
 
+.. _i_fminmax_family:
+
 Floating-point min/max intrinsics comparison
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17321,9 +17321,10 @@ in their handling of :ref:`NaN values <floatnan>`:
    minimumnum/maximumnum. For signaling NaNs, non-deterministically returns
    NaN or the other operand.
 
-Additionally, each of these intrinsics supports two behaviors for signed zeroes.
+Additionally, each of these intrinsics supports two behaviors for signed zeros.
 By default, -0.0 is considered smaller than +0.0. If the ``nsz`` flag is
-specified, the order is non-deterministic.
+specified, the order is non-deterministic: If the two inputs are zeros with
+opposite sign, either input may be returned.
 
 The mapping between the LLVM intrinsics, C functions and IEEE 754 functions is
 as follows (up to divergences permitted by the usual `NaN rules <floatnan>`):


### PR DESCRIPTION
This implements some clarifications for the specification of floating point min/max operations based on the discussion in https://discourse.llvm.org/t/rfc-a-consistent-set-of-semantics-for-the-floating-point-minimum-and-maximum-operations/89006.

The key changes are:

 * Explicitly specify minnum and maxnum with an sNaN operand as non-deterministically either returning NaN or treating sNaN as qNaN. This was implied by our general NaN semantics, but is important to call out here due to the special behavior of sNaN.
 * Explicitly specify the same non-determinism for the minnum/maxnum based vector reductions as well.
 * Explicitly specify the meaning of nsz on float min/max ops. In particular, clarify that unlike normal nsz semantics, it does not allow introducing a zero with a different sign out of thin air.
 * Simplify the semantics comparison section. This now focuses only on NaN and signed zero behavior, but omits information about exceptions that is not relevant for these non-constrained intrinsics.