### PR TITLE
[clang][DependencyScanning] Unify initVFS helpers to return OverlayFileSystem (NFC)

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
+++ b/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
@@ -98,7 +98,8 @@ std::unique_ptr<CompilerInvocation>
 createCompilerInvocation(ArrayRef<std::string> CommandLine,
                          DiagnosticsEngine &Diags);
 
-std::pair<IntrusiveRefCntPtr<llvm::vfs::FileSystem>, std::vector<std::string>>
+std::pair<IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>,
+          std::vector<std::string>>
 initVFSForTUBufferScanning(IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
                            ArrayRef<std::string> CommandLine,
                            StringRef WorkingDirectory,

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -430,7 +430,8 @@ dependencies::createCompilerInvocation(ArrayRef<std::string> CommandLine,
   return Invocation;
 }
 
-std::pair<IntrusiveRefCntPtr<llvm::vfs::FileSystem>, std::vector<std::string>>
+std::pair<IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>,
+          std::vector<std::string>>
 dependencies::initVFSForTUBufferScanning(
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
     ArrayRef<std::string> CommandLine, StringRef WorkingDirectory,
@@ -438,7 +439,6 @@ dependencies::initVFSForTUBufferScanning(
   // Reset what might have been modified in the previous worker invocation.
   BaseFS->setCurrentWorkingDirectory(WorkingDirectory);
 
-  IntrusiveRefCntPtr<llvm::vfs::FileSystem> ModifiedFS;
   auto OverlayFS =
       llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(BaseFS);
   auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
@@ -449,11 +449,10 @@ dependencies::initVFSForTUBufferScanning(
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> InMemoryOverlay = InMemoryFS;
 
   OverlayFS->pushOverlay(InMemoryOverlay);
-  ModifiedFS = OverlayFS;
   std::vector<std::string> ModifiedCommandLine(CommandLine);
   ModifiedCommandLine.emplace_back(InputPath);
 
-  return std::make_pair(ModifiedFS, ModifiedCommandLine);
+  return std::make_pair(OverlayFS, ModifiedCommandLine);
 }
 
 std::pair<IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>,


### PR DESCRIPTION
This patch is part of a series of splitting the work from #169964 into smaller changes (see review linked below).

As part of this work, the regular and by-name dependency scanning APIs need to be extended to allow the VFS to be initialized via the `initVFS-` helpers before invoking the scanning API, with the resulting overlay filesystem passed into the worker instead.

To make the newly added API changes consistent, this patch updates both helpers to return an `OverlayFileSystem`.

https://github.com/llvm/llvm-project/pull/169964#pullrequestreview-3545879529