### PR TITLE
[CFGPrinter] Allow set hide paths at runtime

### DIFF
--- a/llvm/include/llvm/Analysis/CFGPrinter.h
+++ b/llvm/include/llvm/Analysis/CFGPrinter.h
@@ -32,6 +32,7 @@
 #include "llvm/Support/FormatVariadic.h"
 
 #include <functional>
+#include <optional>
 #include <sstream>
 
 namespace llvm {
@@ -75,6 +76,8 @@ private:
   using NodeIdFormatterTy =
       std::function<std::optional<std::string>(const BasicBlock *)>;
   std::optional<NodeIdFormatterTy> NodeIdFormatter;
+  bool HideDeoptimizePaths;
+  bool HideUnreachablePaths;
 
 public:
   DOTFuncInfo(const Function *F) : DOTFuncInfo(F, nullptr, nullptr, 0) {}
@@ -83,7 +86,9 @@ public:
   LLVM_ABI
   DOTFuncInfo(const Function *F, const BlockFrequencyInfo *BFI,
               const BranchProbabilityInfo *BPI, uint64_t MaxFreq,
-              std::optional<NodeIdFormatterTy> NodeIdFormatter = std::nullopt);
+              std::optional<NodeIdFormatterTy> NodeIdFormatter = std::nullopt,
+              std::optional<bool> HideDeoptimizePaths = std::nullopt,
+              std::optional<bool> HideUnreachablePaths = std::nullopt);
 
   const BlockFrequencyInfo *getBFI() const { return BFI; }
 
@@ -114,6 +119,10 @@ public:
   std::optional<NodeIdFormatterTy> getNodeIdFormatter() {
     return NodeIdFormatter;
   }
+
+  bool hideDeoptimizePaths() const { return HideDeoptimizePaths; }
+
+  bool hideUnreachablePaths() const { return HideUnreachablePaths; }
 };
 
 template <>
@@ -346,7 +355,8 @@ struct DOTGraphTraits<DOTFuncInfo *> : public DefaultDOTGraphTraits {
 
   LLVM_ABI bool isNodeHidden(const BasicBlock *Node,
                              const DOTFuncInfo *CFGInfo);
-  LLVM_ABI void computeDeoptOrUnreachablePaths(const Function *F);
+  LLVM_ABI void computeDeoptOrUnreachablePaths(const Function *F,
+                                               const DOTFuncInfo *CFGInfo);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Analysis/CFGPrinter.h
+++ b/llvm/include/llvm/Analysis/CFGPrinter.h
@@ -87,8 +87,8 @@ public:
   DOTFuncInfo(const Function *F, const BlockFrequencyInfo *BFI,
               const BranchProbabilityInfo *BPI, uint64_t MaxFreq,
               std::optional<NodeIdFormatterTy> NodeIdFormatter = std::nullopt,
-              std::optional<bool> HideDeoptimizePaths = std::nullopt,
-              std::optional<bool> HideUnreachablePaths = std::nullopt);
+              bool HideDeoptimizePaths = false,
+              bool HideUnreachablePaths = false);
 
   const BlockFrequencyInfo *getBFI() const { return BFI; }
 

--- a/llvm/lib/Analysis/CFGPrinter.cpp
+++ b/llvm/lib/Analysis/CFGPrinter.cpp
@@ -35,11 +35,11 @@ static cl::opt<std::string> CFGDotFilenamePrefix(
     "cfg-dot-filename-prefix", cl::Hidden,
     cl::desc("The prefix used for the CFG dot file names."));
 
-static cl::opt<bool> HideUnreachablePaths("cfg-hide-unreachable-paths",
-                                          cl::init(false));
+static cl::opt<cl::boolOrDefault>
+    HideUnreachablePaths("cfg-hide-unreachable-paths");
 
-static cl::opt<bool> HideDeoptimizePaths("cfg-hide-deoptimize-paths",
-                                         cl::init(false));
+static cl::opt<cl::boolOrDefault>
+    HideDeoptimizePaths("cfg-hide-deoptimize-paths");
 
 static cl::opt<double> HideColdPaths(
     "cfg-hide-cold-paths", cl::init(0.0),
@@ -94,13 +94,15 @@ static void viewCFG(Function &F, const BlockFrequencyInfo *BFI,
 DOTFuncInfo::DOTFuncInfo(const Function *F, const BlockFrequencyInfo *BFI,
                          const BranchProbabilityInfo *BPI, uint64_t MaxFreq,
                          std::optional<NodeIdFormatterTy> NodeIdFormatter,
-                         std::optional<bool> HideDeoptimizePaths,
-                         std::optional<bool> HideUnreachablePaths)
+                         bool HideDeoptimizePaths, bool HideUnreachablePaths)
     : F(F), BFI(BFI), BPI(BPI), MaxFreq(MaxFreq),
       NodeIdFormatter(NodeIdFormatter),
-      HideDeoptimizePaths(HideDeoptimizePaths.value_or(::HideDeoptimizePaths)),
-      HideUnreachablePaths(
-          HideUnreachablePaths.value_or(::HideUnreachablePaths)) {
+      HideDeoptimizePaths(::HideDeoptimizePaths == cl::BOU_UNSET
+                              ? HideDeoptimizePaths
+                              : (::HideDeoptimizePaths == cl::BOU_TRUE)),
+      HideUnreachablePaths(::HideUnreachablePaths == cl::BOU_UNSET
+                               ? HideUnreachablePaths
+                               : (::HideUnreachablePaths == cl::BOU_TRUE)) {
   ShowHeat = false;
   EdgeWeights = !!BPI; // Print EdgeWeights when BPI is available.
   RawWeights = !!BFI;  // Print RawWeights when BFI is available.


### PR DESCRIPTION
Add HideDeoptimizePaths and HideUnreachablePaths to DOTFunctInfo.
This allows the modification of these settings in an alternative way to the CLI arguments.
If no option is passes, the CLI argument value is used.

This is helpful when creating multiple graphs with different settings in the same process.