### PR TITLE
[flang][runtime] Debug PRINT *, "HI" on GPU

### DIFF
--- a/flang-rt/include/flang-rt/runtime/buffer.h
+++ b/flang-rt/include/flang-rt/runtime/buffer.h
@@ -151,8 +151,13 @@ private:
       char *old{buffer_};
       auto oldSize{size_};
       size_ = std::max<std::int64_t>(bytes, size_ + minBuffer);
-      buffer_ =
-          reinterpret_cast<char *>(AllocateMemoryOrCrash(terminator, size_));
+      std::int64_t toAllocate{size_};
+#ifdef RT_USE_PSEUDO_FILE_UNIT
+      // PseudoOpenFile::Write() needs extra space for a NUL byte.
+      ++toAllocate;
+#endif
+      buffer_ = reinterpret_cast<char *>(
+          AllocateMemoryOrCrash(terminator, toAllocate));
       auto chunk{std::min<std::int64_t>(length_, oldSize - start_)};
       // "memcpy" in glibc has a "nonnull" attribute on the source pointer.
       // Avoid passing a null pointer, since it would result in an undefined

--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -99,14 +99,18 @@ using FileFrameClass = FileFrame<ExternalFileUnit>;
 #else // defined(RT_USE_PSEUDO_FILE_UNIT)
 using OpenFileClass = PseudoOpenFile;
 // Use not so big buffer for the pseudo file unit frame.
-using FileFrameClass = FileFrame<ExternalFileUnit, 1024>;
+using FileFrameClass = FileFrame<ExternalFileUnit, 256>;
 #endif // defined(RT_USE_PSEUDO_FILE_UNIT)
 
 class ExternalFileUnit : public ConnectionState,
                          public OpenFileClass,
                          public FileFrameClass {
 public:
+#ifdef RT_USE_PSEUDO_FILE_UNIT
+  static constexpr int maxAsyncIds{64};
+#else
   static constexpr int maxAsyncIds{64 * 16};
+#endif
 
   explicit RT_API_ATTRS ExternalFileUnit(int unitNumber)
       : unitNumber_{unitNumber} {


### PR DESCRIPTION
Decrease memory allocation for buffers, allocate the pseudo-unit only once on demand, and avoid using a "%*.s" format.