### PR TITLE
[clang][bytecode] Fix pointer comparison to first record member

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -413,7 +413,8 @@ size_t Pointer::computeOffsetForComparison() const {
     }
 
     // Fields, etc.
-    Result += P.getInlineDesc()->Offset;
+    if (unsigned FO = P.getInlineDesc()->Offset; FO != sizeof(InlineDescriptor))
+      Result += FO;
     if (P.isOnePastEnd())
       ++Result;
 

--- a/clang/test/AST/ByteCode/cxx20.cpp
+++ b/clang/test/AST/ByteCode/cxx20.cpp
@@ -1225,3 +1225,25 @@ namespace ConditionalTemporaries {
   static_assert(foo(false)== 13);
   static_assert(foo(true)== 12);
 }
+
+namespace FirstRecordMemberCmp {
+
+  struct tuple {
+    int a;
+    int b;
+  };
+
+  constexpr tuple tpl{1,2};
+  static_assert((void*)&tpl == (void*)&tpl.a);
+
+
+  struct B {
+    int a;
+  };
+
+  struct tuple2 : public B {
+    int b;
+  };
+  constexpr tuple2 tpl2{1,2};
+  static_assert((void*)&tpl2 == (void*)&tpl2.a);
+}


### PR DESCRIPTION
This should compare equal to not adding the offset of the first member.

See https://github.com/llvm/llvm-project/issues/172165