### PR TITLE
[mlir:bazel] Fix missing dependency introduced in #171727.

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -5429,7 +5429,10 @@ gentbl_cc_library(
     ]},
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/LLVMIR/Transforms/Passes.td",
-    deps = [":PassBaseTdFiles"],
+    deps = [
+        ":LLVMOpsTdFiles",
+        ":PassBaseTdFiles",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
That PR added an include to `LLVMOps.td` without adding a target providing that file. Curiously, this does not break the official builds but it *does* break my bazel build.