### PR TITLE
[X86] combineVectorSizedSetCCEquality - ensure the load is a normal load

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -23125,7 +23125,7 @@ static SDValue combineVectorSizedSetCCEquality(EVT VT, SDValue X, SDValue Y,
   auto IsVectorBitCastCheap = [](SDValue X) {
     X = peekThroughBitcasts(X);
     return isa<ConstantSDNode>(X) || X.getValueType().isVector() ||
-           X.getOpcode() == ISD::LOAD;
+           ISD::isNormalLoad(X.getNode());
   };
   if ((!IsVectorBitCastCheap(X) || !IsVectorBitCastCheap(Y)) &&
       !IsOrXorXorTreeCCZero)


### PR DESCRIPTION
Noticed while trying to replace the IsVectorBitCastCheap helper with mayFoldIntoVector (still some work to do as we have a number of multiuse cases) - technically its possible for a extload to reach this point.