### PR TITLE
[TableGen][SchedModel] Add logical combiners for SchedPredicates

### DIFF
--- a/llvm/include/llvm/Target/TargetSchedule.td
+++ b/llvm/include/llvm/Target/TargetSchedule.td
@@ -399,6 +399,19 @@ class SchedPredicate<code pred> : SchedPredicateBase {
 // MCSchedPredicate, this is the default scheduling case used by llvm-mca.
 def NoSchedPred : MCSchedPredicate<TruePred>;
 
+// Logical combiners for schedule predicates.
+class SchedPredicateCombiner<list<SchedPredicateBase> predicates>
+    : SchedPredicateBase {
+  SchedMachineModel SchedModel = ?;
+  list<SchedPredicateBase> Predicates = predicates;
+}
+class AllOfSchedPreds<list<SchedPredicateBase> predicates>
+    : SchedPredicateCombiner<predicates>;
+class AnyOfSchedPreds<list<SchedPredicateBase> predicates>
+    : SchedPredicateCombiner<predicates>;
+class NoneOfSchedPreds<list<SchedPredicateBase> predicates>
+    : SchedPredicateCombiner<predicates>;
+
 // Associate a predicate with a list of SchedReadWrites. By default,
 // the selected SchedReadWrites are still associated with a single
 // operand and assumed to execute sequentially with additive

--- a/llvm/include/llvm/Target/TargetSchedule.td
+++ b/llvm/include/llvm/Target/TargetSchedule.td
@@ -409,8 +409,10 @@ class AllOfSchedPreds<list<SchedPredicateBase> predicates>
     : SchedPredicateCombiner<predicates>;
 class AnyOfSchedPreds<list<SchedPredicateBase> predicates>
     : SchedPredicateCombiner<predicates>;
+class NotSchedPred<SchedPredicateBase predicate>
+    : SchedPredicateCombiner<[predicate]>;
 class NoneOfSchedPreds<list<SchedPredicateBase> predicates>
-    : SchedPredicateCombiner<predicates>;
+    : NotSchedPred<AnyOfSchedPreds<predicates>>;
 
 // Associate a predicate with a list of SchedReadWrites. By default,
 // the selected SchedReadWrites are still associated with a single

--- a/llvm/test/TableGen/ResolveSchedClass.td
+++ b/llvm/test/TableGen/ResolveSchedClass.td
@@ -9,6 +9,7 @@ def TestTarget : Target {
 }
 
 def FeatureFoo : SubtargetFeature<"foo", "HasFoo", "true", "enable foo">;
+def FeatureBar : SubtargetFeature<"bar", "HasBar", "true", "enable bar">;
 
 def ResX0 : ProcResource<1>;
 
@@ -26,13 +27,31 @@ def SchedWriteResA : SchedWriteRes<[ResX0]> {
 def SchedWriteResB : SchedWriteRes<[ResX0]> {
   let Latency = 4;
 }
+def SchedWriteResC : SchedWriteRes<[ResX0]> {
+  let Latency = 8;
+}
+def SchedWriteResD : SchedWriteRes<[ResX0]> {
+  let Latency = 16;
+}
 
 // Check SchedPredicate with subtarget feature.
 def FeatureFooPred : FeatureSchedPredicate<FeatureFoo>;
+def FeatureBarPred : FeatureSchedPredicate<FeatureBar>;
+
+// Check SchedPredicate combiners.
+
+// First, check MC-only combiners.
+def CombinedAllOfPred: AllOfSchedPreds<[FeatureFooPred, MCSchedPredicate<CheckZeroOperand<1>>]>;
+// Then, check nested combiner that can be used with MCInst and MachineInstr.
+def CombinedAnyOfPred: AnyOfSchedPreds<[CombinedAllOfPred,
+                                        NoneOfSchedPreds<[FeatureBarPred,
+                                                          SchedPredicate<[{/*hello=*/false}]>]>]>;
 
 def Variant : SchedWriteVariant<[
   SchedVar<FeatureFooPred, [SchedWriteResA]>,
-  SchedVar<NoSchedPred,    [SchedWriteResB]>
+  SchedVar<NoSchedPred,    [SchedWriteResB]>,
+  SchedVar<CombinedAllOfPred,    [SchedWriteResC]>,
+  SchedVar<CombinedAnyOfPred,    [SchedWriteResD]>
 ]>;
 
 def : InstRW<[Variant], (instrs Inst_A)>;
@@ -46,6 +65,8 @@ def ProcessorA: ProcessorModel<"ProcessorA", SchedModel_A, []>;
 // CHECK-NEXT:   if (CPUID == {{.*}}) { // SchedModel_A
 // CHECK-NEXT:     if (STI.hasFeature(TestTarget::FeatureFoo))
 // CHECK-NEXT:       return {{.*}}; // SchedWriteResA
+// CHECK-NEXT:     if (STI.hasFeature(TestTarget::FeatureFoo) && MI->getOperand(1).getImm() == 0)
+// CHECK-NEXT:       return {{.*}}; // SchedWriteResC
 // CHECK-NEXT:     return {{.*}}; // SchedWriteResB
 
 // CHECK: unsigned resolveVariantSchedClass(unsigned SchedClass,
@@ -61,4 +82,8 @@ def ProcessorA: ProcessorModel<"ProcessorA", SchedModel_A, []>;
 // CHECK-NEXT:     if (SchedModel->getProcessorID() == {{.*}}) { // SchedModel_A
 // CHECK-NEXT:       if (this->hasFeature(TestTarget::FeatureFoo))
 // CHECK-NEXT:         return {{.*}}; // SchedWriteResA
+// CHECK-NEXT:       if (this->hasFeature(TestTarget::FeatureFoo) && MI->getOperand(1).getImm() == 0)
+// CHECK-NEXT:         return {{.*}}; // SchedWriteResC
+// CHECK-NEXT:       if ((this->hasFeature(TestTarget::FeatureFoo) && MI->getOperand(1).getImm() == 0) || !(this->hasFeature(TestTarget::FeatureBar) || (/*hello=*/false)))
+// CHECK-NEXT:         return {{.*}}; // SchedWriteResD
 // CHECK-NEXT:       return {{.*}}; // SchedWriteResB

--- a/llvm/test/TableGen/ResolveSchedClass.td
+++ b/llvm/test/TableGen/ResolveSchedClass.td
@@ -33,6 +33,9 @@ def SchedWriteResC : SchedWriteRes<[ResX0]> {
 def SchedWriteResD : SchedWriteRes<[ResX0]> {
   let Latency = 16;
 }
+def SchedWriteResE : SchedWriteRes<[ResX0]> {
+  let Latency = 32;
+}
 
 // Check SchedPredicate with subtarget feature.
 def FeatureFooPred : FeatureSchedPredicate<FeatureFoo>;
@@ -46,12 +49,16 @@ def CombinedAllOfPred: AllOfSchedPreds<[FeatureFooPred, MCSchedPredicate<CheckZe
 def CombinedAnyOfPred: AnyOfSchedPreds<[CombinedAllOfPred,
                                         NoneOfSchedPreds<[FeatureBarPred,
                                                           SchedPredicate<[{/*hello=*/false}]>]>]>;
+// Check if the inverse predicate correctly wraps (or not wrap) its sub-predicates.
+def CombinedNotPred : NotSchedPred<AllOfSchedPreds<[MCSchedPredicate<CheckZeroOperand<3>>,
+                                                    NotSchedPred<FeatureFooPred>]>>;
 
 def Variant : SchedWriteVariant<[
-  SchedVar<FeatureFooPred, [SchedWriteResA]>,
-  SchedVar<NoSchedPred,    [SchedWriteResB]>,
+  SchedVar<FeatureFooPred,       [SchedWriteResA]>,
+  SchedVar<NoSchedPred,          [SchedWriteResB]>,
   SchedVar<CombinedAllOfPred,    [SchedWriteResC]>,
-  SchedVar<CombinedAnyOfPred,    [SchedWriteResD]>
+  SchedVar<CombinedAnyOfPred,    [SchedWriteResD]>,
+  SchedVar<CombinedNotPred,      [SchedWriteResE]>,
 ]>;
 
 def : InstRW<[Variant], (instrs Inst_A)>;
@@ -67,6 +74,8 @@ def ProcessorA: ProcessorModel<"ProcessorA", SchedModel_A, []>;
 // CHECK-NEXT:       return {{.*}}; // SchedWriteResA
 // CHECK-NEXT:     if (STI.hasFeature(TestTarget::FeatureFoo) && MI->getOperand(1).getImm() == 0)
 // CHECK-NEXT:       return {{.*}}; // SchedWriteResC
+// CHECK-NEXT:     if (!(MI->getOperand(3).getImm() == 0 && !STI.hasFeature(TestTarget::FeatureFoo)))
+// CHECK-NEXT: 	     return {{.*}}; // SchedWriteResE
 // CHECK-NEXT:     return {{.*}}; // SchedWriteResB
 
 // CHECK: unsigned resolveVariantSchedClass(unsigned SchedClass,
@@ -86,4 +95,6 @@ def ProcessorA: ProcessorModel<"ProcessorA", SchedModel_A, []>;
 // CHECK-NEXT:         return {{.*}}; // SchedWriteResC
 // CHECK-NEXT:       if ((this->hasFeature(TestTarget::FeatureFoo) && MI->getOperand(1).getImm() == 0) || !(this->hasFeature(TestTarget::FeatureBar) || (/*hello=*/false)))
 // CHECK-NEXT:         return {{.*}}; // SchedWriteResD
+// CHECK-NEXT:       if (!(MI->getOperand(3).getImm() == 0 && !this->hasFeature(TestTarget::FeatureFoo)))
+// CHECK-NEXT: 	       return {{.*}}; // SchedWriteResE
 // CHECK-NEXT:       return {{.*}}; // SchedWriteResB

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1572,6 +1572,9 @@ static void expandSchedPredicates(const Record *Rec, PredicateExpander &PE,
   } else if (Rec->isSubClassOf("SchedPredicateCombiner")) {
     std::vector<const Record *> SubPreds =
         Rec->getValueAsListOfDefs("Predicates");
+    if (SubPreds.empty())
+      PrintFatalError(Rec, "Empty SchedPredicateCombiner is not allowed");
+
     StringRef Sep;
     if (Rec->isSubClassOf("AllOfSchedPreds"))
       Sep = " && ";
@@ -1579,7 +1582,7 @@ static void expandSchedPredicates(const Record *Rec, PredicateExpander &PE,
              Rec->isSubClassOf("NoneOfSchedPreds"))
       Sep = " || ";
     else
-      llvm_unreachable("Unrecognized SchedPredicateCombiner");
+      PrintFatalError(Rec, "Unrecognized SchedPredicateCombiner");
 
     if (Rec->isSubClassOf("NoneOfSchedPreds")) {
       WrapPredicate = true;
@@ -1666,10 +1669,10 @@ static bool hasMCSchedPredicate(const Record *Rec) {
     return true;
 
   if (Rec->isSubClassOf("SchedPredicateCombiner")) {
-    // Validate its sub-predicates recursively.
+    // Check its sub-predicates recursively.
     std::vector<const Record *> SubPreds =
         Rec->getValueAsListOfDefs("Predicates");
-    return SubPreds.empty() || all_of(SubPreds, hasMCSchedPredicate);
+    return all_of(SubPreds, hasMCSchedPredicate);
   }
 
   return false;

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1551,6 +1551,58 @@ static bool isTruePredicate(const Record *Rec) {
          Rec->getValueAsDef("Pred")->isSubClassOf("MCTrue");
 }
 
+static void expandSchedPredicates(const Record *Rec, PredicateExpander &PE,
+                                  bool WrapPredicate, raw_ostream &OS) {
+  if (Rec->isSubClassOf("MCSchedPredicate")) {
+    PE.expandPredicate(OS, Rec->getValueAsDef("Pred"));
+  } else if (Rec->isSubClassOf("FeatureSchedPredicate")) {
+    const Record *FR = Rec->getValueAsDef("Feature");
+    if (PE.shouldExpandForMC()) {
+      // MC version of this predicate will be emitted into
+      // resolveVariantSchedClassImpl, which accesses MCSubtargetInfo
+      // through argument STI.
+      OS << "STI.";
+    } else {
+      // Otherwise, this predicate will be emitted directly into
+      // TargetGenSubtargetInfo::resolveSchedClass, which can just access
+      // TargetSubtargetInfo / MCSubtargetInfo through `this`.
+      OS << "this->";
+    }
+    OS << "hasFeature(" << PE.getTargetName() << "::" << FR->getName() << ")";
+  } else if (Rec->isSubClassOf("SchedPredicateCombiner")) {
+    std::vector<const Record *> SubPreds =
+        Rec->getValueAsListOfDefs("Predicates");
+    StringRef Sep;
+    if (Rec->isSubClassOf("AllOfSchedPreds"))
+      Sep = " && ";
+    else if (Rec->isSubClassOf("AnyOfSchedPreds") ||
+             Rec->isSubClassOf("NoneOfSchedPreds"))
+      Sep = " || ";
+    else
+      llvm_unreachable("Unrecognized SchedPredicateCombiner");
+
+    if (Rec->isSubClassOf("NoneOfSchedPreds")) {
+      WrapPredicate = true;
+      OS << "!";
+    }
+
+    if (WrapPredicate)
+      OS << "(";
+
+    ListSeparator LS(Sep);
+    for (const Record *SubP : SubPreds)
+      expandSchedPredicates(SubP, PE, /*WrapPredicate=*/true, OS << LS);
+
+    if (WrapPredicate)
+      OS << ")";
+  } else {
+    // Expand this legacy predicate and wrap it around braces if there is more
+    // than one predicate to expand.
+    OS << (WrapPredicate ? "(" : "") << Rec->getValueAsString("Predicate")
+       << (WrapPredicate ? ")" : "");
+  }
+}
+
 static void emitPredicates(const CodeGenSchedTransition &T,
                            const CodeGenSchedClass &SC, PredicateExpander &PE,
                            raw_ostream &OS) {
@@ -1582,34 +1634,7 @@ static void emitPredicates(const CodeGenSchedTransition &T,
         SS << "&& ";
       }
 
-      if (Rec->isSubClassOf("MCSchedPredicate")) {
-        PE.expandPredicate(SS, Rec->getValueAsDef("Pred"));
-        continue;
-      }
-
-      if (Rec->isSubClassOf("FeatureSchedPredicate")) {
-        const Record *FR = Rec->getValueAsDef("Feature");
-        if (PE.shouldExpandForMC()) {
-          // MC version of this predicate will be emitted into
-          // resolveVariantSchedClassImpl, which accesses MCSubtargetInfo
-          // through argument STI.
-          SS << "STI.";
-        } else {
-          // Otherwise, this predicate will be emitted directly into
-          // TargetGenSubtargetInfo::resolveSchedClass, which can just access
-          // TargetSubtargetInfo / MCSubtargetInfo through `this`.
-          SS << "this->";
-        }
-        SS << "hasFeature(" << PE.getTargetName() << "::" << FR->getName()
-           << ")";
-        continue;
-      }
-
-      // Expand this legacy predicate and wrap it around braces if there is more
-      // than one predicate to expand.
-      SS << ((NumNonTruePreds > 1) ? "(" : "")
-         << Rec->getValueAsString("Predicate")
-         << ((NumNonTruePreds > 1) ? ")" : "");
+      expandSchedPredicates(Rec, PE, /*WrapPredicate=*/NumNonTruePreds > 1, SS);
     }
 
     SS << ")\n"; // end of if-stmt
@@ -1635,11 +1660,22 @@ static void emitSchedModelHelperEpilogue(raw_ostream &OS,
   OS << "  report_fatal_error(\"Expected a variant SchedClass\");\n";
 }
 
+static bool hasMCSchedPredicate(const Record *Rec) {
+  if (Rec->isSubClassOf("MCSchedPredicate") ||
+      Rec->isSubClassOf("FeatureSchedPredicate"))
+    return true;
+
+  if (Rec->isSubClassOf("SchedPredicateCombiner")) {
+    // Validate its sub-predicates recursively.
+    std::vector<const Record *> SubPreds =
+        Rec->getValueAsListOfDefs("Predicates");
+    return SubPreds.empty() || all_of(SubPreds, hasMCSchedPredicate);
+  }
+
+  return false;
+}
 static bool hasMCSchedPredicates(const CodeGenSchedTransition &T) {
-  return all_of(T.PredTerm, [](const Record *Rec) {
-    return Rec->isSubClassOf("MCSchedPredicate") ||
-           Rec->isSubClassOf("FeatureSchedPredicate");
-  });
+  return all_of(T.PredTerm, hasMCSchedPredicate);
 }
 
 static void collectVariantClasses(const CodeGenSchedModels &SchedModels,


### PR DESCRIPTION
Sometimes we want to create a SchedPredicate out of different types of SchedPredicate: composing a `FeatureSchedPredicate` with a `MCSchedPredicate`, for example. For those cases, this patch creates several new TableGen constructions so that users can create a SchedPredicate like
```
AllOfSchedPreds<[FeatureFooPred,
                 MCSchedPredicate<CheckZeroOperand<1>>]>
```
which evaluates to true only when both `FeatureFooPred` and `MCSchedPredicate<CheckZeroOperand<1>>` hold.

--------

This PR is a prerequisite for a patch, #172111 , that further limits the enabling conditions of RISC-V's vector zero-stride load in some scheduling models.