### PR TITLE
[libc++] Mini-cleanup for `[[nodiscard]]`

### DIFF
--- a/libcxx/include/__filesystem/copy_options.h
+++ b/libcxx/include/__filesystem/copy_options.h
@@ -50,15 +50,15 @@ enum class copy_options : unsigned short {
   return static_cast<copy_options>(~static_cast<unsigned short>(__lhs));
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline copy_options& operator&=(copy_options& __lhs, copy_options __rhs) {
+_LIBCPP_HIDE_FROM_ABI inline copy_options& operator&=(copy_options& __lhs, copy_options __rhs) {
   return __lhs = __lhs & __rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline copy_options& operator|=(copy_options& __lhs, copy_options __rhs) {
+_LIBCPP_HIDE_FROM_ABI inline copy_options& operator|=(copy_options& __lhs, copy_options __rhs) {
   return __lhs = __lhs | __rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline copy_options& operator^=(copy_options& __lhs, copy_options __rhs) {
+_LIBCPP_HIDE_FROM_ABI inline copy_options& operator^=(copy_options& __lhs, copy_options __rhs) {
   return __lhs = __lhs ^ __rhs;
 }
 

--- a/libcxx/include/__mdspan/mdspan.h
+++ b/libcxx/include/__mdspan/mdspan.h
@@ -214,7 +214,7 @@ public:
     }(make_index_sequence<rank()>()));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr size_type size() const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr size_type size() const noexcept {
     // Could leave this as only checked in debug mode: semantically size() is never
     // guaranteed to be related to any accessible range
     _LIBCPP_ASSERT_UNCATEGORIZED(

--- a/libcxx/test/libcxx/containers/views/mdspan/mdspan/assert.size.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/mdspan/assert.size.pass.cpp
@@ -43,7 +43,7 @@ int main(int, char**) {
     assert(map.required_span_size() == static_cast<signed char>(12));
     // 100 x 3 exceeds 256
     {
-      TEST_LIBCPP_ASSERT_FAILURE(([=] { mds.size(); }()), "mdspan: size() is not representable as size_type");
+      TEST_LIBCPP_ASSERT_FAILURE(([=] { (void)mds.size(); }()), "mdspan: size() is not representable as size_type");
     }
   }
   return 0;

--- a/libcxx/test/libcxx/containers/views/mdspan/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/nodiscard.verify.cpp
@@ -33,6 +33,8 @@ void test() {
   mdsp.static_extent(0); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   mdsp.extent(0);        // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
 
+  mdsp.size(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
   mdsp.extents();     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   mdsp.data_handle(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   mdsp.mapping();     // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}

--- a/libcxx/test/libcxx/diagnostics/algorithm.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/algorithm.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <algorithm> functions are marked [[nodiscard]]
 
 // clang-format off
@@ -188,11 +186,13 @@ void test() {
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::max(1, 2, std::greater<int>());
 
+#if TEST_STD_VER >= 11
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::max({1, 2, 3});
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::max({1, 2, 3}, std::greater<int>());
+#endif
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::min_element(std::begin(arr), std::end(arr));
@@ -206,11 +206,13 @@ void test() {
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::min(1, 2, std::greater<int>());
 
+#if TEST_STD_VER >= 11
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::min({1, 2, 3});
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::min({1, 2, 3}, std::greater<int>());
+#endif
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::minmax_element(std::begin(arr), std::end(arr));
@@ -224,11 +226,13 @@ void test() {
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::minmax(1, 2, std::greater<int>());
 
+#if TEST_STD_VER >= 11
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::minmax({1, 2, 3});
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::minmax({1, 2, 3}, std::greater<int>());
+#endif
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::mismatch(std::begin(arr), std::end(arr), std::begin(arr));

--- a/libcxx/test/libcxx/diagnostics/array.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/array.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <array> functions are marked [[nodiscard]]
 
 #include <array>
@@ -18,7 +16,7 @@
 template <std::size_t N>
 void test_members() {
   std::array<int, N> a;
-  const std::array<int, N> ca{};
+  const std::array<int, N> ca = {};
 
   a.begin();    // expected-warning 2 {{ignoring return value of function declared with 'nodiscard' attribute}}
   ca.begin();   // expected-warning 2 {{ignoring return value of function declared with 'nodiscard' attribute}}
@@ -57,7 +55,7 @@ void test_members() {
 
 template <typename ArrT>
 void test_get() {
-  std::array<int, 94> a{};
+  std::array<int, 94> a = {};
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::get<0>(a);

--- a/libcxx/test/libcxx/diagnostics/cstdlib.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/cstdlib.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // We don't control the implementation of the stdlib.h functions on windows
 // UNSUPPORTED: windows
 

--- a/libcxx/test/libcxx/diagnostics/deque.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/deque.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <deque> functions are marked [[nodiscard]]
 
 #include <deque>

--- a/libcxx/test/libcxx/diagnostics/forward_list.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/forward_list.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <forward_list> functions are marked [[nodiscard]]
 
 #include <forward_list>

--- a/libcxx/test/libcxx/diagnostics/functional.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/functional.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <functional> functions are marked [[nodiscard]]
 
 #include <cstddef>
@@ -20,7 +18,7 @@ void test() {
 
   // Function wrappers
 
-#if !defined(TEST_HAS_NO_RTTI)
+#if TEST_STD_VER >= 11 && !defined(TEST_HAS_NO_RTTI)
   std::function<void(int)> f;
   const std::function<void(int)> cf;
 
@@ -48,14 +46,16 @@ void test() {
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::bind_front([](int a) { return a; }, 94);
 #endif
+#if TEST_STD_VER >= 11
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::bind([](int a) { return a; }, 94);
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::bind<float>([](int a) { return a; }, 94);
+#endif
 
   // Reference wrappers
 
-  std::reference_wrapper<int> rw{i};
+  std::reference_wrapper<int> rw = i;
   rw.get(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
 
   std::ref(i);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}

--- a/libcxx/test/libcxx/diagnostics/limits.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/limits.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <limits> functions are marked [[nodiscard]]
 
 #include <limits>

--- a/libcxx/test/libcxx/diagnostics/list.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/list.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <list> functions are marked [[nodiscard]]
 
 #include <list>

--- a/libcxx/test/libcxx/diagnostics/mutex.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/mutex.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // UNSUPPORTED: no-threads
 
 // check that <mutex> functions are marked [[nodiscard]]
@@ -47,14 +45,14 @@ void test() {
     std::unique_lock<M> other;
 
     // clang-format off
-    std::unique_lock<M>{};                      // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
-    std::unique_lock<M>{m};                     // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
-    std::unique_lock<M>{m, std::defer_lock};    // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
-    std::unique_lock<M>{m, std::try_to_lock};   // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
-    std::unique_lock<M>{m, std::adopt_lock};    // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
-    std::unique_lock<M>{m, time_point};         // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
-    std::unique_lock<M>{m, duration};           // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
-    std::unique_lock<M>(std::move(other));      // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    std::unique_lock<M>();                        // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    (std::unique_lock<M>)(m);                     // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    std::unique_lock<M>(m, std::defer_lock_t());  // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    std::unique_lock<M>(m, std::try_to_lock_t()); // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    std::unique_lock<M>(m, std::adopt_lock_t());  // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    std::unique_lock<M>(m, time_point);           // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    std::unique_lock<M>(m, duration);             // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    std::unique_lock<M>(std::move(other));        // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
     // clang-format on
   }
 
@@ -62,8 +60,8 @@ void test() {
   {
     std::mutex m;
     // clang-format off
-    std::lock_guard<std::mutex>{m};                  // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
-    std::lock_guard<std::mutex>{m, std::adopt_lock}; // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    (std::lock_guard<std::mutex>)(m);                    // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
+    std::lock_guard<std::mutex>(m, std::adopt_lock_t()); // expected-warning {{ignoring temporary created by a constructor declared with 'nodiscard' attribute}}
     // clang-format on
   }
 }

--- a/libcxx/test/libcxx/diagnostics/new.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/new.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <array> functions are marked [[nodiscard]]
 
 // clang-format off

--- a/libcxx/test/libcxx/diagnostics/queue.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/queue.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <queue> functions are marked [[nodiscard]]
 
 #include <queue>
@@ -15,7 +13,7 @@
 void test() {
   {
     std::queue<int> q;
-    const std::queue<int> cq{};
+    const std::queue<int> cq;
 
     q.empty();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
     q.size();   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}

--- a/libcxx/test/libcxx/diagnostics/stack.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/stack.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <stack> functions are marked [[nodiscard]]
 
 #include <stack>

--- a/libcxx/test/libcxx/diagnostics/string.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/string.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <string> functions are marked [[nodiscard]]
 
 #include <string>

--- a/libcxx/test/libcxx/diagnostics/string_view.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/string_view.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <string_view> functions are marked [[nodiscard]]
 
 #include <string_view>
@@ -126,7 +124,7 @@ void test_nonmembers() {
 
   std::hash<std::string_view> hash;
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  hash(std::string_view{});
+  hash(std::string_view());
 
 #if TEST_STD_VER >= 14
   // string_view literals

--- a/libcxx/test/libcxx/diagnostics/utility.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/utility.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <utility> functions are marked [[nodiscard]]
 
 #include <utility>

--- a/libcxx/test/libcxx/diagnostics/vector.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/vector.nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // check that <vector> functions are marked [[nodiscard]]
 
 #include <type_traits>
@@ -44,11 +42,11 @@ void test_non_vector_bool() {
 }
 
 void instantiate() {
-  test<std::vector<int>>();
-  test<const std::vector<int>>();
-  test<std::vector<bool>>();
-  test<const std::vector<bool>>();
+  test<std::vector<int> >();
+  test<const std::vector<int> >();
+  test<std::vector<bool> >();
+  test<const std::vector<bool> >();
 
-  test_non_vector_bool<std::vector<int>>();
-  test_non_vector_bool<const std::vector<int>>();
+  test_non_vector_bool<std::vector<int> >();
+  test_non_vector_bool<const std::vector<int> >();
 }

--- a/libcxx/test/libcxx/thread/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/thread/nodiscard.verify.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
 // UNSUPPORTED: no-threads
 
 // Check that functions are marked [[nodiscard]]
@@ -65,7 +64,7 @@ void test() {
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     m.try_lock();
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-    m.try_lock_for(std::chrono::nanoseconds{82});
+    m.try_lock_for(std::chrono::nanoseconds(82));
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     m.try_lock_until(timePoint);
   }
@@ -75,7 +74,7 @@ void test() {
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     m.try_lock();
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-    m.try_lock_for(std::chrono::nanoseconds{82});
+    m.try_lock_for(std::chrono::nanoseconds(82));
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     m.try_lock_until(timePoint);
   }
@@ -86,8 +85,10 @@ void test() {
 
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     std::try_lock(m1, m2);
+#if TEST_STD_VER >= 11
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     std::try_lock(m1, m2, m3);
+#endif
   }
 
   // Condition variables

--- a/libcxx/test/libcxx/utilities/smartptr/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/utilities/smartptr/nodiscard.verify.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++03
-
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_ENABLE_CXX20_REMOVED_SHARED_PTR_UNIQUE -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
 
 // <memory>
@@ -42,7 +40,7 @@ void test() {
     std::make_unique_for_overwrite<int[]>(5);
 #endif
 
-    std::hash<std::unique_ptr<int>> hash;
+    std::hash<std::unique_ptr<int> > hash;
     hash(uPtr); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   }
   { // [util.smartptr.weak.bad]
@@ -127,7 +125,7 @@ void test() {
     std::get_deleter<int[]>(sPtr);
 #endif
 
-    std::hash<std::shared_ptr<int[]>> hash;
+    std::hash<std::shared_ptr<int[]> > hash;
     hash(sPtr); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   }
   { // [util.smartptr.weak]

--- a/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
@@ -73,12 +73,12 @@ constexpr bool test_bitmask_binary_operations() {
       }
       {
         auto e = elem;
-        e &= elem;
+        assert(&(e &= elem) == &e);
         assert(e == elem);
       }
       {
         auto e = elem;
-        e ^= elem;
+        assert(&(e ^= elem) == &e);
         assert(e == E::none);
       }
     }

--- a/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
@@ -22,6 +22,71 @@ namespace fs = std::filesystem;
 
 constexpr fs::copy_options ME(int val) { return static_cast<fs::copy_options>(val); }
 
+// Verify binary operations on std::filesystem::copy_options bitmask constants.
+// Also verify that compound assignment operators are not incorrectly marked [[nodiscard]],
+// to avoid regression in https://llvm.org/PR171085.
+constexpr bool test_bitmask_binary_operations() {
+  using E = fs::copy_options;
+  constexpr E bitmask_elems[]{
+      // non-empty standard bitmask elements
+      E::skip_existing,
+      E::overwrite_existing,
+      E::update_existing,
+      E::recursive,
+      E::copy_symlinks,
+      E::skip_symlinks,
+      E::directories_only,
+      E::create_symlinks,
+      E::create_hard_links,
+  };
+
+  for (auto elem : bitmask_elems) {
+    assert((E::none | elem) == elem);
+    assert((E::none & elem) == E::none);
+    assert((E::none ^ elem) == elem);
+
+    assert((elem | elem) == elem);
+    assert((elem & elem) == elem);
+    assert((elem ^ elem) == E::none);
+
+    if (!TEST_IS_CONSTANT_EVALUATED) {
+      {
+        auto e = E::none;
+        e |= elem;
+        assert(e == elem);
+      }
+      {
+        auto e = E::none;
+        e &= elem;
+        assert(e == E::none);
+      }
+      {
+        auto e = E::none;
+        e ^= elem;
+        assert(e == elem);
+      }
+
+      {
+        auto e = elem;
+        elem |= elem;
+        assert(e == elem);
+      }
+      {
+        auto e = elem;
+        e &= elem;
+        assert(e == elem);
+      }
+      {
+        auto e = elem;
+        e ^= elem;
+        assert(e == E::none);
+      }
+    }
+  }
+
+  return true;
+}
+
 int main(int, char**) {
   typedef fs::copy_options E;
   static_assert(std::is_enum<E>::value, "");
@@ -61,14 +126,8 @@ int main(int, char**) {
           E::create_hard_links   == ME(256),
         "Expected enumeration values do not match");
 
-  // Verify that compound assignment operators are not incorrectly marked [[nodiscard]],
-  // to avoid regression in https://llvm.org/PR171085.
-  {
-    E e = E::none;
-    e &= E::skip_existing;
-    e |= E::recursive;
-    e ^= E::create_hard_links;
-  }
+  test_bitmask_binary_operations();
+  static_assert(test_bitmask_binary_operations());
 
   return 0;
 }

--- a/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
@@ -52,23 +52,23 @@ constexpr bool test_bitmask_binary_operations() {
     if (!TEST_IS_CONSTANT_EVALUATED) {
       {
         auto e = E::none;
-        e |= elem;
+        assert(&(e |= elem) == &e);
         assert(e == elem);
       }
       {
         auto e = E::none;
-        e &= elem;
+        assert(&(e &= elem) == &e);
         assert(e == E::none);
       }
       {
         auto e = E::none;
-        e ^= elem;
+        assert(&(e ^= elem) == &e);
         assert(e == elem);
       }
 
       {
         auto e = elem;
-        elem |= elem;
+        assert(&(e |= elem) == &e);
         assert(e == elem);
       }
       {

--- a/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.enum/enum.copy_options.pass.cpp
@@ -61,5 +61,14 @@ int main(int, char**) {
           E::create_hard_links   == ME(256),
         "Expected enumeration values do not match");
 
+  // Verify that compound assignment operators are not incorrectly marked [[nodiscard]],
+  // to avoid regression in https://llvm.org/PR171085.
+  {
+    E e = E::none;
+    e &= E::skip_existing;
+    e |= E::recursive;
+    e ^= E::create_hard_links;
+  }
+
   return 0;
 }


### PR DESCRIPTION
1. Remove incorrect `[[nodiscard]]` from compound assignment operators in `<__filesystem/copy_options.h>`. Also add regression tests.
2. Add missing `[[nodiscard]]` mark for `mdspan::size` in `<__mdspan/mdspan.h>` and test it.
3. Enable verifying `[[nodiscard]]` in C++03 for various components. These components are either present in C++03 or backported by libc++ from C++11/17.