### PR TITLE
[OFFLOAD] Add missing interop API for libomptarget migration

### DIFF
--- a/offload/liboffload/API/Device.td
+++ b/offload/liboffload/API/Device.td
@@ -131,3 +131,65 @@ def olGetDeviceInfoSize : Function {
     Return<"OL_ERRC_INVALID_DEVICE">
   ];
 }
+
+def olCreateInterop : Function {
+  let desc = "Create OpenMP interop with the given interop context.";
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+    Param<"int32_t", "InteropContext", "Interop Context", PARAM_IN>,
+    Param<"void *", "InteropSpec", "Interop Spec", PARAM_IN>,
+    Param<"void**", "Interop", "output for the interop", PARAM_OUT>
+  ];
+  let returns = [];
+}
+
+def olReleaseInterop : Function {
+  let desc = "Release OpenMP interop object.";
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+    Param<"void *", "InteropSpec", "Interop Context", PARAM_IN>
+  ];
+  let returns = [];
+}
+
+def olSelectInterop : Function {
+  let desc = "Return OpenMP interop object that the device supports.";
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+    Param<"int32_t", "InteropType", "Interop Context", PARAM_IN>,
+    Param<"int32_t", "InteropPreferencesSize", "Interop Context", PARAM_IN>,
+    Param<"void*", "InteropPreferences", "Interop Context", PARAM_IN>,
+    Param<"void*", "InteropSpec", "output for the interop", PARAM_OUT>
+  ];
+  let returns = [];
+}
+
+def olFlushQueueInterop : Function {
+    let desc = "Flush the queue associated with the interop object if necessary.";
+    let details = [];
+    let params = [
+      Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+      Param<"void *", "Interop", "Interop", PARAM_IN>
+    ];
+    let returns = [];
+}
+
+def olSyncBarrierInterop : Function {
+    let desc = "Perform a host synchronization with the queue associated with the interop object and wait for it to complete.";
+    let details = [];
+    let params = [
+      Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+      Param<"void *", "Interop", "Interop", PARAM_IN>
+    ];
+    let returns = [];
+}
+
+def olAsyncBarrierInterop : Function {
+    let desc = "Queue an asynchronous barrier in the queue associated with the interop object and return immediately.";
+    let details = [];
+    let params = [
+      Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+      Param<"void *", "Interop", "Interop", PARAM_IN>
+    ];
+    let returns = [];
+}

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1214,5 +1214,58 @@ Error olLaunchHostFunction_impl(ol_queue_handle_t Queue,
                                                 Queue->AsyncInfo);
 }
 
+Error olCreateInterop_impl(ol_device_handle_t Device, int32_t InteropContext, void *InteropSpec,
+                           void **Interop) {
+  auto Rc = Device->Device->createInterop(InteropContext, 
+                                          *static_cast<interop_spec_t *>(InteropSpec));
+  if (!Rc)
+    return Rc.takeError();
+  *Interop = *Rc;
+  return Error::success();
+}
+
+Error olReleaseInterop_impl(ol_device_handle_t Device, void *InteropSpec) {
+  auto Rc = Device->Device->releaseInterop(static_cast<omp_interop_val_t *>(InteropSpec));
+  if (Rc)
+    return Rc;
+  return Error::success();
+}
+
+Error olSelectInterop_impl(ol_device_handle_t Device, int32_t InteropType,
+                           int32_t InteropPreferencesSize, 
+                           void *InteropPreferences, void *InteropSpec) {
+  *static_cast<interop_spec_t *>(InteropSpec) = Device->Device->selectInteropPreference(
+      InteropType, InteropPreferencesSize, 
+      static_cast<interop_spec_t *>(InteropPreferences));
+  return Error::success();
+}
+
+Error olFlushQueueInterop_impl(ol_device_handle_t Device, void *Interop) {
+  Expected<int32_t> Rc =
+      Device->Device->Plugin.flush_queue(static_cast<omp_interop_val_t *>(Interop));
+  if (Rc) {
+    return Rc.takeError();
+  }
+  return Error::success();
+}
+
+Error olSyncBarrierInterop_impl(ol_device_handle_t Device, void *Interop) {
+  Expected<int32_t> Rc =
+      Device->Device->Plugin.sync_barrier(static_cast<omp_interop_val_t *>(Interop));
+  if (Rc) {
+    return Rc.takeError();
+  }
+  return Error::success();
+}
+
+Error olAsyncBarrierInterop_impl(ol_device_handle_t Device, void *Interop) {
+
+  Expected<int32_t> Rc = Device->Device->Plugin.async_barrier(static_cast<omp_interop_val_t *>(Interop));
+  if (Rc){
+    return Rc.takeError();
+  }
+  return Error::success();
+}
+
 } // namespace offload
 } // namespace llvm


### PR DESCRIPTION
Add missing liboffload interop API for libomptarget migration

This PR adds liboffload interop API that needed to make libomptarget to use liboffload