### PR TITLE
[orc-rt] Add build options for EH and RTTI, and a config.h header.

### DIFF
--- a/orc-rt/CMakeLists.txt
+++ b/orc-rt/CMakeLists.txt
@@ -30,6 +30,8 @@ option(ORC_RT_INCLUDE_DOCS "Build the ORC-RT documentation." ON)
 option(ORC_RT_ENABLE_ASSERTIONS "Enable assertions independent of build mode." ON)
 option(ORC_RT_ENABLE_PEDANTIC "Compile with pedantic enabled." ON)
 option(ORC_RT_ENABLE_WERROR "Fail and stop if a warning is triggered." OFF)
+option(ORC_RT_ENABLE_RTTI "Enable RTTI." ON)
+option(ORC_RT_ENABLE_EXCEPTIONS "Enable exceptions." ON)
 option(ORC_RT_INCLUDE_TESTS "Build ORC-RT tests." ${LLVM_INCLUDE_TESTS})
 
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
@@ -39,6 +41,23 @@ set(CMAKE_FOLDER "orc-rt")
 
 set(ORC_RT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(ORC_RT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+# Configure RTTI and exceptions compile flags
+set(ORC_RT_COMPILE_FLAGS)
+if(NOT ORC_RT_ENABLE_RTTI)
+  list(APPEND ORC_RT_COMPILE_FLAGS -fno-rtti)
+endif()
+
+if(NOT ORC_RT_ENABLE_EXCEPTIONS)
+  list(APPEND ORC_RT_COMPILE_FLAGS -fno-exceptions)
+endif()
+
+# Generate config header
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/orc-rt-c/config.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/include/orc-rt-c/config.h
+  @ONLY
+)
 
 #===============================================================================
 # Setup Source Code

--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -31,16 +31,28 @@ set(ORC_RT_HEADERS
     orc-rt/span.h
 )
 
+# Add generated config header
+set(ORC_RT_GENERATED_HEADERS
+    ${CMAKE_CURRENT_BINARY_DIR}/orc-rt-c/config.h
+)
+
 # TODO: Switch to filesets when we move to cmake-3.23.
 add_library(orc-rt-headers INTERFACE)
 target_include_directories(orc-rt-headers INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 set_property(TARGET orc-rt-headers
-    PROPERTY PUBLIC_HEADER ${ORC_RT_HEADERS}
+    PROPERTY PUBLIC_HEADER ${ORC_RT_HEADERS} ${ORC_RT_GENERATED_HEADERS}
 )
 install(TARGETS orc-rt-headers
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
+    COMPONENT OrcRT_Development
+)
+
+# Install generated config header
+install(FILES ${ORC_RT_GENERATED_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/orc-rt-c/
     COMPONENT OrcRT_Development
 )

--- a/orc-rt/lib/executor/CMakeLists.txt
+++ b/orc-rt/lib/executor/CMakeLists.txt
@@ -12,6 +12,9 @@ add_library(orc-rt-executor STATIC ${files})
 target_link_libraries(orc-rt-executor
   PUBLIC orc-rt-headers
   )
+
+# Apply RTTI and exceptions compile flags
+target_compile_options(orc-rt-executor PRIVATE ${ORC_RT_COMPILE_FLAGS})
 install(TARGETS orc-rt-executor
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
           COMPONENT OrcRT_Development


### PR DESCRIPTION
Clients should be able to build the ORC runtime with or without exceptions/RTTI, and this choice should be able to be made independently of the corresponding settings for LLVM (e.g. it should be fine to build LLVM with exceptions/RTTI disabled, and orc-rt with them enabled).

The orc-rt-c/config.h header will provide C defines that can be used by both the ORC runtime and API clients to determine the value of the options.

Future patches should build on this work to provide APIs that enable some interoperability between the ORC runtime's error return mechanism (Error/Expected) and C++ exceptions.