### PR TITLE
Revert "[X86][APX] Add pattern for zext(X86setcc ..) -> SETZUCCr (#170806)"

### DIFF
--- a/llvm/lib/Target/X86/X86InstrCMovSetCC.td
+++ b/llvm/lib/Target/X86/X86InstrCMovSetCC.td
@@ -167,10 +167,6 @@ let Uses = [EFLAGS], isCodeGenOnly = 1, ForceDisassemble = 1,
   }
 }
 
-let Predicates = [HasZU] in
-  def : Pat<(i32 (zext (X86setcc timm:$cond, EFLAGS))),
-            (INSERT_SUBREG (i32 (IMPLICIT_DEF)), (SETZUCCr ccode:$cond), sub_8bit)>;
-
 // SALC is an undocumented instruction. Information for this instruction can be found
 // here http://www.rcollins.org/secrets/opcodes/SALC.html
 // Set AL if carry. 

--- a/llvm/test/CodeGen/X86/apx/setzucc.ll
+++ b/llvm/test/CodeGen/X86/apx/setzucc.ll
@@ -89,15 +89,3 @@ bb1:
 bb2:
   ret i32 0
 }
-
-define i32 @highmask_i32_mask32(i32 %val) {
-; CHECK-LABEL: highmask_i32_mask32:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    testl $-1048576, %edi # imm = 0xFFF00000
-; CHECK-NEXT:    setzune %al
-; CHECK-NEXT:    retq
-  %and = and i32 %val, -1048576
-  %cmp = icmp ne i32 %and, 0
-  %ret = zext i1 %cmp to i32
-  ret i32 %ret
-}


### PR DESCRIPTION
This reverts commit 2612dc9b5faeaeb180c5a5e0c282642faef8891b but keeps `Predicates = [HasNDD]` removed.

There are two issues identified related to the change. One is INSERT_SUBREG cannot guarantee source and dest to be the same register. It mostly happens on O0. The other one is zero_extend is not a chain node, as a result, we will lose the chain for SETZUCCr.