### PR TITLE
[CIR][NFC] Fix the mms-bitfields test file

### DIFF
--- a/clang/test/CIR/CodeGen/mms-bitfields.c
+++ b/clang/test/CIR/CodeGen/mms-bitfields.c
@@ -1,8 +1,8 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mms-bitfields -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fms-layout-compatibility=microsoft -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mms-bitfields -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fms-layout-compatibility=microsoft -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mms-bitfields -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fms-layout-compatibility=microsoft -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
 
 struct s1 {


### PR DESCRIPTION
Fix the args in the mms-bitfields test file to be aligned with the same test in classical codegen (clang/test/CodeGen/mms-bitfields.c). After #71148 is merged