### PR TITLE
[libcxx][docs] Fix boostrapping build configure command

### DIFF
--- a/libcxx/docs/VendorDocumentation.rst
+++ b/libcxx/docs/VendorDocumentation.rst
@@ -81,14 +81,15 @@ CMake invocation at ``<monorepo>/llvm``:
 .. code-block:: bash
 
   $ mkdir build
+  $ # Configure
   $ cmake -G Ninja -S llvm -B build                                       \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo                               \
-          -DLLVM_ENABLE_PROJECTS="clang"                                  \  # Configure
+          -DLLVM_ENABLE_PROJECTS="clang"                                  \
           -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;compiler-rt" \
           -DLLVM_RUNTIME_TARGETS="<target-triple>"
-  $ ninja -C build runtimes                                                  # Build
-  $ ninja -C build check-runtimes                                            # Test
-  $ ninja -C build install-runtimes                                          # Install
+  $ ninja -C build runtimes          # Build
+  $ ninja -C build check-runtimes    # Test
+  $ ninja -C build install-runtimes  # Install
 
 .. note::
   - This type of build is also commonly called a "Runtimes build", but we would like to move


### PR DESCRIPTION
If I take the command from the page and add my triple like so:

$ cmake -G Ninja -S llvm -B build                                       \
        -DCMAKE_BUILD_TYPE=RelWithDebInfo                               \
        -DLLVM_ENABLE_PROJECTS="clang"                                  \  # Configure
        -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;compiler-rt" \
        -DLLVM_RUNTIME_TARGETS="aarch64-unknown-linux-gnu"
CMake Warning:
  Ignoring extra path from command line:

   " "
<...>
-- Build files have been written to: /home/david.spickett/llvm-project/build -bash: -DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi;libunwind;compiler-rt: command not found

As the comment is after the backslash, it's considered part of the next line. This comments out the ENABLE_RUNTIMES line and makes the RUNTIME_TARGETS line look like another command.

To fix this, put the comment before the configure command.

I also moved the other inline comments (which are fine) closer to the text since they don't have to line up with the configure one anymore.