### PR TITLE
[lldb][AppleObjCDeclVendor] Fix format specifiers when printing log

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCDeclVendor.cpp
@@ -79,9 +79,9 @@ public:
               static_cast<void *>(&tag_decl->getASTContext()),
               static_cast<void *>(tag_decl), tag_decl->getName().str().c_str());
 
-    LLDB_LOG(log, "  AOEAS::CT Before:\n{1}", ClangUtil::DumpDecl(tag_decl));
+    LLDB_LOG(log, "  AOEAS::CT Before:\n{0}", ClangUtil::DumpDecl(tag_decl));
 
-    LLDB_LOG(log, "  AOEAS::CT After:{1}", ClangUtil::DumpDecl(tag_decl));
+    LLDB_LOG(log, "  AOEAS::CT After:{0}", ClangUtil::DumpDecl(tag_decl));
   }
 
   void CompleteType(clang::ObjCInterfaceDecl *interface_decl) override {


### PR DESCRIPTION
This was causing a crash when enabling the expression log:
```
4   LLDB                          	       0x1376d68d0 llvm::formatv_object_base::parseFormatString(llvm::StringRef, unsigned long, bool) + 532
5   LLDB                          	       0x13776d838 llvm::formatv_object_base::format(llvm::raw_ostream&) const + 84
6   LLDB                          	       0x13776d7d4 llvm::raw_ostream::operator<<(llvm::formatv_object_base const&) + 36
7   LLDB                          	       0x1375f4980 lldb_private::Log::Format(llvm::StringRef, llvm::StringRef, llvm::formatv_object_base const&) + 164
8   LLDB                          	       0x12f7b39f0 lldb_private::AppleObjCExternalASTSource::CompleteType(clang::TagDecl*) + 416
9   LLDB                          	       0x12fa038dc lldb_private::ClangASTSource::FindExternalLexicalDecls(clang::DeclContext const*, llvm::function_ref<bool (clang::Decl::Kind)>, llvm::SmallVectorImpl<clang::Decl*>&) + 1132
10  LLDB                          	       0x135d94838 clang::ExternalASTSource::FindExternalLexicalDecls(clang::DeclContext const*, llvm::SmallVectorImpl<clang::Decl*>&) + 92
11  LLDB                          	       0x135d94690 clang::DeclContext::LoadLexicalDeclsFromExternalStorage() const + 204
12  LLDB                          	       0x135d95ca0 clang::DeclContext::buildLookup() + 308
13  LLDB                          	       0x135d964b8 clang::DeclContext::lookupImpl(clang::DeclarationName, clang::DeclContext const*) const + 824
14  LLDB                          	       0x135d96168 clang::DeclContext::lookup(clang::DeclarationName) const + 124
15  LLDB                          	       0x134f093d4 clang::Sema::CheckImplicitSpecialMemberDeclaration(clang::Scope*, clang::FunctionDecl*) + 128
16  LLDB                          	       0x134efb488 clang::Sema::DeclareImplicitDestructor(clang::CXXRecordDecl*) + 932
17  LLDB                          	       0x1352ddf24 clang::Sema::LookupSpecialMember(clang::CXXRecordDecl*, clang::CXXSpecialMemberKind, bool, bool, bool, bool, bool)::$_0::operator()() const + 36
```