### PR TITLE
[OFFLOAD] Add missing device properties for libomptarget migration

### DIFF
--- a/offload/liboffload/API/Device.td
+++ b/offload/liboffload/API/Device.td
@@ -44,6 +44,8 @@ def ol_device_info_t : Enum {
     TaggedEtor<"MAX_MEM_ALLOC_SIZE", "uint64_t", "The maximum size of memory object allocation in bytes">,
     TaggedEtor<"GLOBAL_MEM_SIZE", "uint64_t", "The size of global device memory in bytes">,
     TaggedEtor<"WORK_GROUP_LOCAL_MEM_SIZE", "uint64_t", "The maximum size of local shared memory per work group in bytes">,
+    TaggedEtor<"ID", "int32_t", "Device ID">,
+    TaggedEtor<"USE_AUTO_ZERO_COPY", "bool", "Use Auto Zero Copy">,
   ];
   list<TaggedEtor> fp_configs = !foreach(type, ["Single", "Double", "Half"], TaggedEtor<type # "_FP_CONFIG", "ol_device_fp_capability_flags_t", type # " precision floating point capability">);
   list<TaggedEtor> native_vec_widths = !foreach(type, ["char","short","int","long","float","double","half"], TaggedEtor<"NATIVE_VECTOR_WIDTH_" # type, "uint32_t", "Native vector width for " # type>);

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -449,6 +449,11 @@ Error olGetDeviceInfoImplDetail(ol_device_handle_t Device,
     return Info.write<uint64_t>(Mem);
   } break;
 
+  case OL_DEVICE_INFO_ID:
+    return Info.write<int32_t>(Device->DeviceNum);
+  case OL_DEVICE_INFO_USE_AUTO_ZERO_COPY:
+    return Info.write<bool>(Device->Device->useAutoZeroCopy());
+
   default:
     break;
   }
@@ -599,6 +604,10 @@ Error olGetDeviceInfoImplDetailHost(ol_device_handle_t Device,
   case OL_DEVICE_INFO_GLOBAL_MEM_SIZE:
   case OL_DEVICE_INFO_WORK_GROUP_LOCAL_MEM_SIZE:
     return Info.write<uint64_t>(0);
+  case OL_DEVICE_INFO_ID:
+    return Info.write<int32_t>(Device->DeviceNum);
+  case OL_DEVICE_INFO_USE_AUTO_ZERO_COPY:
+    return Info.write<bool>(Device->Device->useAutoZeroCopy());
   default:
     return createOffloadError(ErrorCode::INVALID_ENUMERATION,
                               "getDeviceInfo enum '%i' is invalid", PropName);


### PR DESCRIPTION
Add missing liboffload device properties for libomptarget migration

This PR adds liboffload device properties that needed to make libomptarget to use liboffload