### PR TITLE
[flang-rt][device] Use snprintf result for length

### DIFF
--- a/flang-rt/lib/runtime/external-unit.cpp
+++ b/flang-rt/lib/runtime/external-unit.cpp
@@ -201,9 +201,9 @@ bool ExternalFileUnit::OpenAnonymousUnit(common::optional<OpenStatus> status,
   // I/O to an unconnected unit reads/creates a local file, e.g. fort.7
   std::size_t pathMaxLen{32};
   auto path{SizedNew<char>{handler}(pathMaxLen)};
-  std::snprintf(path.get(), pathMaxLen, "fort.%d", unitNumber_);
+  int len = std::snprintf(path.get(), pathMaxLen, "fort.%d", unitNumber_);
   OpenUnit(status, action, position, std::move(path),
-      runtime::strlen(path.get()), convert, handler);
+      len >= 0 ? static_cast<std::size_t>(len) : 0, convert, handler);
   return IsConnected();
 }
 


### PR DESCRIPTION
The buffer might not be null terminated on the device and result in 1 byte invalid read when trying to get the length. 