### PR TITLE
[OFFLOAD] Add missing initialize record replay API for libomptarget migration

### DIFF
--- a/offload/liboffload/API/Device.td
+++ b/offload/liboffload/API/Device.td
@@ -44,6 +44,7 @@ def ol_device_info_t : Enum {
     TaggedEtor<"MAX_MEM_ALLOC_SIZE", "uint64_t", "The maximum size of memory object allocation in bytes">,
     TaggedEtor<"GLOBAL_MEM_SIZE", "uint64_t", "The size of global device memory in bytes">,
     TaggedEtor<"WORK_GROUP_LOCAL_MEM_SIZE", "uint64_t", "The maximum size of local shared memory per work group in bytes">,
+    TaggedEtor<"IS_VA_SUPPORTED", "bool", "Is virtual address management supported on this device.">,
   ];
   list<TaggedEtor> fp_configs = !foreach(type, ["Single", "Double", "Half"], TaggedEtor<type # "_FP_CONFIG", "ol_device_fp_capability_flags_t", type # " precision floating point capability">);
   list<TaggedEtor> native_vec_widths = !foreach(type, ["char","short","int","long","float","double","half"], TaggedEtor<"NATIVE_VECTOR_WIDTH_" # type, "uint32_t", "Native vector width for " # type>);
@@ -132,15 +133,3 @@ def olGetDeviceInfoSize : Function {
   ];
 }
 
-def olInitializeRecordReplay : Function {
-  let desc = "Initializes the record and replay mechanism.";
-  let params = [
-    Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
-    Param<"uint64_t", "MemorySize", " The number of bytes to be (pre-)allocated by the bump allocator", PARAM_IN>,
-    Param<"void *", "VAddr", "handle of the destination device", PARAM_IN>,
-    Param<"bool", "IsRecord", "Activates the record replay mechanism in 'record' mode or 'replay' mode", PARAM_IN>,
-    Param<"bool", "SaveOutput", "Store the device memory after kernel execution on persistent storage", PARAM_IN>,
-    Param<"uint64_t *", "ReqPtrArgOffset", "handle of the destination device", PARAM_OUT>,
-  ];
-  let returns = [];
-}

--- a/offload/liboffload/API/Device.td
+++ b/offload/liboffload/API/Device.td
@@ -131,3 +131,16 @@ def olGetDeviceInfoSize : Function {
     Return<"OL_ERRC_INVALID_DEVICE">
   ];
 }
+
+def olInitializeRecordReplay : Function {
+  let desc = "Initializes the record and replay mechanism.";
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+    Param<"uint64_t", "MemorySize", " The number of bytes to be (pre-)allocated by the bump allocator", PARAM_IN>,
+    Param<"void *", "VAddr", "handle of the destination device", PARAM_IN>,
+    Param<"bool", "IsRecord", "Activates the record replay mechanism in 'record' mode or 'replay' mode", PARAM_IN>,
+    Param<"bool", "SaveOutput", "Store the device memory after kernel execution on persistent storage", PARAM_IN>,
+    Param<"uint64_t *", "ReqPtrArgOffset", "handle of the destination device", PARAM_OUT>,
+  ];
+  let returns = [];
+}

--- a/offload/liboffload/API/Memory.td
+++ b/offload/liboffload/API/Memory.td
@@ -131,3 +131,35 @@ def olMemFill : Function {
     Return<"OL_ERRC_INVALID_SIZE", ["`FillSize % PatternSize != 0`"]>
   ];
 }
+
+def olMemVAMap : Function {
+  let desc = "Allocates memory on device and map it to a provided virtual address.";
+  let details = [
+        "Allocates Size bytes (rounded up to page size) and hints the driver to",
+        "map it to VAddr. The obtained address is returned in Addr. At return",
+        "RSize contains the actual size which can be equal or larger than the",
+        "requested size."
+  ];
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+    Param<"void *", "Vaddr", "virtual address", PARAM_IN>,
+    Param<"size_t", "Size", "requested size of the memory in bytes", PARAM_IN>,
+    Param<"void **", "Addr", "pointer to the allocated memory", PARAM_OUT>,
+    Param<"size_t *", "RSize", "actual allocated memory size", PARAM_OUT>
+  ];
+  let returns = [
+    Return<"OL_ERRC_INVALID_SIZE", [
+      "`Size == 0`"
+    ]>
+  ];
+}
+
+def olMemVAUnmap : Function {
+  let desc = "De-allocates device memory and unmaps the virtual address.";
+  let params = [
+    Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+    Param<"void *", "Vaddr", "virtual address", PARAM_IN>,
+    Param<"size_t", "Size", "size of the allocated memory", PARAM_IN>
+  ];
+  let returns = [];
+}

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -530,6 +530,9 @@ Error olGetDeviceInfoImplDetail(ol_device_handle_t Device,
     return Info.write(Out);
   }
 
+  case OL_DEVICE_INFO_IS_VA_SUPPORTED:
+    return Info.write<bool>(Device->Device->supportVAManagement()); 
+
   default:
     llvm_unreachable("Unimplemented device info");
   }
@@ -1214,19 +1217,18 @@ Error olLaunchHostFunction_impl(ol_queue_handle_t Queue,
                                                 Queue->AsyncInfo);
 }
 
-Error olInitializeRecordReplay_impl(ol_device_handle_t Device,
-                                    uint64_t MemorySize, void *VAddr,
-                                    bool IsRecord, bool SaveOutput,
-                                    uint64_t *ReqPtrArgOffset) {
-  uint64_t ReqPtrArgOffsetOut = 0;
-  Expected<int> Rc = Device->Device->Plugin.initialize_record_replay(
-      Device->DeviceNum, MemorySize, VAddr, IsRecord, SaveOutput,
-      ReqPtrArgOffsetOut);
-  if (Rc) {
-    return Rc.takeError();
-  }
-  *ReqPtrArgOffset = ReqPtrArgOffsetOut;
-  return Error::success();
+Error olMemVAMap_impl(ol_device_handle_t Device, void *Vaddr, size_t Size,
+                         void **Addr, size_t *RSize) {
+  size_t MemorySize = Size;
+  Error Err = Device->Device->memoryVAMap(Addr, Vaddr, &MemorySize);
+
+  *RSize = MemorySize;
+
+  return Err;
+}
+
+Error olMemVAUnmap_impl(ol_device_handle_t Device, void *Vaddr, size_t Size) {
+  return Device->Device->memoryVAUnMap(Vaddr, Size);
 }
 
 } // namespace offload

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1214,5 +1214,20 @@ Error olLaunchHostFunction_impl(ol_queue_handle_t Queue,
                                                 Queue->AsyncInfo);
 }
 
+Error olInitializeRecordReplay_impl(ol_device_handle_t Device,
+                                    uint64_t MemorySize, void *VAddr,
+                                    bool IsRecord, bool SaveOutput,
+                                    uint64_t *ReqPtrArgOffset) {
+  uint64_t ReqPtrArgOffsetOut = 0;
+  Expected<int> Rc = Device->Device->Plugin.initialize_record_replay(
+      Device->DeviceNum, MemorySize, VAddr, IsRecord, SaveOutput,
+      ReqPtrArgOffsetOut);
+  if (Rc) {
+    return Rc.takeError();
+  }
+  *ReqPtrArgOffset = ReqPtrArgOffsetOut;
+  return Error::success();
+}
+
 } // namespace offload
 } // namespace llvm


### PR DESCRIPTION
Add missing liboffload initialize record replay API for libomptarget migration

This PR adds liboffload initialize record replay API that needed to make libomptarget to use liboffload