### PR TITLE
[clang] Allow extra semicolons inside classes also in C++ pedantic mode.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -211,6 +211,10 @@ C++17 Feature Support
 Resolutions to C++ Defect Reports
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Implement DR1693 and DR3079 by allowing extra semicolons inside class member
+  declaration lists even in -pedantic mode. The warnings are still available
+  with -Wextra-semi. (#GH155538)
+
 C Language Changes
 ------------------
 

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -40,8 +40,12 @@ let CategoryName = "Parse Issue" in {
 def ext_empty_translation_unit : Extension<
   "ISO C requires a translation unit to contain at least one declaration">,
   InGroup<DiagGroup<"empty-translation-unit">>;
-def warn_cxx98_compat_top_level_semi : Warning<
-  "extra ';' outside of a function is incompatible with C++98">,
+def warn_cxx98_compat_extra_semi : Warning<
+  "%select{|||multiple }0extra ';' %select{"
+  "outside of a function|"
+  "inside a %1|"
+  "inside instance variable list|"
+  "after member function definition}0 is incompatible with C++98">,
   InGroup<CXX98CompatExtraSemi>, DefaultIgnore;
 def ext_extra_semi : Extension<
   "extra ';' %select{"
@@ -51,7 +55,11 @@ def ext_extra_semi : Extension<
   "after member function definition}0">,
   InGroup<ExtraSemi>;
 def ext_extra_semi_cxx11 : Extension<
-  "extra ';' outside of a function is a C++11 extension">,
+  "%select{|||multiple }0extra ';' %select{"
+  "outside of a function|"
+  "inside a %1|"
+  "inside instance variable list|"
+  "after member function definition}0 is a C++11 extension">,
   InGroup<CXX11ExtraSemi>;
 def warn_extra_semi_after_mem_fn_def : Warning<
   "extra ';' after member function definition">,

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -3096,7 +3096,9 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclaration(
       LateParsedAttrs.clear();
 
       // Consume the ';' - it's optional unless we have a delete or default
-      if (Tok.is(tok::semi))
+      if (Tok.is(tok::semi) &&
+          DefinitionKind != FunctionDefinitionKind::Defaulted &&
+          DefinitionKind != FunctionDefinitionKind::Deleted)
         ConsumeExtraSemi(ExtraSemiKind::AfterMemberFunctionDefinition);
 
       return DeclGroupPtrTy::make(DeclGroupRef(FunDecl));

--- a/clang/test/CXX/drs/cwg16xx.cpp
+++ b/clang/test/CXX/drs/cwg16xx.cpp
@@ -438,6 +438,26 @@ namespace cwg1692 { // cwg1692: 9
   }
 } // namespace cwg1692
 
+namespace cwg1693 { // cwg1693: 22
+  namespace issue_example {
+#if __cplusplus >= 201103L
+    struct A {
+      void f1() = delete;
+      void f2() = delete;;
+      void f3() = delete;;;
+    };
+#endif
+  }
+  struct A {
+    ; // cxx98-error{{extra ';' inside a struct is a C++11 extension}}
+    struct B {};; // cxx98-error{{extra ';' inside a struct is a C++11 extension}}
+    int a;; // cxx98-error{{extra ';' inside a struct is a C++11 extension}}
+    void f();; // cxx98-error{{extra ';' inside a struct is a C++11 extension}}
+    void h(){
+    };; // cxx98-error{{multiple extra ';' after member function definition is a C++11 extension}}
+  };
+} // namespace cwg1693
+
 namespace cwg1696 { // cwg1696: 7
   namespace std_examples {
 #if __cplusplus >= 201402L

--- a/clang/test/CXX/drs/cwg30xx.cpp
+++ b/clang/test/CXX/drs/cwg30xx.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++98 -pedantic-errors -verify=expected %s
+// RUN: %clang_cc1 -std=c++98 -pedantic-errors -verify=expected,cxx98 %s
 // RUN: %clang_cc1 -std=c++11 -pedantic-errors -verify=expected %s
 // RUN: %clang_cc1 -std=c++14 -pedantic-errors -verify=expected %s
 // RUN: %clang_cc1 -std=c++17 -pedantic-errors -verify=expected %s
@@ -18,6 +18,11 @@ void f(
     int _;
     // expected-error@-1 {{redefinition of '_'}}
     // expected-note@#cwg3005-first-param {{previous declaration is here}}
+}
+
+namespace cwg3079 { // cwg3079: 22 ready 2025-08-27
+  struct A { union {int x;;} u; }; // cxx98-error{{extra ';' inside a union is a C++11 extension}}
+  struct B { union {int x;;}; }; // cxx98-error{{extra ';' inside a union is a C++11 extension}}
 }
 
 } // namespace cwg3005

--- a/clang/test/Parser/cxx-class.cpp
+++ b/clang/test/Parser/cxx-class.cpp
@@ -20,11 +20,16 @@ public:
   ; // ok, one extra ';' is permitted
   void m() {
     int l = 2;
-  };; // expected-warning{{extra ';' after member function definition}}
-
+  };;
+#if __cplusplus < 201103L
+  // expected-warning@-2{{extra ';' after member function definition is a C++11 extension}}
+#endif
   template<typename T> void mt(T) { }
   ;
-  ; // expected-warning{{extra ';' inside a class}}
+  ;
+#if __cplusplus < 201103L
+  // expected-warning@-2{{extra ';' inside a class is a C++11 extension}}
+#endif
 
   virtual int vf() const volatile = 0;
 

--- a/clang/test/Parser/cxx-extra-semi.cpp
+++ b/clang/test/Parser/cxx-extra-semi.cpp
@@ -1,86 +1,82 @@
-// RUN: %clang_cc1 -fsyntax-only -pedantic -verify -DPEDANTIC %s
-// RUN: %clang_cc1 -fsyntax-only -Wextra-semi -verify %s
-// RUN: %clang_cc1 -fsyntax-only -Wextra-semi -verify -std=c++11 %s
+// RUN: %clang_cc1 -fsyntax-only -pedantic -verify=compat98 -std=c++98 %s
+// RUN: %clang_cc1 -fsyntax-only -pedantic -verify=cxx11_pedantic -std=c++11 %s
+// RUN: %clang_cc1 -fsyntax-only -Wextra-semi -verify=wextra,compat98 -std=c++98 %s
+// RUN: %clang_cc1 -fsyntax-only -Wextra-semi -verify=wextra,compat11 -std=c++11 %s
 // RUN: cp %s %t
 // RUN: %clang_cc1 -x c++ -Wextra-semi -fixit %t
 // RUN: %clang_cc1 -x c++ -Wextra-semi -Werror %t
 
-#if __cplusplus >= 201103L && defined(PEDANTIC)
 // In C++11 extra semicolons inside classes are allowed via defect reports.
-// expected-no-diagnostics
+// cxx11_pedantic-no-diagnostics
+ 
 class A {
   void A1();
   void A2() { };
-  void A2b() { };; 
-  ; 
-  void A2c() { }
-  ;
-  void A3() { };  ;; 
-  ;;;;;;; 
-  ; 
-  ; ;;		 ;  ;;; 
-    ;  ; 	;	;  ;; 
-  void A4();
-
-  union {
-    ;
-    int a;
-    ;
-  };
-};
-
-union B {
-  int a1;
-  int a2;; 
-};
-
-;
-; ;;
-
-#else
-
-class A {
-  void A1();
-  void A2() { };
-#ifndef PEDANTIC
   // This warning is only produced if we specify -Wextra-semi, and not if only
   // -pedantic is specified, since one semicolon is technically permitted.
-  // expected-warning@-4{{extra ';' after member function definition}}
-#endif
-  void A2b() { };; // expected-warning{{multiple extra ';' after member function definition}}
-  ; // expected-warning{{extra ';' inside a class}}
-  void A2c() { }
+  // wextra-warning@-3{{extra ';' after member function definition}}
+  void A2b() { };;
+  // compat98-warning@-1{{multiple extra ';' after member function definition is a C++11 extension}}
+  // compat11-warning@-2{{multiple extra ';' after member function definition is incompatible with C++98}}
   ;
-#ifndef PEDANTIC
-  // expected-warning@-2{{extra ';' after member function definition}}
-#endif
-  void A3() { };  ;; // expected-warning{{multiple extra ';' after member function definition}}
-  ;;;;;;; // expected-warning{{extra ';' inside a class}}
-  ; // expected-warning{{extra ';' inside a class}}
-  ; ;;		 ;  ;;; // expected-warning{{extra ';' inside a class}}
-    ;  ; 	;	;  ;; // expected-warning{{extra ';' inside a class}}
+  // compat98-warning@-1{{extra ';' inside a class is a C++11 extension}}
+  // compat11-warning@-2{{extra ';' inside a class is incompatible with C++98}}
+  void A2c() { }
+  ; // wextra-warning{{extra ';' after member function definition}}
+  void A3() { };  ;;
+  // compat98-warning@-1{{multiple extra ';' after member function definition is a C++11 extension}}
+  // compat11-warning@-2{{multiple extra ';' after member function definition is incompatible with C++98}}
+  ;;;;;;;
+  // compat98-warning@-1{{extra ';' inside a class is a C++11 extension}}
+  // compat11-warning@-2{{extra ';' inside a class is incompatible with C++98}}
+  ;
+  // compat98-warning@-1{{extra ';' inside a class is a C++11 extension}}
+  // compat11-warning@-2{{extra ';' inside a class is incompatible with C++98}}
+  ; ;;		 ;  ;;;
+  // compat98-warning@-1{{extra ';' inside a class is a C++11 extension}}
+  // compat11-warning@-2{{extra ';' inside a class is incompatible with C++98}}
+    ;  ; 	;	;  ;;
+  // compat98-warning@-1{{extra ';' inside a class is a C++11 extension}}
+  // compat11-warning@-2{{extra ';' inside a class is incompatible with C++98}}
   void A4();
   
   union {
-    ; // expected-warning{{extra ';' inside a union}}
+    ;
+    // compat98-warning@-1{{extra ';' inside a union is a C++11 extension}}
+    // compat11-warning@-2{{extra ';' inside a union is incompatible with C++98}}
     int a;
-    ; // expected-warning{{extra ';' inside a union}}
+    ;
+    // compat98-warning@-1{{extra ';' inside a union is a C++11 extension}}
+    // compat11-warning@-2{{extra ';' inside a union is incompatible with C++98}}
   };
+
+  virtual void f() = 0;
+  virtual void g() = 0;;
+  // compat11-warning@-1{{extra ';' inside a class is incompatible with C++98}}
+  // compat98-warning@-2{{extra ';' inside a class is a C++11 extension}}
+
+#if __cplusplus >= 201103L
+  void h() = delete;
+  void i() = delete;; // compat11-warning{{extra ';' inside a class is incompatible with C++98}}
+  void j() = delete;;; // compat11-warning{{extra ';' inside a class is incompatible with C++98}}
+  
+  A(const A&) = default;
+  A(A&&) = default;;  // compat11-warning{{extra ';' inside a class is incompatible with C++98}}
+  A(A&) = default;;;  // compat11-warning{{extra ';' inside a class is incompatible with C++98}}
+#endif
 };
 
 union B {
   int a1;
-  int a2;; // expected-warning{{extra ';' inside a union}}
+  int a2;;
+  // compat11-warning@-1{{extra ';' inside a union is incompatible with C++98}}
+  // compat98-warning@-2{{extra ';' inside a union is a C++11 extension}}
 };
 
 ;
 ; ;;
-#if __cplusplus < 201103L
-// expected-warning@-3{{extra ';' outside of a function is a C++11 extension}}
-// expected-warning@-3{{extra ';' outside of a function is a C++11 extension}}
-#elif !defined(PEDANTIC)
-// expected-warning@-6{{extra ';' outside of a function is incompatible with C++98}}
-// expected-warning@-6{{extra ';' outside of a function is incompatible with C++98}}
-#endif
+// compat98-warning@-2{{extra ';' outside of a function is a C++11 extension}}
+// compat98-warning@-2{{extra ';' outside of a function is a C++11 extension}}
+// compat11-warning@-4{{extra ';' outside of a function is incompatible with C++98}}
+// compat11-warning@-4{{extra ';' outside of a function is incompatible with C++98}}
 
-#endif

--- a/clang/test/Parser/cxx-extra-semi.cpp
+++ b/clang/test/Parser/cxx-extra-semi.cpp
@@ -5,6 +5,40 @@
 // RUN: %clang_cc1 -x c++ -Wextra-semi -fixit %t
 // RUN: %clang_cc1 -x c++ -Wextra-semi -Werror %t
 
+#if __cplusplus >= 201103L && defined(PEDANTIC)
+// In C++11 extra semicolons inside classes are allowed via defect reports.
+// expected-no-diagnostics
+class A {
+  void A1();
+  void A2() { };
+  void A2b() { };; 
+  ; 
+  void A2c() { }
+  ;
+  void A3() { };  ;; 
+  ;;;;;;; 
+  ; 
+  ; ;;		 ;  ;;; 
+    ;  ; 	;	;  ;; 
+  void A4();
+
+  union {
+    ;
+    int a;
+    ;
+  };
+};
+
+union B {
+  int a1;
+  int a2;; 
+};
+
+;
+; ;;
+
+#else
+
 class A {
   void A1();
   void A2() { };
@@ -13,19 +47,25 @@ class A {
   // -pedantic is specified, since one semicolon is technically permitted.
   // expected-warning@-4{{extra ';' after member function definition}}
 #endif
-  void A2b() { };; // expected-warning{{extra ';' after member function definition}}
+  void A2b() { };; // expected-warning{{multiple extra ';' after member function definition}}
   ; // expected-warning{{extra ';' inside a class}}
   void A2c() { }
   ;
 #ifndef PEDANTIC
   // expected-warning@-2{{extra ';' after member function definition}}
 #endif
-  void A3() { };  ;; // expected-warning{{extra ';' after member function definition}}
+  void A3() { };  ;; // expected-warning{{multiple extra ';' after member function definition}}
   ;;;;;;; // expected-warning{{extra ';' inside a class}}
   ; // expected-warning{{extra ';' inside a class}}
   ; ;;		 ;  ;;; // expected-warning{{extra ';' inside a class}}
     ;  ; 	;	;  ;; // expected-warning{{extra ';' inside a class}}
   void A4();
+  
+  union {
+    ; // expected-warning{{extra ';' inside a union}}
+    int a;
+    ; // expected-warning{{extra ';' inside a union}}
+  };
 };
 
 union B {
@@ -41,4 +81,6 @@ union B {
 #elif !defined(PEDANTIC)
 // expected-warning@-6{{extra ';' outside of a function is incompatible with C++98}}
 // expected-warning@-6{{extra ';' outside of a function is incompatible with C++98}}
+#endif
+
 #endif

--- a/clang/test/Parser/cxx0x-decl.cpp
+++ b/clang/test/Parser/cxx0x-decl.cpp
@@ -62,15 +62,6 @@ namespace OpaqueEnumDecl {
 
 int decltype(f())::*ptr_mem_decltype;
 
-class ExtraSemiAfterMemFn {
-  // Due to a peculiarity in the C++11 grammar, a deleted or defaulted function
-  // is permitted to be followed by either one or two semicolons.
-  void f() = delete // expected-error {{expected ';' after delete}}
-  void g() = delete; // ok
-  void h() = delete;; // ok
-  void i() = delete;;; // expected-error {{extra ';' after member function definition}}
-};
-
 int *const const p = 0; // expected-error {{duplicate 'const' declaration specifier}}
 const const int *q = 0; // expected-error {{duplicate 'const' declaration specifier}}
 

--- a/clang/test/SemaObjC/warn-extra-semi.m
+++ b/clang/test/SemaObjC/warn-extra-semi.m
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -x objective-c++ %s -std=c++11 -fsyntax-only -verify=expected,wextra -Wextra-semi
+// RUN: %clang_cc1 -x objective-c++ %s -std=c++11 -fsyntax-only -verify=expected -pedantic
+
+@interface X
+{
+  ; // expected-warning {{extra ';' inside instance variable list}}
+  int a;
+  ; // expected-warning {{extra ';' inside instance variable list}}
+  ;; // expected-warning {{extra ';' inside instance variable list}}
+}
+@end


### PR DESCRIPTION
With DR 1693 and DR 3079 C++ also allows empty declaration, i.e. extra semicolons, inside class member declaration lists in all contexts (as far as I can tell).

This removes warnings for such extra semicolons from -pedantic but keeps them as a C++98 compatibility warning as well as -Wextra-semi, analogously to extra semicolons at namespace scope.

fixes #155538