### PR TITLE
[clang-format] Align different categories together

### DIFF
--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -372,6 +372,7 @@ AlignTokenSequence(const FormatStyle &Style, unsigned Start, unsigned End,
         (ScopeStack.size() == 1u && CurrentChange.NewlinesBefore > 0 &&
          InsideNestedScope)) {
       LineShifted = true;
+      CurrentChange.IndentedFromColumn += Shift;
       CurrentChange.Spaces += Shift;
     }
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -20879,6 +20879,14 @@ TEST_F(FormatTest, AlignWithLineBreaks) {
                "                   };",
                Style);
 
+  verifyFormat("const char *const MatHtool[] = {};\n"
+               "const char        Htool[]    = \"@article{m,\\n\"\n"
+               "                               \" \"\n"
+               "                               \" \"\n"
+               "                               \" \"\n"
+               "                               \"}\\n\";",
+               Style);
+
   Style.ColumnLimit = 15;
   verifyFormat("int i1 = 1;\n"
                "k      = bar(\n"


### PR DESCRIPTION
How the program figured out which lines to move along the aligned lines in 75c85bafb830e5.  Aligning the lines caused the information to be out of date for aligning different categories later on.  It caused a regression.

Fixes #171021.

new, with the options `AlignConsecutiveAssignments` and `AlignConsecutiveDeclarations` enabled

```C++
const char *const MatHtoolCompressorTypes[] = {"sympartialACA", "fullACA",
                                               "SVD"};
const char        HtoolCitation[]           = "@article{marchand2020two,\n"
                                              "  "
                                              "  "
                                              "  "
                                              "}\n";
```

old

```C++
const char *const MatHtoolCompressorTypes[] = {"sympartialACA", "fullACA"};
const char        HtoolCitation[]           = "@article{marchand2020two,\n"
                                    "  "
                                    "  "
                                    "  "
                                    "}\n";
```