### PR TITLE
[clang-tidy][NFC] Remove obsolete FIXME comment

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
@@ -91,10 +91,6 @@ public:
   ClangTidyContext &operator=(const ClangTidyContext &) = delete;
 
   /// Report any errors detected using this method.
-  ///
-  /// This is still under heavy development and will likely change towards using
-  /// tablegen'd diagnostic IDs.
-  /// FIXME: Figure out a way to manage ID spaces.
   DiagnosticBuilder diag(StringRef CheckName, SourceLocation Loc,
                          StringRef Description,
                          DiagnosticIDs::Level Level = DiagnosticIDs::Warning);


### PR DESCRIPTION
This comment was written 12 years ago. It's no longer correct to say that diagnostic reporting is under heavy development, and we seem to be doing just fine without tablegenned IDs, so I think we can simply remove it.