### PR TITLE
[RISCV] Guard zero-stride load SchedPredicate with subtarget feature as well

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrPredicates.td
@@ -12,7 +12,12 @@
 
 // This predicate is true when the rs2 operand of vlse or vsse is x0, false
 // otherwise.
-def VLDSX0Pred : MCSchedPredicate<CheckRegOperand<3, X0>>;
+// Note: in our pseudo RVV MachinInstr, rs2 is the fourth operand. However,
+// it's the third operand of its MCInst form, so this predicate will not
+// be triggered by llvm-mca, which checks against MCInst.
+def VLDSX0Pred
+    : AllOfSchedPreds<[FeatureSchedPredicate<TuneOptimizedZeroStrideLoad>,
+                       MCSchedPredicate<CheckRegOperand<3, X0>>]>;
 
 // This scheduling predicate is true when subtarget feature TuneHasSingleElementVecFP64
 // is enabled.


### PR DESCRIPTION
Stacks on top of #172106 

The SchedPredicate for zero-stride vector load will now only trigger when the `rs2` operand is X0 and the subtarget has TuneOptimizedZeroStrideLoad.

This is effectively a NFC, as all the existing processors that use `VLDSX0Pred` all have `TuneOptimizedZeroStrideLoad`. 

-----

 As I pointed out in the code comment right next to `VLDSX0Pred`: we have never ever (even before this patch) been able to test this predicate with llvm-mca because the operand index of `rs2` are different between MachineInstr (used by codegen & scheduler) and MCInst (used by llvm-mca). I cannot think of a better way to test this change at this moment.
