### PR TITLE
[lldb] Prefer exact address match when looking up symbol by address

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -497,7 +497,8 @@ uint32_t Module::ResolveSymbolContextForAddress(
         addr_t file_address = so_addr.GetFileAddress();
         Symbol *matching_symbol = symtab->FindSymbolAtFileAddress(file_address);
 
-        if (!matching_symbol) {
+        if (!matching_symbol ||
+            matching_symbol->GetType() == eSymbolTypeInvalid) {
           symtab->ForEachSymbolContainingFileAddress(
               file_address, [&matching_symbol](Symbol *symbol) -> bool {
                 if (symbol->GetType() != eSymbolTypeInvalid) {


### PR DESCRIPTION
The current behavior will pick the first symbol that contains the address, this causes LLDB to pick the wrong symbol when looking for swift reflection metadata on Linux, as in that case it is valid for a symbol to completely encompass another one.

Instead, this function should prefer the symbol which is an exact, if it exists. As a bonus, this should also be faster in the vast majority of the cases, as we probably query symbols by their exact address most of the time.

rdar://166344740