### PR TITLE
[lld][WebAssembly] Add new __rodata_start/__rodata_end symbols

### DIFF
--- a/lld/test/wasm/data-layout.s
+++ b/lld/test/wasm/data-layout.s
@@ -1,11 +1,11 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %p/Inputs/hello.s -o %t.hello32.o
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown %s -o %t32.o
-# RUN: wasm-ld -m wasm32 -no-gc-sections --export=__data_end --export=__heap_base --allow-undefined --no-entry -o %t32.wasm %t32.o %t.hello32.o
+# RUN: wasm-ld -m wasm32 -no-gc-sections --export=__rodata_start --export=__rodata_end --export=__data_end --export=__heap_base --allow-undefined --no-entry -o %t32.wasm %t32.o %t.hello32.o
 # RUN: obj2yaml %t32.wasm | FileCheck -DPTR=I32 %s
 #
 # RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-unknown %p/Inputs/hello.s -o %t.hello64.o
 # RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-unknown %s -o %t64.o
-# RUN: wasm-ld -m wasm64 -no-gc-sections --export=__data_end --export=__heap_base --allow-undefined --no-entry -o %t64.wasm %t64.o %t.hello64.o
+# RUN: wasm-ld -m wasm64 -no-gc-sections --export=__rodata_start --export=__rodata_end --export=__data_end --export=__heap_base --allow-undefined --no-entry -o %t64.wasm %t64.o %t.hello64.o
 # RUN: obj2yaml %t64.wasm | FileCheck --check-prefixes CHECK,CHK64 -DPTR=I64 %s
 
         .section .data.foo,"",@
@@ -25,6 +25,13 @@ aligned_bar:
         .int32  3
         .size   aligned_bar, 4
 
+        .section .rodata.baz,"",@
+        .globl  baz
+        .hidden  baz
+        .p2align        2
+baz:
+        .int32  42
+        .size   baz, 4
 
         .section .data.external_ref,"",@
         .globl  external_ref
@@ -75,6 +82,18 @@ local_struct_internal_ptr:
 # CHECK-NEXT:         Mutable:         false
 # CHECK-NEXT:         InitExpr:
 # CHECK-NEXT:           Opcode:          [[PTR]]_CONST
+# CHECK-NEXT:           Value:           65536
+# CHECK-NEXT:       - Index:           3
+# CHECK-NEXT:         Type:            [[PTR]]
+# CHECK-NEXT:         Mutable:         false
+# CHECK-NEXT:         InitExpr:
+# CHECK-NEXT:           Opcode:          [[PTR]]_CONST
+# CHECK-NEXT:           Value:           65547
+# CHECK-NEXT:       - Index:           4
+# CHECK-NEXT:         Type:            [[PTR]]
+# CHECK-NEXT:         Mutable:         false
+# CHECK-NEXT:         InitExpr:
+# CHECK-NEXT:           Opcode:          [[PTR]]_CONST
 # CHECK-NEXT:           Value:           65600
 
 # CHECK:        - Type:            DATA
@@ -84,8 +103,8 @@ local_struct_internal_ptr:
 # CHECK-NEXT:         Offset:
 # CHECK-NEXT:           Opcode:          [[PTR]]_CONST
 # CHECK-NEXT:           Value:           65536
-# CHECK-NEXT:         Content:         68656C6C6F0A00
-# CHECK-NEXT:       - SectionOffset:   22
+# CHECK-NEXT:         Content:         2A00000068656C6C6F0A00
+# CHECK-NEXT:       - SectionOffset:   26
 # CHECK-NEXT:         InitFlags:       0
 # CHECK-NEXT:         Offset:
 # CHECK-NEXT:           Opcode:          [[PTR]]_CONST

--- a/lld/test/wasm/export-all.s
+++ b/lld/test/wasm/export-all.s
@@ -34,21 +34,27 @@ foo:
 # CHECK-NEXT:       - Name:            __data_end
 # CHECK-NEXT:         Kind:            GLOBAL
 # CHECK-NEXT:         Index:           5
-# CHECK-NEXT:       - Name:            __stack_low
+# CHECK-NEXT:       - Name:            __rodata_start
 # CHECK-NEXT:         Kind:            GLOBAL
 # CHECK-NEXT:         Index:           6
-# CHECK-NEXT:       - Name:            __stack_high
+# CHECK-NEXT:       - Name:            __rodata_end
 # CHECK-NEXT:         Kind:            GLOBAL
 # CHECK-NEXT:         Index:           7
-# CHECK-NEXT:       - Name:            __global_base
+# CHECK-NEXT:       - Name:            __stack_low
 # CHECK-NEXT:         Kind:            GLOBAL
 # CHECK-NEXT:         Index:           8
-# CHECK-NEXT:       - Name:            __heap_base
+# CHECK-NEXT:       - Name:            __stack_high
 # CHECK-NEXT:         Kind:            GLOBAL
 # CHECK-NEXT:         Index:           9
-# CHECK-NEXT:       - Name:            __heap_end
+# CHECK-NEXT:       - Name:            __global_base
 # CHECK-NEXT:         Kind:            GLOBAL
 # CHECK-NEXT:         Index:           10
+# CHECK-NEXT:       - Name:            __heap_base
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         Index:           11
+# CHECK-NEXT:       - Name:            __heap_end
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         Index:           12
 # CHECK-NEXT:       - Name:            __memory_base
 # CHECK-NEXT:         Kind:            GLOBAL
 # CHECK-NEXT:         Index:           1
@@ -57,7 +63,7 @@ foo:
 # CHECK-NEXT:         Index:           2
 # CHECK-NEXT:       - Name:            __wasm_first_page_end
 # CHECK-NEXT:         Kind:            GLOBAL
-# CHECK-NEXT:         Index:           11
+# CHECK-NEXT:         Index:           13
 # CHECK-NEXT:       - Name:            __tls_base
 # CHECK-NEXT:         Kind:            GLOBAL
 # CHECK-NEXT:         Index:           3

--- a/lld/test/wasm/mutable-global-exports.s
+++ b/lld/test/wasm/mutable-global-exports.s
@@ -91,21 +91,27 @@ _start:
 # CHECK-ALL-NEXT:      - Name:            __data_end
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
 # CHECK-ALL-NEXT:        Index:           7
-# CHECK-ALL-NEXT:      - Name:            __stack_low
+# CHECK-ALL-NEXT:      - Name:            __rodata_start
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
 # CHECK-ALL-NEXT:        Index:           8
-# CHECK-ALL-NEXT:      - Name:            __stack_high
+# CHECK-ALL-NEXT:      - Name:            __rodata_end
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
 # CHECK-ALL-NEXT:        Index:           9
-# CHECK-ALL-NEXT:      - Name:            __global_base
+# CHECK-ALL-NEXT:      - Name:            __stack_low
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
 # CHECK-ALL-NEXT:        Index:           10
-# CHECK-ALL-NEXT:      - Name:            __heap_base
+# CHECK-ALL-NEXT:      - Name:            __stack_high
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
 # CHECK-ALL-NEXT:        Index:           11
-# CHECK-ALL-NEXT:      - Name:            __heap_end
+# CHECK-ALL-NEXT:      - Name:            __global_base
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
 # CHECK-ALL-NEXT:        Index:           12
+# CHECK-ALL-NEXT:      - Name:            __heap_base
+# CHECK-ALL-NEXT:        Kind:            GLOBAL
+# CHECK-ALL-NEXT:        Index:           13
+# CHECK-ALL-NEXT:      - Name:            __heap_end
+# CHECK-ALL-NEXT:        Kind:            GLOBAL
+# CHECK-ALL-NEXT:        Index:           14
 # CHECK-ALL-NEXT:      - Name:            __memory_base
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
 # CHECK-ALL-NEXT:        Index:           1
@@ -114,7 +120,7 @@ _start:
 # CHECK-ALL-NEXT:        Index:           2
 # CHECK-ALL-NEXT:      - Name:            __wasm_first_page_end
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
-# CHECK-ALL-NEXT:        Index:           13
+# CHECK-ALL-NEXT:        Index:           15
 # CHECK-ALL-NEXT:      - Name:            __tls_base
 # CHECK-ALL-NEXT:        Kind:            GLOBAL
 # CHECK-ALL-NEXT:        Index:           3

--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -174,6 +174,11 @@ struct Ctx {
     // Symbol whose value is the alignment of the TLS block.
     GlobalSymbol *tlsAlign;
 
+    // __rodata_start/__rodata_end
+    // Symbols marking the start/end of readonly data
+    DefinedData *rodataStart;
+    DefinedData *rodataEnd;
+
     // __data_end
     // Symbol marking the end of the data and bss.
     DefinedData *dataEnd;

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -988,8 +988,11 @@ static void createOptionalSymbols() {
 
   ctx.sym.dsoHandle = symtab->addOptionalDataSymbol("__dso_handle");
 
-  if (!ctx.arg.shared)
+  if (!ctx.arg.shared) {
     ctx.sym.dataEnd = symtab->addOptionalDataSymbol("__data_end");
+    ctx.sym.rodataStart = symtab->addOptionalDataSymbol("__rodata_start");
+    ctx.sym.rodataEnd = symtab->addOptionalDataSymbol("__rodata_end");
+  }
 
   if (!ctx.isPic) {
     ctx.sym.stackLow = symtab->addOptionalDataSymbol("__stack_low");

--- a/lld/wasm/Writer.cpp
+++ b/lld/wasm/Writer.cpp
@@ -401,7 +401,15 @@ void Writer::layoutMemory() {
       }
     }
 
+    if (ctx.sym.rodataStart && seg->name.starts_with(".rodata") &&
+        !ctx.sym.rodataStart->getVA())
+      ctx.sym.rodataStart->setVA(memoryPtr);
+
     memoryPtr += seg->size;
+
+    // Might get set more than once if segment merging is not enabled.
+    if (ctx.sym.rodataEnd && seg->name.starts_with(".rodata"))
+      ctx.sym.rodataEnd->setVA(memoryPtr);
   }
 
   // Make space for the memory initialization flag


### PR DESCRIPTION
This is similar to etext/_etext in the ELF linker.  Its useful in emscripten to know where the RO data data ends and the data begins (even though the Wasm format itself has no concept of RO data).

See https://github.com/emscripten-core/emscripten/discussions/25939#discussioncomment-15243731