### PR TITLE
[BOLT] Introduce BinaryFunctionListType. NFC

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -65,6 +65,9 @@ namespace bolt {
 
 class BinaryFunction;
 
+using BinaryFunctionListType = std::vector<BinaryFunction *>;
+using ConstBinaryFunctionListType = std::vector<const BinaryFunction *>;
+
 /// Information on loadable part of the file.
 struct SegmentInfo {
   uint64_t Address;           /// Address of the segment in memory.
@@ -228,11 +231,11 @@ class BinaryContext {
   /// Store all functions in the binary, sorted by original address.
   std::map<uint64_t, BinaryFunction> BinaryFunctions;
 
-  /// A mutex that is used to control parallel accesses to BinaryFunctions
+  /// A mutex that is used to control parallel accesses to BinaryFunctions.
   mutable llvm::sys::RWMutex BinaryFunctionsMutex;
 
-  /// Functions injected by BOLT
-  std::vector<BinaryFunction *> InjectedBinaryFunctions;
+  /// Functions injected by BOLT.
+  BinaryFunctionListType InjectedBinaryFunctions;
 
   /// Jump tables for all functions mapped by address.
   std::map<uint64_t, JumpTable *> JumpTables;
@@ -567,13 +570,13 @@ public:
                          const InstructionListType &Instructions,
                          const Twine &Name = "");
 
-  std::vector<BinaryFunction *> &getInjectedBinaryFunctions() {
+  BinaryFunctionListType &getInjectedBinaryFunctions() {
     return InjectedBinaryFunctions;
   }
 
   /// Return vector with all functions, i.e. include functions from the input
   /// binary and functions created by BOLT.
-  std::vector<BinaryFunction *> getAllBinaryFunctions();
+  BinaryFunctionListType getAllBinaryFunctions();
 
   /// Construct a jump table for \p Function at \p Address or return an existing
   /// one at that location.
@@ -1385,7 +1388,7 @@ public:
                                   const uint32_t SrcCUID, unsigned FileIndex);
 
   /// Return functions in output layout order
-  std::vector<BinaryFunction *> getSortedFunctions();
+  BinaryFunctionListType getSortedFunctions();
 
   /// Do the best effort to calculate the size of the function by emitting
   /// its code, and relaxing branch instructions. By default, branch

--- a/bolt/include/bolt/Core/BinaryFunctionCallGraph.h
+++ b/bolt/include/bolt/Core/BinaryFunctionCallGraph.h
@@ -9,6 +9,7 @@
 #ifndef BOLT_PASSES_BINARY_FUNCTION_CALLGRAPH_H
 #define BOLT_PASSES_BINARY_FUNCTION_CALLGRAPH_H
 
+#include "bolt/Core/BinaryContext.h"
 #include "bolt/Core/CallGraph.h"
 #include <deque>
 #include <functional>
@@ -18,7 +19,6 @@ namespace llvm {
 namespace bolt {
 
 class BinaryFunction;
-class BinaryContext;
 
 class BinaryFunctionCallGraph : public CallGraph {
 public:
@@ -46,7 +46,7 @@ public:
 
 private:
   std::unordered_map<const BinaryFunction *, NodeId> FuncToNodeId;
-  std::vector<BinaryFunction *> Funcs;
+  BinaryFunctionListType Funcs;
 };
 
 using CgFilterFunction = std::function<bool(const BinaryFunction &BF)>;

--- a/bolt/include/bolt/Passes/CacheMetrics.h
+++ b/bolt/include/bolt/Passes/CacheMetrics.h
@@ -13,6 +13,7 @@
 #ifndef BOLT_PASSES_CACHEMETRICS_H
 #define BOLT_PASSES_CACHEMETRICS_H
 
+#include "bolt/Core/BinaryContext.h"
 #include <vector>
 
 namespace llvm {
@@ -20,12 +21,10 @@ namespace llvm {
 class raw_ostream;
 
 namespace bolt {
-class BinaryFunction;
 namespace CacheMetrics {
 
 /// Calculate and print various metrics related to instruction cache performance
-void printAll(raw_ostream &OS,
-              const std::vector<BinaryFunction *> &BinaryFunctions);
+void printAll(raw_ostream &OS, const BinaryFunctionListType &BinaryFunctions);
 
 } // namespace CacheMetrics
 } // namespace bolt

--- a/bolt/include/bolt/Passes/LongJmp.h
+++ b/bolt/include/bolt/Passes/LongJmp.h
@@ -82,15 +82,13 @@ class LongJmpPass : public BinaryFunctionPass {
   /// purposes, we need to do a size worst-case estimation. Real layout is done
   /// by RewriteInstance::mapFileSections()
   void tentativeLayout(const BinaryContext &BC,
-                       std::vector<BinaryFunction *> &SortedFunctions);
-  uint64_t
-  tentativeLayoutRelocMode(const BinaryContext &BC,
-                           std::vector<BinaryFunction *> &SortedFunctions,
-                           uint64_t DotAddress);
-  uint64_t
-  tentativeLayoutRelocColdPart(const BinaryContext &BC,
-                               std::vector<BinaryFunction *> &SortedFunctions,
-                               uint64_t DotAddress);
+                       BinaryFunctionListType &SortedFunctions);
+  uint64_t tentativeLayoutRelocMode(const BinaryContext &BC,
+                                    BinaryFunctionListType &SortedFunctions,
+                                    uint64_t DotAddress);
+  uint64_t tentativeLayoutRelocColdPart(const BinaryContext &BC,
+                                        BinaryFunctionListType &SortedFunctions,
+                                        uint64_t DotAddress);
   void tentativeBBLayout(const BinaryFunction &Func);
 
   /// Update stubs addresses with their exact address after a round of stub

--- a/bolt/include/bolt/Profile/YAMLProfileReader.h
+++ b/bolt/include/bolt/Profile/YAMLProfileReader.h
@@ -68,7 +68,7 @@ public:
     }
 
     /// Returns the binary functions with the parameter neighbor hash.
-    std::optional<std::vector<BinaryFunction *>>
+    std::optional<BinaryFunctionListType>
     getBFsWithNeighborHash(uint64_t NeighborHash) {
       auto It = NeighborHashToBFs.find(NeighborHash);
       return It == NeighborHashToBFs.end() ? std::nullopt
@@ -93,7 +93,7 @@ public:
     DenseMap<BinaryFunction *, std::set<BinaryFunction *>> BFAdjacencyMap;
 
     /// Maps neighbor hashes to binary functions.
-    DenseMap<uint64_t, std::vector<BinaryFunction *>> NeighborHashToBFs;
+    DenseMap<uint64_t, BinaryFunctionListType> NeighborHashToBFs;
 
     /// Adjacency map for profile functions in the call graph.
     DenseMap<yaml::bolt::BinaryFunctionProfile *,
@@ -187,7 +187,7 @@ private:
   StringSet<> ProfileFunctionNames;
 
   /// BinaryFunction pointers indexed by YamlBP functions.
-  std::vector<BinaryFunction *> ProfileBFs;
+  BinaryFunctionListType ProfileBFs;
 
   // Pseudo probe function GUID to inline tree node
   GUIDInlineTreeMap TopLevelGUIDToInlineTree;

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -826,7 +826,7 @@ void BinaryContext::populateJumpTables() {
 }
 
 void BinaryContext::skipMarkedFragments() {
-  std::vector<BinaryFunction *> FragmentQueue;
+  BinaryFunctionListType FragmentQueue;
   // Copy the functions to FragmentQueue.
   FragmentQueue.assign(FragmentsToSkip.begin(), FragmentsToSkip.end());
   auto addToWorklist = [&](BinaryFunction *Function) -> void {
@@ -1715,8 +1715,8 @@ unsigned BinaryContext::addDebugFilenameToUnit(const uint32_t DestCUID,
                                DestCUID, DstUnit->getVersion()));
 }
 
-std::vector<BinaryFunction *> BinaryContext::getSortedFunctions() {
-  std::vector<BinaryFunction *> SortedFunctions(BinaryFunctions.size());
+BinaryFunctionListType BinaryContext::getSortedFunctions() {
+  BinaryFunctionListType SortedFunctions(BinaryFunctions.size());
   llvm::transform(llvm::make_second_range(BinaryFunctions),
                   SortedFunctions.begin(),
                   [](BinaryFunction &BF) { return &BF; });
@@ -1725,8 +1725,8 @@ std::vector<BinaryFunction *> BinaryContext::getSortedFunctions() {
   return SortedFunctions;
 }
 
-std::vector<BinaryFunction *> BinaryContext::getAllBinaryFunctions() {
-  std::vector<BinaryFunction *> AllFunctions;
+BinaryFunctionListType BinaryContext::getAllBinaryFunctions() {
+  BinaryFunctionListType AllFunctions;
   AllFunctions.reserve(BinaryFunctions.size() + InjectedBinaryFunctions.size());
   llvm::transform(llvm::make_second_range(BinaryFunctions),
                   std::back_inserter(AllFunctions),

--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -232,7 +232,7 @@ void BinaryEmitter::emitAll(StringRef OrgSecPrefix) {
 }
 
 void BinaryEmitter::emitFunctions() {
-  auto emit = [&](const std::vector<BinaryFunction *> &Functions) {
+  auto emit = [&](const BinaryFunctionListType &Functions) {
     const bool HasProfile = BC.NumProfiledFuncs > 0;
     const bool OriginalAllowAutoPadding = Streamer.getAllowAutoPadding();
     for (BinaryFunction *Function : Functions) {
@@ -282,7 +282,7 @@ void BinaryEmitter::emitFunctions() {
   }
 
   // Emit functions in sorted order.
-  std::vector<BinaryFunction *> SortedFunctions = BC.getSortedFunctions();
+  BinaryFunctionListType SortedFunctions = BC.getSortedFunctions();
   emit(SortedFunctions);
 
   // Emit functions added by BOLT.

--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -1609,7 +1609,7 @@ Error PrintProgramStats::runOnFunctions(BinaryContext &BC) {
   }
 
   if (!opts::PrintSortedBy.empty()) {
-    std::vector<BinaryFunction *> Functions;
+    BinaryFunctionListType Functions;
     std::map<const BinaryFunction *, DynoStats> Stats;
 
     for (auto &BFI : BC.getBinaryFunctions()) {
@@ -1700,7 +1700,7 @@ Error PrintProgramStats::runOnFunctions(BinaryContext &BC) {
 
   // Collect and print information about suboptimal code layout on input.
   if (opts::ReportBadLayout) {
-    std::vector<BinaryFunction *> SuboptimalFuncs;
+    BinaryFunctionListType SuboptimalFuncs;
     for (auto &BFI : BC.getBinaryFunctions()) {
       BinaryFunction &BF = BFI.second;
       if (!BF.hasValidProfile())

--- a/bolt/lib/Passes/CacheMetrics.cpp
+++ b/bolt/lib/Passes/CacheMetrics.cpp
@@ -30,7 +30,7 @@ constexpr unsigned ITLBEntries = 16;
 
 /// Initialize and return a position map for binary basic blocks
 void extractBasicBlockInfo(
-    const std::vector<BinaryFunction *> &BinaryFunctions,
+    const BinaryFunctionListType &BinaryFunctions,
     std::unordered_map<BinaryBasicBlock *, uint64_t> &BBAddr,
     std::unordered_map<BinaryBasicBlock *, uint64_t> &BBSize) {
 
@@ -54,7 +54,7 @@ void extractBasicBlockInfo(
 /// the ordering of basic blocks. The method returns a pair
 /// (the number of fallthrough branches, the total number of branches)
 std::pair<uint64_t, uint64_t>
-calcTSPScore(const std::vector<BinaryFunction *> &BinaryFunctions,
+calcTSPScore(const BinaryFunctionListType &BinaryFunctions,
              const std::unordered_map<BinaryBasicBlock *, uint64_t> &BBAddr,
              const std::unordered_map<BinaryBasicBlock *, uint64_t> &BBSize) {
   uint64_t Score = 0;
@@ -95,7 +95,7 @@ using Predecessors = std::vector<std::pair<BinaryFunction *, uint64_t>>;
 /// Build a simplified version of the call graph: For every function, keep
 /// its callers and the frequencies of the calls
 std::unordered_map<const BinaryFunction *, Predecessors>
-extractFunctionCalls(const std::vector<BinaryFunction *> &BinaryFunctions) {
+extractFunctionCalls(const BinaryFunctionListType &BinaryFunctions) {
   std::unordered_map<const BinaryFunction *, Predecessors> Calls;
 
   for (BinaryFunction *SrcFunction : BinaryFunctions) {
@@ -140,7 +140,7 @@ extractFunctionCalls(const std::vector<BinaryFunction *> &BinaryFunctions) {
 /// the page. The following procedure detects short and long calls, and
 /// estimates the expected number of cache misses for the long ones.
 double expectedCacheHitRatio(
-    const std::vector<BinaryFunction *> &BinaryFunctions,
+    const BinaryFunctionListType &BinaryFunctions,
     const std::unordered_map<BinaryBasicBlock *, uint64_t> &BBAddr,
     const std::unordered_map<BinaryBasicBlock *, uint64_t> &BBSize) {
   std::unordered_map<const BinaryFunction *, Predecessors> Calls =
@@ -213,7 +213,7 @@ double expectedCacheHitRatio(
 } // namespace
 
 void CacheMetrics::printAll(raw_ostream &OS,
-                            const std::vector<BinaryFunction *> &BFs) {
+                            const BinaryFunctionListType &BFs) {
   // Stats related to hot-cold code splitting
   size_t NumFunctions = 0;
   size_t NumProfiledFunctions = 0;

--- a/bolt/lib/Passes/IdenticalCodeFolding.cpp
+++ b/bolt/lib/Passes/IdenticalCodeFolding.cpp
@@ -368,8 +368,8 @@ typedef std::unordered_map<BinaryFunction *, std::set<BinaryFunction *>,
                            KeyHash, KeyCongruent>
     CongruentBucketsMap;
 
-typedef std::unordered_map<BinaryFunction *, std::vector<BinaryFunction *>,
-                           KeyHash, KeyEqual>
+typedef std::unordered_map<BinaryFunction *, BinaryFunctionListType, KeyHash,
+                           KeyEqual>
     IdenticalBucketsMap;
 
 namespace llvm {
@@ -522,7 +522,7 @@ Error IdenticalCodeFolding::runOnFunctions(BinaryContext &BC) {
 
       for (auto &IBI : IdenticalBuckets) {
         // Functions identified as identical.
-        std::vector<BinaryFunction *> &Twins = IBI.second;
+        BinaryFunctionListType &Twins = IBI.second;
         if (Twins.size() < 2)
           continue;
 

--- a/bolt/lib/Passes/Inliner.cpp
+++ b/bolt/lib/Passes/Inliner.cpp
@@ -571,7 +571,7 @@ Error Inliner::runOnFunctions(BinaryContext &BC) {
     InliningCandidates.clear();
     findInliningCandidates(BC);
 
-    std::vector<BinaryFunction *> ConsideredFunctions;
+    BinaryFunctionListType ConsideredFunctions;
     for (auto &BFI : BC.getBinaryFunctions()) {
       BinaryFunction &Function = BFI.second;
       if (!shouldOptimize(Function))

--- a/bolt/lib/Passes/LongJmp.cpp
+++ b/bolt/lib/Passes/LongJmp.cpp
@@ -304,7 +304,7 @@ void LongJmpPass::tentativeBBLayout(const BinaryFunction &Func) {
 }
 
 uint64_t LongJmpPass::tentativeLayoutRelocColdPart(
-    const BinaryContext &BC, std::vector<BinaryFunction *> &SortedFunctions,
+    const BinaryContext &BC, BinaryFunctionListType &SortedFunctions,
     uint64_t DotAddress) {
   DotAddress = alignTo(DotAddress, llvm::Align(opts::AlignFunctions));
   for (BinaryFunction *Func : SortedFunctions) {
@@ -325,9 +325,10 @@ uint64_t LongJmpPass::tentativeLayoutRelocColdPart(
   return DotAddress;
 }
 
-uint64_t LongJmpPass::tentativeLayoutRelocMode(
-    const BinaryContext &BC, std::vector<BinaryFunction *> &SortedFunctions,
-    uint64_t DotAddress) {
+uint64_t
+LongJmpPass::tentativeLayoutRelocMode(const BinaryContext &BC,
+                                      BinaryFunctionListType &SortedFunctions,
+                                      uint64_t DotAddress) {
   // Compute hot cold frontier
   int64_t LastHotIndex = -1u;
   uint32_t CurrentIndex = 0;
@@ -398,8 +399,8 @@ uint64_t LongJmpPass::tentativeLayoutRelocMode(
   return DotAddress;
 }
 
-void LongJmpPass::tentativeLayout(
-    const BinaryContext &BC, std::vector<BinaryFunction *> &SortedFunctions) {
+void LongJmpPass::tentativeLayout(const BinaryContext &BC,
+                                  BinaryFunctionListType &SortedFunctions) {
   uint64_t DotAddress = BC.LayoutStartAddress;
 
   if (!BC.HasRelocations) {
@@ -920,7 +921,7 @@ Error LongJmpPass::runOnFunctions(BinaryContext &BC) {
   }
 
   BC.outs() << "BOLT-INFO: Starting stub-insertion pass\n";
-  std::vector<BinaryFunction *> Sorted = BC.getSortedFunctions();
+  BinaryFunctionListType Sorted = BC.getSortedFunctions();
   bool Modified;
   uint32_t Iterations = 0;
   do {

--- a/bolt/lib/Passes/ProfileQualityStats.cpp
+++ b/bolt/lib/Passes/ProfileQualityStats.cpp
@@ -37,7 +37,7 @@ static cl::opt<unsigned> PercentileForProfileQualityCheck(
 } // namespace opts
 
 namespace {
-using FunctionListType = std::vector<const BinaryFunction *>;
+using FunctionListType = ConstBinaryFunctionListType;
 using function_iterator = FunctionListType::iterator;
 
 // Function number -> vector of flows for BBs in the function

--- a/bolt/lib/Passes/ReorderFunctions.cpp
+++ b/bolt/lib/Passes/ReorderFunctions.cpp
@@ -296,7 +296,7 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
   case RT_NONE:
     break;
   case RT_EXEC_COUNT: {
-    std::vector<BinaryFunction *> SortedFunctions(BFs.size());
+    BinaryFunctionListType SortedFunctions(BFs.size());
     llvm::transform(llvm::make_second_range(BFs), SortedFunctions.begin(),
                     [](BinaryFunction &BF) { return &BF; });
     llvm::stable_sort(SortedFunctions,
@@ -471,7 +471,7 @@ Error ReorderFunctions::runOnFunctions(BinaryContext &BC) {
   }
 
   if (FuncsFile || LinkSectionsFile) {
-    std::vector<BinaryFunction *> SortedFunctions(BFs.size());
+    BinaryFunctionListType SortedFunctions(BFs.size());
     llvm::transform(llvm::make_second_range(BFs), SortedFunctions.begin(),
                     [](BinaryFunction &BF) { return &BF; });
 

--- a/bolt/lib/Profile/YAMLProfileReader.cpp
+++ b/bolt/lib/Profile/YAMLProfileReader.cpp
@@ -559,7 +559,7 @@ size_t YAMLProfileReader::matchWithCallGraph(BinaryContext &BC) {
     auto BFsWithSameHashOpt = CGMatcher.getBFsWithNeighborHash(Hash);
     if (!BFsWithSameHashOpt)
       continue;
-    std::vector<BinaryFunction *> BFsWithSameHash = BFsWithSameHashOpt.value();
+    BinaryFunctionListType BFsWithSameHash = BFsWithSameHashOpt.value();
     // Finds the binary function with the longest common prefix to the profiled
     // function and matches.
     BinaryFunction *ClosestBF = nullptr;
@@ -725,7 +725,7 @@ size_t YAMLProfileReader::matchWithNameSimilarity(BinaryContext &BC) {
     NamespaceToProfiledBFSizes[YamlBFNamespace].insert(YamlBF.NumBasicBlocks);
   }
 
-  StringMap<std::vector<BinaryFunction *>> NamespaceToBFs;
+  StringMap<BinaryFunctionListType> NamespaceToBFs;
 
   // Maps namespaces to BFs excluding binary functions with no equal sized
   // profiled functions belonging to the same namespace.
@@ -760,7 +760,7 @@ size_t YAMLProfileReader::matchWithNameSimilarity(BinaryContext &BC) {
       continue;
 
     std::string &YamlBFDemangledName = ProfileBFDemangledNames[I];
-    std::vector<BinaryFunction *> BFs = It->second;
+    BinaryFunctionListType BFs = It->second;
     unsigned MinEditDistance = UINT_MAX;
     BinaryFunction *ClosestNameBF = nullptr;
 


### PR DESCRIPTION
Use `BinaryFunctionListType` as an alias for `std::vector<BinaryFunction *>`.