### PR TITLE
[CIR] Rename allEnumCasesCovered to all_enum_cases_covered

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1216,7 +1216,7 @@ def CIR_SwitchOp : CIR_Op<"switch", [
 
   let arguments = (ins 
     CIR_IntType:$condition,
-    UnitAttr:$allEnumCasesCovered
+    UnitAttr:$all_enum_cases_covered
   );
 
   let regions = (region AnyRegion:$body);
@@ -1229,7 +1229,7 @@ def CIR_SwitchOp : CIR_Op<"switch", [
 
   let assemblyFormat = [{
     `(` $condition `:` qualified(type($condition)) `)` 
-     (`allEnumCasesCovered` $allEnumCasesCovered^)?
+     (`all_enum_cases_covered` $all_enum_cases_covered^)?
     $body
     attr-dict
   }];

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -1282,7 +1282,7 @@ void testSwitchCoverAllCase(M m) {
     break;
   }
 }
-// CIR: cir.switch(%[[ARG:.*]] : !s32i) allEnumCasesCovered {
+// CIR: cir.switch(%[[ARG:.*]] : !s32i) all_enum_cases_covered {
 
 void testSwitchNotCoverAllCase(M m) {
   switch (m) {

--- a/clang/test/CIR/IR/switch.cir
+++ b/clang/test/CIR/IR/switch.cir
@@ -40,7 +40,7 @@ cir.func @s0() {
 
 // Pretends that this is lowered from a C file and was tagged with allEnumCasesCovered = true
 cir.func @s1(%1 : !s32i) {
-  cir.switch (%1 : !s32i) allEnumCasesCovered {
+  cir.switch (%1 : !s32i) all_enum_cases_covered {
     cir.case (default, []) {
       cir.return
     }
@@ -54,7 +54,7 @@ cir.func @s1(%1 : !s32i) {
   } { }
   cir.return
 } 
-// CHECK: cir.switch(%[[ARG:.*]] : !s32i) allEnumCasesCovered {
+// CHECK: cir.switch(%[[ARG:.*]] : !s32i) all_enum_cases_covered {
 // CHECK-NEXT: cir.case(default, []) {
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }


### PR DESCRIPTION
Use the convetional snake_case for MLIR assembly and align with operation documentation that already mentions snake_cased attribute.