### PR TITLE
[libc][CPP] make the string trap on OOM

### DIFF
--- a/libc/src/__support/CPP/string.h
+++ b/libc/src/__support/CPP/string.h
@@ -132,7 +132,7 @@ public:
     // by 8 is cheap. We guard the extension so the operation doesn't overflow.
     if (new_capacity < SIZE_MAX / 11)
       new_capacity = new_capacity * 11 / 8;
-    
+
     if (void *Ptr = ::realloc(buffer_ == get_empty_string() ? nullptr : buffer_,
                               new_capacity)) {
       buffer_ = static_cast<char *>(Ptr);

--- a/libc/src/__support/CPP/string.h
+++ b/libc/src/__support/CPP/string.h
@@ -136,9 +136,10 @@ public:
                               new_capacity)) {
       buffer_ = static_cast<char *>(Ptr);
       capacity_ = new_capacity;
-    } else {
-      __builtin_unreachable(); // out of memory
     }
+    // Out of memory: this is not handled in current implementation,
+    // We trap the program and exits.
+    __builtin_trap();
   }
 
   LIBC_INLINE void resize(size_t size) {

--- a/libc/src/__support/CPP/string.h
+++ b/libc/src/__support/CPP/string.h
@@ -132,10 +132,12 @@ public:
     // by 8 is cheap. We guard the extension so the operation doesn't overflow.
     if (new_capacity < SIZE_MAX / 11)
       new_capacity = new_capacity * 11 / 8;
+    
     if (void *Ptr = ::realloc(buffer_ == get_empty_string() ? nullptr : buffer_,
                               new_capacity)) {
       buffer_ = static_cast<char *>(Ptr);
       capacity_ = new_capacity;
+      return;
     }
     // Out of memory: this is not handled in current implementation,
     // We trap the program and exits.


### PR DESCRIPTION
This PR makes the string trap on OOM.

Previously, the `__builtin_unreachable` has made debugging tricky as it makes the control flow of OOM as an undefined behavior.
We can run into OOM with testing configuration easily where memory is statically bounded.

We did not settle with the best solution of this but making it trap is at least better than UB 
in this case.
