### PR TITLE
[clang-tidy] Suggest `std::views::reverse` instead of `std::ranges::reverse_view` in `modernize-use-ranges`

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
@@ -1079,7 +1079,7 @@ llvm::StringRef LoopConvertCheck::getReverseFunction() const {
   if (!ReverseFunction.empty())
     return ReverseFunction;
   if (UseReverseRanges)
-    return "std::ranges::reverse_view";
+    return "std::views::reverse";
   return "";
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseRangesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseRangesCheck.cpp
@@ -197,8 +197,7 @@ std::optional<UseRangesCheck::ReverseIteratorDescriptor>
 UseRangesCheck::getReverseDescriptor() const {
   static const std::pair<StringRef, StringRef> Refs[] = {
       {"::std::rbegin", "::std::rend"}, {"::std::crbegin", "::std::crend"}};
-  return ReverseIteratorDescriptor{UseReversePipe ? "std::views::reverse"
-                                                  : "std::ranges::reverse_view",
-                                   "<ranges>", Refs, UseReversePipe};
+  return ReverseIteratorDescriptor{"std::views::reverse", "<ranges>", Refs,
+                                   UseReversePipe};
 }
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -508,6 +508,11 @@ Changes in existing checks
   on Windows when the check was enabled with a 32-bit :program:`clang-tidy`
   binary.
 
+- Improved :doc:`modernize-use-ranges
+  <clang-tidy/checks/modernize/use-ranges>` check to suggest using
+  the more idiomatic ``std::views::reverse`` where it used to suggest
+  ``std::ranges::reverse_view``.
+
 - Improved :doc:`modernize-use-scoped-lock
   <clang-tidy/checks/modernize/use-scoped-lock>` check by fixing a crash
   on malformed code (common when using :program:`clang-tidy` through

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/loop-convert.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/loop-convert.rst
@@ -147,7 +147,7 @@ Options
 .. option:: UseCxx20ReverseRanges
 
    When set to true convert loops when in C++20 or later mode using
-   ``std::ranges::reverse_view``.
+   ``std::views::reverse``.
    Default value is `true`.
 
 .. option:: MakeReverseRangeFunction
@@ -155,7 +155,7 @@ Options
    Specify the function used to reverse an iterator pair, the function should
    accept a class with ``rbegin`` and ``rend`` methods and return a
    class with ``begin`` and ``end`` methods that call the ``rbegin`` and
-   ``rend`` methods respectively. Common examples are ``ranges::reverse_view``
+   ``rend`` methods respectively. Common examples are ``std::views::reverse``
    and ``llvm::reverse``.
    Default value is an empty string.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-ranges.rst
@@ -122,8 +122,8 @@ Transforms to:
 
 .. code-block:: c++
 
-  auto AreSame = std::ranges::equal(std::ranges::reverse_view(Items1),
-                                    std::ranges::reverse_view(Items2));
+  auto AreSame = std::ranges::equal(std::views::reverse(Items1),
+                                    std::views::reverse(Items2));
 
 Options
 -------

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-reverse.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-reverse.cpp
@@ -95,7 +95,7 @@ void constContainer(const Reversable<int> &Numbers) {
     observe(*I);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES-RANGES: for (int Number : std::ranges::reverse_view(Numbers)) {
+  // CHECK-FIXES-RANGES: for (int Number : std::views::reverse(Numbers)) {
   // CHECK-FIXES-CUSTOM: for (int Number : llvm::reverse(Numbers)) {
   //   CHECK-FIXES-NEXT:   observe(Number);
   //   CHECK-FIXES-NEXT: }
@@ -104,7 +104,7 @@ void constContainer(const Reversable<int> &Numbers) {
     observe(*I);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES-RANGES: for (int Number : std::ranges::reverse_view(Numbers)) {
+  // CHECK-FIXES-RANGES: for (int Number : std::views::reverse(Numbers)) {
   // CHECK-FIXES-CUSTOM: for (int Number : llvm::reverse(Numbers)) {
   //   CHECK-FIXES-NEXT:   observe(Number);
   //   CHECK-FIXES-NEXT: }
@@ -113,7 +113,7 @@ void constContainer(const Reversable<int> &Numbers) {
     observe(*I);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES-RANGES: for (int Number : std::ranges::reverse_view(Numbers)) {
+  // CHECK-FIXES-RANGES: for (int Number : std::views::reverse(Numbers)) {
   // CHECK-FIXES-CUSTOM: for (int Number : llvm::reverse(Numbers)) {
   //   CHECK-FIXES-NEXT:   observe(Number);
   //   CHECK-FIXES-NEXT: }
@@ -122,7 +122,7 @@ void constContainer(const Reversable<int> &Numbers) {
     observe(*I);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES-RANGES: for (int Number : std::ranges::reverse_view(Numbers)) {
+  // CHECK-FIXES-RANGES: for (int Number : std::views::reverse(Numbers)) {
   // CHECK-FIXES-CUSTOM: for (int Number : llvm::reverse(Numbers)) {
   //   CHECK-FIXES-NEXT:   observe(Number);
   //   CHECK-FIXES-NEXT: }
@@ -141,7 +141,7 @@ void nonConstContainer(Reversable<int> &Numbers) {
     mutate(*I);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES-RANGES: for (int & Number : std::ranges::reverse_view(Numbers)) {
+  // CHECK-FIXES-RANGES: for (int & Number : std::views::reverse(Numbers)) {
   // CHECK-FIXES-CUSTOM: for (int & Number : llvm::reverse(Numbers)) {
   //   CHECK-FIXES-NEXT:   mutate(Number);
   //   CHECK-FIXES-NEXT: }
@@ -150,7 +150,7 @@ void nonConstContainer(Reversable<int> &Numbers) {
     observe(*I);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES-RANGES: for (int Number : std::ranges::reverse_view(Numbers)) {
+  // CHECK-FIXES-RANGES: for (int Number : std::views::reverse(Numbers)) {
   // CHECK-FIXES-CUSTOM: for (int Number : llvm::reverse(Numbers)) {
   //   CHECK-FIXES-NEXT:   observe(Number);
   //   CHECK-FIXES-NEXT: }
@@ -159,7 +159,7 @@ void nonConstContainer(Reversable<int> &Numbers) {
     mutate(*I);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES-RANGES: for (int & Number : std::ranges::reverse_view(Numbers)) {
+  // CHECK-FIXES-RANGES: for (int & Number : std::views::reverse(Numbers)) {
   // CHECK-FIXES-CUSTOM: for (int & Number : llvm::reverse(Numbers)) {
   //   CHECK-FIXES-NEXT:   mutate(Number);
   //   CHECK-FIXES-NEXT: }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-ranges-pipe.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-ranges-pipe.cpp
@@ -12,7 +12,6 @@ void stdLib() {
   std::vector<int> I;
   std::find(I.rbegin(), I.rend(), 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
-  // CHECK-FIXES-NOPIPE: std::ranges::find(std::ranges::reverse_view(I), 0);
+  // CHECK-FIXES-NOPIPE: std::ranges::find(std::views::reverse(I), 0);
   // CHECK-FIXES-PIPE: std::ranges::find(I | std::views::reverse, 0);
-
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-ranges.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-ranges.cpp
@@ -94,19 +94,19 @@ void Reverse(){
 
   std::find(K.rbegin(), K.rend(), std::unique_ptr<int>());
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
-  // CHECK-FIXES: std::ranges::find(std::ranges::reverse_view(K), std::unique_ptr<int>());
+  // CHECK-FIXES: std::ranges::find(std::views::reverse(K), std::unique_ptr<int>());
 
   std::find(I.rbegin(), I.rend(), 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
-  // CHECK-FIXES: std::ranges::find(std::ranges::reverse_view(I), 0);
+  // CHECK-FIXES: std::ranges::find(std::views::reverse(I), 0);
 
   std::equal(std::rbegin(I), std::rend(I), J.begin(), J.end());
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
-  // CHECK-FIXES: std::ranges::equal(std::ranges::reverse_view(I), J);
+  // CHECK-FIXES: std::ranges::equal(std::views::reverse(I), J);
 
   std::equal(I.begin(), I.end(), std::crbegin(J), std::crend(J));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
-  // CHECK-FIXES: std::ranges::equal(I, std::ranges::reverse_view(J));
+  // CHECK-FIXES: std::ranges::equal(I, std::views::reverse(J));
 }
 
 void Negatives() {


### PR DESCRIPTION
`std::views::FOO` should in almost all cases be preferred over `std::ranges::FOO_view`. For a detailed explanation of why that is, see https://brevzin.github.io/c++/2023/03/14/prefer-views-meow/. The TLDR is that it's shorter to spell (which is obvious) and can in certain cases be more efficient (which is less obvious; see the article if curious).