### PR TITLE
[libc++] Remove unused __parent_pointer alias from __tree and map

### DIFF
--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -907,8 +907,6 @@ public:
   using __end_node_t _LIBCPP_NODEBUG       = __tree_end_node<__node_base_pointer>;
   using __end_node_pointer _LIBCPP_NODEBUG = __rebind_pointer_t<__void_pointer, __end_node_t>;
 
-  using __parent_pointer _LIBCPP_NODEBUG = __end_node_pointer; // TODO: Remove this once the uses in <map> are removed
-
   using __node_allocator _LIBCPP_NODEBUG = __rebind_alloc<__alloc_traits, __node>;
   using __node_traits _LIBCPP_NODEBUG    = allocator_traits<__node_allocator>;
 

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -1418,7 +1418,6 @@ private:
   typedef typename __base::__node_allocator __node_allocator;
   typedef typename __base::__node_pointer __node_pointer;
   typedef typename __base::__node_base_pointer __node_base_pointer;
-  typedef typename __base::__parent_pointer __parent_pointer;
 
   typedef __map_node_destructor<__node_allocator> _Dp;
   typedef unique_ptr<__node, _Dp> __node_holder;


### PR DESCRIPTION
The `__parent_pointer` type alias was marked to be removed in d163ab3323495560eb0255ac807da2bf24d3c629.
At that time, <map> still had uses of `__parent_pointer` as a local variable type in operator[] and at()

Those uses were removed in 4a2dd31f16d60b65a46696a909efad5c11b18c19, which refactored `__find_equal` to return a pair instead of using an out parameter

However, the typedef in <map> and the alias in __tree were left behind

This patch removes the unused typedef from <map> and the `__parent_pointer` alias from __tree
