### PR TITLE
[flang] restrict fir.convert lowering

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -816,6 +816,16 @@ struct ConvertOpConversion : public fir::FIROpConversion<fir::ConvertOp> {
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto fromFirTy = convert.getValue().getType();
     auto toFirTy = convert.getRes().getType();
+
+    // Let more specialized conversions (e.g. FIR to memref
+    // converters) handle fir.convert when either side is a memref. This
+    // avoids interfering with descriptor-based flows such as fir.box /
+    // fir.box_addr and keeps this pattern focused on value conversions.
+    if (mlir::isa<mlir::MemRefType>(fromFirTy) ||
+        mlir::isa<mlir::MemRefType>(toFirTy)) {
+      return mlir::failure();
+    }
+
     auto fromTy = convertType(fromFirTy);
     auto toTy = convertType(toFirTy);
     mlir::Value op0 = adaptor.getOperands()[0];

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -822,9 +822,8 @@ struct ConvertOpConversion : public fir::FIROpConversion<fir::ConvertOp> {
     // avoids interfering with descriptor-based flows such as fir.box /
     // fir.box_addr and keeps this pattern focused on value conversions.
     if (mlir::isa<mlir::MemRefType>(fromFirTy) ||
-        mlir::isa<mlir::MemRefType>(toFirTy)) {
+        mlir::isa<mlir::MemRefType>(toFirTy))
       return mlir::failure();
-    }
 
     auto fromTy = convertType(fromFirTy);
     auto toTy = convertType(toFirTy);

--- a/flang/test/Fir/convert-memref-codegen.mlir
+++ b/flang/test/Fir/convert-memref-codegen.mlir
@@ -1,0 +1,15 @@
+// RUN: not fir-opt --fir-to-llvm-ir="target=x86_64-unknown-linux-gnu" %s -o - 2>&1 | FileCheck %s
+
+// This test ensures that the FIR CodeGen ConvertOpConversion
+// rejects fir.convert when either the source or the destination
+// type is a memref (i.e. it fails to legalize those ops).
+
+module {
+  // CHECK: error: failed to legalize operation 'fir.convert'
+  func.func @memref_to_ref_convert(%arg0: memref<f32>) {
+    %0 = fir.convert %arg0 : (memref<f32>) -> !fir.ref<f32>
+    return
+  }
+}
+
+


### PR DESCRIPTION
Restrict lowering of fir.convert and exclude core memref types from it. This is in preparation for a lowering that accommodates MemRef dialect.