### PR TITLE
[llvm][examples] Disable some JIT examples when threading is disabled

### DIFF
--- a/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/CMakeLists.txt
@@ -12,7 +12,7 @@ set(LLVM_LINK_COMPONENTS
   nativecodegen
   )
 
-if (LLVM_INCLUDE_UTILS)
+if (LLVM_INCLUDE_UTILS AND LLVM_ENABLE_THREADS)
   add_llvm_example(LLJITWithRemoteDebugging
     LLJITWithRemoteDebugging.cpp
     RemoteJITUtils.cpp

--- a/llvm/examples/SpeculativeJIT/CMakeLists.txt
+++ b/llvm/examples/SpeculativeJIT/CMakeLists.txt
@@ -10,6 +10,8 @@ set(LLVM_LINK_COMPONENTS
   Passes
   )
 
-add_llvm_example(SpeculativeJIT
-  SpeculativeJIT.cpp
+if(LLVM_ENABLE_THREADS)
+  add_llvm_example(SpeculativeJIT
+    SpeculativeJIT.cpp
   )
+endif()

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -200,7 +200,7 @@ if(LLVM_INCLUDE_EXAMPLES)
     OrcV2CBindingsLazy
     OrcV2CBindingsVeryLazy
     )
-  if(CMAKE_HOST_UNIX)
+  if(CMAKE_HOST_UNIX AND LLVM_ENABLE_THREADS)
     list(APPEND LLVM_TEST_DEPENDS
       LLJITWithRemoteDebugging
       )

--- a/llvm/test/Examples/OrcV2Examples/lljit-with-remote-debugging.test
+++ b/llvm/test/Examples/OrcV2Examples/lljit-with-remote-debugging.test
@@ -3,7 +3,7 @@
 
 # Instructions for debugging can be found in LLJITWithRemoteDebugging.cpp
 
-# REQUIRES: default_triple
+# REQUIRES: default_triple, thread_support
 # UNSUPPORTED: target=powerpc64{{.*}}, target=s390{{.*}}
 
 # RUN: LLJITWithRemoteDebugging %p/Inputs/argc_sub1.ll 2>&1 | FileCheck --check-prefix=CHECK0 %s


### PR DESCRIPTION
This fixes an error on our Armv8 bot:
```
<...>/RemoteJITUtils.cpp:132:24: error: use of undeclared identifier 'DynamicThreadPoolTaskDispatcher'
  132 |       std::make_unique<DynamicThreadPoolTaskDispatcher>(std::nullopt),
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

These examples require LLVM_ENABLE_THREADS to be ON, and cannot run otherwise. As a comment says elsewhere:
```
  // Out of process mode using SimpleRemoteEPC depends on threads.
```