### PR TITLE
[MLIR][Vector] Add distribution pattern for `vector::ConstantMaskOp`

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
@@ -1100,12 +1100,14 @@ struct WarpOpShapeCast : public WarpDistributionPattern {
   }
 };
 
-/// Sink out vector.create_mask op feeding into a warp op yield.
+/// Sink out vector.create_mask / vector.constant_mask op feeding into a warp op
+/// yield.
 /// ```
 /// %0 = ...
 /// %1 = gpu.warp_execute_on_lane_0(%arg0) -> (vector<1xf32>) {
 ///   ...
 ///   %mask = vector.create_mask %0 : vector<32xi1>
+///   // or %mask = vector.constant_mask[2] : vector<32xi1>
 ///   gpu.yield %mask : vector<32xi1>
 /// }
 /// ```


### PR DESCRIPTION
This PR enables `vector::ConstantMaskOp` (attribute-based indices) distribution by extending the distribution of its SSA-variant sibling `vector::CreateMaskOp`. Both ops offer equivalent semantics, so we can materialize attributes as SSA values and plug into the existing distribution logic.