### PR TITLE
[lldb][nfc] Change ProcessGDBRemote::ParseMultiMemReadPacket signature

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -147,10 +147,10 @@ private:
   llvm::Expected<StringExtractorGDBRemote>
   SendMultiMemReadPacket(llvm::ArrayRef<Range<lldb::addr_t, size_t>> ranges);
 
-  llvm::Expected<llvm::SmallVector<llvm::MutableArrayRef<uint8_t>>>
-  ParseMultiMemReadPacket(llvm::StringRef response_str,
-                          llvm::MutableArrayRef<uint8_t> buffer,
-                          unsigned expected_num_ranges);
+  llvm::Error ParseMultiMemReadPacket(
+      llvm::StringRef response_str, llvm::MutableArrayRef<uint8_t> buffer,
+      unsigned expected_num_ranges,
+      llvm::SmallVectorImpl<llvm::MutableArrayRef<uint8_t>> &parsed_ranges);
 
 public:
   Status

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -150,7 +150,7 @@ private:
   llvm::Error ParseMultiMemReadPacket(
       llvm::StringRef response_str, llvm::MutableArrayRef<uint8_t> buffer,
       unsigned expected_num_ranges,
-      llvm::SmallVectorImpl<llvm::MutableArrayRef<uint8_t>> &parsed_ranges);
+      llvm::SmallVectorImpl<llvm::MutableArrayRef<uint8_t>> &memory_regions);
 
 public:
   Status


### PR DESCRIPTION
Instead of returning an `Expected<vector<...>>` it now returns an Error, and receives a vector argument to fill in. This will be useful to support a change were ParseMultiMemReadPacket will be called multiple times in a loop with the same vector; without this change, we would have to concatenate vectors and copy memory around.