### PR TITLE
[ADT] Only call reserve on empty containers in append_values

### DIFF
--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -701,6 +701,41 @@ TEST(STLExtrasTest, AppendValues) {
   EXPECT_THAT(Set, UnorderedElementsAre(1, 2, 3));
 }
 
+TEST(STLExtrasTest, AppendValuesReserve) {
+  // A vector wrapper that tracks reserve() calls.
+  struct TrackedVector : std::vector<int> {
+    using std::vector<int>::vector;
+    size_t LastReservedSize = 0;
+    unsigned ReserveCallCount = 0;
+
+    void reserve(size_t N) {
+      LastReservedSize = N;
+      ++ReserveCallCount;
+      std::vector<int>::reserve(N);
+    }
+  };
+
+  // When empty, reserve should be called.
+  TrackedVector Empty;
+  append_values(Empty, 1, 2, 3);
+  EXPECT_EQ(Empty.ReserveCallCount, 1u);
+  EXPECT_EQ(Empty.LastReservedSize, 3u);
+  EXPECT_THAT(Empty, ElementsAre(1, 2, 3));
+
+  // When non-empty, reserve should NOT be called to avoid preventing
+  // exponential growth.
+  TrackedVector NonEmpty = {1, 2};
+  append_values(NonEmpty, 3, 4);
+  EXPECT_EQ(NonEmpty.ReserveCallCount, 0u);
+  EXPECT_THAT(NonEmpty, ElementsAre(1, 2, 3, 4));
+
+  // Appending more values to a now non-empty container should still not
+  // reserve.
+  append_values(Empty, 4, 5);
+  EXPECT_EQ(Empty.ReserveCallCount, 1u); // Still 1 from initial call.
+  EXPECT_THAT(Empty, ElementsAre(1, 2, 3, 4, 5));
+}
+
 TEST(STLExtrasTest, ADLTest) {
   some_namespace::some_struct s{{1, 2, 3, 4, 5}, ""};
   some_namespace::some_struct s2{{2, 4, 6, 8, 10}, ""};

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -722,18 +722,18 @@ TEST(STLExtrasTest, AppendValuesReserve) {
   EXPECT_EQ(Empty.LastReservedSize, 3u);
   EXPECT_THAT(Empty, ElementsAre(1, 2, 3));
 
+  // Appending more values to a now non-empty container should still not
+  // reserve.
+  append_values(Empty, 4, 5);
+  EXPECT_EQ(Empty.ReserveCallCount, 1u);
+  EXPECT_THAT(Empty, ElementsAre(1, 2, 3, 4, 5));
+
   // When non-empty, reserve should NOT be called to avoid preventing
   // exponential growth.
   TrackedVector NonEmpty = {1, 2};
   append_values(NonEmpty, 3, 4);
   EXPECT_EQ(NonEmpty.ReserveCallCount, 0u);
   EXPECT_THAT(NonEmpty, ElementsAre(1, 2, 3, 4));
-
-  // Appending more values to a now non-empty container should still not
-  // reserve.
-  append_values(Empty, 4, 5);
-  EXPECT_EQ(Empty.ReserveCallCount, 1u); // Still 1 from initial call.
-  EXPECT_THAT(Empty, ElementsAre(1, 2, 3, 4, 5));
 }
 
 TEST(STLExtrasTest, ADLTest) {


### PR DESCRIPTION
Calling reserve in a loop can prevent amortized constant time appends when the container doesn't round up the capacity.