### PR TITLE
[lldb] Use ReadCStringsFromMemory to speed-up AppleObjCClassDescriptorV2::method_t lookup

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
@@ -173,6 +173,10 @@ private:
     bool Read(DataExtractor &extractor, Process *process, lldb::addr_t addr,
               lldb::addr_t relative_string_base_addr, bool is_small,
               bool has_direct_sel, bool has_relative_types);
+
+    /// Fill in `m_name` and `m_types` efficiently by batching read requests.
+    static void ReadNames(llvm::MutableArrayRef<method_t> methods,
+                          Process &process);
   };
 
   llvm::SmallVector<method_t, 0>


### PR DESCRIPTION
With this improvement, compiling a simple Objective-C program like:

```
int main() {
    @autoreleasepool {
        NSDictionary *mapping = @{ @"one": @1, @"two": @2, @"three": @3 };
        return 0; //breakhere
    }
}
```

And running `expr -O -- mapping[@"one"]`, we can observe the following packet count for the expression evaluation:

```
Before:
  multi mem read ($MultiMemRead)        :    94
  read memory ($x)                      :  1070
After:
  multi mem read ($MultiMemRead)        :   188
  read memory ($x)                      :   665
```

In other words, we save 311 packets.

Depends on:
* https://github.com/llvm/llvm-project/pull/172026


rdar://151850617