### PR TITLE
[lldb] fix failing diagnostics test when Unicode is supported

### DIFF
--- a/lldb/test/Shell/Commands/command-expr-diagnostics.test
+++ b/lldb/test/Shell/Commands/command-expr-diagnostics.test
@@ -24,7 +24,7 @@
 # RUN: "expression -- FOO(\"\")" 2>&1 | FileCheck %s --check-prefix=CHECK4
 #            (lldb) expression -- FOO("")
 # CHECK4:{{^                     (\^|˄)}}
-# CHECK4: {{^                     note: in instantiation of function template}}
+# CHECK4: {{^                     (╰─ )?note: in instantiation of function template}}
 # CHECK4: error: <user expression
 
 # RUN: echo expression --\na\n+\nb


### PR DESCRIPTION
This patch fixes a test failure introduced by https://github.com/llvm/llvm-project/pull/171832 due to a check which was not properly updated.