### PR TITLE
[GitHub][CI] Drop manual build of universal-ctags from abi container

### DIFF
--- a/.github/workflows/containers/github-action-ci-tooling/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-tooling/Dockerfile
@@ -109,14 +109,7 @@ RUN apt-get update && \
     abi-dumper \
     autoconf \
     parallel \
-    pkg-config && \
+    pkg-config \
+    universal-ctags && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://github.com/universal-ctags/ctags.git && \
-    cd ctags && \
-    ./autogen.sh && \
-    ./configure && \
-    sudo make install && \
-    rm -Rf ../ctags
-


### PR DESCRIPTION
This package is available in Ubuntu now, so we don't need to build it manually.