### PR TITLE
[lldb][ClangExpressionParser] Emit more accurate language note for Objective-C++ fallback

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -607,15 +607,21 @@ static void SetupLangOpts(CompilerInstance &compiler,
     lang_opts.CPlusPlus11 = true;
     compiler.getHeaderSearchOpts().UseLibcxx = true;
     [[fallthrough]];
-  case lldb::eLanguageTypeC_plus_plus_03:
+  case lldb::eLanguageTypeC_plus_plus_03: {
     lang_opts.CPlusPlus = true;
     if (process_sp
         // We're stopped in a frame without debug-info. The user probably
         // intends to make global queries (which should include Objective-C).
-        && !(frame_sp && frame_sp->HasDebugInformation()))
+        && !(frame_sp && frame_sp->HasDebugInformation())) {
       lang_opts.ObjC =
           process_sp->GetLanguageRuntime(lldb::eLanguageTypeObjC) != nullptr;
-    break;
+      if (lang_opts.ObjC) {
+        language_for_note = lldb::eLanguageTypeObjC_plus_plus;
+        language_fallback_reason = "Possibly stopped inside system library, so "
+                                   "speculatively enabled Objective-C. ";
+      }
+    }
+  } break;
   case lldb::eLanguageTypeObjC_plus_plus:
   case lldb::eLanguageTypeUnknown:
   default:

--- a/lldb/test/Shell/Expr/TestExprLanguageNote_NoDebug.cpp
+++ b/lldb/test/Shell/Expr/TestExprLanguageNote_NoDebug.cpp
@@ -1,0 +1,19 @@
+// REQUIRES: system-darwin
+//
+// Tests the language fall back diagnostic for when we fall back to
+// Objective-C++ when stopped in frames with no debug-info.
+//
+// RUN: %clangxx_host %s -o %t.out
+//
+// RUN: %lldb %t.out \
+// RUN:    -o "b main" \
+// RUN:    -o run \
+// RUN:    -o "expr --language c++ -- blah" -o quit 2>&1 | FileCheck %s
+
+// CHECK: (lldb) expr
+// CHECK: note: Possibly stopped inside system library, so speculatively enabled Objective-C. Ran expression as 'Objective C++'.
+
+int main() {
+  int x = 10;
+  return x;
+}


### PR DESCRIPTION
We fall back to `Objective-C++` when running C++ expressions in frames that don't have debug-info. But we were missing a fallback note for this situation. We would now print following note on expression error:
```
note: Possibly stopped inside system library, so speculatively enabled Objective-C. Ran expression as 'Objective C++'.
```