### PR TITLE
[orc-rt] Ensure EH/RTTI=On overrides LLVM opts, applies to unit tests.

### DIFF
--- a/orc-rt/CMakeLists.txt
+++ b/orc-rt/CMakeLists.txt
@@ -44,11 +44,15 @@ set(ORC_RT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 # Configure RTTI and exceptions compile flags
 set(ORC_RT_COMPILE_FLAGS)
-if(NOT ORC_RT_ENABLE_RTTI)
+if(ORC_RT_ENABLE_RTTI)
+  list(APPEND ORC_RT_COMPILE_FLAGS -frtti)
+else()
   list(APPEND ORC_RT_COMPILE_FLAGS -fno-rtti)
 endif()
 
-if(NOT ORC_RT_ENABLE_EXCEPTIONS)
+if(ORC_RT_ENABLE_EXCEPTIONS)
+  list(APPEND ORC_RT_COMPILE_FLAGS -fexceptions)
+else()
   list(APPEND ORC_RT_COMPILE_FLAGS -fno-exceptions)
 endif()
 

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -39,4 +39,5 @@ add_orc_rt_unittest(CoreTests
   span-test.cpp
   DISABLE_LLVM_LINK_LLVM_DYLIB
   )
+target_compile_options(CoreTests PRIVATE ${ORC_RT_COMPILE_FLAGS})
 target_link_libraries(CoreTests PRIVATE orc-rt-executor)


### PR DESCRIPTION
When -DORC_RT_ENABLE_EXCEPTIONS=On and -DORC_RT_ENABLE_RTTI=On are passed we need to ensure that the resulting compiler flags (e.g. -fexceptions, -frtti for clang/GCC) are appended so that we override any inherited options (e.g. -fno-exceptions, -fno-rtti) from LLVM.

Updates unit tests to ensure that these compiler options are applied to them too.