### PR TITLE
[LLVM][Examples][Cygwin] Exclude examples that are not built from test dependencies

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -205,7 +205,7 @@ if(LLVM_INCLUDE_EXAMPLES)
       LLJITWithRemoteDebugging
       )
   endif()
-  if (NOT WIN32)
+  if (NOT WIN32 AND NOT CYGWIN)
     list(APPEND LLVM_TEST_DEPENDS
       Bye
       ExampleIRTransforms

--- a/llvm/test/Examples/lit.local.cfg
+++ b/llvm/test/Examples/lit.local.cfg
@@ -1,4 +1,4 @@
-if not config.include_examples or sys.platform in ["win32"]:
+if not config.include_examples or sys.platform in ["win32", "cygwin"]:
     config.unsupported = True
 
 # Test discovery should ignore subdirectories that contain test inputs.


### PR DESCRIPTION
`Bye` and `ExampleIRTransforms` are not built on Cygwin.