### PR TITLE
Partially revert "[NFCI][lldb][test][asm] Enable AT&T syntax explicitly (#166770)"

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -320,13 +320,6 @@ ifeq "$(MAKE_GMODULES)" "YES"
 	CXXFLAGS += $(MANDATORY_MODULE_BUILD_CFLAGS)
 endif
 
-# Our files use x86 AT&T assembly throughout.
-# Enable it explicitly so any local Clang preference for Intel syntax gets overriden.
-ifeq ($(CC_TYPE), clang)
-	CFLAGS += -mllvm -x86-asm-syntax=att
-	CXXFLAGS += -mllvm -x86-asm-syntax=att
-endif
-
 CFLAGS += $(CFLAGS_EXTRAS)
 CXXFLAGS += -std=c++11 $(CFLAGS) $(ARCH_CXXFLAGS)
 # Copy common options to the linker flags (dwarf, arch. & etc).

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -242,10 +242,6 @@ def use_support_substitutions(config):
     # The clang module cache is used for building inferiors.
     host_flags += ["-fmodules-cache-path={}".format(config.clang_module_cache)]
 
-    # Our files use x86 AT&T assembly throughout.
-    # Enable it explicitly so any local Clang preference for Intel syntax gets overriden.
-    host_flags += ["-mllvm", "-x86-asm-syntax=att"]
-
     if config.cmake_sysroot:
         host_flags += ["--sysroot={}".format(config.cmake_sysroot)]
 


### PR DESCRIPTION
Flag changes reverted as those require the X86 target to be enabled.  
Don't have time to test fixes as I need to go to sleep so will revert for now.

Reverts: 423919d31f4b55f22b09cd5066534f7c91e71d4b