### PR TITLE
[mlir][PDL] Add CallableOpInterface to pdl.pattern and inlining support to pdl

### DIFF
--- a/mlir/include/mlir/Dialect/PDL/IR/PDLOps.h
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLOps.h
@@ -18,6 +18,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
+++ b/mlir/include/mlir/Dialect/PDL/IR/PDLOps.td
@@ -16,6 +16,7 @@
 include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
@@ -393,7 +394,8 @@ def PDL_OperationOp : PDL_Op<"operation", [AttrSizedOperandSegments]> {
 
 def PDL_PatternOp : PDL_Op<"pattern", [
     IsolatedFromAbove, SingleBlock, Symbol,
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
+    CallableOpInterface
   ]> {
   let summary = "Define a rewrite pattern";
   let description = [{
@@ -449,6 +451,67 @@ def PDL_PatternOp : PDL_Op<"pattern", [
 
     /// Returns the rewrite operation of this pattern.
     RewriteOp getRewriter();
+  
+    //===------------------------------------------------------------------===//
+    // ArgAndResultAttrsOpInterface Methods
+    //===------------------------------------------------------------------===//
+    /// Get the arguments attributes.
+    ArrayAttr getArgAttrsAttr() {
+      return nullptr;
+    }
+
+    /// Get the result attributes.
+    ArrayAttr getResAttrsAttr() {
+      return nullptr;
+    }
+
+    /// Set the argument attributes.
+    /// NOTE: PDL patterns do not support argument attributes, calling this
+    /// method will assert.
+    void setArgAttrsAttr(Attribute attrs) {
+        (void)attrs;
+        assert(false && "PDL patterns do not support argument attributes.");
+    }
+  
+    /// Set the result attributes.
+    /// NOTE: PDL patterns do not support argument attributes, calling this
+    /// method will assert.
+    void setResAttrsAttr(Attribute attrs) {
+      (void)attrs;
+      assert(false && "PDL patterns do not support result attributes.");
+    }
+
+    /// Remove the argument attributes.
+    /// NOTE: this method is a no-op for PDL patterns.
+    Attribute removeArgAttrsAttr() {
+      return nullptr;
+    }
+
+    /// Remove the result attributes.
+    /// NOTE: this method is a no-op for PDL patterns.
+    Attribute removeResAttrsAttr() {
+      return nullptr;
+    }
+
+    //===------------------------------------------------------------------===//
+    // CallableOpInterface Methods
+    //===------------------------------------------------------------------===//
+    /// Get the callable region.
+    Region * getCallableRegion() {
+      return &getBodyRegion();
+    }
+
+    /// Get the argument types.
+    ArrayRef<Type> getArgumentTypes() {
+      // Patterns take no arguments.
+      return {};
+    }
+
+    /// Get the result types.
+    ArrayRef<Type> getResultTypes() {
+      // Patterns return no results.
+      return {};
+    }
   }];
   let hasRegionVerifier = 1;
 }

--- a/mlir/lib/Dialect/PDL/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/PDL/IR/CMakeLists.txt
@@ -10,6 +10,7 @@ add_mlir_dialect_library(MLIRPDLDialect
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRCallInterfaces
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces
   )

--- a/mlir/lib/Dialect/PDL/IR/PDL.cpp
+++ b/mlir/lib/Dialect/PDL/IR/PDL.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include <optional>
 
@@ -23,12 +24,31 @@ using namespace mlir::pdl;
 // PDLDialect
 //===----------------------------------------------------------------------===//
 
+namespace {
+/// This class defines the interface for handling inlining for pdl
+/// dialect operations.
+struct PDLInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+  // Everything can be inlined.
+  bool isLegalToInline(Operation *, Operation *, bool) const final {
+    return true;
+  }
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+  bool isLegalToInline(Region *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
+
 void PDLDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "mlir/Dialect/PDL/IR/PDLOps.cpp.inc"
       >();
   registerTypes();
+  addInterfaces<PDLInlinerInterface>();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/PDL/inlining.mlir
+++ b/mlir/test/Dialect/PDL/inlining.mlir
@@ -1,0 +1,30 @@
+// RUN: mlir-opt -inline %s | FileCheck %s
+
+func.func private @pattern_body() -> (!pdl.type, !pdl.type, !pdl.operation) {
+  %0 = pdl.type : i32
+  %1 = pdl.type
+  %2 = pdl.operation  -> (%0, %1 : !pdl.type, !pdl.type)
+  return %0, %1, %2 : !pdl.type, !pdl.type, !pdl.operation
+}
+
+func.func private @rewrite_body(%arg0: !pdl.type, %arg1: !pdl.type, %arg2: !pdl.operation) {
+  %0 = pdl.operation "foo.op"  -> (%arg0, %arg1 : !pdl.type, !pdl.type)
+  pdl.apply_native_rewrite "NativeRewrite"(%0, %arg2 : !pdl.operation, !pdl.operation)
+  return
+}
+
+// CHECK-LABEL:   pdl.pattern @nonmaterializable_pattern : benefit(1) nonmaterializable {
+// CHECK:           %[[VAL_0:.*]] = type : i32
+// CHECK:           %[[VAL_1:.*]] = type
+// CHECK:           %[[VAL_2:.*]] = operation  -> (%[[VAL_0]], %[[VAL_1]] : !pdl.type, !pdl.type)
+// CHECK:           rewrite %[[VAL_2]] {
+// CHECK:             %[[VAL_3:.*]] = operation "foo.op"  -> (%[[VAL_0]], %[[VAL_1]] : !pdl.type, !pdl.type)
+// CHECK:             apply_native_rewrite "NativeRewrite"(%[[VAL_3]], %[[VAL_2]] : !pdl.operation, !pdl.operation)
+// CHECK:           }
+// CHECK:         }
+pdl.pattern @nonmaterializable_pattern : benefit(1) nonmaterializable {
+  %0:3 = func.call @pattern_body() : () -> (!pdl.type, !pdl.type, !pdl.operation)
+  rewrite %0#2 {
+    func.call @rewrite_body(%0#0, %0#1, %0#2) : (!pdl.type, !pdl.type, !pdl.operation) -> ()
+  }
+}


### PR DESCRIPTION
This commit enables inlining of calls within PDL patterns by:

1. Adding CallableOpInterface to PatternOp, and implementing the required
   interface methods (getCallableRegion, getArgumentTypes, getResultTypes)
   and the ArgAndResultAttrsOpInterface stubs to make pdl.pattern a
   valid callable.

2. Adding the dialect inliner interface that marks all operations as legal
  to inline.

This is particularly useful for nonmaterializable patterns that may
contain func.call operations to external functions defining pattern
matching or rewrite logic. After inlining, these patterns can be
transformed into standard materializable PDL patterns.

NOTE: The pattern op needs to be marked callable as the inliner doesn't
allow inlining if there's no callable ancestor.

Example:
```mlir
func.func private @pattern_body() -> (!pdl.type, !pdl.type, !pdl.operation) {
  %0 = pdl.type : i32
  %1 = pdl.type
  %2 = pdl.operation  -> (%0, %1 : !pdl.type, !pdl.type)
  return %0, %1, %2 : !pdl.type, !pdl.type, !pdl.operation
}
func.func private @rewrite_body(%arg0: !pdl.type, %arg1: !pdl.type, %arg2: !pdl.operation) {
  %0 = pdl.operation "foo.op"  -> (%arg0, %arg1 : !pdl.type, !pdl.type)
  pdl.apply_native_rewrite "NativeRewrite"(%0, %arg2 : !pdl.operation, !pdl.operation)
  return
}
pdl.pattern @nonmaterializable_pattern : benefit(1) nonmaterializable {
  %0:3 = func.call @pattern_body() : () -> (!pdl.type, !pdl.type, !pdl.operation)
  rewrite %0#2 {
    func.call @rewrite_body(%0#0, %0#1, %0#2) : (!pdl.type, !pdl.type, !pdl.operation) -> ()
  }
}
// mlir-opt --inline
pdl.pattern @nonmaterializable_pattern : benefit(1) nonmaterializable {
  %0 = type : i32
  %1 = type
  %2 = operation  -> (%0, %1 : !pdl.type, !pdl.type)
  rewrite %2 {
    %3 = operation "foo.op"  -> (%0, %1 : !pdl.type, !pdl.type)
    apply_native_rewrite "NativeRewrite"(%3, %2 : !pdl.operation, !pdl.operation)
  }
}
```