### PR TITLE
[flang] Fix ISO_C_BINDING type sizes for Windows

### DIFF
--- a/flang/module/iso_c_binding.f90
+++ b/flang/module/iso_c_binding.f90
@@ -43,7 +43,11 @@ module iso_c_binding
   integer, parameter, public :: &
     c_int = c_int32_t, &
     c_short = c_int16_t, &
+#if defined(_WIN32)
+    c_long = c_int32_t, &
+#else
     c_long = c_int64_t, &
+#endif
     c_long_long = c_int64_t, &
     c_signed_char = c_int8_t, &
     c_size_t = kind(c_sizeof(1)), &
@@ -76,6 +80,8 @@ module iso_c_binding
     c_double = 8, &
 #if __x86_64__
     c_long_double = 10
+#elif defined(_WIN32) && defined(__aarch64__)
+    c_long_double = 8
 #else
     c_long_double = 16
 #endif
@@ -117,9 +123,13 @@ module iso_c_binding
     c_unsigned_char = c_uint8_t, &
     c_unsigned_short = c_uint16_t, &
     c_unsigned = c_uint32_t, &
+#if defined(_WIN32)
+    c_unsigned_long = c_uint32_t, &
+#else
     c_unsigned_long = c_uint64_t, &
-    c_unsigned_long_long = c_unsigned_long, &
-#if __powerpc__
+#endif
+    c_unsigned_long_long = c_uint64_t, &
+#if __powerpc__ || defined(_WIN32)
     c_uintmax_t = c_uint64_t
 #else
     c_uintmax_t = c_uint128_t

--- a/flang/module/iso_c_binding.f90
+++ b/flang/module/iso_c_binding.f90
@@ -78,7 +78,7 @@ module iso_c_binding
   integer, parameter, public :: &
     c_float = 4, &
     c_double = 8, &
-#if __x86_64__
+#if defined(__x86_64__)
     c_long_double = 10
 #elif defined(_WIN32) && defined(__aarch64__)
     c_long_double = 8
@@ -129,7 +129,7 @@ module iso_c_binding
     c_unsigned_long = c_uint64_t, &
 #endif
     c_unsigned_long_long = c_uint64_t, &
-#if __powerpc__ || defined(_WIN32)
+#if defined(__powerpc__) || defined(_WIN32)
     c_uintmax_t = c_uint64_t
 #else
     c_uintmax_t = c_uint128_t


### PR DESCRIPTION
Fix several ISO_C_BINDING type parameters for Windows compatibility:

- c_long/c_unsigned_long: Use 32-bit on Windows (LLP64 data model)
- c_long_double: Use 64-bit (kind=8) on Windows ARM64
  https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/9#issuecomment-2573385824
- c_unsigned_long_long: Explicitly use c_uint64_t instead of depending on c_unsigned_long
- c_uintmax_t: Use 64-bit on Windows (consistent with MSVC/MinGW)

Fixes issue reported in https://github.com/msys2/MINGW-packages/pull/16579

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
