### PR TITLE
[OFFLOAD] Add missing memory data locking API for libomptarget migration

### DIFF
--- a/offload/liboffload/API/Memory.td
+++ b/offload/liboffload/API/Memory.td
@@ -131,3 +131,27 @@ def olMemFill : Function {
     Return<"OL_ERRC_INVALID_SIZE", ["`FillSize % PatternSize != 0`"]>
   ];
 }
+
+def olMemDataLock : Function {
+  let desc = "Locks / pins host memory using the plugin runtime.";
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device to allocate on", PARAM_IN>,
+    Param<"void *", "Ptr", "Host Pointer", PARAM_IN>,
+    Param<"size_t", "Size", "size of the allocation in bytes", PARAM_IN>,
+    Param<"void**", "LockedPtr", "output for the allocated pointer", PARAM_OUT>
+  ];
+  let returns = [
+    Return<"OL_ERRC_INVALID_SIZE", [
+      "`Size == 0`"
+    ]>
+  ];
+}
+
+def olMemDataUnLock : Function {
+  let desc = "Unlocks / unpins host memory using the plugin runtime.";
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device to allocate on", PARAM_IN>,
+    Param<"void *", "Ptr", "Host Pointer", PARAM_IN>
+  ];
+  let returns = [];
+}

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1214,5 +1214,20 @@ Error olLaunchHostFunction_impl(ol_queue_handle_t Queue,
                                                 Queue->AsyncInfo);
 }
 
+Error olMemDataLock_impl(ol_device_handle_t Device, void *Ptr, size_t Size,
+                         void** LockedPtr) {
+  Expected<void*> LockedPtrOrErr = Device->Device->dataLock(Ptr, Size);
+  if (!LockedPtrOrErr)
+    return LockedPtrOrErr.takeError();
+
+  *LockedPtr = *LockedPtrOrErr;
+
+  return Error::success();
+}
+
+Error olMemDataUnLock_impl(ol_device_handle_t Device, void *Ptr) {
+  return Device->Device->dataUnlock(Ptr);
+}
+
 } // namespace offload
 } // namespace llvm


### PR DESCRIPTION
Add missing liboffload memory data locking API for libomptarget migration

This PR adds liboffload memory data locking API that needed to make libomptarget to use liboffload