### PR TITLE
ADT: Improve DenseMap documentation for insertion APIs

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -208,16 +208,9 @@ public:
     return ValueT();
   }
 
-  /// Returns the mapped value for the given key, or a provided default.
+  /// Returns the mapped value for Val if present, otherwise Default.
   ///
-  /// If the key exists in the map, its mapped value is returned. Otherwise,
-  /// the supplied default value is returned.
-  ///
-  /// This function is useful when the mapped type is not default-constructible.
-  ///
-  /// \param Val The key to look up.
-  /// \param Default The value to return if the key is not found.
-  /// \returns The mapped value or the provided default.
+  /// This is useful when the mapped type is not default-constructible.
   template <typename U = std::remove_cv_t<ValueT>>
   [[nodiscard]] ValueT lookup_or(const_arg_type_t<KeyT> Val,
                                  U &&Default) const {
@@ -256,25 +249,14 @@ public:
     return try_emplace_impl(std::move(KV.first), std::move(KV.second));
   }
 
-  /// Attempts to insert a new element into the map.
-  ///
-  /// If the key does not already exist in the map, a new element is inserted
-  /// and the mapped value is constructed in-place using the provided arguments.
-  ///
-  /// If the key already exists, no insertion is performed and the existing
-  /// mapped value is left unchanged.
-  ///
-  /// \param Key The key to insert.
-  /// \param Args Arguments forwarded to construct the mapped value if insertion
-  /// occurs.
-  /// \returns A pair consisting of an iterator to the element and a boolean
-  ///          indicating whether insertion took place.
+  /// Inserts a value for Key if absent, forwarding Args to construct it.
+  /// Returns an iterator to the element and whether insertion occurred.
   template <typename... Ts>
   std::pair<iterator, bool> try_emplace(KeyT &&Key, Ts &&...Args) {
     return try_emplace_impl(std::move(Key), std::forward<Ts>(Args)...);
   }
 
-   /// \overload
+   
   template <typename... Ts>
   std::pair<iterator, bool> try_emplace(const KeyT &Key, Ts &&...Args) {
     return try_emplace_impl(Key, std::forward<Ts>(Args)...);
@@ -310,15 +292,8 @@ public:
     insert(adl_begin(R), adl_end(R));
   }
 
-  /// Inserts a new element or assigns to the existing one.
-  ///
-  /// If the key does not exist, a new element is inserted. If the key already
-  /// exists, the mapped value is replaced with the provided value.
-  ///
-  /// \param Key The key to insert or update.
-  /// \param Val The value to insert or assign.
-  /// \returns A pair consisting of an iterator to the element and a boolean
-  ///          indicating whether insertion took place.
+  /// Inserts a value for Key if absent, otherwise assigns Val.
+  /// Returns an iterator to the element and whether insertion occurred.
   template <typename V>
   std::pair<iterator, bool> insert_or_assign(const KeyT &Key, V &&Val) {
     auto Ret = try_emplace(Key, std::forward<V>(Val));
@@ -327,7 +302,7 @@ public:
     return Ret;
   }
   
-  /// \overload
+
   template <typename V>
   std::pair<iterator, bool> insert_or_assign(KeyT &&Key, V &&Val) {
     auto Ret = try_emplace(std::move(Key), std::forward<V>(Val));
@@ -336,16 +311,8 @@ public:
     return Ret;
   }
 
-  /// Inserts a new element or assigns a newly constructed value.
-  ///
-  /// If the key does not exist, a new element is inserted and the mapped value
-  /// is constructed in-place from the provided arguments. If the key exists,
-  /// the mapped value is replaced.
-  ///
-  /// \param Key The key to insert or update.
-  /// \param Args Arguments used to construct the mapped value.
-  /// \returns A pair consisting of an iterator to the element and a boolean
-  ///          indicating whether insertion took place.
+  /// Inserts a value for Key if absent, otherwise assigns a newly constructed one.
+  /// Returns an iterator to the element and whether insertion occurred.
   template <typename... Ts>
   std::pair<iterator, bool> emplace_or_assign(const KeyT &Key, Ts &&...Args) {
     auto Ret = try_emplace(Key, std::forward<Ts>(Args)...);
@@ -354,7 +321,7 @@ public:
     return Ret;
   }
 
-  /// \overload
+  
   template <typename... Ts>
   std::pair<iterator, bool> emplace_or_assign(KeyT &&Key, Ts &&...Args) {
     auto Ret = try_emplace(std::move(Key), std::forward<Ts>(Args)...);
@@ -382,18 +349,13 @@ public:
     incrementNumTombstones();
   }
 
-  /// Returns a reference to the mapped value for the given key.
-  ///
-  /// If the key does not exist, a new element is inserted with a
-  /// default-constructed mapped value.
-  ///
-  /// \param Key The key to access.
-  /// \returns A reference to the mapped value.
+  /// Returns a reference to the mapped value for Key, inserting a
+  /// default-constructed value if necessary.
   ValueT &operator[](const KeyT &Key) {
     return lookupOrInsertIntoBucket(Key).first->second;
   }
 
-  /// \overload
+  
   ValueT &operator[](KeyT &&Key) {
     return lookupOrInsertIntoBucket(std::move(Key)).first->second;
   }

--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -355,7 +355,6 @@ public:
     return lookupOrInsertIntoBucket(Key).first->second;
   }
 
-  
   ValueT &operator[](KeyT &&Key) {
     return lookupOrInsertIntoBucket(std::move(Key)).first->second;
   }


### PR DESCRIPTION
This PR improves the documentation of non-trivial insertion APIs in
llvm::DenseMap.

The updated comments clarify the behaviour of:
1. try_emplace overloads
2. insert_or_assign
3. emplace_or_assign
4. lookup_or

Specifically, the documentation now explains:
1. When mapped values are constructed
2. When existing values are preserved or replaced
3. behaviour with non-default-constructible mapped types

Addresses #166155.
