### PR TITLE
[flang] improve compatibility with mingw headers

### DIFF
--- a/flang-rt/lib/runtime/command.cpp
+++ b/flang-rt/lib/runtime/command.cpp
@@ -23,11 +23,9 @@
 #define unlink _unlink
 #define PATH_MAX MAX_PATH
 
-#ifdef _MSC_VER
 // On Windows GetCurrentProcessId returns a DWORD aka uint32_t
 #include <processthreadsapi.h>
 inline pid_t getpid() { return GetCurrentProcessId(); }
-#endif
 #else
 #include <unistd.h> //getpid() unlink()
 

--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -16,7 +16,9 @@
 #include <limits>
 
 #ifdef _WIN32
+#ifdef _MSC_VER
 extern char **_environ;
+#endif
 #elif defined(__FreeBSD__)
 // FreeBSD has environ in crt rather than libc. Using "extern char** environ"
 // in the code of a shared library makes it fail to link with -Wl,--no-undefined

--- a/flang/include/flang/Common/windows-include.h
+++ b/flang/include/flang/Common/windows-include.h
@@ -20,7 +20,9 @@
 
 // Target Windows 2000 and above. This is needed for newer Windows API
 // functions, e.g. GetComputerNameExA()
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0500
+#endif
 
 #include <windows.h>
 


### PR DESCRIPTION
The mingw headers declare `__environ` already, leading to warnings due
to missing dllimport here. Similarly with _WIN32_WINNT may be already
defined from a header leading to nuisance warnings. And the getpid is
not defined in the current header set (it is in process.h), so that
needs to be defined, just like MSVC (this replaces
https://github.com/msys2/MINGW-packages/blob/576fc4bbfa9bff4d5ab81779a706723b5214fd7d/mingw-w64-flang/0103-fix-build-on-mingw.patch).
