### PR TITLE
[MLIR][GPU] Support grid constant, byval, byref on gpu.func

### DIFF
--- a/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
+++ b/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Conversion/GPUCommon/GPUCommonPass.h"
 #include "mlir/Conversion/LLVMCommon/VectorPattern.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -360,6 +359,14 @@ GPUFuncOpLowering::matchAndRewrite(gpu::GPUFuncOp gpuFuncOp, OpAdaptor adaptor,
     if (argAttr.empty())
       continue;
 
+    const bool isArgTypeUnchanged =
+        remapping->size == 1 &&
+        llvmFuncOp.getArgument(remapping->inputNo).getType() == argTy;
+    if (isArgTypeUnchanged) {
+      llvmFuncOp.setArgAttrs(remapping->inputNo, argAttr);
+      continue;
+    }
+
     copyAttribute(LLVM::LLVMDialect::getReturnedAttrName());
     copyAttribute(LLVM::LLVMDialect::getNoUndefAttrName());
     copyAttribute(LLVM::LLVMDialect::getInRegAttrName());
@@ -370,10 +377,7 @@ GPUFuncOpLowering::matchAndRewrite(gpu::GPUFuncOp gpuFuncOp, OpAdaptor adaptor,
     }
 
     if (lowersToPointer) {
-      copyPointerAttribute(mlir::NVVM::NVVMDialect::getGridConstantAttrName());
       copyPointerAttribute(LLVM::LLVMDialect::getNoAliasAttrName());
-      copyPointerAttribute(LLVM::LLVMDialect::getByValAttrName());
-      copyPointerAttribute(LLVM::LLVMDialect::getByRefAttrName());
       copyPointerAttribute(LLVM::LLVMDialect::getNoCaptureAttrName());
       copyPointerAttribute(LLVM::LLVMDialect::getNoFreeAttrName());
       copyPointerAttribute(LLVM::LLVMDialect::getAlignAttrName());

--- a/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
+++ b/mlir/lib/Conversion/GPUCommon/GPUOpsLowering.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Conversion/GPUCommon/GPUCommonPass.h"
 #include "mlir/Conversion/LLVMCommon/VectorPattern.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -369,7 +370,10 @@ GPUFuncOpLowering::matchAndRewrite(gpu::GPUFuncOp gpuFuncOp, OpAdaptor adaptor,
     }
 
     if (lowersToPointer) {
+      copyPointerAttribute(mlir::NVVM::NVVMDialect::getGridConstantAttrName());
       copyPointerAttribute(LLVM::LLVMDialect::getNoAliasAttrName());
+      copyPointerAttribute(LLVM::LLVMDialect::getByValAttrName());
+      copyPointerAttribute(LLVM::LLVMDialect::getByRefAttrName());
       copyPointerAttribute(LLVM::LLVMDialect::getNoCaptureAttrName());
       copyPointerAttribute(LLVM::LLVMDialect::getNoFreeAttrName());
       copyPointerAttribute(LLVM::LLVMDialect::getAlignAttrName());

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -5448,7 +5448,8 @@ LogicalResult NVVMDialect::verifyRegionArgAttribute(Operation *op,
   if (!funcOp)
     return success();
 
-  bool isKernel = op->hasAttr(NVVMDialect::getKernelFuncAttrName());
+  const bool isKernel = op->hasAttr(NVVMDialect::getKernelFuncAttrName()) ||
+                        op->hasAttr(gpu::GPUDialect::getKernelFuncAttrName());
   StringAttr attrName = argAttr.getName();
   if (attrName == NVVM::NVVMDialect::getGridConstantAttrName()) {
     if (!isKernel) {

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
@@ -1150,7 +1150,7 @@ gpu.module @test_module_56 {
   }
 }
 
-// Check that nvvm.grid_constant is a valid argument attribute on gpu.kernel.
+// Check that nvvm.grid_constant, llvm.byref, and llvm.byval are valid argument attributes on gpu.kernel.
 gpu.module @test_module_57 {
   // CHECK:       gpu.module @test_module_57
   // CHECK-LABEL:   llvm.func @test_kernel(

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
@@ -1149,3 +1149,19 @@ gpu.module @test_module_56 {
     func.return %sin16, %cos16, %sin32, %cos32, %sin64, %cos64 : f16, f16, f32, f32, f64, f64
   }
 }
+
+// Check that nvvm.grid_constant is a valid argument attribute on gpu.kernel.
+gpu.module @test_module_57 {
+  // CHECK:       gpu.module @test_module_57
+  // CHECK-LABEL:   llvm.func @test_kernel(
+  // CHECK-SAME:      %[[VAL_0:.*]]: !llvm.ptr {llvm.byval = i64, nvvm.grid_constant}
+  // CHECK-SAME:      %[[VAL_1:.*]]: !llvm.ptr {llvm.byref = i64}
+  // CHECK:           llvm.return
+  // CHECK:         }
+  // CHECK:       }
+  gpu.func @test_kernel(
+      %arg0: !llvm.ptr {nvvm.grid_constant, llvm.byval = i64},
+      %arg1: !llvm.ptr {llvm.byref = i64}) kernel {
+    gpu.return
+  }
+}


### PR DESCRIPTION
Adds support for the argument attributes required to mark pointer arguments on gpu.func ops as grid-constant.