### PR TITLE
[CIR] Add BuildableType traits to relevant constraints (NFC)

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -588,7 +588,7 @@ public:
 
   cir::CmpOp createCompare(mlir::Location loc, cir::CmpOpKind kind,
                            mlir::Value lhs, mlir::Value rhs) {
-    return cir::CmpOp::create(*this, loc, getBoolTy(), kind, lhs, rhs);
+    return cir::CmpOp::create(*this, loc, kind, lhs, rhs);
   }
 
   cir::VecCmpOp createVecCompare(mlir::Location loc, cir::CmpOpKind kind,

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypeConstraints.td
@@ -47,7 +47,8 @@ class CIR_TypeSummaries<list<Type> types> {
 // Bool Type predicates
 //===----------------------------------------------------------------------===//
 
-def CIR_AnyBoolType : CIR_TypeBase<"::cir::BoolType", "boolean type">;
+def CIR_AnyBoolType : CIR_TypeBase<"::cir::BoolType", "boolean type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
 
 //===----------------------------------------------------------------------===//
 // IntType predicates
@@ -132,18 +133,25 @@ def CIR_AnyFundamentalSIntType
 // Float Type predicates
 //===----------------------------------------------------------------------===//
 
-def CIR_AnySingleType : CIR_TypeBase<"::cir::SingleType", "single float type">;
+def CIR_AnySingleType : CIR_TypeBase<"::cir::SingleType", "single float type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
 def CIR_AnyFP32Type : TypeAlias<CIR_AnySingleType>;
 
-def CIR_AnyDoubleType : CIR_TypeBase<"::cir::DoubleType", "double float type">;
+def CIR_AnyDoubleType : CIR_TypeBase<"::cir::DoubleType", "double float type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
 def CIR_AnyFP64Type : TypeAlias<CIR_AnyDoubleType>;
 
-def CIR_AnyFP16Type : CIR_TypeBase<"::cir::FP16Type", "f16 type">;
-def CIR_AnyBFloat16Type : CIR_TypeBase<"::cir::BF16Type", "bf16 type">;
-def CIR_AnyFP80Type : CIR_TypeBase<"::cir::FP80Type", "f80 type">;
-def CIR_AnyFP128Type : CIR_TypeBase<"::cir::FP128Type", "f128 type">;
+def CIR_AnyFP16Type : CIR_TypeBase<"::cir::FP16Type", "f16 type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
+def CIR_AnyBFloat16Type : CIR_TypeBase<"::cir::BF16Type", "bf16 type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
+def CIR_AnyFP80Type : CIR_TypeBase<"::cir::FP80Type", "f80 type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
+def CIR_AnyFP128Type : CIR_TypeBase<"::cir::FP128Type", "f128 type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
 def CIR_AnyLongDoubleType : CIR_TypeBase<"::cir::LongDoubleType",
-    "long double type">;
+    "long double type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
 
 def CIR_AnyFloatType : AnyTypeOf<[
     CIR_AnySingleType, CIR_AnyDoubleType, CIR_AnyFP16Type,
@@ -196,19 +204,25 @@ def CIR_AnyArrayType : CIR_TypeBase<"::cir::ArrayType", "array type">;
 def CIR_AnyPtrType : CIR_TypeBase<"::cir::PointerType", "pointer type">;
 
 // Pointer to type constraint bases
-class CIR_IsPtrToPred<code type> : CPred<"$_self.isPtrTo<" # type # ">()">;
+class CIR_IsPtrToPred<Type type>
+    : CPred<"$_self.isPtrTo<" # type.cppType # ">()">;
 
-class CIR_PtrTo<code type, string summary>
+class CIR_PtrTo<Type type, string summary>
     : CIR_ConfinedType<CIR_AnyPtrType, [CIR_IsPtrToPred<type>],
-        "pointer to " # summary>;
+        "pointer to " # summary>,
+      SameBuildabilityAs<type,
+        "$_builder.getType<" # cppType # ">(" # type.builderCall # ")">;
 
 // Pointer to pointer constraint bases
-class CIR_IsPtrToPtrToPred<code type>
-    : CPred<"$_self.isPtrToPtrTo<" # type # ">()">;
+class CIR_IsPtrToPtrToPred<Type type>
+    : CPred<"$_self.isPtrToPtrTo<" # type.cppType # ">()">;
 
-class CIR_PtrToPtrTo<code type, string summary>
+class CIR_PtrToPtrTo<Type type, string summary>
     : CIR_ConfinedType<CIR_AnyPtrType, [CIR_IsPtrToPtrToPred<type>],
-        "pointer to pointer to " # summary>;
+        "pointer to pointer to " # summary>,
+      SameBuildabilityAs<type,
+          "$_builder.getType<" # cppType # ">($_builder.getType<" # cppType #
+          ">(" # type.builderCall # "))">;
 
 // Pointee type constraint bases
 class CIR_PointeePred<Pred pred> : SubstLeaves<"$_self",
@@ -221,17 +235,14 @@ class CIR_PtrToAnyOf<list<Type> types, string summary = "">
       "pointer to " # CIR_TypeSummaries<types>.value,
       summary)>;
 
-// Void pointer type constraints
-def CIR_VoidPtrType
-    : CIR_PtrTo<"::cir::VoidType", "void type">,
-      BuildableType<"$_builder.getType<" # cppType # ">("
-        "cir::VoidType::get($_builder.getContext()))">;
+// Void type constraints
+def CIR_AnyVoidType : CIR_TypeBase<"::cir::VoidType", "void type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
 
-def CIR_PtrToVoidPtrType
-    : CIR_PtrToPtrTo<"::cir::VoidType", "void type">,
-      BuildableType<"$_builder.getType<" # cppType # ">("
-        "$_builder.getType<" # cppType # ">("
-        "cir::VoidType::get($_builder.getContext())))">;
+// Void pointer type constraints
+def CIR_VoidPtrType : CIR_PtrTo<CIR_AnyVoidType, "void type">;
+
+def CIR_PtrToVoidPtrType : CIR_PtrToPtrTo<CIR_AnyVoidType, "void type">;
 
 class CIR_PtrToType<Type type> : CIR_PtrToAnyOf<[type]>;
 
@@ -323,9 +334,12 @@ def CIR_AnyDataMemberType : CIR_TypeBase<"::cir::DataMemberType",
 // VPtr type predicates
 //===----------------------------------------------------------------------===//
 
-def CIR_AnyVPtrType : CIR_TypeBase<"::cir::VPtrType", "vptr type">;
+def CIR_AnyVPtrType : CIR_TypeBase<"::cir::VPtrType", "vptr type">,
+      BuildableType<"$_builder.getType<" # cppType # ">()">;
 
-def CIR_PtrToVPtr : CIR_PtrToType<CIR_AnyVPtrType>;
+def CIR_PtrToVPtr : CIR_PtrToType<CIR_AnyVPtrType>,
+      BuildableType<"$_builder.getType<" # cppType # ">("
+        "$_builder.getType<::cir::VPtrType>())">;
 
 //===----------------------------------------------------------------------===//
 // Scalar Type predicates

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -440,8 +440,8 @@ void CIRGenFunction::initializeVTablePointer(mlir::Location loc,
   // vtable field is derived from `this` pointer, therefore they should be in
   // the same addr space.
   assert(!cir::MissingFeatures::addressSpace());
-  auto vtablePtr = cir::VTableGetVPtrOp::create(
-      builder, loc, builder.getPtrToVPtrType(), classAddr.getPointer());
+  auto vtablePtr =
+      cir::VTableGetVPtrOp::create(builder, loc, classAddr.getPointer());
   Address vtableField = Address(vtablePtr, classAddr.getAlignment());
   builder.createStore(loc, vtableAddressPoint, vtableField);
   assert(!cir::MissingFeatures::opTBAA());
@@ -1244,8 +1244,8 @@ bool CIRGenFunction::shouldEmitVTableTypeCheckedLoad(const CXXRecordDecl *rd) {
 
 mlir::Value CIRGenFunction::getVTablePtr(mlir::Location loc, Address thisAddr,
                                          const CXXRecordDecl *rd) {
-  auto vtablePtr = cir::VTableGetVPtrOp::create(
-      builder, loc, builder.getPtrToVPtrType(), thisAddr.getPointer());
+  auto vtablePtr =
+      cir::VTableGetVPtrOp::create(builder, loc, thisAddr.getPointer());
   Address vtablePtrAddr = Address(vtablePtr, thisAddr.getAlignment());
 
   auto vtable = builder.createLoad(loc, vtablePtrAddr);

--- a/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
@@ -535,9 +535,8 @@ void AggExprEmitter::emitArrayInit(Address destPtr, cir::ArrayType arrayTy,
         /*condBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
           cir::LoadOp currentElement = builder.createLoad(loc, tmpAddr);
-          mlir::Type boolTy = cgf.convertType(cgf.getContext().BoolTy);
-          cir::CmpOp cmp = cir::CmpOp::create(
-              builder, loc, boolTy, cir::CmpOpKind::ne, currentElement, end);
+          cir::CmpOp cmp = cir::CmpOp::create(builder, loc, cir::CmpOpKind::ne,
+                                              currentElement, end);
           builder.createCondition(cmp);
         },
         /*bodyBuilder=*/

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -217,8 +217,7 @@ public:
         rewriter, op.getLoc(), uIntType, CastKind::integral, rangeLength);
 
     cir::CmpOp cmpResult = cir::CmpOp::create(
-        rewriter, op.getLoc(), cir::BoolType::get(op.getContext()),
-        cir::CmpOpKind::le, uDiffValue, uRangeLength);
+        rewriter, op.getLoc(), cir::CmpOpKind::le, uDiffValue, uRangeLength);
     cir::BrCondOp::create(rewriter, op.getLoc(), cmpResult, rangeDestination,
                           defaultDestination);
     return resBlock;

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1029,8 +1029,7 @@ static void lowerArrayDtorCtorIntoLoop(cir::CIRBaseBuilderTy &builder,
       /*condBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc) {
         auto currentElement = cir::LoadOp::create(b, loc, eltTy, tmpAddr);
-        mlir::Type boolTy = cir::BoolType::get(b.getContext());
-        auto cmp = cir::CmpOp::create(builder, loc, boolTy, cir::CmpOpKind::ne,
+        auto cmp = cir::CmpOp::create(builder, loc, cir::CmpOpKind::ne,
                                       currentElement, stop);
         builder.createCondition(cmp);
       },

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepareItaniumCXXABI.cpp
@@ -119,10 +119,7 @@ buildDynamicCastToVoidAfterNullCheck(cir::CIRBaseBuilderTy &builder,
   // Access vtable to get the offset from the given object to its containing
   // complete object.
   // TODO: Add a specialized operation to get the object offset?
-  auto vptrTy = cir::VPtrType::get(builder.getContext());
-  cir::PointerType vptrPtrTy = builder.getPointerTo(vptrTy);
-  auto vptrPtr =
-      cir::VTableGetVPtrOp::create(builder, loc, vptrPtrTy, op.getSrc());
+  auto vptrPtr = cir::VTableGetVPtrOp::create(builder, loc, op.getSrc());
   mlir::Value vptr = builder.createLoad(loc, vptrPtr);
   mlir::Value elementPtr =
       builder.createBitcast(vptr, builder.getPointerTo(vtableElemTy));


### PR DESCRIPTION
This also eliminates some explicit uses of buildable types.